### PR TITLE
ci: switch Lean CI trigger from paths-ignore to paths allowlist

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -4,17 +4,21 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - 'python/**'
-      - '**/*.md'
-      - 'LICENSE'
+    paths:
+      - '**/*.lean'
+      - 'lakefile.toml'
+      - 'lean-toolchain'
+      - 'lake-manifest.json'
+      - '.github/workflows/lean_action_ci.yml'
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - 'python/**'
-      - '**/*.md'
-      - 'LICENSE'
+    paths:
+      - '**/*.lean'
+      - 'lakefile.toml'
+      - 'lean-toolchain'
+      - 'lake-manifest.json'
+      - '.github/workflows/lean_action_ci.yml'
   workflow_dispatch:
 
 # Cancel superseded runs on the same branch / PR.


### PR DESCRIPTION
The previous `paths-ignore` denylist was too permissive — any change outside `python/`, `*.md`, or `LICENSE` triggered a full Lean build, including unrelated workflow files like `python_ci.yml` (visible on PR #7).

Flipped to an allowlist of files that can actually affect the Lean build:

```yaml
paths:
  - '**/*.lean'
  - 'lakefile.toml'
  - 'lean-toolchain'
  - 'lake-manifest.json'
  - '.github/workflows/lean_action_ci.yml'
```

Anything else — `python/`, docs, LICENSE, `.gitignore`, other workflow files — is now skipped automatically without needing to enumerate it.