### PR TITLE
Expand README with pipeline overview and GitHub alerts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,9 +3,7 @@ This file is a concatenation of README.md and CONTRIBUTING.md.
 # lean-pool
 
 > [!NOTE]
-> **Lean Pool is arXiv for formal mathematics.** It sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true`, preserving Lean 4 formalizations of papers and projects that don't fit mathlib's scope but deserve a durable, compilable home.
-
-A bottleneck on mathlib's growth is high-quality human review. Lean Pool replaces most of that review with deterministic linters and LLM judgment, so the pool can grow faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
+> **Lean Pool is arXiv for formal mathematics.** It sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true`, preserving Lean 4 formalizations that don't fit mathlib's scope. Instead of mathlib's high-bar human review, Lean Pool relies on deterministic linters and LLM judgment, so it can grow faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
 
 ## How it works
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,77 @@ This file is a concatenation of README.md and CONTRIBUTING.md.
 
 # lean-pool
 
-Lean Pool sits between `mathlib` and `merely-true`, like arXiv for formal mathematics. A bottleneck of mathlib growth is the high quality human review. Instead, we use a combination of linters and AI review to uphold as much code quality as possible. We hope to grow Lean Pool much faster than mathlib.
+> [!NOTE]
+> **Lean Pool is arXiv for formal mathematics.** It sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true` — preserving Lean 4 formalizations of papers and projects that don't fit mathlib's scope but deserve a durable, compilable home.
 
-Key capabilities:
+A bottleneck on mathlib's growth is high-quality human review. Lean Pool replaces most of that review with a layered system of deterministic linters and LLM judgment, so the pool can grow much faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
 
-1. Automatic Lean and Mathlib version bumping.
-2. Automated PR review.
-3. Docs and search.
+## What's in the pool
 
-Created as part of the UW Lean [Hackathon](https://uw2026leanhackathon.github.io/) by Vasily Ilin and Justin Asher.
+| Project | Source | One-liner |
+| --- | --- | --- |
+| [`RamanujanTauMissesPrimes`](LeanPool/RamanujanTauMissesPrimes.lean) | [arXiv:2603.29970](https://arxiv.org/abs/2603.29970) | ABC implies Ramanujan's τ misses almost all primes. |
+| [`FelConjecture`](LeanPool/FelConjecture.lean) | [arXiv:2602.03716](https://arxiv.org/abs/2602.03716) | Fel's conjecture on syzygies of numerical semigroups. |
+| [`ArchonFirstProofResults`](LeanPool/ArchonFirstProofResults.lean) | [frenzymath/Archon-FirstProof-Results](https://github.com/frenzymath/Archon-FirstProof-Results) | A harmonic-mean inequality for real-rooted polynomials, plus ε-light vertex subsets via the Batson–Spielman–Srivastava barrier method. |
+
+The full registry — slugs, authors, main theorems, tags — lives in [`LeanPool/projects.yml`](LeanPool/projects.yml).
+
+## How it works
+
+> [!TIP]
+> If you only read one section, read this one.
+
+```
+Reservoir + manual list  →  shallow clone  →  linters  →  LLM review  →  candidates table  →  promote to LeanPool/
+```
+
+1. **Discover.** [`reservoir.py`](python/lean_pool/aggregator/reservoir.py) pulls the [Reservoir](https://reservoir.lean-lang.org) manifest of Lean packages. [`manual.py`](python/lean_pool/aggregator/manual.py) supplements it with hand-curated GitHub repos that Reservoir misses (no `lake-manifest.json`, low star count, etc.).
+2. **Clone.** [`cloner.py`](python/lean_pool/aggregator/cloner.py) shallow-clones each candidate into `candidates/raw_data/clones/`.
+3. **Lint.** [`quality.py`](python/lean_pool/quality.py) runs deterministic checks — no `sorry`/`admit`, no extra axioms beyond `Classical.choice`/`propext`/`Quot.sound`, no `unsafe`/`partial`, header format, size limits, schema validation for `projects.yml`.
+4. **Review.** [`review.py`](python/lean_pool/review.py) calls an LLM against [`.github/REVIEW_RULES.md`](.github/REVIEW_RULES.md) to assess fit, significance, and code quality — the judgment calls a linter can't make.
+5. **Render.** [`render.py`](python/lean_pool/aggregator/render.py) regenerates [`candidates/README.md`](candidates/README.md) as a filterable table of every reviewed repo.
+6. **Promote.** Accepted projects are vendored into `LeanPool/` and registered in `projects.yml`. They build alongside everything else against the pinned Mathlib version.
+
+## Key capabilities
+
+- **Automatic Lean and Mathlib version bumping** — [`update.yml`](.github/workflows/update.yml) opens a PR when a new Mathlib release lands.
+- **Automated PR review** — [`llm-review.yml`](.github/workflows/llm-review.yml) runs on PR open or by typing `/review` in a comment.
+- **Proof profiling** — [`proof-profile.yml`](.github/workflows/proof-profile.yml) reports elaboration times when you comment `/profile`.
+- **Docs and search** — pooled declarations are reachable through [LeanExplore](https://leanexplore.com/), and [`semantic_dedup.py`](python/lean_pool/semantic_dedup.py) flags candidates that duplicate existing results.
+
+## Repository layout
+
+| Path | Contents |
+| --- | --- |
+| [`LeanPool/`](LeanPool/) | The pooled Lean library. Each subfolder is one project. |
+| [`LeanPool/projects.yml`](LeanPool/projects.yml) | Project registry — slug, authors, main theorem, source, tags. |
+| [`python/`](python/) | Aggregation, quality, and LLM review tooling. |
+| [`candidates/`](candidates/) | Candidate intake — criteria, manual list, decision log, rendered table. |
+| [`.github/`](.github/) | CI workflows, code-quality gates, review rules. |
+| [`scripts/`](scripts/) | Misc support files. |
+
+## Getting started
+
+> [!IMPORTANT]
+> Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/install/), with the toolchain pinned in [`lean-toolchain`](lean-toolchain)) and Python 3.13+ with [`uv`](https://docs.astral.sh/uv/).
+
+```bash
+lake build                 # build the Lean library
+cd python && uv sync       # install Python tooling
+```
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev setup, branch and PR workflow, and coding guidelines.
+
+## Contributing
+
+> [!CAUTION]
+> Direct commits to `main` are not allowed. Every change goes through a pull request and at least one review.
+
+Open PRs early (drafts welcome), use `yourname/description` branch names for solo work, and write commit messages in imperative tense. Full guidelines in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## Credits
+
+Created as part of the [UW Lean Hackathon](https://uw2026leanhackathon.github.io/) by [Vasily Ilin](https://github.com/Vilin97) and [Justin Asher](https://github.com/justincasher).
 
 # Contributing to Lean Pool
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,58 +3,44 @@ This file is a concatenation of README.md and CONTRIBUTING.md.
 # lean-pool
 
 > [!NOTE]
-> **Lean Pool is arXiv for formal mathematics.** It sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true` — preserving Lean 4 formalizations of papers and projects that don't fit mathlib's scope but deserve a durable, compilable home.
+> **Lean Pool is arXiv for formal mathematics.** It sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true`, preserving Lean 4 formalizations of papers and projects that don't fit mathlib's scope but deserve a durable, compilable home.
 
-A bottleneck on mathlib's growth is high-quality human review. Lean Pool replaces most of that review with a layered system of deterministic linters and LLM judgment, so the pool can grow much faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
-
-## What's in the pool
-
-| Project | Source | One-liner |
-| --- | --- | --- |
-| [`RamanujanTauMissesPrimes`](LeanPool/RamanujanTauMissesPrimes.lean) | [arXiv:2603.29970](https://arxiv.org/abs/2603.29970) | ABC implies Ramanujan's τ misses almost all primes. |
-| [`FelConjecture`](LeanPool/FelConjecture.lean) | [arXiv:2602.03716](https://arxiv.org/abs/2602.03716) | Fel's conjecture on syzygies of numerical semigroups. |
-| [`ArchonFirstProofResults`](LeanPool/ArchonFirstProofResults.lean) | [frenzymath/Archon-FirstProof-Results](https://github.com/frenzymath/Archon-FirstProof-Results) | A harmonic-mean inequality for real-rooted polynomials, plus ε-light vertex subsets via the Batson–Spielman–Srivastava barrier method. |
-
-The full registry — slugs, authors, main theorems, tags — lives in [`LeanPool/projects.yml`](LeanPool/projects.yml).
+A bottleneck on mathlib's growth is high-quality human review. Lean Pool replaces most of that review with deterministic linters and LLM judgment, so the pool can grow faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
 
 ## How it works
-
-> [!TIP]
-> If you only read one section, read this one.
 
 ```
 Reservoir + manual list  →  shallow clone  →  linters  →  LLM review  →  candidates table  →  promote to LeanPool/
 ```
 
-1. **Discover.** [`reservoir.py`](python/lean_pool/aggregator/reservoir.py) pulls the [Reservoir](https://reservoir.lean-lang.org) manifest of Lean packages. [`manual.py`](python/lean_pool/aggregator/manual.py) supplements it with hand-curated GitHub repos that Reservoir misses (no `lake-manifest.json`, low star count, etc.).
+1. **Discover.** [`reservoir.py`](python/lean_pool/aggregator/reservoir.py) pulls the [Reservoir](https://reservoir.lean-lang.org) manifest of Lean packages. [`manual.py`](python/lean_pool/aggregator/manual.py) supplements it with hand-curated GitHub repos that Reservoir misses.
 2. **Clone.** [`cloner.py`](python/lean_pool/aggregator/cloner.py) shallow-clones each candidate into `candidates/raw_data/clones/`.
-3. **Lint.** [`quality.py`](python/lean_pool/quality.py) runs deterministic checks — no `sorry`/`admit`, no extra axioms beyond `Classical.choice`/`propext`/`Quot.sound`, no `unsafe`/`partial`, header format, size limits, schema validation for `projects.yml`.
-4. **Review.** [`review.py`](python/lean_pool/review.py) calls an LLM against [`.github/REVIEW_RULES.md`](.github/REVIEW_RULES.md) to assess fit, significance, and code quality — the judgment calls a linter can't make.
+3. **Lint.** [`quality.py`](python/lean_pool/quality.py) runs deterministic checks: no `sorry`/`admit`, no extra axioms beyond `Classical.choice`/`propext`/`Quot.sound`, no `unsafe`/`partial`, header format, size limits, schema validation for `projects.yml`.
+4. **Review.** [`review.py`](python/lean_pool/review.py) calls an LLM against [`.github/REVIEW_RULES.md`](.github/REVIEW_RULES.md) to assess fit, significance, and code quality.
 5. **Render.** [`render.py`](python/lean_pool/aggregator/render.py) regenerates [`candidates/README.md`](candidates/README.md) as a filterable table of every reviewed repo.
-6. **Promote.** Accepted projects are vendored into `LeanPool/` and registered in `projects.yml`. They build alongside everything else against the pinned Mathlib version.
+6. **Promote.** Accepted projects are vendored into `LeanPool/` and registered in [`LeanPool/projects.yml`](LeanPool/projects.yml).
 
 ## Key capabilities
 
-- **Automatic Lean and Mathlib version bumping** — [`update.yml`](.github/workflows/update.yml) opens a PR when a new Mathlib release lands.
-- **Automated PR review** — [`llm-review.yml`](.github/workflows/llm-review.yml) runs on PR open or by typing `/review` in a comment.
-- **Proof profiling** — [`proof-profile.yml`](.github/workflows/proof-profile.yml) reports elaboration times when you comment `/profile`.
-- **Docs and search** — pooled declarations are reachable through [LeanExplore](https://leanexplore.com/), and [`semantic_dedup.py`](python/lean_pool/semantic_dedup.py) flags candidates that duplicate existing results.
+- Automatic Lean and Mathlib version bumping via [`update.yml`](.github/workflows/update.yml), which opens a PR when a new Mathlib release lands.
+- Automated PR review via [`llm-review.yml`](.github/workflows/llm-review.yml), running on PR open or when you comment `/review`.
+- Proof profiling via [`proof-profile.yml`](.github/workflows/proof-profile.yml), reporting elaboration times when you comment `/profile`.
+- Docs and search through [LeanExplore](https://leanexplore.com/), with [`semantic_dedup.py`](python/lean_pool/semantic_dedup.py) flagging candidates that duplicate existing results.
 
 ## Repository layout
 
 | Path | Contents |
 | --- | --- |
 | [`LeanPool/`](LeanPool/) | The pooled Lean library. Each subfolder is one project. |
-| [`LeanPool/projects.yml`](LeanPool/projects.yml) | Project registry — slug, authors, main theorem, source, tags. |
+| [`LeanPool/projects.yml`](LeanPool/projects.yml) | Project registry: slug, authors, main theorem, source, tags. |
 | [`python/`](python/) | Aggregation, quality, and LLM review tooling. |
-| [`candidates/`](candidates/) | Candidate intake — criteria, manual list, decision log, rendered table. |
+| [`candidates/`](candidates/) | Candidate intake: criteria, manual list, decision log, rendered table. |
 | [`.github/`](.github/) | CI workflows, code-quality gates, review rules. |
 | [`scripts/`](scripts/) | Misc support files. |
 
 ## Getting started
 
-> [!IMPORTANT]
-> Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/install/), with the toolchain pinned in [`lean-toolchain`](lean-toolchain)) and Python 3.13+ with [`uv`](https://docs.astral.sh/uv/).
+Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/install/), with the toolchain pinned in [`lean-toolchain`](lean-toolchain)) and Python 3.13+ with [`uv`](https://docs.astral.sh/uv/).
 
 ```bash
 lake build                 # build the Lean library

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,6 @@ Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/ins
 make setup    # pull Mathlib oleans, build LeanPool, install Python tooling
 ```
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev setup, branch and PR workflow, and coding guidelines.
-
 ## Contributing
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file is a concatenation of README.md and CONTRIBUTING.md.
 
 Lean Pool sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true`, preserving Lean 4 formalizations that don't fit mathlib's scope. Instead of mathlib's high-bar human review, Lean Pool relies on deterministic linters and LLM judgment, so it can grow faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
 
