### PR TITLE
Import SamuelSchlesinger/sensitivity-conjecture (√(deg) ≤ sensitivity)

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -198,6 +198,15 @@ import LeanPool.RlTheoryInLean.Probability.MarkovChain.Finite.Defs
 import LeanPool.RlTheoryInLean.Probability.MarkovChain.Trajectory
 import LeanPool.RlTheoryInLean.StochasticApproximation
 import LeanPool.RlTheoryInLean.StochasticApproximation.DiscreteGronwall
+import LeanPool.Sensitivity
+import LeanPool.Sensitivity.Basic
+import LeanPool.Sensitivity.Consequences
+import LeanPool.Sensitivity.Defs
+import LeanPool.Sensitivity.HuangBridge
+import LeanPool.Sensitivity.Main
+import LeanPool.Sensitivity.Multilinear
+import LeanPool.Sensitivity.Parity
+import LeanPool.Sensitivity.Subcube
 import LeanPool.SumsThreeSquares
 import LeanPool.SumsThreeSquares.MinkowskiConvex
 import LeanPool.SumsThreeSquares.SumThreeSquares

--- a/LeanPool/Sensitivity.lean
+++ b/LeanPool/Sensitivity.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+import LeanPool.Sensitivity.Defs
+import LeanPool.Sensitivity.Basic
+import LeanPool.Sensitivity.Multilinear
+import LeanPool.Sensitivity.Subcube
+import LeanPool.Sensitivity.Parity
+import LeanPool.Sensitivity.HuangBridge
+import LeanPool.Sensitivity.Main
+import LeanPool.Sensitivity.Consequences
+
+/-!
+# Sensitivity Conjecture: √(deg) ≤ sensitivity
+
+Source: url:https://github.com/SamuelSchlesinger/sensitivity-conjecture
+Authors: Samuel Schlesinger
+Status: verified
+Main declarations: `LeanPoolSensitivity.sensitivity_ge_sqrt_degree`
+Tags: combinatorics, boolean-functions
+-/
+
+/-!
+## Mathematical overview
+
+For a Boolean function `f : (Fin n → Bool) → Bool`, the *sensitivity* `s(f)`
+is the maximum, over all inputs `x`, of the number of coordinates `i` at
+which flipping bit `i` changes the value of `f`. The *multilinear degree*
+`deg(f)` is the maximum cardinality of a set `S ⊆ Fin n` whose Möbius
+coefficient in the multilinear polynomial representing `f` is nonzero.
+
+This project formalises the quantitative form of the Nisan–Szegedy/Huang
+sensitivity conjecture: for every Boolean function `f` with `deg(f) ≥ 1`,
+`√(deg(f)) ≤ s(f)`. Squaring this inequality recovers the corollary
+`deg(f) ≤ s(f)²`. The argument restricts `f` to a subcube of dimension
+`deg(f)` on which the top Möbius coefficient is preserved, derives a
+parity-sign imbalance there, and feeds the result into the Huang hypercube
+lemma `Sensitivity.huang_degree_theorem` from `Mathlib`'s
+`Archive.Sensitivity`.
+
+The exported modules follow the proof structure: core definitions
+(`LeanPool.Sensitivity.Defs`, `LeanPool.Sensitivity.Basic`), the multilinear
+representation (`LeanPool.Sensitivity.Multilinear`), restrictions to subcubes
+(`LeanPool.Sensitivity.Subcube`), the parity imbalance lemma
+(`LeanPool.Sensitivity.Parity`), the bridge to Mathlib's Huang theorem
+(`LeanPool.Sensitivity.HuangBridge`), the main bound
+`LeanPoolSensitivity.sensitivity_ge_sqrt_degree`
+(`LeanPool.Sensitivity.Main`), and the corollary
+`LeanPoolSensitivity.degree_le_sensitivity_sq`
+(`LeanPool.Sensitivity.Consequences`).
+
+## Provenance
+
+Imported from <https://github.com/SamuelSchlesinger/sensitivity-conjecture>.
+Upstream contains no `sorry`s. Ported from Lean v4.28.0 to Lean Pool's
+v4.30.0-rc2. The upstream `Sensitivity` namespace has been renamed to
+`LeanPoolSensitivity` to avoid polluting Mathlib's `Sensitivity` namespace,
+which is used by `Archive.Sensitivity` for the underlying Huang lemma.
+-/

--- a/LeanPool/Sensitivity/Basic.lean
+++ b/LeanPool/Sensitivity/Basic.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+import LeanPool.Sensitivity.Defs
+
+/-!
+# Elementary Properties of Sensitivity
+
+Basic bounds and symmetries for the sensitivity of Boolean functions.
+
+## Main results
+
+* `LeanPoolSensitivity.BoolFun.localSensitivity_not` — taking the negation of
+  a Boolean function preserves local sensitivity.
+* `LeanPoolSensitivity.BoolFun.sensitivity_not` — and likewise sensitivity.
+* `LeanPoolSensitivity.BoolFun.localSensitivity_le` — local sensitivity at
+  any input is at most `n`.
+* `LeanPoolSensitivity.BoolFun.sensitiveAt_flipBit` — the sensitivity
+  predicate is invariant under flipping the same coordinate at the input.
+-/
+
+namespace LeanPoolSensitivity
+
+variable {n : ℕ}
+
+namespace BoolFun
+
+/-- The local sensitivity of the negation of `f` equals the local sensitivity
+of `f`. -/
+theorem localSensitivity_not (f : BoolFun n) (x : Fin n → Bool) :
+    BoolFun.localSensitivity (fun y => !f y) x = f.localSensitivity x := by
+  unfold localSensitivity sensitiveAt
+  congr 1
+  ext i
+  simp
+
+/-- The sensitivity of the negation of `f` equals the sensitivity of `f`. -/
+theorem sensitivity_not (f : BoolFun n) :
+    BoolFun.sensitivity (fun y => !f y) = f.sensitivity := by
+  unfold sensitivity
+  congr 1
+  funext x
+  exact f.localSensitivity_not x
+
+/-- The local sensitivity of `f` at any input `x` is at most `n`. -/
+theorem localSensitivity_le (f : BoolFun n) (x : Fin n → Bool) :
+    f.localSensitivity x ≤ n := by
+  unfold localSensitivity
+  calc (Finset.univ.filter fun i => f.sensitiveAt x i).card
+      ≤ Finset.univ.card := Finset.card_filter_le _ _
+    _ = n := Finset.card_fin n
+
+/-- Unfolding lemma: `f` is sensitive at `x` in coordinate `i` iff flipping
+that coordinate changes the value of `f`. -/
+theorem sensitiveAt_iff (f : BoolFun n) (x : Fin n → Bool) (i : Fin n) :
+    f.sensitiveAt x i ↔ f (flipBit x i) ≠ f x :=
+  Iff.rfl
+
+/-- Sensitivity at `x` is symmetric in the following sense: `f` is sensitive
+at `x` in direction `i` iff `f` is sensitive at `flipBit x i` in direction
+`i`. -/
+theorem sensitiveAt_flipBit (f : BoolFun n) (x : Fin n → Bool) (i : Fin n) :
+    f.sensitiveAt (flipBit x i) i ↔ f.sensitiveAt x i := by
+  unfold sensitiveAt
+  rw [flipBit_flipBit_same]
+  exact ne_comm
+
+end BoolFun
+
+end LeanPoolSensitivity

