### PR TITLE
Import testing-lower-bounds formalization

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -236,3 +236,11 @@ import LeanPool.Sensitivity.Subcube
 import LeanPool.SumsThreeSquares
 import LeanPool.SumsThreeSquares.MinkowskiConvex
 import LeanPool.SumsThreeSquares.SumThreeSquares
+import LeanPool.TestingLowerBounds
+import LeanPool.TestingLowerBounds.ForMathlib.AbsolutelyContinuous
+import LeanPool.TestingLowerBounds.ForMathlib.CountableOrCountablyGenerated
+import LeanPool.TestingLowerBounds.ForMathlib.EReal
+import LeanPool.TestingLowerBounds.ForMathlib.Integrable
+import LeanPool.TestingLowerBounds.ForMathlib.KernelFstSnd
+import LeanPool.TestingLowerBounds.ForMathlib.MaxMinEqAbs
+import LeanPool.TestingLowerBounds.Kernel.Deterministic

--- a/LeanPool/TestingLowerBounds.lean
+++ b/LeanPool/TestingLowerBounds.lean
@@ -1,0 +1,24 @@
+/-
+Copyright (c) 2026 Rémy Degenne, Lorenzo Luccioli. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rémy Degenne, Lorenzo Luccioli
+-/
+
+import LeanPool.TestingLowerBounds.ForMathlib.AbsolutelyContinuous
+import LeanPool.TestingLowerBounds.ForMathlib.CountableOrCountablyGenerated
+import LeanPool.TestingLowerBounds.ForMathlib.EReal
+import LeanPool.TestingLowerBounds.ForMathlib.Integrable
+import LeanPool.TestingLowerBounds.ForMathlib.KernelFstSnd
+import LeanPool.TestingLowerBounds.ForMathlib.MaxMinEqAbs
+import LeanPool.TestingLowerBounds.Kernel.Deterministic
+
+/-!
+# Lower bounds for hypothesis testing based on information theory
+
+Source: url:https://github.com/RemyDegenne/testing-lower-bounds
+Authors: Rémy Degenne, Lorenzo Luccioli
+Status: verified
+Main declarations: `ProbabilityTheory.Kernel.fst'`, `ProbabilityTheory.Kernel.snd'`
+Tags: probability, information-theory, measure-theory
+MSC: 62F03, 62B10, 94A17, 60A10
+-/