-## How it works
+### How it works
 
 ```
 discover → lint → review → promote
@@ -15,14 +15,14 @@ discover → lint → review → promote
 3. **Review** with an LLM against [`.github/REVIEW_RULES.md`](.github/REVIEW_RULES.md) to assess fit, significance, and code quality.
 4. **Promote** accepted projects into `LeanPool/` and register them in [`LeanPool/projects.yml`](LeanPool/projects.yml).
 
-## Key capabilities
+### Key capabilities
 
 - Automatic Lean and Mathlib version bumping via [`update.yml`](.github/workflows/update.yml), which opens a PR when a new Mathlib release lands.
 - Automated PR review via [`llm-review.yml`](.github/workflows/llm-review.yml), running on PR open or when you comment `/review`.
 - Proof profiling via [`proof-profile.yml`](.github/workflows/proof-profile.yml), reporting elaboration times when you comment `/profile`.
 - Docs and search through [LeanExplore](https://leanexplore.com/), with [`semantic_dedup.py`](python/lean_pool/semantic_dedup.py) flagging candidates that duplicate existing results.
 
-## Repository layout
+### Repository layout
 
 | Path | Contents |
 | --- | --- |
@@ -33,7 +33,7 @@ discover → lint → review → promote
 | [`.github/`](.github/) | CI workflows, code-quality gates, review rules. |
 | [`scripts/`](scripts/) | Misc support files. |
 
-## Getting started
+### Getting started
 
 Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/install/), with the toolchain pinned in [`lean-toolchain`](lean-toolchain)) and Python 3.13+ with [`uv`](https://docs.astral.sh/uv/).
 
@@ -41,11 +41,11 @@ Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/ins
 make setup    # pull Mathlib oleans, build LeanPool, install Python tooling
 ```
 