--- a/LeanPool/Sensitivity/Consequences.lean
+++ b/LeanPool/Sensitivity/Consequences.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+import LeanPool.Sensitivity.Defs
+import LeanPool.Sensitivity.Basic
+import LeanPool.Sensitivity.Multilinear
+import LeanPool.Sensitivity.Main
+
+/-!
+# Consequences of the Sensitivity Theorem
+
+A direct numerical corollary of `sensitivity_ge_sqrt_degree`: the
+multilinear degree of any Boolean function is bounded above by the square
+of its sensitivity.
+
+## Main results
+
+* `LeanPoolSensitivity.degree_le_sensitivity_sq` — `f.degree ≤ f.sensitivity^2`.
+-/
+
+namespace LeanPoolSensitivity
+
+/-- The multilinear degree is at most the square of the sensitivity, an
+immediate corollary of the sensitivity theorem `√d ≤ s(f)`: squaring both
+sides yields `d ≤ s(f)^2`. -/
+theorem degree_le_sensitivity_sq {n : ℕ} (f : BoolFun n) :
+    f.degree ≤ f.sensitivity ^ 2 := by
+  by_cases hd : f.degree = 0
+  · simp [hd]
+  · have hd' : 1 ≤ f.degree := by omega
+    have hsqrt := sensitivity_ge_sqrt_degree f hd'
+    have hsq : (f.degree : ℝ) ≤ (f.sensitivity : ℝ) ^ 2 := by
+      nlinarith [Real.sq_sqrt (Nat.cast_nonneg (α := ℝ) f.degree),
+                 Real.sqrt_nonneg (↑f.degree : ℝ)]
+    exact_mod_cast hsq
+
+end LeanPoolSensitivity

--- a/LeanPool/Sensitivity/Defs.lean
+++ b/LeanPool/Sensitivity/Defs.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+import Mathlib.Data.Fin.Basic
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Fintype.Pi
+import Mathlib.Data.Finset.Lattice.Fold
+
+/-!
+# Boolean Function Definitions
+
+Core definitions for Boolean functions on the hypercube `Fin n → Bool`,
+including bit flips, sensitivity, and local sensitivity.
+
+## Main definitions
+
+* `LeanPoolSensitivity.BoolFun` — a Boolean function on `n` variables.
+* `LeanPoolSensitivity.flipBit` — flip the `i`-th coordinate of an input.
+* `LeanPoolSensitivity.BoolFun.sensitiveAt` — predicate: `f` changes value when
+  flipping coordinate `i` at input `x`.
+* `LeanPoolSensitivity.BoolFun.localSensitivity` — the number of sensitive
+  coordinates of `f` at a given input.
+* `LeanPoolSensitivity.BoolFun.sensitivity` — the maximum local sensitivity
+  over all inputs.
+* `LeanPoolSensitivity.flipCoords` — flip all bits inside a finite set of
+  coordinates simultaneously.
+-/
+
+namespace LeanPoolSensitivity
+
+/-- A Boolean function on `n` variables, viewed as a map
+`(Fin n → Bool) → Bool`. -/
+abbrev BoolFun (n : ℕ) := (Fin n → Bool) → Bool
+
+variable {n : ℕ}
+
+/-- Flip the `i`-th bit of an input `x : Fin n → Bool`, leaving all other
+coordinates fixed. -/
+def flipBit (x : Fin n → Bool) (i : Fin n) : Fin n → Bool :=
+  Function.update x i (!x i)
+
+@[simp]
+theorem flipBit_apply_same (x : Fin n → Bool) (i : Fin n) :
+    flipBit x i i = !x i := by
+  simp [flipBit]
+
+@[simp]
+theorem flipBit_apply_ne (x : Fin n → Bool) (i : Fin n) {j : Fin n} (h : j ≠ i) :
+    flipBit x i j = x j := by
+  simp [flipBit, Function.update_of_ne h]
+
+@[simp]
+theorem flipBit_flipBit_same (x : Fin n → Bool) (i : Fin n) :
+    flipBit (flipBit x i) i = x := by
+  ext j
+  by_cases h : j = i
+  · subst h; simp [flipBit, Bool.not_not]
+  · simp [flipBit, Function.update_of_ne h]
+
+/-- `flipBit x i` is never equal to `x` itself: the `i`-th coordinate
+differs. -/
+theorem flipBit_ne_self (x : Fin n → Bool) (i : Fin n) :
+    flipBit x i ≠ x := by
+  intro h
+  have := congr_fun h i
+  simp [flipBit] at this
+
+/-- Different coordinates produce different bit flips of `x`. -/
+theorem flipBit_injective (x : Fin n → Bool) : Function.Injective (flipBit x) := by
+  intro i j hij
+  by_contra h
+  have h1 : flipBit x i i = !x i := flipBit_apply_same x i
+  have h2 : flipBit x j i = x i := flipBit_apply_ne x j h
+  rw [congr_fun hij i, h2] at h1
+  simp at h1
+
+namespace BoolFun
+
+/-- `f` is sensitive at input `x` in coordinate `i` when flipping bit `i`
+changes the value of `f`. -/
+def sensitiveAt (f : BoolFun n) (x : Fin n → Bool) (i : Fin n) : Prop :=
+  f (flipBit x i) ≠ f x
+
+instance (f : BoolFun n) (x : Fin n → Bool) (i : Fin n) :
+    Decidable (f.sensitiveAt x i) :=
+  inferInstanceAs (Decidable (f (flipBit x i) ≠ f x))
+
+/-- The local sensitivity of `f` at input `x`: number of coordinates `i` at
+which `f` is sensitive. -/
+def localSensitivity (f : BoolFun n) (x : Fin n → Bool) : ℕ :=
+  (Finset.univ.filter fun i => f.sensitiveAt x i).card
+
+/-- The sensitivity of `f`: the maximum of `f.localSensitivity x` over all
+inputs `x`. -/
+noncomputable def sensitivity (f : BoolFun n) : ℕ :=
+  Finset.univ.sup (fun x => f.localSensitivity x)
+
+/-- The sensitivity of any Boolean function on `n` variables is at most `n`. -/
+theorem sensitivity_le (f : BoolFun n) : f.sensitivity ≤ n := by
+  apply Finset.sup_le
+  intro x _
+  unfold localSensitivity
+  calc (Finset.univ.filter fun i => f.sensitiveAt x i).card
+      ≤ Finset.univ.card := Finset.card_filter_le _ _
+    _ = n := Finset.card_fin n
+
+/-- The local sensitivity at any specific input is bounded above by the
+sensitivity of `f`. -/
+theorem localSensitivity_le_sensitivity (f : BoolFun n) (x : Fin n → Bool) :
+    f.localSensitivity x ≤ f.sensitivity := by
+  exact Finset.le_sup (f := fun x => f.localSensitivity x) (Finset.mem_univ x)
+
+end BoolFun
+
+/-- Flip all bits whose index lies in the finite set `S`, leaving the
+remaining coordinates fixed. -/
+def flipCoords (x : Fin n → Bool) (S : Finset (Fin n)) : Fin n → Bool :=
+  fun j => if j ∈ S then !x j else x j
+
+end LeanPoolSensitivity

