### PR TITLE
ci: surface per-file errors from the proof-profile step

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -161,15 +161,37 @@ jobs:
 
       - name: Proof profile (advisory)
         run: |
-          set -euo pipefail
+          # Profile every Lean file under LeanPool/. Per-file failures don't
+          # stop the loop; instead they surface in the step's UI (annotation +
+          # log tail) and are summarized at the end. The full log is uploaded
+          # as the proof-profile artifact regardless of outcome.
+          set -uo pipefail
           : > proof-profile.log
+          failed_files=()
           while IFS= read -r -d '' file; do
-            {
-              echo "## $file"
-              ~/.elan/bin/lake env lean --profile "$file"
+            echo "## $file" >> proof-profile.log
+            if ! ~/.elan/bin/lake env lean --profile "$file" >> proof-profile.log 2>&1; then
+              rc=$?
+              failed_files+=("$file")
+              echo "::warning file=$file::lake env lean --profile exited $rc"
               echo
-            } >> proof-profile.log 2>&1
+              echo "----- $file (last 30 lines of profile output) -----"
+              awk -v marker="## $file" '
+                $0 == marker { in_section = 1; next }
+                /^## / && in_section { exit }
+                in_section { print }
+              ' proof-profile.log | tail -n 30
+              echo "----- end $file -----"
+              echo
+            fi
+            echo >> proof-profile.log
           done < <(find LeanPool -name '*.lean' -print0 | sort -z)
+          if [ ${#failed_files[@]} -gt 0 ]; then
+            echo "::error::Proof profiling failed for ${#failed_files[@]} file(s):"
+            printf '  - %s\n' "${failed_files[@]}"
+            echo "Full output is uploaded as the 'proof-profile' artifact."
+            exit 1
+          fi
 
       - name: Upload proof profile
         if: always()


### PR DESCRIPTION
The proof-profile step today fails opaquely. The shell loop runs under `set -euo pipefail` and pipes everything to `proof-profile.log`, so when `lake env lean --profile` exits non-zero on any file the step UI shows only:

> Error: Process completed with exit code 1.

Actual error output ends up in the uploaded `proof-profile.log` artifact, forcing a download to debug.

## Change

- Drop `set -e`; track failures in a bash array instead.
- On each per-file failure: emit a `::warning file=<path>::` annotation (clickable in the UI) and print the last 30 lines of *that file's* profile output to stdout.
- At the end: emit `::error::` with a count and the list of failed files; exit 1.
- Full log continues to upload as the `proof-profile` artifact.

The step remains `continue-on-error: true`, so the job is still unaffected.

## Example

For a hypothetical failure on `LeanPool/Foo.lean`, the step UI would show:

```
::warning file=LeanPool/Foo.lean::lake env lean --profile exited 1

----- LeanPool/Foo.lean (last 30 lines of profile output) -----
LeanPool/Foo.lean:42:1: error: ...
----- end LeanPool/Foo.lean -----

::error::Proof profiling failed for 1 file(s):
  - LeanPool/Foo.lean
Full output is uploaded as the 'proof-profile' artifact.
```