### PR TITLE
Add Makefile with build, lint, check, test, update, and agent-docs targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,109 @@
+This file is a concatenation of README.md and CONTRIBUTING.md.
+
+# lean-pool
+
+Lean Pool sits between `mathlib` and `merely-true`, like arXiv for formal mathematics. A bottleneck of mathlib growth is the high quality human review. Instead, we use a combination of linters and AI review to uphold as much code quality as possible. We hope to grow Lean Pool much faster than mathlib.
+
+Key capabilities:
+
+1. Automatic Lean and Mathlib version bumping.
+2. Automated PR review.
+3. Docs and search.
+
+Created as part of the UW Lean [Hackathon](https://uw2026leanhackathon.github.io/) by Vasily Ilin and Justin Asher.
+
+# Contributing to Lean Pool
+
+Lean Pool sits between `mathlib` and `merely-true` — like arXiv for formal mathematics. Contributions of all sizes are welcome.
+
+
+## Finding Work
+
+Check the [issues](https://github.com/Vilin97/lean-pool/issues) for things to work on.
+
+
+## Dev Setup
+
+### Prerequisites
+
+- **Lean** via [elan](https://leanprover-community.github.io/install/) (toolchain pinned in `lean-toolchain`)
+- **Python 3.13+**
+- **[uv](https://docs.astral.sh/uv/)** (Python package manager)
+
+### Lean
+
+```bash
+lake build
+```
+
+### Python
+
+```bash
+cd python
+uv sync               # install runtime + dev (lint/format) deps
+uv sync --group test  # also install test deps when running pytest
+```
+
+See [`python/README.md`](python/README.md) for common commands.
+
+
+## Branch and PR Workflow
+
+Direct commits to `main` are not allowed. All changes go through pull requests.
+
+**Branch naming.** Use `yourname/description` for solo work (e.g., `justin/aggregator-draft`). Use `feature/` or `fix/` prefixes for branches where multiple people may contribute (e.g., `feature/manifest-summary`, `fix/timeout-default`).
+
+**Open PRs early.** Push and open a PR as soon as you have something, even if incomplete. Use GitHub's draft PR feature and label with `WIP` if needed.
+
+**Link issues.** Use `Closes #123` in the PR description to automatically close the related issue on merge.
+
+**Commit messages.** Write clear, concise commit messages in imperative tense (e.g., "Add manifest fetcher", not "Added manifest fetcher"). Do not include AI-generated tags (e.g., "Generated with Claude", "Co-authored-by: Codex") in commits or PRs.
+
+**Review and merge.** All PRs require at least one review from another contributor before merging.
+
+
+## Linting and Testing
+
+### Lean
+
+CI currently runs `lake exe mk_all --check`, `lake build LeanPool`, and `lake exe runLinter LeanPool` (see [`.github/workflows/lean_action_ci.yml`](.github/workflows/lean_action_ci.yml)). Build locally with `lake build`. Project-wide code-quality conventions and planned automated checks are documented in [`.github/CODE_QUALITY.md`](.github/CODE_QUALITY.md); many are roadmap items not yet enforced in CI.
+
+### Python
+
+Run from `python/` before pushing:
+
+```bash
+uv run ruff check    # lint
+uv run ruff format   # format
+```
+
+When you add Python code, add tests under `python/tests/` and run them with:
+
+```bash
+uv run --group test pytest
+```
+
+
+## Coding Guidelines
+
+### General
+
+**Naming.** Avoid abbreviations in variable, function, and class names. Use full words for clarity (e.g., `configuration` not `config`, `manifest` not `mfst`).
+
+**Comments.** Add inline comments only when the *why* is non-obvious — a hidden constraint, a subtle invariant, or a workaround. Don't restate what the code does.
+
+**Functions.** Keep function bodies under 40 lines (soft limit). Write self-documenting code with descriptive variable and function names.
+
+**Logging.** Use loggers, not `print` statements, in library code. CLI entry points may print user-facing output.
+
+### Python
+
+**Absolute imports.** Use absolute imports throughout (e.g., `from lean_pool.aggregator.reservoir import fetch_manifest`). All imports must be at the top of the file.
+
+**Type hints.** Use modern Python type hints (PEP 604 and PEP 585): `|` instead of `Union`, `| None` instead of `Optional`, and built-in collection types (`list`, `dict`, `set`, `tuple`) instead of their `typing` equivalents.
+
+**Documentation.** Every module must have a module-level docstring. Every non-trivial function must have a Google-style docstring.
+
+### Lean
+
+See [`.github/CODE_QUALITY.md`](.github/CODE_QUALITY.md) for the full list of automated checks and conventions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+This file is a concatenation of README.md and CONTRIBUTING.md.
+
+# lean-pool
+
+Lean Pool sits between `mathlib` and `merely-true`, like arXiv for formal mathematics. A bottleneck of mathlib growth is the high quality human review. Instead, we use a combination of linters and AI review to uphold as much code quality as possible. We hope to grow Lean Pool much faster than mathlib.
+
+Key capabilities:
+
+1. Automatic Lean and Mathlib version bumping.
+2. Automated PR review.
+3. Docs and search.
+
+Created as part of the UW Lean [Hackathon](https://uw2026leanhackathon.github.io/) by Vasily Ilin and Justin Asher.
+
+# Contributing to Lean Pool
+
+Lean Pool sits between `mathlib` and `merely-true` — like arXiv for formal mathematics. Contributions of all sizes are welcome.
+
+
+## Finding Work
+
+Check the [issues](https://github.com/Vilin97/lean-pool/issues) for things to work on.
+
+
+## Dev Setup
+
+### Prerequisites
+
+- **Lean** via [elan](https://leanprover-community.github.io/install/) (toolchain pinned in `lean-toolchain`)
+- **Python 3.13+**
+- **[uv](https://docs.astral.sh/uv/)** (Python package manager)
+
+### Lean
+
+```bash
+lake build
+```
+
+### Python
+
+```bash
+cd python
+uv sync               # install runtime + dev (lint/format) deps
+uv sync --group test  # also install test deps when running pytest
+```
+
+See [`python/README.md`](python/README.md) for common commands.
+
+
+## Branch and PR Workflow
+
+Direct commits to `main` are not allowed. All changes go through pull requests.
+
+**Branch naming.** Use `yourname/description` for solo work (e.g., `justin/aggregator-draft`). Use `feature/` or `fix/` prefixes for branches where multiple people may contribute (e.g., `feature/manifest-summary`, `fix/timeout-default`).
+
+**Open PRs early.** Push and open a PR as soon as you have something, even if incomplete. Use GitHub's draft PR feature and label with `WIP` if needed.
+
+**Link issues.** Use `Closes #123` in the PR description to automatically close the related issue on merge.
+
+**Commit messages.** Write clear, concise commit messages in imperative tense (e.g., "Add manifest fetcher", not "Added manifest fetcher"). Do not include AI-generated tags (e.g., "Generated with Claude", "Co-authored-by: Codex") in commits or PRs.
+
+**Review and merge.** All PRs require at least one review from another contributor before merging.
+
+
+## Linting and Testing
+
+### Lean
+
+CI currently runs `lake exe mk_all --check`, `lake build LeanPool`, and `lake exe runLinter LeanPool` (see [`.github/workflows/lean_action_ci.yml`](.github/workflows/lean_action_ci.yml)). Build locally with `lake build`. Project-wide code-quality conventions and planned automated checks are documented in [`.github/CODE_QUALITY.md`](.github/CODE_QUALITY.md); many are roadmap items not yet enforced in CI.
+
+### Python
+
+Run from `python/` before pushing:
+
+```bash
+uv run ruff check    # lint
+uv run ruff format   # format
+```
+
+When you add Python code, add tests under `python/tests/` and run them with:
+
+```bash
+uv run --group test pytest
+```
+
+
+## Coding Guidelines
+
+### General
+
+**Naming.** Avoid abbreviations in variable, function, and class names. Use full words for clarity (e.g., `configuration` not `config`, `manifest` not `mfst`).
+
+**Comments.** Add inline comments only when the *why* is non-obvious — a hidden constraint, a subtle invariant, or a workaround. Don't restate what the code does.
+
+**Functions.** Keep function bodies under 40 lines (soft limit). Write self-documenting code with descriptive variable and function names.
+
+**Logging.** Use loggers, not `print` statements, in library code. CLI entry points may print user-facing output.
+
+### Python
+
+**Absolute imports.** Use absolute imports throughout (e.g., `from lean_pool.aggregator.reservoir import fetch_manifest`). All imports must be at the top of the file.
+
+**Type hints.** Use modern Python type hints (PEP 604 and PEP 585): `|` instead of `Union`, `| None` instead of `Optional`, and built-in collection types (`list`, `dict`, `set`, `tuple`) instead of their `typing` equivalents.
+
+**Documentation.** Every module must have a module-level docstring. Every non-trivial function must have a Google-style docstring.
+
+### Lean
+
+See [`.github/CODE_QUALITY.md`](.github/CODE_QUALITY.md) for the full list of automated checks and conventions.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: agent-docs
+
+# Generate CLAUDE.md and AGENTS.md from README.md and CONTRIBUTING.md.
+# Run this whenever README.md or CONTRIBUTING.md changes so agents pick
+# up the latest contributor guidance.
+agent-docs:
+	@echo "This file is a concatenation of README.md and CONTRIBUTING.md." > CLAUDE.md
+	@echo "" >> CLAUDE.md
+	@cat README.md >> CLAUDE.md
+	@echo "" >> CLAUDE.md
+	@cat CONTRIBUTING.md >> CLAUDE.md
+	@cp CLAUDE.md AGENTS.md
+	@echo "Generated CLAUDE.md and AGENTS.md"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,27 @@
-.PHONY: build update agent-docs
+.PHONY: build lint lint-fix check test update agent-docs
 
 # Build the Lean project.
 build:
 	lake build LeanPool
+
+# Run all CI-equivalent linters (Lean and Python).
+lint:
+	lake exe runLinter LeanPool
+	cd python && uv run ruff check
+	cd python && uv run ruff format --check
+
+# Auto-fix Python lint and formatting issues.
+lint-fix:
+	cd python && uv run ruff check --fix
+	cd python && uv run ruff format
+
+# Verify LeanPool.lean imports the full file set (CI gate).
+check:
+	lake exe mk_all --check
+
+# Run the Python test suite.
+test:
+	cd python && uv run --group test pytest
 
 # Update Lean and Python dependencies. Refreshes lake-manifest.json,
 # pulls the matching Mathlib oleans cache, and re-syncs the Python

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,16 @@
-.PHONY: agent-docs
+.PHONY: build update agent-docs
+
+# Build the Lean project.
+build:
+	lake build LeanPool
+
+# Update Lean and Python dependencies. Refreshes lake-manifest.json,
+# pulls the matching Mathlib oleans cache, and re-syncs the Python
+# environment with all dependency groups.
+update:
+	lake update
+	lake exe cache get
+	cd python && uv sync --all-groups
 
 # Generate CLAUDE.md and AGENTS.md from README.md and CONTRIBUTING.md.
 # Run this whenever README.md or CONTRIBUTING.md changes so agents pick


### PR DESCRIPTION
## Summary

- Adds a root `Makefile` with the targets contributors are most likely to want locally:
  - `make build` — `lake build LeanPool`.
  - `make lint` — Lean linter + Python `ruff check` + `ruff format --check`.
  - `make lint-fix` — auto-fixable Python `ruff check --fix` + `ruff format`.
  - `make check` — `lake exe mk_all --check` (matches the CI gate).
  - `make test` — `uv run --group test pytest`.
  - `make update` — `lake update`, `lake exe cache get`, `uv sync --all-groups`.
  - `make agent-docs` — concatenates `README.md` and `CONTRIBUTING.md` into `CLAUDE.md`, then copies it to `AGENTS.md`.
- Commits the initial generated `CLAUDE.md` and `AGENTS.md` so agents (Claude Code, Codex, etc.) have project context without further setup.
- Mirrors the same pattern used in our sister project (Numina Fuse).