--- a/LeanPool/Sensitivity/HuangBridge.lean
+++ b/LeanPool/Sensitivity/HuangBridge.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+import LeanPool.Sensitivity.Defs
+import Archive.Sensitivity
+import Mathlib.Data.Fintype.Pi
+
+/-!
+# Bridge to Mathlib's Huang Theorem
+
+Repackages Mathlib's `Sensitivity.huang_degree_theorem` (the Huang hypercube
+lemma) in a form that uses `Finset (Fin (m+1) → Bool)` and the `flipBit`
+predicate from `LeanPool.Sensitivity.Defs`, ready to feed into the
+sensitivity-conjecture argument.
+
+The Mathlib formalisation in `Archive.Sensitivity` originated in the
+[lean-sensitivity](https://github.com/leanprover-community/lean-sensitivity)
+project, a community formalisation of Huang's proof carried out shortly after
+the original paper appeared in 2019.
+-/
+
+namespace LeanPoolSensitivity
+
+/-- A finset-flavoured restatement of Mathlib's
+`Sensitivity.huang_degree_theorem`: any subset `H` of the hypercube of size
+at least `2^m + 1` contains a vertex `q` with at least `√(m+1)` neighbours
+in `H`, where neighbours are bit-flip images `flipBit q i`. -/
+theorem huang_finset {m : ℕ} (H : Finset (Fin (m + 1) → Bool))
+    (hH : 2 ^ m + 1 ≤ H.card) :
+    ∃ q ∈ H, Real.sqrt (↑m + 1) ≤
+      ↑(H.filter (fun p => ∃ i, p = flipBit q i)).card := by
+  classical
+  let HQ : Set (Sensitivity.Q m.succ) :=
+    {x | (show Fin (m + 1) → Bool from x) ∈ H}
+  letI : DecidablePred (fun a : Sensitivity.Q m.succ => a ∈ HQ) :=
+    Classical.decPred _
+  let eEmb : Sensitivity.Q m.succ ↪ (Fin (m + 1) → Bool) :=
+    ⟨fun x => (show Fin (m + 1) → Bool from x), fun _ _ h => h⟩
+  have hmap : HQ.toFinset.map eEmb = H := by
+    ext x
+    simp [HQ, eEmb]
+  have hHQcard : HQ.toFinset.card = H.card := by
+    calc
+      HQ.toFinset.card = (HQ.toFinset.map eEmb).card := by simp
+      _ = H.card := by rw [hmap]
+  have hHQ : HQ.toFinset.card ≥ 2 ^ m + 1 := by
+    omega
+  obtain ⟨q, hqH, hbound⟩ := Sensitivity.huang_degree_theorem HQ hHQ
+  have hqH' : (show Fin (m + 1) → Bool from q) ∈ H := by
+    simpa [HQ] using hqH
+  refine ⟨(show Fin (m + 1) → Bool from q), hqH', le_trans hbound ?_⟩
+  push_cast [Nat.cast_le]
+  apply Finset.card_le_card
+  intro p hp
+  simp only [Set.mem_toFinset, Set.mem_inter_iff] at hp
+  rw [Finset.mem_filter]
+  refine ⟨hp.1, ?_⟩
+  simp only [Sensitivity.Q.adjacent, Set.mem_setOf_eq] at hp
+  obtain ⟨i, hne, huniq⟩ := hp.2
+  exact ⟨i, funext fun j => by
+    by_cases hji : j = i
+    · subst hji; simp only [flipBit_apply_same]
+      revert hne; cases q j <;> cases p j <;> simp
+    · rw [flipBit_apply_ne _ _ hji]
+      have hne' : ¬¬ q j = p j := mt (huniq j) hji
+      exact (Classical.not_not.mp hne').symm⟩
+
+end LeanPoolSensitivity

--- a/LeanPool/Sensitivity/Main.lean
+++ b/LeanPool/Sensitivity/Main.lean
@@ -1,0 +1,149 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+import LeanPool.Sensitivity.Defs
+import LeanPool.Sensitivity.Multilinear
+import LeanPool.Sensitivity.Subcube
+import LeanPool.Sensitivity.Parity
+import LeanPool.Sensitivity.HuangBridge
+
+/-!
+# The Sensitivity Theorem
+
+This file proves the main quantitative form of the sensitivity conjecture:
+for every Boolean function `f` of multilinear degree `d ≥ 1`, the sensitivity
+of `f` is bounded below by `√d`. The proof combines the parity imbalance
+lemma with the Huang hypercube lemma imported from `Mathlib`'s
+`Archive.Sensitivity`.
+
+## Proof outline
+
+1. Find a `d`-dimensional subcube on which the restriction of `f` has full
+   degree `d`.
+2. Reindex this subcube to `Fin (m+1) → Bool` and obtain a parity-sign
+   imbalance: a class of more than `2^m` vertices with the same parity sign.
+3. Apply the Huang hypercube lemma to extract a vertex with at least
+   `√(m+1)` same-class neighbours.
+4. Each such neighbour is a bit-flip image `flipBit q i` along a distinct
+   coordinate `i`, and at each such `i` the function `f` is sensitive.
+5. Lift this lower bound on the local sensitivity of the restriction back to
+   `f` itself.
+-/
+
+namespace LeanPoolSensitivity
+
+/-- **Sensitivity Theorem** (Huang 2019). For any Boolean function `f` of
+multilinear degree `d ≥ 1`, the sensitivity `s(f)` satisfies
+`√d ≤ s(f)`. -/
+theorem sensitivity_ge_sqrt_degree {n : ℕ} (f : BoolFun n) (hd : 1 ≤ f.degree) :
+    Real.sqrt (f.degree : ℝ) ≤ (f.sensitivity : ℝ) := by
+  obtain ⟨S, hcard, _, hmoeb⟩ := f.exists_fullDegree_restriction (by omega)
+  set f' := f.restrictTo S (fun _ => false) with f'_def
+  obtain ⟨m, hm⟩ : ∃ m, f.degree = m + 1 := ⟨f.degree - 1, by omega⟩
+  have hcard' : Fintype.card S = Fintype.card (Fin (m + 1)) := by
+    rw [Fintype.card_coe, Fintype.card_fin]; omega
+  let e : S ≃ Fin (m + 1) := Fintype.equivOfCardEq hcard'
+  let toN : Fin (m + 1) → Fin n := fun i => (e.symm i).val
+  let g : BoolFun (m + 1) := fun y =>
+    f (fun j => if hj : j ∈ S then y (e ⟨j, hj⟩) else false)
+  have toN_inj : Function.Injective toN :=
+    fun i j h => e.symm.injective (Subtype.ext h)
+  have hg_moeb : g.moebius Finset.univ ≠ 0 := by
+    suffices h : g.moebius Finset.univ = f'.moebius S by rwa [h]
+    have toN_e : ∀ (j : Fin n) (hj : j ∈ S), toN (e ⟨j, hj⟩) = j :=
+      fun j hj => show (e.symm (e ⟨j, hj⟩)).val = j by simp
+    unfold BoolFun.moebius
+    apply Finset.sum_nbij (fun U => U.map ⟨toN, toN_inj⟩)
+    · intro U _; rw [Finset.mem_powerset]; intro j hj
+      obtain ⟨i, _, rfl⟩ := Finset.mem_map.mp hj; exact (e.symm i).property
+    · exact fun _ _ _ _ h => Finset.map_injective ⟨toN, toN_inj⟩ h
+    · intro T hT
+      simp only [Finset.mem_coe, Finset.mem_powerset] at hT
+      rw [Set.mem_image]
+      refine ⟨T.preimage toN (toN_inj.injOn.mono (Set.subset_univ _)),
+              Finset.mem_coe.mpr (Finset.mem_powerset.mpr (Finset.subset_univ _)),
+              Finset.ext fun j => ?_⟩
+      simp only [Finset.mem_map, Finset.mem_preimage, Function.Embedding.coeFn_mk]
+      exact ⟨fun ⟨i, hi, hij⟩ => hij ▸ hi,
+             fun hj => ⟨e ⟨j, hT hj⟩,
+               show toN (e ⟨j, hT hj⟩) ∈ T by rw [toN_e]; exact hj,
+               toN_e j (hT hj)⟩⟩
+    · intro U _
+      congr 1
+      · congr 1
+        rw [Finset.card_univ, Fintype.card_fin, Finset.card_map]; omega
+      · congr 1
+        change f (fun j => if hj : j ∈ S then indicator U (e ⟨j, hj⟩) else false) =
+               f (embed S (fun _ => false) (indicator (U.map ⟨toN, toN_inj⟩)))
+        congr 1; funext j; simp only [embed]
+        by_cases hj : j ∈ S
+        · simp only [hj, dite_true, ite_true, indicator,
+                    Finset.mem_map, Function.Embedding.coeFn_mk]
+          have hiff : (e ⟨j, hj⟩ ∈ U) ↔ (∃ a ∈ U, toN a = j) :=
+            ⟨fun h => ⟨e ⟨j, hj⟩, h, toN_e j hj⟩,
+             fun ⟨i, hi, hij⟩ => by
+               rwa [show i = e ⟨j, hj⟩ from by
+                 rw [← Equiv.apply_symm_apply e i]; congr 1
+                 exact Subtype.ext hij] at hi⟩
+          simp only [hiff]
+        · simp only [hj, dite_false, ite_false]
+  obtain ⟨c, _, hH⟩ := fullDegree_imbalance g (Nat.succ_pos m) hg_moeb
+  set H := Finset.univ.filter (fun x : Fin (m + 1) → Bool => g.paritySigned x = c)
+  rw [show m + 1 - 1 = m from by omega] at hH
+  obtain ⟨q, hqH, hq_bound⟩ := huang_finset H (by omega)
+  have hq_par : g.paritySigned q = c := (Finset.mem_filter.mp hqH).2
+  rw [show (f.degree : ℝ) = ↑m + 1 from by exact_mod_cast hm]
+  apply le_trans hq_bound
+  push_cast [Nat.cast_le]
+  let embedQ : Fin n → Bool := fun j => if hj : j ∈ S then q (e ⟨j, hj⟩) else false
+  have toN_e : ∀ (j : Fin n) (hj : j ∈ S), toN (e ⟨j, hj⟩) = j :=
+    fun j hj => show (e.symm (e ⟨j, hj⟩)).val = j by simp
+  have e_toN : ∀ (i : Fin (m + 1)), e ⟨toN i, (e.symm i).property⟩ = i :=
+    fun i => show e (e.symm i) = i by simp
+  have toN_mem : ∀ (i : Fin (m + 1)), toN i ∈ S := fun i => (e.symm i).property
+  have g_flip_eq : ∀ i, g (flipBit q i) = f (flipBit embedQ (toN i)) := by
+    intro i; change f _ = f _; congr 1; funext j
+    by_cases hj : j ∈ S
+    · simp only [hj, dite_true]
+      by_cases hji : j = toN i
+      · subst hji
+        rw [show (e ⟨toN i, hj⟩ : Fin (m + 1)) = i from e_toN i,
+            flipBit_apply_same, flipBit_apply_same]
+        have : embedQ (toN i) = q i := by
+          change (if h : toN i ∈ S then q (e ⟨toN i, h⟩) else false) = q i
+          rw [dif_pos (toN_mem i)]
+          congr 1; exact e_toN i
+        rw [this]
+      · have : e ⟨j, hj⟩ ≠ i := fun h => hji (by rw [← toN_e j hj, h])
+        rw [flipBit_apply_ne _ _ this, flipBit_apply_ne _ _ hji]
+        change q (e ⟨j, hj⟩) = (if h : j ∈ S then q (e ⟨j, h⟩) else false)
+        rw [dif_pos hj]
+    · simp only [hj, dite_false]
+      have : j ≠ toN i := fun h => hj (h ▸ toN_mem i)
+      rw [flipBit_apply_ne _ _ this]
+      change false = embedQ j
+      change false = (if h : j ∈ S then q (e ⟨j, h⟩) else false)
+      rw [dif_neg hj]
+  have g_to_f : ∀ i, g.sensitiveAt q i → f.sensitiveAt embedQ (toN i) := by
+    intro i hi; unfold BoolFun.sensitiveAt at hi ⊢; rwa [← g_flip_eq]
+  calc (H.filter (fun p => ∃ i, p = flipBit q i)).card
+      ≤ g.localSensitivity q := by
+        unfold BoolFun.localSensitivity
+        have key : H.filter (fun p => ∃ i, p = flipBit q i) ⊆
+            (Finset.univ.filter (fun i => g.sensitiveAt q i)).image (flipBit q) := by
+          intro p hp
+          simp only [H, Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_image] at hp ⊢
+          obtain ⟨hp_par, i, rfl⟩ := hp
+          exact ⟨i, g.sensitiveAt_of_paritySigned_eq q i (hp_par.trans hq_par.symm), rfl⟩
+        exact le_trans (Finset.card_le_card key) Finset.card_image_le
+    _ ≤ f.localSensitivity embedQ := by
+        unfold BoolFun.localSensitivity
+        apply Finset.card_le_card_of_injOn toN
+          (fun i hi => Finset.mem_filter.mpr ⟨Finset.mem_univ _,
+            g_to_f i (Finset.mem_filter.mp hi).2⟩)
+          (fun _ _ _ _ h => toN_inj h)
+    _ ≤ f.sensitivity := f.localSensitivity_le_sensitivity embedQ
+
+end LeanPoolSensitivity

--- a/LeanPool/Sensitivity/Multilinear.lean
+++ b/LeanPool/Sensitivity/Multilinear.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+import LeanPool.Sensitivity.Defs
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Data.Finset.Powerset
+import Mathlib.Data.Fintype.Powerset
+import Mathlib.Data.Int.Basic
+
+/-!
+# Multilinear Representation and Degree
+
+Every Boolean function `f : (Fin n → Bool) → Bool` has a unique multilinear
+polynomial representation over `ℤ`. This file defines the Möbius coefficients
+of that representation and the multilinear degree of `f`.
+
+## Main definitions
+
+* `LeanPoolSensitivity.indicator` — the indicator assignment of a finite set
+  of coordinates.
+* `LeanPoolSensitivity.boolToInt` — the integer encoding of a Boolean value.
+* `LeanPoolSensitivity.BoolFun.moebius` — the Möbius coefficient
+  `c_S(f) = ∑_{T ⊆ S} (-1)^{|S|-|T|} f(1_T)`.
+* `LeanPoolSensitivity.BoolFun.degree` — the multilinear degree of `f`.
+-/
+
+namespace LeanPoolSensitivity
+
+variable {n : ℕ}
+
+/-- The Boolean assignment that is `true` on coordinates in `S` and `false`
+elsewhere. -/
+def indicator (S : Finset (Fin n)) : Fin n → Bool :=
+  fun i => decide (i ∈ S)
+
+@[simp]
+theorem indicator_mem {S : Finset (Fin n)} {i : Fin n} :
+    indicator S i = true ↔ i ∈ S := by
+  simp [indicator]
+
+@[simp]
+theorem indicator_not_mem {S : Finset (Fin n)} {i : Fin n} :
+    indicator S i = false ↔ i ∉ S := by
+  simp [indicator]
+
+/-- Integer encoding of a Boolean value: `true ↦ 1` and `false ↦ 0`. -/
+def boolToInt (b : Bool) : ℤ := if b then 1 else 0
+
+@[simp] theorem boolToInt_true : boolToInt true = 1 := rfl
+@[simp] theorem boolToInt_false : boolToInt false = 0 := rfl
+
+namespace BoolFun
+
+/-- The Möbius coefficient of `f` at `S`: the coefficient of the monomial
+`∏_{i ∈ S} x_i` in the unique multilinear polynomial representing `f`,
+computed by inclusion–exclusion as
+`c_S(f) = ∑_{T ⊆ S} (-1)^{|S|-|T|} f(1_T)`. -/
+def moebius (f : BoolFun n) (S : Finset (Fin n)) : ℤ :=
+  ∑ T ∈ S.powerset,
+    (-1) ^ (S.card - T.card) * boolToInt (f (indicator T))
+
+/-- The multilinear degree of `f`: the maximum cardinality of `S` for which
+the Möbius coefficient `c_S(f)` is nonzero. -/
+noncomputable def degree (f : BoolFun n) : ℕ :=
+  ((Finset.univ : Finset (Finset (Fin n))).filter (fun S => f.moebius S ≠ 0)).sup
+    Finset.card
+
+/-- The multilinear degree of `f` is at most `n`. -/
+theorem degree_le (f : BoolFun n) : f.degree ≤ n := by
+  apply Finset.sup_le
+  intro S hS
+  rw [Finset.mem_filter] at hS
+  exact le_trans (Finset.card_le_univ S) (le_of_eq (Fintype.card_fin n))
+
+/-- If the multilinear degree is positive, there exists a "witness" set `S`
+of cardinality equal to the degree at which the Möbius coefficient is
+nonzero. -/
+theorem exists_degree_witness (f : BoolFun n) (hd : 0 < f.degree) :
+    ∃ S : Finset (Fin n), S.card = f.degree ∧ f.moebius S ≠ 0 := by
+  unfold degree at hd ⊢
+  set F := (Finset.univ : Finset (Finset (Fin n))).filter (fun S => f.moebius S ≠ 0)
+  have hne : F.Nonempty := by
+    by_contra h
+    rw [Finset.not_nonempty_iff_eq_empty] at h
+    simp [F, h] at hd
+  obtain ⟨S, hS, heq⟩ := Finset.exists_mem_eq_sup F hne Finset.card
+  rw [Finset.mem_filter] at hS
+  exact ⟨S, heq.symm, hS.2⟩
+
+end BoolFun
+
+end LeanPoolSensitivity

--- a/LeanPool/Sensitivity/Parity.lean
+++ b/LeanPool/Sensitivity/Parity.lean
@@ -1,0 +1,289 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+import LeanPool.Sensitivity.Defs
+import LeanPool.Sensitivity.Multilinear
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Data.Fintype.Pi
+import Mathlib.Data.Fintype.Powerset
+import Mathlib.Data.Fintype.BigOperators
+import Mathlib.Data.Nat.Choose.Sum
+
+/-!
+# Parity Function and the Imbalance Lemma
+
+The parity function `(-1)^{|x|}` and its interaction with the Möbius
+expansion of a Boolean function. The main quantitative output is a parity
+imbalance lemma: a Boolean function whose top Möbius coefficient is nonzero
+must have a "majority" parity-sign class strictly larger than `2^{n-1}`.
+
+## Main results
+
+* `LeanPoolSensitivity.parity_flipBit` — flipping any bit negates the parity.
+* `LeanPoolSensitivity.moebius_parity_sum` — the sum of `f`'s parity-signed
+  values equals `2 · (-1)^n · c_univ(f)`.
+* `LeanPoolSensitivity.fullDegree_imbalance` — if `f` has full multilinear
+  degree, one parity-sign class has more than `2^{n-1}` vertices.
+-/
+
+namespace LeanPoolSensitivity
+
+variable {n : ℕ}
+
+/-- The parity sign of an input: `(-1)^{number of true coordinates}`. -/
+def parity (x : Fin n → Bool) : ℤ :=
+  (-1) ^ (Finset.univ.filter (fun i => x i)).card
+
+namespace BoolFun
+
+/-- The `±1`-valued encoding of a Boolean function: `true ↦ 1`,
+`false ↦ -1`. -/
+def pmOne (f : BoolFun n) (x : Fin n → Bool) : ℤ :=
+  if f x then 1 else -1
+
+/-- The parity-signed function `g(x) = f_pm(x) · parity(x)`. -/
+def paritySigned (f : BoolFun n) (x : Fin n → Bool) : ℤ :=
+  f.pmOne x * parity x
+
+/-- The `±1` encoding is never zero. -/
+theorem pmOne_ne_zero (f : BoolFun n) (x : Fin n → Bool) :
+    f.pmOne x ≠ 0 := by
+  unfold pmOne; split <;> omega
+
+end BoolFun
+
+/-- The parity sign is never zero. -/
+theorem parity_ne_zero (x : Fin n → Bool) : parity x ≠ 0 := by
+  unfold parity; positivity
+
+private theorem filter_flipBit_true (x : Fin n → Bool) (i : Fin n) (hi : x i = true) :
+    Finset.univ.filter (fun j : Fin n => flipBit x i j = true) =
+    (Finset.univ.filter (fun j : Fin n => x j = true)).erase i := by
+  ext j
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_erase]
+  constructor
+  · intro hj
+    by_cases hji : j = i
+    · subst hji; simp [flipBit_apply_same, hi] at hj
+    · exact ⟨hji, by rwa [flipBit_apply_ne x i hji] at hj⟩
+  · intro ⟨hji, hj⟩
+    rwa [flipBit_apply_ne x i hji]
+
+private theorem filter_flipBit_false (x : Fin n → Bool) (i : Fin n) (hi : x i = false) :
+    Finset.univ.filter (fun j : Fin n => flipBit x i j = true) =
+    insert i (Finset.univ.filter (fun j : Fin n => x j = true)) := by
+  ext j
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_insert]
+  constructor
+  · intro hj
+    by_cases hji : j = i
+    · left; exact hji
+    · right; rwa [flipBit_apply_ne x i hji] at hj
+  · intro hj
+    rcases hj with rfl | hj
+    · simp [flipBit_apply_same, hi]
+    · by_cases hji : j = i
+      · subst hji; simp [flipBit_apply_same, hi]
+      · rwa [flipBit_apply_ne x i hji]
+
+/-- Flipping any single bit negates the parity. -/
+theorem parity_flipBit (x : Fin n → Bool) (i : Fin n) :
+    parity (flipBit x i) = -parity x := by
+  unfold parity
+  have key : ∀ (a b : ℕ), a + 1 = b ∨ b + 1 = a →
+      (-1 : ℤ) ^ a = -((-1 : ℤ) ^ b) := by
+    intro a b hab
+    rcases hab with ⟨rfl⟩ | ⟨rfl⟩ <;> simp [pow_succ]
+  apply key
+  cases hxi : x i
+  · right
+    have hS : Finset.univ.filter (fun j : Fin n => flipBit x i j) =
+              insert i (Finset.univ.filter (fun j : Fin n => x j)) := by
+      ext j; simp [flipBit]; by_cases h : j = i <;> simp [h, hxi, Function.update]
+    have hni : i ∉ Finset.univ.filter (fun j : Fin n => x j) := by simp [hxi]
+    rw [hS, Finset.card_insert_of_notMem hni]
+  · left
+    have hS : Finset.univ.filter (fun j : Fin n => flipBit x i j) =
+              (Finset.univ.filter (fun j : Fin n => x j)).erase i := by
+      ext j; simp [flipBit]; by_cases h : j = i <;> simp [h, hxi, Function.update]
+    have hi : i ∈ Finset.univ.filter (fun j : Fin n => x j) := by simp [hxi]
+    rw [hS, Finset.card_erase_of_mem hi]
+    have hpos := Finset.card_pos.mpr ⟨i, hi⟩
+    omega
+
+namespace BoolFun
+
+/-- If the parity-signed value of `f` is unchanged by a bit flip, then `f` is
+sensitive at that input in that direction. -/
+theorem sensitiveAt_of_paritySigned_eq (f : BoolFun n)
+    (x : Fin n → Bool) (i : Fin n)
+    (h : f.paritySigned (flipBit x i) = f.paritySigned x) :
+    f.sensitiveAt x i := by
+  unfold sensitiveAt
+  unfold paritySigned pmOne at h
+  rw [parity_flipBit] at h
+  intro heq
+  rw [heq] at h
+  have hpnz := parity_ne_zero x
+  have : (if f x then (1 : ℤ) else -1) * (-parity x - parity x) = 0 := by linarith
+  rw [show -parity x - parity x = -2 * parity x from by ring] at this
+  have := mul_eq_zero.mp this
+  rcases this with h1 | h1
+  · split_ifs at h1; all_goals omega
+  · exact hpnz (by linarith)
+
+end BoolFun
+
+/-- For `n ≥ 1`, the sum of parity signs over all inputs is zero, since
+flipping bit `0` is an involution that negates parity. -/
+private theorem parity_sum_zero (hn : 0 < n) :
+    ∑ x : Fin n → Bool, parity x = 0 := by
+  have i₀ : Fin n := ⟨0, hn⟩
+  have hbij : Function.Bijective (fun x : Fin n → Bool => flipBit x i₀) :=
+    ⟨fun a b h => by
+       have h' : flipBit a i₀ = flipBit b i₀ := h
+       calc a = flipBit (flipBit a i₀) i₀ := (flipBit_flipBit_same a i₀).symm
+         _ = flipBit (flipBit b i₀) i₀ := by rw [h']
+         _ = b := flipBit_flipBit_same b i₀,
+     fun y => ⟨flipBit y i₀, flipBit_flipBit_same y i₀⟩⟩
+  have h : ∑ x : Fin n → Bool, parity x =
+           ∑ x : Fin n → Bool, -parity x := by
+    conv_lhs =>
+      rw [← Fintype.sum_bijective _ hbij _ _ (fun x => rfl)]
+    simp [parity_flipBit]
+  linarith [Finset.sum_neg_distrib (f := fun x : Fin n → Bool => parity x)
+              (s := Finset.univ)]
+
+/-- The indicator function is a left inverse to the "true bits" map. -/
+private theorem indicator_filter_true (x : Fin n → Bool) :
+    indicator (Finset.univ.filter (fun i => x i)) = x := by
+  ext i
+  simp [indicator]
+
+/-- The "true bits" map is a left inverse to indicator. -/
+private theorem filter_true_indicator (T : Finset (Fin n)) :
+    Finset.univ.filter (fun i => indicator T i = true) = T := by
+  ext i
+  simp [indicator]
+
+/-- Key identity: the parity-weighted sum recovers the top Möbius coefficient,
+`∑_x f_pm(x) · parity(x) = 2 · (-1)^n · c_univ(f)`. -/
+theorem moebius_parity_sum (f : BoolFun n) (hn : 0 < n) :
+    ∑ x : Fin n → Bool, f.paritySigned x =
+    2 * (-1 : ℤ) ^ n * f.moebius Finset.univ := by
+  have pmOne_eq : ∀ x, f.pmOne x = 2 * boolToInt (f x) - 1 := by
+    intro x; unfold BoolFun.pmOne boolToInt; split <;> ring
+  simp_rw [BoolFun.paritySigned, pmOne_eq, sub_mul, Finset.sum_sub_distrib, one_mul]
+  rw [parity_sum_zero hn, sub_zero]
+  suffices h : ∑ x : Fin n → Bool, boolToInt (f x) * parity x =
+               (-1 : ℤ) ^ n * f.moebius Finset.univ by
+    simp_rw [show ∀ x : Fin n → Bool,
+      2 * boolToInt (f x) * parity x = 2 * (boolToInt (f x) * parity x) from
+      fun x => by ring]
+    rw [← Finset.mul_sum, h]; ring
+  unfold BoolFun.moebius parity
+  rw [Finset.mul_sum]
+  conv_rhs =>
+    arg 2; ext T
+    rw [← mul_assoc, ← pow_add, Finset.card_univ, Fintype.card_fin]
+    rw [show n + (n - Finset.card T) =
+        Finset.card T + 2 * (n - Finset.card T) from by
+      have : T.card ≤ n := by
+        have := Finset.card_le_univ T
+        rwa [Fintype.card_fin] at this
+      omega]
+    rw [pow_add, pow_mul, neg_one_sq, one_pow, mul_one]
+  rw [show Finset.univ.powerset = (Finset.univ : Finset (Finset (Fin n))) from by
+    ext S; simp]
+  symm
+  apply Fintype.sum_equiv
+    (Equiv.ofBijective (fun T : Finset (Fin n) => indicator T)
+      ⟨fun S T h => by
+         have h' : indicator S = indicator T := h
+         rw [← filter_true_indicator S, h', filter_true_indicator],
+       fun x => ⟨Finset.univ.filter (fun i => x i), indicator_filter_true x⟩⟩)
+  intro T
+  simp only [Equiv.ofBijective_apply]
+  have hcard := congrArg Finset.card (filter_true_indicator T)
+  -- Both sides display as `{i | indicator T i = true}.card`; the hypothesis
+  -- and the goal use the same set-builder form for the same Finset.
+  rw [show
+        (-1 : ℤ) ^ T.card * boolToInt (f (indicator T)) =
+          boolToInt (f (indicator T)) * (-1) ^ T.card from by ring]
+  congr 2
+  exact hcard.symm
+
+/-- If `f` has full multilinear degree (`c_univ(f) ≠ 0`), then the
+parity-weighted sum is nonzero. -/
+theorem fullDegree_paritySigned_sum_ne_zero (f : BoolFun n) (hn : 0 < n)
+    (h : f.moebius Finset.univ ≠ 0) :
+    ∑ x : Fin n → Bool, f.paritySigned x ≠ 0 := by
+  rw [moebius_parity_sum _ hn]
+  refine mul_ne_zero (mul_ne_zero ?_ ?_) h
+  · omega
+  · positivity
+
+/-- **Parity imbalance.** If `f` has full multilinear degree, then one of the
+two parity-sign classes contains more than `2^{n-1}` inputs. -/
+theorem fullDegree_imbalance (f : BoolFun n) (hn : 0 < n)
+    (h : f.moebius Finset.univ ≠ 0) :
+    ∃ c : ℤ, (c = 1 ∨ c = -1) ∧
+      2 ^ (n - 1) < (Finset.univ.filter (fun x : Fin n → Bool =>
+        f.paritySigned x = c)).card := by
+  have hne := fullDegree_paritySigned_sum_ne_zero f hn h
+  have hval : ∀ x : Fin n → Bool, f.paritySigned x = 1 ∨ f.paritySigned x = -1 := by
+    intro x; unfold BoolFun.paritySigned BoolFun.pmOne parity
+    rcases neg_one_pow_eq_or (R := ℤ)
+      (Finset.univ.filter (fun i => x i)).card with h | h <;>
+      cases f x <;> simp [h]
+  set A := Finset.univ.filter (fun x : Fin n → Bool => f.paritySigned x = 1)
+  set B := Finset.univ.filter (fun x : Fin n → Bool => f.paritySigned x = -1)
+  have hunion : A ∪ B = Finset.univ := by
+    ext x; simp only [Finset.mem_union, Finset.mem_filter, Finset.mem_univ, true_and, A, B]
+    exact iff_of_true (hval x) trivial
+  have hdisj : Disjoint A B := by
+    rw [Finset.disjoint_left]
+    intro x hxA hxB
+    simp only [A, B, Finset.mem_filter, Finset.mem_univ, true_and] at hxA hxB
+    linarith
+  have hsum : ∑ x : Fin n → Bool, f.paritySigned x = ↑A.card - ↑B.card := by
+    have hA_sum : ∑ x ∈ A, f.paritySigned x = (A.card : ℤ) := by
+      calc ∑ x ∈ A, f.paritySigned x = ∑ _ ∈ A, (1 : ℤ) :=
+            Finset.sum_congr rfl (fun x hx => by
+              simp only [A, Finset.mem_filter, Finset.mem_univ, true_and] at hx; exact hx)
+        _ = ↑A.card := by simp
+    have hB_sum : ∑ x ∈ B, f.paritySigned x = -(↑B.card : ℤ) := by
+      calc ∑ x ∈ B, f.paritySigned x = ∑ _ ∈ B, (-1 : ℤ) :=
+            Finset.sum_congr rfl (fun x hx => by
+              simp only [B, Finset.mem_filter, Finset.mem_univ, true_and] at hx; exact hx)
+        _ = -(↑B.card : ℤ) := by simp
+    have key : ∑ x ∈ A ∪ B, f.paritySigned x = ↑A.card - ↑B.card := by
+      rw [Finset.sum_union hdisj, hA_sum, hB_sum]; ring
+    rwa [hunion] at key
+  have htotal : A.card + B.card = 2 ^ n := by
+    rw [← Finset.card_union_of_disjoint hdisj, hunion, Finset.card_univ,
+        Fintype.card_pi_const, Fintype.card_bool]
+  by_cases hA : A.card > 2 ^ (n - 1)
+  · exact ⟨1, Or.inl rfl, hA⟩
+  · refine ⟨-1, Or.inr rfl, ?_⟩
+    have hA : A.card ≤ 2 ^ (n - 1) := Nat.not_lt.mp hA
+    change 2 ^ (n - 1) < B.card
+    suffices hne' : B.card ≠ 2 ^ (n - 1) by
+      have h2pow : 2 ^ n = 2 * 2 ^ (n - 1) := by
+        conv_lhs => rw [show n = (n - 1) + 1 from by omega]
+        rw [pow_succ]; ring
+      set p := 2 ^ (n - 1)
+      omega
+    intro heq
+    have hA_eq : A.card = 2 ^ (n - 1) := by
+      have h2pow : 2 ^ n = 2 * 2 ^ (n - 1) := by
+        conv_lhs => rw [show n = (n - 1) + 1 from by omega]
+        rw [pow_succ]; ring
+      set p := 2 ^ (n - 1)
+      omega
+    apply hne
+    rw [hsum, hA_eq, heq]; push_cast; omega
+
+end LeanPoolSensitivity

--- a/LeanPool/Sensitivity/Subcube.lean
+++ b/LeanPool/Sensitivity/Subcube.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+import LeanPool.Sensitivity.Defs
+import LeanPool.Sensitivity.Multilinear
+
+/-!
+# Subcube Restriction
+
+We define the restriction of a Boolean function to a subcube by fixing some
+coordinates to a base assignment, and prove that this operation can only
+decrease sensitivity and preserves Möbius coefficients on subsets of the
+"free" coordinates.
+
+## Main definitions
+
+* `LeanPoolSensitivity.embed` — embed a free-coordinate assignment into a
+  full input by reading the remaining coordinates from a base assignment.
+* `LeanPoolSensitivity.BoolFun.restrictTo` — restrict `f` by fixing the
+  coordinates outside `free` to `base`.
+
+## Main results
+
+* `LeanPoolSensitivity.BoolFun.restrictTo_sensitivity_le` — restriction
+  cannot increase sensitivity.
+* `LeanPoolSensitivity.BoolFun.exists_fullDegree_restriction` — if `f` has
+  positive degree `d`, there is a subcube of dimension `d` on which the
+  restriction has full degree `d`.
+-/
+
+namespace LeanPoolSensitivity
+
+variable {n : ℕ}
+
+/-- Embed an assignment of the "free" coordinates into the full hypercube by
+copying values from `base` on the non-free coordinates. -/
+def embed (free : Finset (Fin n)) (base : Fin n → Bool)
+    (x : Fin n → Bool) : Fin n → Bool :=
+  fun j => if j ∈ free then x j else base j
+
+/-- For a free coordinate `i`, embedding commutes with flipping bit `i`. -/
+theorem embed_flipBit_free (free : Finset (Fin n)) (base x : Fin n → Bool)
+    (i : Fin n) (hi : i ∈ free) :
+    embed free base (flipBit x i) = flipBit (embed free base x) i := by
+  funext j
+  by_cases hji : j = i
+  · subst hji; simp [embed, flipBit, hi]
+  · by_cases hj : j ∈ free
+    · simp [embed, hj, flipBit, Function.update_of_ne hji]
+    · simp only [embed, hj, ↓reduceIte, flipBit]
+      rw [Function.update_of_ne hji]
+      simp [embed, hj]
+
+/-- For a non-free coordinate `i`, embedding ignores flips at `i`. -/
+theorem embed_flipBit_nonfree (free : Finset (Fin n)) (base x : Fin n → Bool)
+    (i : Fin n) (hi : i ∉ free) :
+    embed free base (flipBit x i) = embed free base x := by
+  funext j
+  simp only [embed, flipBit]
+  by_cases hj : j ∈ free
+  · simp [hj, Function.update_of_ne (ne_of_mem_of_not_mem hj hi)]
+  · simp [hj]
+
+/-- Embedding the indicator of `T ⊆ S ⊆ free` with `base = false` recovers
+the original indicator of `T`. -/
+theorem embed_indicator_subset (free S T : Finset (Fin n))
+    (hS : S ⊆ free) (hT : T ⊆ S) :
+    embed free (fun _ => false) (indicator T) = indicator T := by
+  funext j
+  simp only [embed]
+  by_cases hj : j ∈ free
+  · simp only [if_pos hj]
+  · simp only [if_neg hj, indicator]
+    have : j ∉ T := fun hjT => absurd (hS (hT hjT)) hj
+    simp only [decide_eq_false this]
+
+namespace BoolFun
+
+/-- Restriction of `f` to the subcube parametrised by the free coordinates
+`free` and the fixed assignment `base` on the remaining coordinates. -/
+def restrictTo (f : BoolFun n) (free : Finset (Fin n))
+    (base : Fin n → Bool) : BoolFun n :=
+  fun x => f (embed free base x)
+
+/-- Flipping a coordinate outside `free` does not change the restriction. -/
+theorem restrictTo_flipBit_nonfree (f : BoolFun n) (free : Finset (Fin n))
+    (base : Fin n → Bool) (x : Fin n → Bool) (i : Fin n) (hi : i ∉ free) :
+    f.restrictTo free base (flipBit x i) = f.restrictTo free base x := by
+  unfold restrictTo
+  rw [embed_flipBit_nonfree free base x i hi]
+
+/-- The restriction is never sensitive in a coordinate outside `free`. -/
+theorem restrictTo_not_sensitiveAt_nonfree (f : BoolFun n) (free : Finset (Fin n))
+    (base : Fin n → Bool) (x : Fin n → Bool) (i : Fin n) (hi : i ∉ free) :
+    ¬(f.restrictTo free base).sensitiveAt x i := by
+  unfold sensitiveAt
+  intro hcontra
+  exact hcontra (f.restrictTo_flipBit_nonfree free base x i hi)
+
+/-- Restriction cannot increase sensitivity. -/
+theorem restrictTo_sensitivity_le (f : BoolFun n) (free : Finset (Fin n))
+    (base : Fin n → Bool) :
+    (f.restrictTo free base).sensitivity ≤ f.sensitivity := by
+  apply Finset.sup_le
+  intro x _
+  apply le_trans _ (f.localSensitivity_le_sensitivity (embed free base x))
+  unfold localSensitivity
+  apply Finset.card_le_card
+  intro i
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+  intro hi
+  unfold sensitiveAt at hi ⊢
+  by_cases him : i ∈ free
+  · unfold restrictTo at hi
+    rw [embed_flipBit_free free base x i him] at hi
+    exact hi
+  · exfalso
+    exact f.restrictTo_not_sensitiveAt_nonfree free base x i him hi
+
+/-- Restricting with `base = false` preserves Möbius coefficients on subsets
+of the free coordinates. -/
+theorem restrictTo_moebius_subset (f : BoolFun n) (free : Finset (Fin n))
+    (S : Finset (Fin n)) (hS : S ⊆ free) :
+    (f.restrictTo free (fun _ => false)).moebius S = f.moebius S := by
+  unfold moebius restrictTo
+  apply Finset.sum_congr rfl
+  intro T hT
+  rw [Finset.mem_powerset] at hT
+  congr 1
+  rw [embed_indicator_subset free S T hS hT]
+
+/-- Key lemma: if `f` has degree `d ≥ 1`, there is a subcube of dimension `d`
+on which the restriction has full degree `d` (its top Möbius coefficient is
+nonzero). -/
+theorem exists_fullDegree_restriction (f : BoolFun n) (hd : 0 < f.degree) :
+    ∃ S : Finset (Fin n),
+      S.card = f.degree ∧
+      f.moebius S ≠ 0 ∧
+      (f.restrictTo S (fun _ => false)).moebius S ≠ 0 := by
+  obtain ⟨S, hcard, hne⟩ := f.exists_degree_witness hd
+  exact ⟨S, hcard, hne, by rwa [f.restrictTo_moebius_subset S S Finset.Subset.rfl]⟩
+
+end BoolFun
+
+end LeanPoolSensitivity

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -191,3 +191,17 @@ projects:
       - number-theory
       - quadratic-forms
       - geometry-of-numbers
+  - slug: sensitivity
+    title: 'Sensitivity Conjecture: √(deg) ≤ sensitivity'
+    entry_module: LeanPool.Sensitivity
+    authors:
+      - Samuel Schlesinger
+    source:
+      url: https://github.com/SamuelSchlesinger/sensitivity-conjecture
+      github_repo: samuelschlesinger/sensitivity-conjecture
+    status: verified
+    main_declarations:
+      - LeanPoolSensitivity.sensitivity_ge_sqrt_degree
+    tags:
+      - combinatorics
+      - boolean-functions


### PR DESCRIPTION
## Summary
- Imports a Lean 4 formalisation of the quantitative form of the Nisan-Szegedy / Huang sensitivity bound under `LeanPool/Sensitivity/`.
- Headline: for every Boolean function `f` with `deg(f) ≥ 1`, `√(deg(f)) ≤ sensitivity(f)` (`LeanPoolSensitivity.sensitivity_ge_sqrt_degree`); hence `deg(f) ≤ sensitivity(f)²` (`LeanPoolSensitivity.degree_le_sensitivity_sq`).
- Ported `leanprover/lean4:v4.28.0` → `v4.30.0-rc2`.
- Adds entry to `LeanPool/projects.yml` with `source.github_repo: samuelschlesinger/sensitivity-conjecture`.
## Proof sketch
The argument restricts `f` to a subcube of dimension `deg(f)` on which the top Möbius coefficient of the multilinear representation is preserved, derives a parity-sign imbalance there, and feeds the result into the Huang hypercube lemma `Sensitivity.huang_degree_theorem` from Mathlib's `Archive.Sensitivity`.
## Files
- `LeanPool/Sensitivity.lean` — index
- `LeanPool/Sensitivity/Defs.lean`, `Basic.lean` — core definitions of sensitivity and degree
- `LeanPool/Sensitivity/Multilinear.lean` — multilinear (Fourier-Walsh / Möbius) representation of Boolean functions
- `LeanPool/Sensitivity/Subcube.lean` — restriction to subcubes preserving the top coefficient
- `LeanPool/Sensitivity/Parity.lean` — parity-sign imbalance lemma
- `LeanPool/Sensitivity/HuangBridge.lean` — adapter to Mathlib's `Archive.Sensitivity`
- `LeanPool/Sensitivity/Main.lean` — the `√(deg) ≤ sensitivity` bound
- `LeanPool/Sensitivity/Consequences.lean` — squared corollary
## Notable porting work
- **Namespace clash**: upstream uses `namespace Sensitivity`, but Mathlib has its own `Sensitivity` namespace (used by `Archive.Sensitivity` for the underlying Huang lemma). Renamed all upstream declarations to `namespace LeanPoolSensitivity` so both can coexist; `HuangBridge.lean` imports `Archive.Sensitivity` to access `Sensitivity.huang_degree_theorem` from the original namespace.
- `BoolFun.sensitivity` and `BoolFun.degree` are `noncomputable` (using `Finset.sup` over `Finset.univ`), matching upstream.
- All public declarations carry docstrings (`docBlame` linter-clean).
Author: Samuel Schlesinger.