### PR TITLE
ci: add Python CI for ruff + pytest under python/

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -1,0 +1,71 @@
+name: Python CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'python/**'
+      - '.github/workflows/python_ci.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'python/**'
+      - '.github/workflows/python_ci.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint (ruff)
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install dev dependencies
+        run: cd python && uv sync --locked --group dev
+
+      - name: Ruff check
+        run: cd python && uv run ruff check .
+
+      - name: Ruff format check
+        run: cd python && uv run ruff format --check .
+
+  test:
+    runs-on: ubuntu-latest
+    name: Test (pytest)
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install test dependencies
+        run: cd python && uv sync --locked --group test
+
+      - name: Pytest
+        run: |
+          cd python
+          # Skip cleanly when no tests have been written yet (pytest exits 5
+          # on "no tests collected"). Remove this guard once tests exist.
+          if compgen -G "tests/test_*.py" > /dev/null || compgen -G "tests/**/test_*.py" > /dev/null; then
+            uv run pytest --cov
+          else
+            echo "No test files under tests/; skipping pytest."
+          fi

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -62,10 +62,15 @@ jobs:
       - name: Pytest
         run: |
           cd python
-          # Skip cleanly when no tests have been written yet (pytest exits 5
-          # on "no tests collected"). Remove this guard once tests exist.
-          if compgen -G "tests/test_*.py" > /dev/null || compgen -G "tests/**/test_*.py" > /dev/null; then
-            uv run pytest --cov
-          else
-            echo "No test files under tests/; skipping pytest."
+          # Translate pytest's exit code 5 ("no tests collected") to success
+          # so CI passes while tests/ is still empty. Remove this once tests
+          # exist; any other failure still fails the job.
+          set +e
+          uv run pytest --cov
+          status=$?
+          set -e
+          if [ "$status" -eq 5 ]; then
+            echo "No tests collected; skipping pytest."
+            exit 0
           fi
+          exit "$status"


### PR DESCRIPTION
Mirrors the pattern from numina/fuse for the `python/` package.

- `astral-sh/setup-uv` with cache enabled.
- `uv sync --locked --group <dev|test>` — fails CI if `python/uv.lock` drifts.
- Separate `lint` (ruff check + ruff format check) and `test` (pytest) jobs.
- Triggers only when `python/**` or this workflow file changes.
- `concurrency.cancel-in-progress` and read-only `GITHUB_TOKEN`.

The pytest step is guarded against pytest's exit-5 "no tests collected" since `python/tests/` is empty so far. Remove the guard once real tests land.