### PR TITLE
Drop facebookresearch/wybecoder from manual candidates

### DIFF
--- a/aggregator/candidates/manual.txt
+++ b/aggregator/candidates/manual.txt
@@ -263,7 +263,6 @@ https://github.com/ertwro/one_third_two_thirds
 https://github.com/estradilua/pointwise-birkhoff
 https://github.com/extism/lean4-sdk
 https://github.com/ezhuchko/RLTL-derivatives
-https://github.com/facebookresearch/wybecoder
 https://github.com/faenuccio-teaching/M1_ENS_26
 https://github.com/femtomc/logical_relations.lean
 https://github.com/Ferinko/LeanAStar


### PR DESCRIPTION
## Summary
- The recent full `clone` run (PR #21) failed on 8 repos. Seven were renamed/deleted/private and come from the Reservoir manifest, so they self-heal on the next Reservoir refresh and are out of our control. The only failure that lives in `manual.txt` is `facebookresearch/wybecoder`, which times out at 120s on every attempt. Removing it.
- We can re-add it if it stops timing out.