--- a/LeanPool/TestingLowerBounds/ForMathlib/AbsolutelyContinuous.lean
+++ b/LeanPool/TestingLowerBounds/ForMathlib/AbsolutelyContinuous.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 Rémy Degenne, Lorenzo Luccioli. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rémy Degenne, Lorenzo Luccioli
+-/
+import Mathlib.Probability.Kernel.Composition.AbsolutelyContinuous
+import Mathlib.Probability.Kernel.RadonNikodym
+import LeanPool.TestingLowerBounds.ForMathlib.KernelFstSnd
+
+/-!
+# Bridging `Measure.compProd` and `Kernel.compProd`
+
+A handful of helper lemmas relating compositions of measures and kernels that have not yet
+been merged into Mathlib.
+-/
+
+open ProbabilityTheory MeasurableSpace Set
+
+open scoped ENNReal
+
+namespace MeasureTheory.Measure
+
+variable {α γ : Type*} {mα : MeasurableSpace α} {mγ : MeasurableSpace γ}
+  {μ ν : Measure α} {κ η : Kernel α γ}
+
+lemma mutuallySingular_compProd_left (hμν : μ ⟂ₘ ν) (κ η : Kernel α γ) :
+    μ ⊗ₘ κ ⟂ₘ ν ⊗ₘ η := by
+  by_cases hμ : SFinite μ
+  swap; · rw [compProd_of_not_sfinite _ _ hμ]; simp
+  by_cases hν : SFinite ν
+  swap; · rw [compProd_of_not_sfinite _ _ hν]; simp
+  by_cases hκ : IsSFiniteKernel κ
+  swap; · rw [compProd_of_not_isSFiniteKernel _ _ hκ]; simp
+  by_cases hη : IsSFiniteKernel η
+  swap; · rw [compProd_of_not_isSFiniteKernel _ _ hη]; simp
+  refine ⟨hμν.nullSet ×ˢ univ, hμν.measurableSet_nullSet.prod .univ, ?_⟩
+  rw [compProd_apply_prod hμν.measurableSet_nullSet .univ, compl_prod_eq_union]
+  simp only [MutuallySingular.restrict_nullSet, lintegral_zero_measure, compl_univ,
+    prod_empty, union_empty, true_and]
+  rw [compProd_apply_prod hμν.measurableSet_nullSet.compl .univ]
+  simp
+
+lemma mutuallySingular_compProd_iff_of_same_right (μ ν : Measure α) [IsFiniteMeasure μ]
+    [IsFiniteMeasure ν] (κ : Kernel α γ) [IsFiniteKernel κ] [hκ : ∀ x, NeZero (κ x)] :
+    μ ⊗ₘ κ ⟂ₘ ν ⊗ₘ κ ↔ μ ⟂ₘ ν := by
+  refine ⟨fun h ↦ ?_, fun h ↦ mutuallySingular_compProd_left h _ _⟩
+  rw [← withDensity_rnDeriv_eq_zero]
+  have hh := mutuallySingular_of_mutuallySingular_compProd h ?_ ?_ (ξ  := ν.withDensity (∂μ/∂ν))
+  rotate_left
+  · exact absolutelyContinuous_of_le (μ.withDensity_rnDeriv_le ν)
+  · exact withDensity_absolutelyContinuous _ _
+  simp_rw [MutuallySingular.self_iff, (hκ _).ne] at hh
+  exact ae_eq_bot.mp (Filter.eventually_false_iff_eq_bot.mp hh)
+
+lemma absolutelyContinuous_compProd_of_compProd'
+    [SigmaFinite μ] [SigmaFinite ν] [IsSFiniteKernel κ] [IsSFiniteKernel η]
+    (hκη : μ ⊗ₘ κ ≪ ν ⊗ₘ η) :
+    μ ⊗ₘ κ ≪ μ ⊗ₘ η := by
+  rw [ν.haveLebesgueDecomposition_add μ, compProd_add_left, add_comm] at hκη
+  have h : μ ⊗ₘ κ ≪ μ.withDensity (∂ν/∂μ) ⊗ₘ η :=
+    absolutelyContinuous_of_add_of_mutuallySingular hκη
+      (mutuallySingular_compProd_left (mutuallySingular_singularPart _ _).symm _ _)
+  refine h.trans ?_
+  exact (withDensity_absolutelyContinuous _ _).compProd_left _
+
+variable [CountableOrCountablyGenerated α γ]
+
+lemma mutuallySingular_compProd_right
+    (μ ν : Measure α) {κ η : Kernel α γ} [IsFiniteKernel κ] [IsFiniteKernel η]
+    (hκη : ∀ᵐ a ∂μ, κ a ⟂ₘ η a) :
+    μ ⊗ₘ κ ⟂ₘ ν ⊗ₘ η :=
+  MutuallySingular.compProd_of_right μ ν hκη
+
+lemma mutuallySingular_compProd_right'
+    (μ ν : Measure α) {κ η : Kernel α γ} [IsFiniteKernel κ] [IsFiniteKernel η]
+    (hκη : ∀ᵐ a ∂ν, κ a ⟂ₘ η a) :
+    μ ⊗ₘ κ ⟂ₘ ν ⊗ₘ η := by
+  by_cases hμ : SFinite μ
+  swap; · rw [compProd_of_not_sfinite _ _ hμ]; simp
+  by_cases hν : SFinite ν
+  swap; · rw [compProd_of_not_sfinite _ _ hν]; simp
+  refine (mutuallySingular_compProd_right _ _ ?_).symm
+  simp_rw [MutuallySingular.comm, hκη]
+
+lemma mutuallySingular_compProd_iff_of_same_left (μ : Measure α) [SFinite μ]
+    (κ η : Kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel η] :
+    μ ⊗ₘ κ ⟂ₘ μ ⊗ₘ η ↔ ∀ᵐ a ∂μ, κ a ⟂ₘ η a := by
+  refine ⟨fun h ↦ ?_, fun h ↦ mutuallySingular_compProd_right _ _ h⟩
+  exact mutuallySingular_of_mutuallySingular_compProd h (fun _ a ↦ a) (fun _ a ↦ a)
+
+end MeasureTheory.Measure
+
+open MeasureTheory
+
+lemma ProbabilityTheory.Kernel.absolutelyContinuous_compProd_iff
+    {α β γ : Type*} {_ : MeasurableSpace α} {_ : MeasurableSpace β} {_ : MeasurableSpace γ}
+    [CountableOrCountablyGenerated β γ] {κ₁ η₁ : Kernel α β}
+    {κ₂ η₂ : Kernel (α × β) γ} [IsFiniteKernel κ₁] [IsFiniteKernel η₁] [IsFiniteKernel κ₂]
+    [IsFiniteKernel η₂] (a : α) [∀ b, NeZero (κ₂ (a, b))] :
+    (κ₁ ⊗ₖ κ₂) a ≪ (η₁ ⊗ₖ η₂) a ↔ κ₁ a ≪ η₁ a ∧ ∀ᵐ b ∂κ₁ a, κ₂ (a, b) ≪ η₂ (a, b) := by
+  rw [Kernel.compProd_apply_eq_compProd_snd', Kernel.compProd_apply_eq_compProd_snd',
+    Measure.absolutelyContinuous_compProd_iff, Measure.absolutelyContinuous_compProd_right_iff]
+  simp_rw [Kernel.snd'_apply]

--- a/LeanPool/TestingLowerBounds/ForMathlib/CountableOrCountablyGenerated.lean
+++ b/LeanPool/TestingLowerBounds/ForMathlib/CountableOrCountablyGenerated.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2026 Rémy Degenne, Lorenzo Luccioli. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rémy Degenne, Lorenzo Luccioli
+-/
+import Mathlib.MeasureTheory.MeasurableSpace.CountablyGenerated
+
+/-!
+# Instance form of the product-swap closure for `CountableOrCountablyGenerated`
+
+Mathlib provides `countableOrCountablyGenerated_prod_left_swap` as a lemma. Type-class
+resolution does not pick lemmas up automatically, so we re-export the same content as an
+instance, which the downstream divergence files rely on.
+-/
+
+namespace MeasurableSpace
+
+variable {α β γ : Type*}
+variable [MeasurableSpace α] [MeasurableSpace β] [MeasurableSpace γ]
+
+instance instCountableOrCountablyGeneratedProdSwap [h : CountableOrCountablyGenerated (α × β) γ] :
+    CountableOrCountablyGenerated (β × α) γ :=
+  countableOrCountablyGenerated_prod_left_swap
+
+end MeasurableSpace

--- a/LeanPool/TestingLowerBounds/ForMathlib/EReal.lean
+++ b/LeanPool/TestingLowerBounds/ForMathlib/EReal.lean
@@ -1,0 +1,156 @@
+/-
+Copyright (c) 2026 Rémy Degenne, Lorenzo Luccioli. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rémy Degenne, Lorenzo Luccioli
+-/
+import Mathlib.MeasureTheory.Constructions.BorelSpace.Real
+
+/-!
+# Auxiliary `EReal` results
+
+Most of the lemmas this project originally vendored under `ForMathlib/EReal.lean` have moved
+to Mathlib; only the ones that are still unique to this project (or convenient aliases for
+naming) remain here.
+-/
+
+open scoped ENNReal NNReal Topology
+open Filter Set
+
+namespace EReal
+
+lemma top_mul_ennreal_coe {x : ℝ≥0∞} (hx : x ≠ 0) : ⊤ * (x : EReal) = ⊤ :=
+  top_mul_coe_ennreal hx
+
+lemma ennreal_coe_mul_top {x : ℝ≥0∞} (hx : x ≠ 0) : (x : EReal) * ⊤ = ⊤ :=
+  coe_ennreal_mul_top hx
+
+lemma lt_neg_iff_lt_neg {x y : EReal} : x < -y ↔ y < -x := by
+  nth_rw 1 [← neg_neg x, neg_lt_neg_iff]
+
+lemma le_neg_iff_le_neg {x y : EReal} : x ≤ -y ↔ y ≤ -x := by
+  nth_rw 1 [← neg_neg x, neg_le_neg_iff]
+
+lemma neg_le_iff_neg_le {x y : EReal} : -x ≤ y ↔ -y ≤ x := by
+  nth_rw 1 [← neg_neg y, neg_le_neg_iff]
+
+lemma add_ne_top_iff_of_ne_bot {x y : EReal} (hx : x ≠ ⊥) (hy : y ≠ ⊥) :
+    x + y ≠ ⊤ ↔ x ≠ ⊤ ∧ y ≠ ⊤ := by
+  refine ⟨?_, fun h ↦ EReal.add_ne_top h.1 h.2⟩
+  induction x <;> simp_all
+  induction y <;> simp_all
+
+lemma add_ne_bot {x y : EReal} (hx : x ≠ ⊥) (hy : y ≠ ⊥) : x + y ≠ ⊥ :=
+  EReal.add_ne_bot_iff.mpr ⟨hx, hy⟩
+
+lemma coe_mul_add_of_nonneg {x : ℝ} (hx_nonneg : 0 ≤ x) (y z : EReal) :
+    x * (y + z) = x * y + x * z := by
+  by_cases hx0 : x = 0
+  · simp [hx0]
+  have hx_pos : 0 < x := lt_of_le_of_ne hx_nonneg (Ne.symm hx0)
+  induction y
+  · simp [EReal.coe_mul_bot_of_pos hx_pos]
+  · induction z
+    · simp [EReal.coe_mul_bot_of_pos hx_pos]
+    · norm_cast
+      rw [mul_add]
+    · simp only [coe_add_top, EReal.coe_mul_top_of_pos hx_pos]
+      rw [← EReal.coe_mul, EReal.coe_add_top]
+  · simp only [EReal.coe_mul_top_of_pos hx_pos]
+    induction z
+    · simp [EReal.coe_mul_bot_of_pos hx_pos]
+    · simp only [top_add_coe, EReal.coe_mul_top_of_pos hx_pos]
+      rw [← EReal.coe_mul, EReal.top_add_coe]
+    · simp [EReal.coe_mul_top_of_pos hx_pos]
+
+lemma add_mul_coe_of_nonneg {x : ℝ} (hx_nonneg : 0 ≤ x) (y z : EReal) :
+    (y + z) * x = y * x + z * x := by
+  simp_rw [mul_comm _ (x : EReal)]
+  exact EReal.coe_mul_add_of_nonneg hx_nonneg y z
+
+lemma add_sub_cancel (x : EReal) (y : ℝ) : x + y - y = x := by
+  induction x
+  · simp
+  · norm_cast
+    ring
+  · simp
+
+lemma add_sub_cancel' (x : EReal) (y : ℝ) : y + x - y = x := by
+  rw [add_comm, EReal.add_sub_cancel]
+
+lemma top_sub_of_ne_top {x : EReal} (hx : x ≠ ⊤) : ⊤ - x = ⊤ := by
+  induction x <;> tauto
+
+lemma top_mul_add_of_nonneg {x y : EReal} (hx : 0 ≤ x) (hy : 0 ≤ y) :
+    ⊤ * (x + y) = ⊤ * x + ⊤ * y := by
+  induction x, y using EReal.induction₂_symm with
+  | symm h =>
+    rw [add_comm, add_comm (⊤ * _)]
+    exact h hy hx
+  | top_top => simp
+  | top_pos _ h =>
+    rw [top_add_coe, top_mul_top, top_mul_of_pos, top_add_top]
+    exact mod_cast h
+  | top_zero => simp
+  | top_neg _ h =>
+    refine absurd hy ?_
+    exact not_le.mpr (mod_cast h)
+  | top_bot => simp
+  | pos_bot => simp
+  | coe_coe x y =>
+    by_cases hx0 : x = 0
+    · simp [hx0]
+    by_cases hy0 : y = 0
+    · simp [hy0]
+    have hx_pos : 0 < (x : EReal) := by
+      apply lt_of_le_of_ne hx
+      exact (Ne.symm (by exact_mod_cast hx0))
+    have hy_pos : 0 < (y : EReal) := by
+      apply lt_of_le_of_ne hy
+      exact (Ne.symm (by exact_mod_cast hy0))
+    rw [top_mul_of_pos hx_pos, top_mul_of_pos hy_pos, top_mul_of_pos]
+    · simp
+    · exact EReal.add_pos hx_pos hy_pos
+  | zero_bot => simp
+  | neg_bot => simp
+  | bot_bot => simp
+
+lemma mul_add_coe_of_nonneg (x : EReal) {y z : ℝ} (hy : 0 ≤ y) (hz : 0 ≤ z) :
+    x * (y + z) = x * y + x * z := by
+  by_cases hx_top : x = ⊤
+  · rw [hx_top]
+    exact top_mul_add_of_nonneg (mod_cast hy) (mod_cast hz)
+  by_cases hx_bot : x = ⊥
+  · rw [hx_bot]
+    by_cases hy0 : y = 0
+    · simp [hy0]
+    by_cases hz0 : z = 0
+    · simp [hz0]
+    have hy_pos : 0 < (y : EReal) := by
+      apply lt_of_le_of_ne (mod_cast hy)
+      exact (Ne.symm (by exact_mod_cast hy0))
+    have hz_pos : 0 < (z : EReal) := by
+      apply lt_of_le_of_ne (mod_cast hz)
+      exact (Ne.symm (by exact_mod_cast hz0))
+    rw [bot_mul_of_pos hy_pos, bot_mul_of_pos hz_pos, bot_mul_of_pos]
+    · simp
+    · exact EReal.add_pos hy_pos hz_pos
+  lift x to ℝ using ⟨hx_top, hx_bot⟩
+  norm_cast
+  rw [mul_add]
+
+lemma coe_add_mul_of_nonneg (x : EReal) {y z : ℝ} (hy : 0 ≤ y) (hz : 0 ≤ z) :
+    (y + z) * x =  y * x + z * x := by
+  simp_rw [mul_comm _ x]
+  exact EReal.mul_add_coe_of_nonneg x hy hz
+
+end EReal
+
+namespace ENNReal
+
+variable {a b c : ℝ≥0∞}
+
+theorem min_mul : min a b * c = min (a * c) (b * c) := mul_left_mono.map_min
+
+theorem mul_min : a * min b c = min (a * b) (a * c) := mul_right_mono.map_min
+
+end ENNReal

--- a/LeanPool/TestingLowerBounds/ForMathlib/Integrable.lean
+++ b/LeanPool/TestingLowerBounds/ForMathlib/Integrable.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 Rémy Degenne, Lorenzo Luccioli. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rémy Degenne, Lorenzo Luccioli
+-/
+import Mathlib.MeasureTheory.Function.L1Space.Integrable
+import Mathlib.MeasureTheory.Measure.Decomposition.RadonNikodym
+
+/-!
+# Integrability of an `rnDeriv`-smul
+
+The other integrability lemmas that previously lived here are all in Mathlib now; only
+`Integrable.rnDeriv_smul`, the convenience wrapper that the divergence files import, remains.
+-/
+
+open scoped ENNReal
+
+namespace MeasureTheory
+
+namespace Integrable
+
+variable {α : Type*} {mα : MeasurableSpace α} {μ ν : Measure α}
+
+lemma rnDeriv_smul {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [μ.HaveLebesgueDecomposition ν] (hμν : μ ≪ ν)
+    [SigmaFinite μ] {f : α → E} (hf : Integrable f μ) :
+    Integrable (fun x ↦ (μ.rnDeriv ν x).toReal • f x) ν :=
+  (integrable_rnDeriv_smul_iff hμν).mpr hf
+
+end Integrable
+
+end MeasureTheory

--- a/LeanPool/TestingLowerBounds/ForMathlib/KernelFstSnd.lean
+++ b/LeanPool/TestingLowerBounds/ForMathlib/KernelFstSnd.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 Rémy Degenne, Lorenzo Luccioli. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rémy Degenne, Lorenzo Luccioli
+-/
+import Mathlib.Probability.Kernel.Composition.MeasureCompProd
+
+/-!
+# `fst'` and `snd'` projections of kernels in the first / second domain coordinate
+
+These are convenience definitions for evaluating a `Kernel (α × β) γ` at a fixed second (or
+first) coordinate, returning a `Kernel α γ` (or `Kernel β γ`).
+-/
+
+open MeasureTheory
+
+open scoped ENNReal ProbabilityTheory
+
+namespace ProbabilityTheory
+
+namespace Kernel
+
+variable {α β γ : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
+  {mγ : MeasurableSpace γ}
+variable {δ : Type*} {mδ : MeasurableSpace δ}
+
+/-- Define a `Kernel α γ` from a `Kernel (α × β) γ` by taking the comap of `fun a ↦ (a, b)` for
+a given `b : β`. -/
+noncomputable def fst' (κ : Kernel (α × β) γ) (b : β) : Kernel α γ :=
+  comap κ (fun a ↦ (a, b)) (measurable_id.prodMk measurable_const)
+
+@[simp]
+theorem fst'_apply (κ : Kernel (α × β) γ) (b : β) (a : α) : fst' κ b a = κ (a, b) := rfl
+
+@[simp]
+lemma fst'_zero (b : β) : fst' (0 : Kernel (α × β) γ) b = 0 := by simp [fst']
+
+instance (κ : Kernel (α × β) γ) (b : β) [IsMarkovKernel κ] : IsMarkovKernel (fst' κ b) := by
+  rw [fst']; infer_instance
+
+instance (κ : Kernel (α × β) γ) (b : β) [IsFiniteKernel κ] : IsFiniteKernel (fst' κ b) := by
+  rw [fst']; infer_instance
+
+instance (κ : Kernel (α × β) γ) (b : β) [IsSFiniteKernel κ] : IsSFiniteKernel (fst' κ b) := by
+  rw [fst']; infer_instance
+
+instance (κ : Kernel (α × β) γ) (a : α) (b : β) [NeZero (κ (a, b))] : NeZero ((fst' κ b) a) := by
+  rw [fst'_apply]; infer_instance
+
+instance (priority := 100) {κ : Kernel (α × β) γ} [∀ b, IsMarkovKernel (fst' κ b)] :
+    IsMarkovKernel κ := by
+  refine ⟨fun _ ↦ ⟨?_⟩⟩
+  rw [← fst'_apply, measure_univ]
+
+lemma comap_fst' (κ : Kernel (α × β) γ) (b : β) {f : δ → α} (hf : Measurable f) :
+    comap (fst' κ b) f hf = comap κ (fun d ↦ (f d, b)) (hf.prodMk measurable_const) := by
+  ext d s
+  rw [comap_apply, fst'_apply, comap_apply]
+
+@[simp]
+lemma fst'_prodMkLeft (α : Type*) [MeasurableSpace α] (κ : Kernel β γ) (a : α) {b : β} :
+    fst' (prodMkLeft α κ) b a = κ b := rfl
+
+@[simp]
+lemma fst'_prodMkRight (β : Type*) [MeasurableSpace β] (κ : Kernel α γ) (b : β) :
+    fst' (prodMkRight β κ) b = κ := rfl
+
+/-- Define a `Kernel β γ` from a `Kernel (α × β) γ` by taking the comap of `fun b ↦ (a, b)` for
+a given `a : α`. -/
+noncomputable def snd' (κ : Kernel (α × β) γ) (a : α) : Kernel β γ :=
+  comap κ (fun b ↦ (a, b)) (measurable_const.prodMk measurable_id)
+
+@[simp]
+theorem snd'_apply (κ : Kernel (α × β) γ) (b : β) (a : α) : snd' κ a b = κ (a, b) := rfl
+
+@[simp]
+lemma snd'_zero (a : α) : snd' (0 : Kernel (α × β) γ) a = 0 := by simp [snd']
+
+instance (κ : Kernel (α × β) γ) (a : α) [IsMarkovKernel κ] : IsMarkovKernel (snd' κ a) := by
+  rw [snd']; infer_instance
+
+instance (κ : Kernel (α × β) γ) (a : α) [IsFiniteKernel κ] : IsFiniteKernel (snd' κ a) := by
+  rw [snd']; infer_instance
+
+instance (κ : Kernel (α × β) γ) (a : α) [IsSFiniteKernel κ] : IsSFiniteKernel (snd' κ a) := by
+  rw [snd']; infer_instance
+
+instance (κ : Kernel (α × β) γ) (a : α) (b : β) [NeZero (κ (a, b))] : NeZero ((snd' κ a) b) := by
+  rw [snd'_apply]; infer_instance
+
+instance (priority := 100) {κ : Kernel (α × β) γ} [∀ b, IsMarkovKernel (snd' κ b)] :
+    IsMarkovKernel κ := by
+  refine ⟨fun _ ↦ ⟨?_⟩⟩
+  rw [← snd'_apply, measure_univ]
+
+lemma comap_snd' (κ : Kernel (α × β) γ) (a : α) {f : δ → β} (hf : Measurable f) :
+    comap (snd' κ a) f hf = comap κ (fun d ↦ (a, f d)) (measurable_const.prodMk hf) := by
+  ext d s
+  rw [comap_apply, snd'_apply, comap_apply]
+
+@[simp]
+lemma snd'_prodMkLeft (α : Type*) [MeasurableSpace α] (κ : Kernel β γ) (a : α) :
+    snd' (prodMkLeft α κ) a = κ := rfl
+
+@[simp]
+lemma snd'_prodMkRight (β : Type*) [MeasurableSpace β] (κ : Kernel α γ) (b : β) {a : α} :
+    snd' (prodMkRight β κ) a b = κ a := rfl
+
+@[simp]
+lemma fst'_swapRight (κ : Kernel (α × β) γ) : fst' (swapLeft κ) = snd' κ := rfl
+
+@[simp]
+lemma snd'_swapRight (κ : Kernel (α × β) γ) : snd' (swapLeft κ) = fst' κ := rfl
+
+lemma compProd_apply_eq_compProd_snd' (κ : Kernel α β) (η : Kernel (α × β) γ)
+    [IsSFiniteKernel κ] [IsSFiniteKernel η] (a : α) :
+    (κ ⊗ₖ η) a = (κ a) ⊗ₘ (snd' η a) := by
+  ext s hs
+  simp_rw [compProd_apply hs, Measure.compProd_apply hs, snd'_apply]
+
+end Kernel
+
+end ProbabilityTheory

--- a/LeanPool/TestingLowerBounds/ForMathlib/MaxMinEqAbs.lean
+++ b/LeanPool/TestingLowerBounds/ForMathlib/MaxMinEqAbs.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2026 Rémy Degenne, Lorenzo Luccioli. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rémy Degenne, Lorenzo Luccioli
+-/
+import Mathlib.Algebra.Order.Field.Basic
+import Mathlib.Algebra.Order.Group.Unbundled.Abs
+import Mathlib.Tactic.Ring.RingNF
+
+/-!
+# Two identities expressing `max`/`min` of two reals via their sum and absolute difference.
+-/
+
+variable {α : Type*} [Field α] [LinearOrder α] [IsStrictOrderedRing α]
+
+lemma max_eq_add_add_abs_sub (a b : α) : max a b = 2⁻¹  * (a + b + |a - b|) := by
+  rw [← max_add_min a, ← max_sub_min_eq_abs', add_sub_left_comm, add_sub_cancel_right]
+  ring
+
+lemma min_eq_add_sub_abs_sub (a b : α) : min a b = 2⁻¹ * (a + b - |a - b|) := by
+  rw [← min_add_max a, ← max_sub_min_eq_abs', add_sub_assoc, sub_sub_cancel]
+  ring

--- a/LeanPool/TestingLowerBounds/Kernel/Deterministic.lean
+++ b/LeanPool/TestingLowerBounds/Kernel/Deterministic.lean
@@ -1,0 +1,29 @@
+/-
+Copyright (c) 2026 Rémy Degenne, Lorenzo Luccioli. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rémy Degenne, Lorenzo Luccioli
+-/
+import Mathlib.Probability.Kernel.Basic
+import Mathlib.Probability.Kernel.Composition.MeasureComp
+
+/-!
+# A convenience alias for `discard_comp`
+
+The basic deterministic kernels (`Kernel.id`, `Kernel.copy`, `Kernel.discard`, `Kernel.swap`)
+that this file once defined are now in Mathlib. We only keep a `bind`-flavoured restatement of
+`discard_comp` (`Measure.comp_discard`) that downstream files use as a simp lemma.
+-/
+
+open MeasureTheory
+
+namespace ProbabilityTheory.Kernel
+
+variable {α : Type*} [MeasurableSpace α]
+
+@[simp]
+lemma _root_.MeasureTheory.Measure.comp_discard (μ : Measure α) :
+    μ.bind (Kernel.discard α) = μ .univ • (Measure.dirac PUnit.unit) := by
+  ext s hs
+  simp [Measure.bind_apply hs (Kernel.aemeasurable _), mul_comm]
+
+end ProbabilityTheory.Kernel

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -444,3 +444,32 @@ projects:
     msc:
       - "11E25"
       - "11H06"
+  - slug: testing-lower-bounds
+    title: Lower bounds for hypothesis testing based on information theory
+    summary: Vendored utility lemmas (`AbsolutelyContinuous`, `EReal`, `KernelFstSnd`, deterministic kernels, etc.) from the `testing-lower-bounds` project. The core divergence content (f-divergence, KL, Hellinger, Rényi, statistical information, risk) failed to bump from Lean 4.13 to 4.30 in this session and was excluded.
+    branch: information theory
+    entry_module: LeanPool.TestingLowerBounds
+    authors:
+      - Rémy Degenne
+      - Lorenzo Luccioli
+    source:
+      url: https://github.com/RemyDegenne/testing-lower-bounds
+      github_repo: RemyDegenne/testing-lower-bounds
+    status: verified
+    main_declarations:
+      - ProbabilityTheory.Kernel.fst'
+      - ProbabilityTheory.Kernel.snd'
+    main_results:
+      - declaration: ProbabilityTheory.Kernel.fst'
+        informal: Evaluate a `Kernel (α × β) γ` at a fixed second coordinate, returning `Kernel α γ`.
+      - declaration: ProbabilityTheory.Kernel.snd'
+        informal: Evaluate a `Kernel (α × β) γ` at a fixed first coordinate, returning `Kernel β γ`.
+    tags:
+      - probability
+      - information-theory
+      - measure-theory
+    msc:
+      - "62F03"
+      - "62B10"
+      - "94A17"
+      - "60A10"


### PR DESCRIPTION
Imported from https://github.com/RemyDegenne/testing-lower-bounds.

**Slug:** `testing-lower-bounds`
**Upstream toolchain:** v4.13.0-rc3 → lean-pool's v4.30.0-rc2 (~17 Mathlib release cycles)
**Status:** partial — only utility helpers survived the bump. See agent notes below.

---

# testing-lower-bounds import notes

Vendored from <https://github.com/RemyDegenne/testing-lower-bounds> at HEAD `5d4c306`.
The upstream is pinned to Lean `v4.13.0-rc3` and a matching `mathlib` revision; lean-pool
targets `v4.30.0-rc2`, ~17 Mathlib release cycles ahead, which introduced large API breaks
across the modules the upstream relies on. The end result is that **the divergence content
(the actual project) did not bump in this session** and only a small set of utility files
survived. The intent of this note is to record what was tried, what was excluded, and what
the next person picking this up should focus on.

## Final state

`LeanPool/TestingLowerBounds/` contains seven files, all CI-clean:

- `ForMathlib/MaxMinEqAbs.lean` — `max_eq_add_add_abs_sub`, `min_eq_add_sub_abs_sub` (over
  `[Field] [LinearOrder] [IsStrictOrderedRing]`, replacing the obsolete `LinearOrderedField`).
- `ForMathlib/EReal.lean` — a trimmed grab-bag of `EReal` lemmas (most of the original file
  moved to Mathlib's `Mathlib.Data.EReal.{Basic, Operations, Inv}`; what remains is the
  cast/multiplication-with-`⊤`/distributivity helpers that the divergence files use).
- `ForMathlib/CountableOrCountablyGenerated.lean` — re-exports
  `countableOrCountablyGenerated_prod_left_swap` as an instance, since Mathlib only ships
  the lemma form.
- `ForMathlib/Integrable.lean` — only `MeasureTheory.Integrable.rnDeriv_smul` remains; the
  other integrability lemmas now live in `Mathlib.MeasureTheory.Function.L1Space.Integrable`.
- `ForMathlib/KernelFstSnd.lean` — the project-specific `Kernel.fst'`/`Kernel.snd'`
  projections, plus the `compProd_apply_eq_compProd_snd'` bridge.
- `ForMathlib/AbsolutelyContinuous.lean` — the comp-prod/mutually-singular lemmas not yet in
  Mathlib (`mutuallySingular_compProd_left`, the kernel-flavoured
  `ProbabilityTheory.Kernel.absolutelyContinuous_compProd_iff`, etc.).
- `Kernel/Deterministic.lean` — `Measure.comp_discard` (Mathlib already ships `Kernel.id`,
  `Kernel.copy`, `Kernel.discard`, `Kernel.swap` and `discard_comp`).

`lake exe mk_all --check`, `lake build LeanPool` (warning-free), `lake exe runLinter LeanPool`,
`lake exe lint-style LeanPool`, and `python -m lean_pool.quality --repo ..` all pass.

## Files excluded (not committed)

The remaining 40 source files were dropped after I exhausted plausible quick fixes. They
break with cascading Mathlib API changes — fixing one tends to surface several more in the
same file or in its downstream consumers.

### Outright sorry'd in the upstream — would need a real proof effort

- `TestingLowerBounds/Sorry/ByParts.lean` — integration-by-parts for Stieltjes integrals.
  Marked `sorry` by the upstream authors with no obvious Mathlib equivalent. Proving it from
  scratch is a non-trivial classical analysis result.
- `TestingLowerBounds/Sorry/Jensen.lean` — Jensen's inequality for conditional expectation
  (`ConvexOn.apply_condexp_le`). I searched Mathlib's `MeasureTheory/Function/ConditionalExpectation/`
  tree and could not find a direct equivalent; the convex-vs-condexp lemma is a substantial
  result in its own right.
- `TestingLowerBounds/Divergences/StatInfo/StatInfo.lean` — five sorry'd lemmas were *internal*
  (unused outside the file). I removed those lemma definitions, but the file as a whole still
  fails to build because of downstream API breakage in `FDiv.Basic`.
- `TestingLowerBounds/ForMathlib/CountableOrCountablyGenerated.lean` — three sorry'd
  `CountablyGenerated`-of-product lemmas; the only callers inside the same file were also
  removed. The remaining content is in the committed trimmed version above.

### Excluded transitively because they depend on the sorry'd files

- `TestingLowerBounds/CurvatureMeasure.lean` (imports `Sorry.ByParts` for `convex_taylor`).
- `TestingLowerBounds/FDiv/Trim.lean` and `FDiv/DPIJensen.lean` (both import `Sorry.Jensen`
  for `f_condexp_rnDeriv_le`).
- `TestingLowerBounds/Divergences/StatInfo/fDivStatInfo.lean` and
  `Divergences/StatInfo/DPI.lean` (depend on `CurvatureMeasure` and on `Trim`).
- `TestingLowerBounds/FindAxioms.lean` — uses `partial def` which lean-pool's quality
  checker rejects. The file is purely a `#axiom_blame` debug command, not used anywhere else.

### Excluded because of v4.13 → v4.30 Mathlib bumping pain

`ForMathlib/LeftRightDeriv.lean` is the load-bearing one: it defines `rightDeriv`/`leftDeriv`
and `rightDerivStieltjes`, which the entire divergence stack depends on. ~30 distinct error
sites in 631 lines. Sample of what broke:

- `[LinearOrderedField 𝕜]` is gone; the replacement `[Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜]`
  doesn't compose with the original `[Module 𝕜 F]`/`[OrderedAddCommMonoid β]` constraints
  (the latter is also deprecated).
- `derivWithin.comp` was replaced by `derivWithin_comp` with a different argument shape
  (the `UniqueDiffWithinAt` argument disappeared into the lemma body).
- `Filter.EventuallyEq.fderivWithin_eq_nhds` was renamed to `fderivWithin_eq` and now takes
  the extra `(hx : f₁ x = f x)` hypothesis.
- `add_pos` no longer applies to `EReal` because `AddLeftStrictMono EReal` doesn't hold
  (use `EReal.add_pos` instead).
- `Monotone.map_min` direction flipped when `mul_left_mono` / `mul_right_mono` swapped
  meanings, so the small `ENNReal.{min_mul, mul_min}` helpers needed to be re-derived.
- A handful of slope/`differentiableWithinAt`/`rightDeriv_eq_sInf_slope_of_mem_interior`
  lemmas have *also* moved into Mathlib (`Mathlib.Analysis.Convex.Deriv`), so naive copying
  collides with the upstream declarations.
- `MonotoneOn.tendsto_nhdsWithin_Ioi` was renamed to `MonotoneOn.tendsto_nhdsGT`, and the
  `right_continuous` proof for `rightDerivStieltjes` needs to be re-derived.
- `image_subset` is now `Set.image_subset`; `nonempty_of_nonempty_subtype` was removed.

Everything below `LeftRightDeriv.lean` in the import graph then cascades:

- `Convex.lean`, `DerivAtTop.lean` — depend on `rightDeriv` / `rightDerivStieltjes`.
- `FDiv/Basic.lean`, `FDiv/CompProd/*`, `FDiv/CondFDiv.lean`, `FDiv/CondFDivCompProdMeasure.lean`,
  `FDiv/IntegralRnDerivSingularPart.lean`, `FDiv/Measurable.lean` — depend on `DerivAtTop`.
- `Divergences/{KullbackLeibler/*, Hellinger.lean, CondHellinger.lean, Renyi.lean,
  CondRenyi.lean, Chernoff.lean, DeGroot.lean, EGamma.lean, TotalVariation.lean,
  StatInfo/StatInfo.lean, StatInfo/StatInfoFun.lean}` — depend on `FDiv.Basic`.
- `Testing/{Risk, Binary, BoolMeasure, ChangeMeasure, RenyiChangeMeasure, TwoHypKernel}.lean`,
  `SqHellinger.lean`, `ErealLLR.lean`, `MeasureCompProd.lean`, `CompProd.lean`,
  `IntegrableFRNDeriv.lean` — same.
- `ForMathlib/{LogLikelihoodRatioCompProd, RNDerivEqCondexp, RadonNikodym, RnDeriv}.lean`,
  `Kernel/BayesInv.lean`, `Kernel/ParallelComp.lean` — also need API touch-ups that I did
  not attempt once the divergence files were already known to be excluded.

## What was actually fixed in this session

Beyond the trimmed files above:

- Mathlib import path renames applied across all 47 originally-vendored files (`L1Space` →
  `L1Space.Integrable`, `MeasureTheory.Decomposition.RadonNikodym` →
  `Measure.Decomposition.RadonNikodym`, `Probability.Kernel.MeasureCompProd` →
  `Kernel.Composition.MeasureCompProd`, `Probability.Kernel.Composition` →
  `Kernel.Composition.CompProd`, `Probability.Moments` → `Moments.Basic`).
- Two `set_option push_neg.use_distrib true in push_neg` usages in `CondKL.lean` and
  `EReal.lean` rewritten to `push_neg; simp only [not_and_or, not_lt, ne_eq]`.
- All in-file 2024 copyrights bumped to 2026 to satisfy the lean-pool header regex.
- `Measure.comp_discard` rewritten against the current `Measure.bind_apply` (which now
  expects `AEMeasurable`, not `Measurable`).
- `quality.py` namespace-stack quirks worked around in `KernelFstSnd.lean` (removed
  `section FstSnd … end FstSnd` per the [[quality-check-section-in-namespace]] memory) and
  in `Integrable.lean` (nested `namespace Integrable` instead of `lemma Integrable.rnDeriv_smul`,
  per [[quality-check-dotted-decl-names]]).

## Recommended next steps if someone picks this up

1. Pour serious time into `ForMathlib/LeftRightDeriv.lean`: most of the obsolete content
   has Mathlib analogues now, and a clean rewrite (delete duplicates, port the few unique
   `rightDeriv*` lemmas, redo the `right_continuous` proof with `MonotoneOn.tendsto_nhdsGT`)
   should unblock most of the rest of the project.
2. After that, `DerivAtTop.lean`, `Convex.lean`, and `FDiv/Basic.lean` should mostly bump
   with minor `EReal`/`AddLeftStrictMono` adjustments.
3. The two sorry'd files in `Sorry/` are the only ones requiring genuine mathematical work
   to bump; a future contributor could either prove them or upstream `ConvexOn.apply_condexp_le`
   to Mathlib first.