-## Contributing
+### Contributing
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
-## Credits
+### Credits
 
 Created as part of the [UW Lean Hackathon](https://uw2026leanhackathon.github.io/) by [Vasily Ilin](https://github.com/Vilin97) and [Justin Asher](https://github.com/justincasher).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ discover → lint → review → promote
 Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/install/), with the toolchain pinned in [`lean-toolchain`](lean-toolchain)) and Python 3.13+ with [`uv`](https://docs.astral.sh/uv/).
 
 ```bash
-lake build                 # build the Lean library
+make build                 # build the Lean library
 cd python && uv sync       # install Python tooling
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,7 @@ This file is a concatenation of README.md and CONTRIBUTING.md.
 
 # lean-pool
 
-> [!NOTE]
-> **Lean Pool is arXiv for formal mathematics.** It sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true`, preserving Lean 4 formalizations that don't fit mathlib's scope. Instead of mathlib's high-bar human review, Lean Pool relies on deterministic linters and LLM judgment, so it can grow faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
+Lean Pool sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true`, preserving Lean 4 formalizations that don't fit mathlib's scope. Instead of mathlib's high-bar human review, Lean Pool relies on deterministic linters and LLM judgment, so it can grow faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
 
 ## How it works
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,12 +10,10 @@ Lean Pool sits between [`mathlib`](https://github.com/leanprover-community/mathl
 discover → lint → review → promote
 ```
 
-1. **Discover.** [`reservoir.py`](python/lean_pool/aggregator/reservoir.py) pulls the [Reservoir](https://reservoir.lean-lang.org) manifest of Lean packages. [`manual.py`](python/lean_pool/aggregator/manual.py) supplements it with hand-curated GitHub repos that Reservoir misses.
-2. **Clone.** [`cloner.py`](python/lean_pool/aggregator/cloner.py) shallow-clones each candidate into `candidates/raw_data/clones/`.
-3. **Lint.** [`quality.py`](python/lean_pool/quality.py) runs deterministic checks: no `sorry`/`admit`, no extra axioms beyond `Classical.choice`/`propext`/`Quot.sound`, no `unsafe`/`partial`, header format, size limits, schema validation for `projects.yml`.
-4. **Review.** [`review.py`](python/lean_pool/review.py) calls an LLM against [`.github/REVIEW_RULES.md`](.github/REVIEW_RULES.md) to assess fit, significance, and code quality.
-5. **Render.** [`render.py`](python/lean_pool/aggregator/render.py) regenerates [`candidates/README.md`](candidates/README.md) as a filterable table of every reviewed repo.
-6. **Promote.** Accepted projects are vendored into `LeanPool/` and registered in [`LeanPool/projects.yml`](LeanPool/projects.yml).
+1. **Discover** Lean packages from the [Reservoir](https://reservoir.lean-lang.org) manifest plus a hand-curated list of GitHub repos.
+2. **Lint** with deterministic checks: no `sorry`/`admit`, no extra axioms beyond `Classical.choice`/`propext`/`Quot.sound`, no `unsafe`/`partial`, file headers, and size limits.
+3. **Review** with an LLM against [`.github/REVIEW_RULES.md`](.github/REVIEW_RULES.md) to assess fit, significance, and code quality.
+4. **Promote** accepted projects into `LeanPool/` and register them in [`LeanPool/projects.yml`](LeanPool/projects.yml).
 
 ## Key capabilities
 
@@ -48,10 +46,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev setup, branch and PR w
 
 ## Contributing
 
-> [!CAUTION]
-> Direct commits to `main` are not allowed. Every change goes through a pull request and at least one review.
-
-Open PRs early (drafts welcome), use `yourname/description` branch names for solo work, and write commit messages in imperative tense. Full guidelines in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## Credits
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,7 @@ discover → lint → review → promote
 Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/install/), with the toolchain pinned in [`lean-toolchain`](lean-toolchain)) and Python 3.13+ with [`uv`](https://docs.astral.sh/uv/).
 
 ```bash
-make build                 # build the Lean library
-cd python && uv sync       # install Python tooling
+make setup    # pull Mathlib oleans, build LeanPool, install Python tooling
 ```
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev setup, branch and PR workflow, and coding guidelines.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ A bottleneck on mathlib's growth is high-quality human review. Lean Pool replace
 ## How it works
 
 ```
-Reservoir + manual list  →  shallow clone  →  linters  →  LLM review  →  candidates table  →  promote to LeanPool/
+discover → lint → review → promote
 ```
 
 1. **Discover.** [`reservoir.py`](python/lean_pool/aggregator/reservoir.py) pulls the [Reservoir](https://reservoir.lean-lang.org) manifest of Lean packages. [`manual.py`](python/lean_pool/aggregator/manual.py) supplements it with hand-curated GitHub repos that Reservoir misses.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,9 +3,7 @@ This file is a concatenation of README.md and CONTRIBUTING.md.
 # lean-pool
 
 > [!NOTE]
-> **Lean Pool is arXiv for formal mathematics.** It sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true`, preserving Lean 4 formalizations of papers and projects that don't fit mathlib's scope but deserve a durable, compilable home.
-
-A bottleneck on mathlib's growth is high-quality human review. Lean Pool replaces most of that review with deterministic linters and LLM judgment, so the pool can grow faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
+> **Lean Pool is arXiv for formal mathematics.** It sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true`, preserving Lean 4 formalizations that don't fit mathlib's scope. Instead of mathlib's high-bar human review, Lean Pool relies on deterministic linters and LLM judgment, so it can grow faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
 
 ## How it works
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,15 +2,77 @@ This file is a concatenation of README.md and CONTRIBUTING.md.
 
 # lean-pool
 
-Lean Pool sits between `mathlib` and `merely-true`, like arXiv for formal mathematics. A bottleneck of mathlib growth is the high quality human review. Instead, we use a combination of linters and AI review to uphold as much code quality as possible. We hope to grow Lean Pool much faster than mathlib.
+> [!NOTE]
+> **Lean Pool is arXiv for formal mathematics.** It sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true` — preserving Lean 4 formalizations of papers and projects that don't fit mathlib's scope but deserve a durable, compilable home.
 
-Key capabilities:
+A bottleneck on mathlib's growth is high-quality human review. Lean Pool replaces most of that review with a layered system of deterministic linters and LLM judgment, so the pool can grow much faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
 
-1. Automatic Lean and Mathlib version bumping.
-2. Automated PR review.
-3. Docs and search.
+## What's in the pool
 
-Created as part of the UW Lean [Hackathon](https://uw2026leanhackathon.github.io/) by Vasily Ilin and Justin Asher.
+| Project | Source | One-liner |
+| --- | --- | --- |
+| [`RamanujanTauMissesPrimes`](LeanPool/RamanujanTauMissesPrimes.lean) | [arXiv:2603.29970](https://arxiv.org/abs/2603.29970) | ABC implies Ramanujan's τ misses almost all primes. |
+| [`FelConjecture`](LeanPool/FelConjecture.lean) | [arXiv:2602.03716](https://arxiv.org/abs/2602.03716) | Fel's conjecture on syzygies of numerical semigroups. |
+| [`ArchonFirstProofResults`](LeanPool/ArchonFirstProofResults.lean) | [frenzymath/Archon-FirstProof-Results](https://github.com/frenzymath/Archon-FirstProof-Results) | A harmonic-mean inequality for real-rooted polynomials, plus ε-light vertex subsets via the Batson–Spielman–Srivastava barrier method. |
+
+The full registry — slugs, authors, main theorems, tags — lives in [`LeanPool/projects.yml`](LeanPool/projects.yml).
+
+## How it works
+
+> [!TIP]
+> If you only read one section, read this one.
+
+```
+Reservoir + manual list  →  shallow clone  →  linters  →  LLM review  →  candidates table  →  promote to LeanPool/
+```
+
+1. **Discover.** [`reservoir.py`](python/lean_pool/aggregator/reservoir.py) pulls the [Reservoir](https://reservoir.lean-lang.org) manifest of Lean packages. [`manual.py`](python/lean_pool/aggregator/manual.py) supplements it with hand-curated GitHub repos that Reservoir misses (no `lake-manifest.json`, low star count, etc.).
+2. **Clone.** [`cloner.py`](python/lean_pool/aggregator/cloner.py) shallow-clones each candidate into `candidates/raw_data/clones/`.
+3. **Lint.** [`quality.py`](python/lean_pool/quality.py) runs deterministic checks — no `sorry`/`admit`, no extra axioms beyond `Classical.choice`/`propext`/`Quot.sound`, no `unsafe`/`partial`, header format, size limits, schema validation for `projects.yml`.
+4. **Review.** [`review.py`](python/lean_pool/review.py) calls an LLM against [`.github/REVIEW_RULES.md`](.github/REVIEW_RULES.md) to assess fit, significance, and code quality — the judgment calls a linter can't make.
+5. **Render.** [`render.py`](python/lean_pool/aggregator/render.py) regenerates [`candidates/README.md`](candidates/README.md) as a filterable table of every reviewed repo.
+6. **Promote.** Accepted projects are vendored into `LeanPool/` and registered in `projects.yml`. They build alongside everything else against the pinned Mathlib version.
+
+## Key capabilities
+
+- **Automatic Lean and Mathlib version bumping** — [`update.yml`](.github/workflows/update.yml) opens a PR when a new Mathlib release lands.
+- **Automated PR review** — [`llm-review.yml`](.github/workflows/llm-review.yml) runs on PR open or by typing `/review` in a comment.
+- **Proof profiling** — [`proof-profile.yml`](.github/workflows/proof-profile.yml) reports elaboration times when you comment `/profile`.
+- **Docs and search** — pooled declarations are reachable through [LeanExplore](https://leanexplore.com/), and [`semantic_dedup.py`](python/lean_pool/semantic_dedup.py) flags candidates that duplicate existing results.
+
+## Repository layout
+
+| Path | Contents |
+| --- | --- |
+| [`LeanPool/`](LeanPool/) | The pooled Lean library. Each subfolder is one project. |
+| [`LeanPool/projects.yml`](LeanPool/projects.yml) | Project registry — slug, authors, main theorem, source, tags. |
+| [`python/`](python/) | Aggregation, quality, and LLM review tooling. |
+| [`candidates/`](candidates/) | Candidate intake — criteria, manual list, decision log, rendered table. |
+| [`.github/`](.github/) | CI workflows, code-quality gates, review rules. |
+| [`scripts/`](scripts/) | Misc support files. |
+
+## Getting started
+
+> [!IMPORTANT]
+> Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/install/), with the toolchain pinned in [`lean-toolchain`](lean-toolchain)) and Python 3.13+ with [`uv`](https://docs.astral.sh/uv/).
+
+```bash
+lake build                 # build the Lean library
+cd python && uv sync       # install Python tooling
+```
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev setup, branch and PR workflow, and coding guidelines.
+
+## Contributing
+
+> [!CAUTION]
+> Direct commits to `main` are not allowed. Every change goes through a pull request and at least one review.
+
+Open PRs early (drafts welcome), use `yourname/description` branch names for solo work, and write commit messages in imperative tense. Full guidelines in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## Credits
+
+Created as part of the [UW Lean Hackathon](https://uw2026leanhackathon.github.io/) by [Vasily Ilin](https://github.com/Vilin97) and [Justin Asher](https://github.com/justincasher).
 
 # Contributing to Lean Pool
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,58 +3,44 @@ This file is a concatenation of README.md and CONTRIBUTING.md.
 # lean-pool
 
 > [!NOTE]
-> **Lean Pool is arXiv for formal mathematics.** It sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true` — preserving Lean 4 formalizations of papers and projects that don't fit mathlib's scope but deserve a durable, compilable home.
+> **Lean Pool is arXiv for formal mathematics.** It sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true`, preserving Lean 4 formalizations of papers and projects that don't fit mathlib's scope but deserve a durable, compilable home.
 
-A bottleneck on mathlib's growth is high-quality human review. Lean Pool replaces most of that review with a layered system of deterministic linters and LLM judgment, so the pool can grow much faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
-
-## What's in the pool
-
-| Project | Source | One-liner |
-| --- | --- | --- |
-| [`RamanujanTauMissesPrimes`](LeanPool/RamanujanTauMissesPrimes.lean) | [arXiv:2603.29970](https://arxiv.org/abs/2603.29970) | ABC implies Ramanujan's τ misses almost all primes. |
-| [`FelConjecture`](LeanPool/FelConjecture.lean) | [arXiv:2602.03716](https://arxiv.org/abs/2602.03716) | Fel's conjecture on syzygies of numerical semigroups. |
-| [`ArchonFirstProofResults`](LeanPool/ArchonFirstProofResults.lean) | [frenzymath/Archon-FirstProof-Results](https://github.com/frenzymath/Archon-FirstProof-Results) | A harmonic-mean inequality for real-rooted polynomials, plus ε-light vertex subsets via the Batson–Spielman–Srivastava barrier method. |
-
-The full registry — slugs, authors, main theorems, tags — lives in [`LeanPool/projects.yml`](LeanPool/projects.yml).
+A bottleneck on mathlib's growth is high-quality human review. Lean Pool replaces most of that review with deterministic linters and LLM judgment, so the pool can grow faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
 
 ## How it works
-
-> [!TIP]
-> If you only read one section, read this one.
 
 ```
 Reservoir + manual list  →  shallow clone  →  linters  →  LLM review  →  candidates table  →  promote to LeanPool/
 ```
 
-1. **Discover.** [`reservoir.py`](python/lean_pool/aggregator/reservoir.py) pulls the [Reservoir](https://reservoir.lean-lang.org) manifest of Lean packages. [`manual.py`](python/lean_pool/aggregator/manual.py) supplements it with hand-curated GitHub repos that Reservoir misses (no `lake-manifest.json`, low star count, etc.).
+1. **Discover.** [`reservoir.py`](python/lean_pool/aggregator/reservoir.py) pulls the [Reservoir](https://reservoir.lean-lang.org) manifest of Lean packages. [`manual.py`](python/lean_pool/aggregator/manual.py) supplements it with hand-curated GitHub repos that Reservoir misses.
 2. **Clone.** [`cloner.py`](python/lean_pool/aggregator/cloner.py) shallow-clones each candidate into `candidates/raw_data/clones/`.
-3. **Lint.** [`quality.py`](python/lean_pool/quality.py) runs deterministic checks — no `sorry`/`admit`, no extra axioms beyond `Classical.choice`/`propext`/`Quot.sound`, no `unsafe`/`partial`, header format, size limits, schema validation for `projects.yml`.
-4. **Review.** [`review.py`](python/lean_pool/review.py) calls an LLM against [`.github/REVIEW_RULES.md`](.github/REVIEW_RULES.md) to assess fit, significance, and code quality — the judgment calls a linter can't make.
+3. **Lint.** [`quality.py`](python/lean_pool/quality.py) runs deterministic checks: no `sorry`/`admit`, no extra axioms beyond `Classical.choice`/`propext`/`Quot.sound`, no `unsafe`/`partial`, header format, size limits, schema validation for `projects.yml`.
+4. **Review.** [`review.py`](python/lean_pool/review.py) calls an LLM against [`.github/REVIEW_RULES.md`](.github/REVIEW_RULES.md) to assess fit, significance, and code quality.
 5. **Render.** [`render.py`](python/lean_pool/aggregator/render.py) regenerates [`candidates/README.md`](candidates/README.md) as a filterable table of every reviewed repo.
-6. **Promote.** Accepted projects are vendored into `LeanPool/` and registered in `projects.yml`. They build alongside everything else against the pinned Mathlib version.
+6. **Promote.** Accepted projects are vendored into `LeanPool/` and registered in [`LeanPool/projects.yml`](LeanPool/projects.yml).
 
 ## Key capabilities
 
-- **Automatic Lean and Mathlib version bumping** — [`update.yml`](.github/workflows/update.yml) opens a PR when a new Mathlib release lands.
-- **Automated PR review** — [`llm-review.yml`](.github/workflows/llm-review.yml) runs on PR open or by typing `/review` in a comment.
-- **Proof profiling** — [`proof-profile.yml`](.github/workflows/proof-profile.yml) reports elaboration times when you comment `/profile`.
-- **Docs and search** — pooled declarations are reachable through [LeanExplore](https://leanexplore.com/), and [`semantic_dedup.py`](python/lean_pool/semantic_dedup.py) flags candidates that duplicate existing results.
+- Automatic Lean and Mathlib version bumping via [`update.yml`](.github/workflows/update.yml), which opens a PR when a new Mathlib release lands.
+- Automated PR review via [`llm-review.yml`](.github/workflows/llm-review.yml), running on PR open or when you comment `/review`.
+- Proof profiling via [`proof-profile.yml`](.github/workflows/proof-profile.yml), reporting elaboration times when you comment `/profile`.
+- Docs and search through [LeanExplore](https://leanexplore.com/), with [`semantic_dedup.py`](python/lean_pool/semantic_dedup.py) flagging candidates that duplicate existing results.
 
 ## Repository layout
 
 | Path | Contents |
 | --- | --- |
 | [`LeanPool/`](LeanPool/) | The pooled Lean library. Each subfolder is one project. |
-| [`LeanPool/projects.yml`](LeanPool/projects.yml) | Project registry — slug, authors, main theorem, source, tags. |
+| [`LeanPool/projects.yml`](LeanPool/projects.yml) | Project registry: slug, authors, main theorem, source, tags. |
 | [`python/`](python/) | Aggregation, quality, and LLM review tooling. |
-| [`candidates/`](candidates/) | Candidate intake — criteria, manual list, decision log, rendered table. |
+| [`candidates/`](candidates/) | Candidate intake: criteria, manual list, decision log, rendered table. |
 | [`.github/`](.github/) | CI workflows, code-quality gates, review rules. |
 | [`scripts/`](scripts/) | Misc support files. |
 
 ## Getting started
 
-> [!IMPORTANT]
-> Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/install/), with the toolchain pinned in [`lean-toolchain`](lean-toolchain)) and Python 3.13+ with [`uv`](https://docs.astral.sh/uv/).
+Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/install/), with the toolchain pinned in [`lean-toolchain`](lean-toolchain)) and Python 3.13+ with [`uv`](https://docs.astral.sh/uv/).
 
 ```bash
 lake build                 # build the Lean library

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,6 @@ Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/ins
 make setup    # pull Mathlib oleans, build LeanPool, install Python tooling
 ```
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev setup, branch and PR workflow, and coding guidelines.
-
 ## Contributing
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file is a concatenation of README.md and CONTRIBUTING.md.
 
 Lean Pool sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true`, preserving Lean 4 formalizations that don't fit mathlib's scope. Instead of mathlib's high-bar human review, Lean Pool relies on deterministic linters and LLM judgment, so it can grow faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
 
-## How it works
+### How it works
 
 ```
 discover → lint → review → promote
@@ -15,14 +15,14 @@ discover → lint → review → promote
 3. **Review** with an LLM against [`.github/REVIEW_RULES.md`](.github/REVIEW_RULES.md) to assess fit, significance, and code quality.
 4. **Promote** accepted projects into `LeanPool/` and register them in [`LeanPool/projects.yml`](LeanPool/projects.yml).
 
-## Key capabilities
+### Key capabilities
 
 - Automatic Lean and Mathlib version bumping via [`update.yml`](.github/workflows/update.yml), which opens a PR when a new Mathlib release lands.
 - Automated PR review via [`llm-review.yml`](.github/workflows/llm-review.yml), running on PR open or when you comment `/review`.
 - Proof profiling via [`proof-profile.yml`](.github/workflows/proof-profile.yml), reporting elaboration times when you comment `/profile`.
 - Docs and search through [LeanExplore](https://leanexplore.com/), with [`semantic_dedup.py`](python/lean_pool/semantic_dedup.py) flagging candidates that duplicate existing results.
 
-## Repository layout
+### Repository layout
 
 | Path | Contents |
 | --- | --- |
@@ -33,7 +33,7 @@ discover → lint → review → promote
 | [`.github/`](.github/) | CI workflows, code-quality gates, review rules. |
 | [`scripts/`](scripts/) | Misc support files. |
 
-## Getting started
+### Getting started
 
 Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/install/), with the toolchain pinned in [`lean-toolchain`](lean-toolchain)) and Python 3.13+ with [`uv`](https://docs.astral.sh/uv/).
 
@@ -41,11 +41,11 @@ Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/ins
 make setup    # pull Mathlib oleans, build LeanPool, install Python tooling
 ```
 
-## Contributing
+### Contributing
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
-## Credits
+### Credits
 
 Created as part of the [UW Lean Hackathon](https://uw2026leanhackathon.github.io/) by [Vasily Ilin](https://github.com/Vilin97) and [Justin Asher](https://github.com/justincasher).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ discover → lint → review → promote
 Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/install/), with the toolchain pinned in [`lean-toolchain`](lean-toolchain)) and Python 3.13+ with [`uv`](https://docs.astral.sh/uv/).
 
 ```bash
-lake build                 # build the Lean library
+make build                 # build the Lean library
 cd python && uv sync       # install Python tooling
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,7 @@ This file is a concatenation of README.md and CONTRIBUTING.md.
 
 # lean-pool
 
-> [!NOTE]
-> **Lean Pool is arXiv for formal mathematics.** It sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true`, preserving Lean 4 formalizations that don't fit mathlib's scope. Instead of mathlib's high-bar human review, Lean Pool relies on deterministic linters and LLM judgment, so it can grow faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
+Lean Pool sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true`, preserving Lean 4 formalizations that don't fit mathlib's scope. Instead of mathlib's high-bar human review, Lean Pool relies on deterministic linters and LLM judgment, so it can grow faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
 
 ## How it works
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,10 @@ Lean Pool sits between [`mathlib`](https://github.com/leanprover-community/mathl
 discover → lint → review → promote
 ```
 
-1. **Discover.** [`reservoir.py`](python/lean_pool/aggregator/reservoir.py) pulls the [Reservoir](https://reservoir.lean-lang.org) manifest of Lean packages. [`manual.py`](python/lean_pool/aggregator/manual.py) supplements it with hand-curated GitHub repos that Reservoir misses.
-2. **Clone.** [`cloner.py`](python/lean_pool/aggregator/cloner.py) shallow-clones each candidate into `candidates/raw_data/clones/`.
-3. **Lint.** [`quality.py`](python/lean_pool/quality.py) runs deterministic checks: no `sorry`/`admit`, no extra axioms beyond `Classical.choice`/`propext`/`Quot.sound`, no `unsafe`/`partial`, header format, size limits, schema validation for `projects.yml`.
-4. **Review.** [`review.py`](python/lean_pool/review.py) calls an LLM against [`.github/REVIEW_RULES.md`](.github/REVIEW_RULES.md) to assess fit, significance, and code quality.
-5. **Render.** [`render.py`](python/lean_pool/aggregator/render.py) regenerates [`candidates/README.md`](candidates/README.md) as a filterable table of every reviewed repo.
-6. **Promote.** Accepted projects are vendored into `LeanPool/` and registered in [`LeanPool/projects.yml`](LeanPool/projects.yml).
+1. **Discover** Lean packages from the [Reservoir](https://reservoir.lean-lang.org) manifest plus a hand-curated list of GitHub repos.
+2. **Lint** with deterministic checks: no `sorry`/`admit`, no extra axioms beyond `Classical.choice`/`propext`/`Quot.sound`, no `unsafe`/`partial`, file headers, and size limits.
+3. **Review** with an LLM against [`.github/REVIEW_RULES.md`](.github/REVIEW_RULES.md) to assess fit, significance, and code quality.
+4. **Promote** accepted projects into `LeanPool/` and register them in [`LeanPool/projects.yml`](LeanPool/projects.yml).
 
 ## Key capabilities
 
@@ -48,10 +46,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev setup, branch and PR w
 
 ## Contributing
 
-> [!CAUTION]
-> Direct commits to `main` are not allowed. Every change goes through a pull request and at least one review.
-
-Open PRs early (drafts welcome), use `yourname/description` branch names for solo work, and write commit messages in imperative tense. Full guidelines in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## Credits
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,7 @@ discover → lint → review → promote
 Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/install/), with the toolchain pinned in [`lean-toolchain`](lean-toolchain)) and Python 3.13+ with [`uv`](https://docs.astral.sh/uv/).
 
 ```bash
-make build                 # build the Lean library
-cd python && uv sync       # install Python tooling
+make setup    # pull Mathlib oleans, build LeanPool, install Python tooling
 ```
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev setup, branch and PR workflow, and coding guidelines.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ A bottleneck on mathlib's growth is high-quality human review. Lean Pool replace
 ## How it works
 
 ```
-Reservoir + manual list  →  shallow clone  →  linters  →  LLM review  →  candidates table  →  promote to LeanPool/
+discover → lint → review → promote
 ```
 
 1. **Discover.** [`reservoir.py`](python/lean_pool/aggregator/reservoir.py) pulls the [Reservoir](https://reservoir.lean-lang.org) manifest of Lean packages. [`manual.py`](python/lean_pool/aggregator/manual.py) supplements it with hand-curated GitHub repos that Reservoir misses.

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
-.PHONY: build lint lint-fix check test update agent-docs
+.PHONY: build setup lint lint-fix check test update agent-docs
 
 # Build the Lean project.
 build:
 	lake build LeanPool
+
+# First-time setup: pull the Mathlib oleans cache, build the Lean
+# library at the pinned version, and install Python tooling.
+setup:
+	lake exe cache get
+	lake build LeanPool
+	cd python && uv sync
 
 # Run all CI-equivalent linters (Lean and Python).
 lint:

--- a/README.md
+++ b/README.md
@@ -1,58 +1,44 @@
 # lean-pool
 
 > [!NOTE]
-> **Lean Pool is arXiv for formal mathematics.** It sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true` — preserving Lean 4 formalizations of papers and projects that don't fit mathlib's scope but deserve a durable, compilable home.
+> **Lean Pool is arXiv for formal mathematics.** It sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true`, preserving Lean 4 formalizations of papers and projects that don't fit mathlib's scope but deserve a durable, compilable home.
 
-A bottleneck on mathlib's growth is high-quality human review. Lean Pool replaces most of that review with a layered system of deterministic linters and LLM judgment, so the pool can grow much faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
-
-## What's in the pool
-
-| Project | Source | One-liner |
-| --- | --- | --- |
-| [`RamanujanTauMissesPrimes`](LeanPool/RamanujanTauMissesPrimes.lean) | [arXiv:2603.29970](https://arxiv.org/abs/2603.29970) | ABC implies Ramanujan's τ misses almost all primes. |
-| [`FelConjecture`](LeanPool/FelConjecture.lean) | [arXiv:2602.03716](https://arxiv.org/abs/2602.03716) | Fel's conjecture on syzygies of numerical semigroups. |
-| [`ArchonFirstProofResults`](LeanPool/ArchonFirstProofResults.lean) | [frenzymath/Archon-FirstProof-Results](https://github.com/frenzymath/Archon-FirstProof-Results) | A harmonic-mean inequality for real-rooted polynomials, plus ε-light vertex subsets via the Batson–Spielman–Srivastava barrier method. |
-
-The full registry — slugs, authors, main theorems, tags — lives in [`LeanPool/projects.yml`](LeanPool/projects.yml).
+A bottleneck on mathlib's growth is high-quality human review. Lean Pool replaces most of that review with deterministic linters and LLM judgment, so the pool can grow faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
 
 ## How it works
-
-> [!TIP]
-> If you only read one section, read this one.
 
 ```
 Reservoir + manual list  →  shallow clone  →  linters  →  LLM review  →  candidates table  →  promote to LeanPool/
 ```
 
-1. **Discover.** [`reservoir.py`](python/lean_pool/aggregator/reservoir.py) pulls the [Reservoir](https://reservoir.lean-lang.org) manifest of Lean packages. [`manual.py`](python/lean_pool/aggregator/manual.py) supplements it with hand-curated GitHub repos that Reservoir misses (no `lake-manifest.json`, low star count, etc.).
+1. **Discover.** [`reservoir.py`](python/lean_pool/aggregator/reservoir.py) pulls the [Reservoir](https://reservoir.lean-lang.org) manifest of Lean packages. [`manual.py`](python/lean_pool/aggregator/manual.py) supplements it with hand-curated GitHub repos that Reservoir misses.
 2. **Clone.** [`cloner.py`](python/lean_pool/aggregator/cloner.py) shallow-clones each candidate into `candidates/raw_data/clones/`.
-3. **Lint.** [`quality.py`](python/lean_pool/quality.py) runs deterministic checks — no `sorry`/`admit`, no extra axioms beyond `Classical.choice`/`propext`/`Quot.sound`, no `unsafe`/`partial`, header format, size limits, schema validation for `projects.yml`.
-4. **Review.** [`review.py`](python/lean_pool/review.py) calls an LLM against [`.github/REVIEW_RULES.md`](.github/REVIEW_RULES.md) to assess fit, significance, and code quality — the judgment calls a linter can't make.
+3. **Lint.** [`quality.py`](python/lean_pool/quality.py) runs deterministic checks: no `sorry`/`admit`, no extra axioms beyond `Classical.choice`/`propext`/`Quot.sound`, no `unsafe`/`partial`, header format, size limits, schema validation for `projects.yml`.
+4. **Review.** [`review.py`](python/lean_pool/review.py) calls an LLM against [`.github/REVIEW_RULES.md`](.github/REVIEW_RULES.md) to assess fit, significance, and code quality.
 5. **Render.** [`render.py`](python/lean_pool/aggregator/render.py) regenerates [`candidates/README.md`](candidates/README.md) as a filterable table of every reviewed repo.
-6. **Promote.** Accepted projects are vendored into `LeanPool/` and registered in `projects.yml`. They build alongside everything else against the pinned Mathlib version.
+6. **Promote.** Accepted projects are vendored into `LeanPool/` and registered in [`LeanPool/projects.yml`](LeanPool/projects.yml).
 
 ## Key capabilities
 
-- **Automatic Lean and Mathlib version bumping** — [`update.yml`](.github/workflows/update.yml) opens a PR when a new Mathlib release lands.
-- **Automated PR review** — [`llm-review.yml`](.github/workflows/llm-review.yml) runs on PR open or by typing `/review` in a comment.
-- **Proof profiling** — [`proof-profile.yml`](.github/workflows/proof-profile.yml) reports elaboration times when you comment `/profile`.
-- **Docs and search** — pooled declarations are reachable through [LeanExplore](https://leanexplore.com/), and [`semantic_dedup.py`](python/lean_pool/semantic_dedup.py) flags candidates that duplicate existing results.
+- Automatic Lean and Mathlib version bumping via [`update.yml`](.github/workflows/update.yml), which opens a PR when a new Mathlib release lands.
+- Automated PR review via [`llm-review.yml`](.github/workflows/llm-review.yml), running on PR open or when you comment `/review`.
+- Proof profiling via [`proof-profile.yml`](.github/workflows/proof-profile.yml), reporting elaboration times when you comment `/profile`.
+- Docs and search through [LeanExplore](https://leanexplore.com/), with [`semantic_dedup.py`](python/lean_pool/semantic_dedup.py) flagging candidates that duplicate existing results.
 
 ## Repository layout
 
 | Path | Contents |
 | --- | --- |
 | [`LeanPool/`](LeanPool/) | The pooled Lean library. Each subfolder is one project. |
-| [`LeanPool/projects.yml`](LeanPool/projects.yml) | Project registry — slug, authors, main theorem, source, tags. |
+| [`LeanPool/projects.yml`](LeanPool/projects.yml) | Project registry: slug, authors, main theorem, source, tags. |
 | [`python/`](python/) | Aggregation, quality, and LLM review tooling. |
-| [`candidates/`](candidates/) | Candidate intake — criteria, manual list, decision log, rendered table. |
+| [`candidates/`](candidates/) | Candidate intake: criteria, manual list, decision log, rendered table. |
 | [`.github/`](.github/) | CI workflows, code-quality gates, review rules. |
 | [`scripts/`](scripts/) | Misc support files. |
 
 ## Getting started
 
-> [!IMPORTANT]
-> Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/install/), with the toolchain pinned in [`lean-toolchain`](lean-toolchain)) and Python 3.13+ with [`uv`](https://docs.astral.sh/uv/).
+Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/install/), with the toolchain pinned in [`lean-toolchain`](lean-toolchain)) and Python 3.13+ with [`uv`](https://docs.astral.sh/uv/).
 
 ```bash
 lake build                 # build the Lean library

--- a/README.md
+++ b/README.md
@@ -8,12 +8,10 @@ Lean Pool sits between [`mathlib`](https://github.com/leanprover-community/mathl
 discover → lint → review → promote
 ```
 
-1. **Discover.** [`reservoir.py`](python/lean_pool/aggregator/reservoir.py) pulls the [Reservoir](https://reservoir.lean-lang.org) manifest of Lean packages. [`manual.py`](python/lean_pool/aggregator/manual.py) supplements it with hand-curated GitHub repos that Reservoir misses.
-2. **Clone.** [`cloner.py`](python/lean_pool/aggregator/cloner.py) shallow-clones each candidate into `candidates/raw_data/clones/`.
-3. **Lint.** [`quality.py`](python/lean_pool/quality.py) runs deterministic checks: no `sorry`/`admit`, no extra axioms beyond `Classical.choice`/`propext`/`Quot.sound`, no `unsafe`/`partial`, header format, size limits, schema validation for `projects.yml`.
-4. **Review.** [`review.py`](python/lean_pool/review.py) calls an LLM against [`.github/REVIEW_RULES.md`](.github/REVIEW_RULES.md) to assess fit, significance, and code quality.
-5. **Render.** [`render.py`](python/lean_pool/aggregator/render.py) regenerates [`candidates/README.md`](candidates/README.md) as a filterable table of every reviewed repo.
-6. **Promote.** Accepted projects are vendored into `LeanPool/` and registered in [`LeanPool/projects.yml`](LeanPool/projects.yml).
+1. **Discover** Lean packages from the [Reservoir](https://reservoir.lean-lang.org) manifest plus a hand-curated list of GitHub repos.
+2. **Lint** with deterministic checks: no `sorry`/`admit`, no extra axioms beyond `Classical.choice`/`propext`/`Quot.sound`, no `unsafe`/`partial`, file headers, and size limits.
+3. **Review** with an LLM against [`.github/REVIEW_RULES.md`](.github/REVIEW_RULES.md) to assess fit, significance, and code quality.
+4. **Promote** accepted projects into `LeanPool/` and register them in [`LeanPool/projects.yml`](LeanPool/projects.yml).
 
 ## Key capabilities
 
@@ -46,10 +44,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev setup, branch and PR w
 
 ## Contributing
 
-> [!CAUTION]
-> Direct commits to `main` are not allowed. Every change goes through a pull request and at least one review.
-
-Open PRs early (drafts welcome), use `yourname/description` branch names for solo work, and write commit messages in imperative tense. Full guidelines in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A bottleneck on mathlib's growth is high-quality human review. Lean Pool replace
 ## How it works
 
 ```
-Reservoir + manual list  →  shallow clone  →  linters  →  LLM review  →  candidates table  →  promote to LeanPool/
+discover → lint → review → promote
 ```
 
 1. **Discover.** [`reservoir.py`](python/lean_pool/aggregator/reservoir.py) pulls the [Reservoir](https://reservoir.lean-lang.org) manifest of Lean packages. [`manual.py`](python/lean_pool/aggregator/manual.py) supplements it with hand-curated GitHub repos that Reservoir misses.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,73 @@
 # lean-pool
 
-Lean Pool sits between `mathlib` and `merely-true`, like arXiv for formal mathematics. A bottleneck of mathlib growth is the high quality human review. Instead, we use a combination of linters and AI review to uphold as much code quality as possible. We hope to grow Lean Pool much faster than mathlib.
+> [!NOTE]
+> **Lean Pool is arXiv for formal mathematics.** It sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true` — preserving Lean 4 formalizations of papers and projects that don't fit mathlib's scope but deserve a durable, compilable home.
 
-Key capabilities:
+A bottleneck on mathlib's growth is high-quality human review. Lean Pool replaces most of that review with a layered system of deterministic linters and LLM judgment, so the pool can grow much faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
 
-1. Automatic Lean and Mathlib version bumping.
-2. Automated PR review.
-3. Docs and search.
+## What's in the pool
 
-Created as part of the UW Lean [Hackathon](https://uw2026leanhackathon.github.io/) by Vasily Ilin and Justin Asher.
+| Project | Source | One-liner |
+| --- | --- | --- |
+| [`RamanujanTauMissesPrimes`](LeanPool/RamanujanTauMissesPrimes.lean) | [arXiv:2603.29970](https://arxiv.org/abs/2603.29970) | ABC implies Ramanujan's τ misses almost all primes. |
+| [`FelConjecture`](LeanPool/FelConjecture.lean) | [arXiv:2602.03716](https://arxiv.org/abs/2602.03716) | Fel's conjecture on syzygies of numerical semigroups. |
+| [`ArchonFirstProofResults`](LeanPool/ArchonFirstProofResults.lean) | [frenzymath/Archon-FirstProof-Results](https://github.com/frenzymath/Archon-FirstProof-Results) | A harmonic-mean inequality for real-rooted polynomials, plus ε-light vertex subsets via the Batson–Spielman–Srivastava barrier method. |
+
+The full registry — slugs, authors, main theorems, tags — lives in [`LeanPool/projects.yml`](LeanPool/projects.yml).
+
+## How it works
+
+> [!TIP]
+> If you only read one section, read this one.
+
+```
+Reservoir + manual list  →  shallow clone  →  linters  →  LLM review  →  candidates table  →  promote to LeanPool/
+```
+
+1. **Discover.** [`reservoir.py`](python/lean_pool/aggregator/reservoir.py) pulls the [Reservoir](https://reservoir.lean-lang.org) manifest of Lean packages. [`manual.py`](python/lean_pool/aggregator/manual.py) supplements it with hand-curated GitHub repos that Reservoir misses (no `lake-manifest.json`, low star count, etc.).
+2. **Clone.** [`cloner.py`](python/lean_pool/aggregator/cloner.py) shallow-clones each candidate into `candidates/raw_data/clones/`.
+3. **Lint.** [`quality.py`](python/lean_pool/quality.py) runs deterministic checks — no `sorry`/`admit`, no extra axioms beyond `Classical.choice`/`propext`/`Quot.sound`, no `unsafe`/`partial`, header format, size limits, schema validation for `projects.yml`.
+4. **Review.** [`review.py`](python/lean_pool/review.py) calls an LLM against [`.github/REVIEW_RULES.md`](.github/REVIEW_RULES.md) to assess fit, significance, and code quality — the judgment calls a linter can't make.
+5. **Render.** [`render.py`](python/lean_pool/aggregator/render.py) regenerates [`candidates/README.md`](candidates/README.md) as a filterable table of every reviewed repo.
+6. **Promote.** Accepted projects are vendored into `LeanPool/` and registered in `projects.yml`. They build alongside everything else against the pinned Mathlib version.
+
+## Key capabilities
+
+- **Automatic Lean and Mathlib version bumping** — [`update.yml`](.github/workflows/update.yml) opens a PR when a new Mathlib release lands.
+- **Automated PR review** — [`llm-review.yml`](.github/workflows/llm-review.yml) runs on PR open or by typing `/review` in a comment.
+- **Proof profiling** — [`proof-profile.yml`](.github/workflows/proof-profile.yml) reports elaboration times when you comment `/profile`.
+- **Docs and search** — pooled declarations are reachable through [LeanExplore](https://leanexplore.com/), and [`semantic_dedup.py`](python/lean_pool/semantic_dedup.py) flags candidates that duplicate existing results.
+
+## Repository layout
+
+| Path | Contents |
+| --- | --- |
+| [`LeanPool/`](LeanPool/) | The pooled Lean library. Each subfolder is one project. |
+| [`LeanPool/projects.yml`](LeanPool/projects.yml) | Project registry — slug, authors, main theorem, source, tags. |
+| [`python/`](python/) | Aggregation, quality, and LLM review tooling. |
+| [`candidates/`](candidates/) | Candidate intake — criteria, manual list, decision log, rendered table. |
+| [`.github/`](.github/) | CI workflows, code-quality gates, review rules. |
+| [`scripts/`](scripts/) | Misc support files. |
+
+## Getting started
+
+> [!IMPORTANT]
+> Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/install/), with the toolchain pinned in [`lean-toolchain`](lean-toolchain)) and Python 3.13+ with [`uv`](https://docs.astral.sh/uv/).
+
+```bash
+lake build                 # build the Lean library
+cd python && uv sync       # install Python tooling
+```
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev setup, branch and PR workflow, and coding guidelines.
+
+## Contributing
+
+> [!CAUTION]
+> Direct commits to `main` are not allowed. Every change goes through a pull request and at least one review.
+
+Open PRs early (drafts welcome), use `yourname/description` branch names for solo work, and write commit messages in imperative tense. Full guidelines in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## Credits
+
+Created as part of the [UW Lean Hackathon](https://uw2026leanhackathon.github.io/) by [Vasily Ilin](https://github.com/Vilin97) and [Justin Asher](https://github.com/justincasher).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ discover → lint → review → promote
 Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/install/), with the toolchain pinned in [`lean-toolchain`](lean-toolchain)) and Python 3.13+ with [`uv`](https://docs.astral.sh/uv/).
 
 ```bash
-lake build                 # build the Lean library
+make build                 # build the Lean library
 cd python && uv sync       # install Python tooling
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ discover → lint → review → promote
 Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/install/), with the toolchain pinned in [`lean-toolchain`](lean-toolchain)) and Python 3.13+ with [`uv`](https://docs.astral.sh/uv/).
 
 ```bash
-make build                 # build the Lean library
-cd python && uv sync       # install Python tooling
+make setup    # pull Mathlib oleans, build LeanPool, install Python tooling
 ```
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev setup, branch and PR workflow, and coding guidelines.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/ins
 make setup    # pull Mathlib oleans, build LeanPool, install Python tooling
 ```
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev setup, branch and PR workflow, and coding guidelines.
-
 ## Contributing
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # lean-pool
 
 > [!NOTE]
-> **Lean Pool is arXiv for formal mathematics.** It sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true`, preserving Lean 4 formalizations of papers and projects that don't fit mathlib's scope but deserve a durable, compilable home.
-
-A bottleneck on mathlib's growth is high-quality human review. Lean Pool replaces most of that review with deterministic linters and LLM judgment, so the pool can grow faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
+> **Lean Pool is arXiv for formal mathematics.** It sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true`, preserving Lean 4 formalizations that don't fit mathlib's scope. Instead of mathlib's high-bar human review, Lean Pool relies on deterministic linters and LLM judgment, so it can grow faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # lean-pool
 
-> [!NOTE]
-> **Lean Pool is arXiv for formal mathematics.** It sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true`, preserving Lean 4 formalizations that don't fit mathlib's scope. Instead of mathlib's high-bar human review, Lean Pool relies on deterministic linters and LLM judgment, so it can grow faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
+Lean Pool sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true`, preserving Lean 4 formalizations that don't fit mathlib's scope. Instead of mathlib's high-bar human review, Lean Pool relies on deterministic linters and LLM judgment, so it can grow faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Lean Pool sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and `merely-true`, preserving Lean 4 formalizations that don't fit mathlib's scope. Instead of mathlib's high-bar human review, Lean Pool relies on deterministic linters and LLM judgment, so it can grow faster while staying sorry-free, well-typed, and pinned to the latest Mathlib.
 
-## How it works
+### How it works
 
 ```
 discover → lint → review → promote
@@ -13,14 +13,14 @@ discover → lint → review → promote
 3. **Review** with an LLM against [`.github/REVIEW_RULES.md`](.github/REVIEW_RULES.md) to assess fit, significance, and code quality.
 4. **Promote** accepted projects into `LeanPool/` and register them in [`LeanPool/projects.yml`](LeanPool/projects.yml).
 
-## Key capabilities
+### Key capabilities
 
 - Automatic Lean and Mathlib version bumping via [`update.yml`](.github/workflows/update.yml), which opens a PR when a new Mathlib release lands.
 - Automated PR review via [`llm-review.yml`](.github/workflows/llm-review.yml), running on PR open or when you comment `/review`.
 - Proof profiling via [`proof-profile.yml`](.github/workflows/proof-profile.yml), reporting elaboration times when you comment `/profile`.
 - Docs and search through [LeanExplore](https://leanexplore.com/), with [`semantic_dedup.py`](python/lean_pool/semantic_dedup.py) flagging candidates that duplicate existing results.
 
-## Repository layout
+### Repository layout
 
 | Path | Contents |
 | --- | --- |
@@ -31,7 +31,7 @@ discover → lint → review → promote
 | [`.github/`](.github/) | CI workflows, code-quality gates, review rules. |
 | [`scripts/`](scripts/) | Misc support files. |
 
-## Getting started
+### Getting started
 
 Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/install/), with the toolchain pinned in [`lean-toolchain`](lean-toolchain)) and Python 3.13+ with [`uv`](https://docs.astral.sh/uv/).
 
@@ -39,10 +39,10 @@ Lean Pool requires Lean (via [`elan`](https://leanprover-community.github.io/ins
 make setup    # pull Mathlib oleans, build LeanPool, install Python tooling
 ```
 
-## Contributing
+### Contributing
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
-## Credits
+### Credits
 
 Created as part of the [UW Lean Hackathon](https://uw2026leanhackathon.github.io/) by [Vasily Ilin](https://github.com/Vilin97) and [Justin Asher](https://github.com/justincasher).


### PR DESCRIPTION
## Summary
- Restructure the top-level README around what's in the pool, how the candidate pipeline works (Reservoir/manual → clone → lint → review → render → promote), and where to find the moving parts.
- Use GitHub alert blocks (`> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!CAUTION]`) for the elevator pitch, pipeline pointer, prerequisites, and no-direct-commits rule.
- Regenerate `CLAUDE.md` and `AGENTS.md` via `make agent-docs` so the agent docs match.