### PR TITLE
Import pcf-theory formalization

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -171,6 +171,13 @@ import LeanPool.Isoperimetric.Isoperimetric
 import LeanPool.Isoperimetric.PrekopaLeindler
 import LeanPool.LatticeTriangle
 import LeanPool.LatticeTriangle.Solution
+import LeanPool.PCFTheory
+import LeanPool.PCFTheory.Background
+import LeanPool.PCFTheory.Background.Club
+import LeanPool.PCFTheory.Background.Cofinality
+import LeanPool.PCFTheory.Background.Ordinal
+import LeanPool.PCFTheory.Background.Topology
+import LeanPool.PCFTheory.ClubGuessing
 import LeanPool.PartialRegularity
 import LeanPool.PartialRegularity.Extension
 import LeanPool.RamanujanTauMissesPrimes

--- a/LeanPool/PCFTheory.lean
+++ b/LeanPool/PCFTheory.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2026 YnirPaz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: YnirPaz
+-/
+
+import LeanPool.PCFTheory.Background
+import LeanPool.PCFTheory.ClubGuessing
+
+/-!
+# PCF Theory
+
+Source: url:https://github.com/YnirPaz/PCF-Theory
+Authors: YnirPaz
+Status: verified
+Main declarations: `Ordinal.exists_isClubGuessing_of_cof_uncountable`
+Tags: set-theory, cardinal-arithmetic, club-guessing
+MSC: 03E04, 03E10, 03E55
+-/
+
+/-!
+## Mathematical overview
+
+A formalization of foundational results from Shelah's Possible Cofinality (PCF)
+theory, following article 14, "Cardinal Arithmetic", in the *Handbook of Set
+Theory*.
+
+The project sets up the basic theory of clubs (closed and unbounded sets) and
+stationary sets below an ordinal, and uses it to prove a fundamental
+*club-guessing* existence result.
+
+## Main results
+
+- `Ordinal.IsClub` and `Ordinal.Club`: clubs below an ordinal.
+- `Ordinal.IsStationary`: stationary sets.
+- `Ordinal.IsClub.sInter`, `IsClub.iInter`, `IsClub.diagInter`: intersection
+  results showing that small intersections and diagonal intersections of clubs
+  are again clubs.
+- `Ordinal.IsClubGuessing`: definition of a club-guessing sequence.
+- `Ordinal.exists_isClubGuessing_of_cof_uncountable` (Handbook theorem 2.17):
+  let `Ϟ` be an ordinal and `S` a stationary subset of `Ϟ` whose elements all
+  have a common uncountable cofinality `κ` with `succ κ < Ϟ.cof`. Then there
+  exists a club-guessing sequence on `S`.
+
+## Provenance
+
+Imported from <https://github.com/YnirPaz/PCF-Theory>; ported from
+Lean v4.18.0-rc1 to Lean Pool's v4.30.0-rc2.
+-/

--- a/LeanPool/PCFTheory/Background.lean
+++ b/LeanPool/PCFTheory/Background.lean
@@ -1,0 +1,16 @@
+/-
+Copyright (c) 2026 YnirPaz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: YnirPaz
+-/
+
+import LeanPool.PCFTheory.Background.Club
+import LeanPool.PCFTheory.Background.Cofinality
+import LeanPool.PCFTheory.Background.Ordinal
+import LeanPool.PCFTheory.Background.Topology
+
+/-!
+# Background
+
+Import-only index for the `Background` directory of the PCF-theory import.
+-/

--- a/LeanPool/PCFTheory/Background/Club.lean
+++ b/LeanPool/PCFTheory/Background/Club.lean
@@ -1,0 +1,419 @@
+/-
+Copyright (c) 2026 YnirPaz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: YnirPaz
+-/
+
+import LeanPool.PCFTheory.Background.Cofinality
+import LeanPool.PCFTheory.Background.Topology
+
+/-!
+# Club and stationary sets
+
+This file sets up the basic theory of clubs (closed and unbounded sets) and stationary sets.
+
+## Main definitions
+
+* `Ordinal.IsClosed`: A set of ordinals `S` is closed in `o` if `S ⊆ Iio o`
+  and `S` contains every `x < o` such that `x.IsAcc S`.
+* `Ordinal.IsClub`: A set of ordinals `S` is a club in `o` if
+  it is closed in `o` and unbounded in `o`.
+
+## Main results
+
+* `isClub_sInter`: The intersection of fewer than `o.cof` clubs in `o` is a club in `o`.
+-/
+
+noncomputable section
+
+open Cardinal Set Order Filter
+
+universe u v
+
+namespace Ordinal
+
+/-- A set of ordinals is a club below an ordinal if it is closed and unbounded in it. -/
+def IsClub (C : Set Ordinal) (o : Ordinal) : Prop :=
+  IsClosedBelow C o ∧ IsAcc o C
+
+/-- A club below an ordinal `α` is a bundled `IsClub` set: closed and unbounded. -/
+structure Club (α : Ordinal) where
+  /-- The underlying set of ordinals. -/
+  carrier : Set Ordinal
+  /-- The proof that the carrier is a club below `α`. -/
+  isClub : IsClub carrier α
+
+instance {α : Ordinal} : SetLike (Club α) Ordinal where
+  coe := Club.carrier
+  coe_injective' s t h := by cases s; cases t; congr
+
+instance {α : Ordinal} : HasSubset (Club α) where
+  Subset := fun C D ↦ C.carrier ⊆ D.carrier
+
+instance {α : Ordinal} : HasSSubset (Club α) where
+  SSubset := fun C D ↦ C.carrier ⊂ D.carrier
+
+instance {α : Ordinal} : IsNonstrictStrictOrder (Club α) (· ⊆ ·) (· ⊂ ·) where
+  right_iff_left_not_left _ _ := Iff.rfl
+
+instance {α : Ordinal} : Std.Antisymm ((· ⊆ ·) : Club α → Club α → Prop) where
+  antisymm _ _ h h' := SetLike.coe_injective (Subset.antisymm h h')
+
+
+theorem isClub_iff {C : Set Ordinal} {o : Ordinal} : IsClub C o
+    ↔ ((∀ p < o, IsAcc p C → p ∈ C) ∧ (o ≠ 0 ∧ ∀ p < o, (C ∩ Ioo p o).Nonempty)) :=
+  and_congr isClosedBelow_iff (isAcc_iff _ _)
+
+namespace IsClub
+
+theorem isClosedBelow {C : Set Ordinal} {o : Ordinal} (h : IsClub C o) :
+    IsClosedBelow C o := h.1
+
+theorem isAcc {C : Set Ordinal} {o : Ordinal} (h : IsClub C o) : IsAcc o C := h.2
+
+theorem pos {C : Set Ordinal} {o : Ordinal} (h : IsClub C o) : 0 < o :=
+  h.isAcc.pos
+
+theorem ne_zero {C : Set Ordinal} {o : Ordinal} {h : IsClub C o} : o ≠ 0 :=
+  h.pos.ne.symm
+
+theorem mem_of_isAcc {C : Set Ordinal} {o p : Ordinal} (h : IsClub C o) (hp : p < o) :
+    IsAcc p C → p ∈ C := (isClub_iff.mp h).1 _ hp
+
+theorem forall_lt {o : Ordinal} {S : Set Ordinal} (h : o.IsClub S) :
+    ∀ p < o, (S ∩ Ioo p o).Nonempty := ((isAcc_iff _ _).mp h.isAcc).2
+
+theorem inter_Iio {C : Set Ordinal} {o : Ordinal} (h : IsClub C o) :
+    IsClub (C ∩ Iio o) o := by
+  apply isClub_iff.mpr
+  constructor
+  · exact fun p hpo hp ↦ ⟨h.mem_of_isAcc hpo (hp.mono inter_subset_left), hpo⟩
+  · refine ⟨h.pos.ne.symm, fun p hpo ↦ ?_⟩
+    convert h.isAcc.inter_Ioo_nonempty hpo using 1
+    ext; simp_all
+
+end IsClub
+
+theorem isClub_univ {α : Ordinal} (h : IsSuccLimit α) : IsClub Set.univ α := by
+  refine isClub_iff.mpr ⟨?_, ?_, ?_⟩
+  · exact fun _ _ _ ↦ mem_univ _
+  · exact h.bot_lt.ne.symm
+  · exact fun p plt ↦ ⟨succ p, ⟨mem_univ _, ⟨lt_succ _, h.succ_lt plt⟩⟩⟩
+
+/-- The trivial club consisting of every ordinal below a successor-limit `α`. -/
+def univ_club {α : Ordinal} (h : IsSuccLimit α) : Club α := ⟨Set.univ, isClub_univ h⟩
+
+namespace IsClub
+
+theorem isClub_of_isAcc {α β : Ordinal} {C : Set Ordinal} (h : β < α) (hC : IsClub C α)
+    (hacc : IsAcc β C) : IsClub C β := by
+  refine isClub_iff.mpr ⟨?_, ?_, ?_⟩
+  · exact fun p plt hp ↦ hC.mem_of_isAcc (plt.trans h) hp
+  · exact hacc.isSuccLimit.bot_lt.ne.symm
+  · exact fun p hp ↦ hacc.forall_lt p hp
+
+end IsClub
+
+
+
+variable {o : Ordinal.{u}} {S : Set (Set Ordinal)}
+variable {ι : Type u} {f : ι → Set Ordinal}
+
+/-- Given less than `o.cof` unbounded sets in `o` and some `q < o`, there is a `q < p < o`
+  such that `Ioo q p` contains an element of every unbounded set. -/
+theorem exists_above_of_lt_cof {p : Ordinal} (h : p < o) (hSemp : Nonempty S)
+    (hSacc : ∀ U ∈ S, o.IsAcc U) (hScard : #S < Cardinal.lift.{u + 1, u} o.cof) :
+    ∃ q < o, p < q ∧ ∀ U ∈ S, (U ∩ Ioo p q).Nonempty := by
+  rw [lift_cof] at hScard
+  have oLim : IsSuccLimit o := hSemp.casesOn fun ⟨T, hT⟩ ↦ (hSacc T hT).isSuccLimit
+  let f : ↑S → Ordinal := fun U ↦ lift.{u + 1, u} (sInf (U ∩ (Ioo p o)))
+  have infMem : ∀ U : S, sInf (↑U ∩ Ioo p o) ∈ ↑U ∩ Ioo p o := fun U ↦
+    csInf_mem ((hSacc U.1 U.2).inter_Ioo_nonempty h : (↑U ∩ Ioo p o).Nonempty)
+  have flto : ∀ U : S, f U < lift.{u + 1, u} o := fun U ↦ by
+    simp_all only [mem_inter_iff, mem_Ioo, lift_lt, f]
+  set q := (iSup f) + 1 with qdef
+  have qlto : q < lift.{u + 1, u} o :=
+    (isSuccLimit_lift.{u + 1, u}.mpr oLim).succ_lt (iSup_lt_of_lt_cof hScard flto)
+  rcases mem_range_lift_of_le qlto.le with ⟨q', hq'⟩
+  use q', lift_lt.mp (hq' ▸ qlto)
+  have fltq : ∀ U, f U < q := fun U ↦ by
+    convert lt_of_le_of_lt (le_ciSup (by apply bddAbove_of_small) U) (qdef ▸ lt_add_one (iSup f))
+  constructor <;> try constructor
+  · rcases hSemp with ⟨U, hU⟩
+    have pltf : lift.{u + 1, u} p < f ⟨U, hU⟩ :=
+      lift_lt.mpr (mem_of_mem_inter_right (infMem ⟨U, hU⟩)).1
+    have := lt_of_lt_of_le pltf (fltq ⟨U, hU⟩).le
+    rwa [← hq', lift_lt] at this
+  intro U hU
+  specialize infMem ⟨U, hU⟩
+  specialize fltq ⟨U, hU⟩
+  have : f ⟨U, hU⟩ ∈ Ioo (lift.{u + 1, u} p) q := ⟨lift_lt.mpr infMem.2.1, fltq⟩
+  rw [← hq'] at fltq
+  rcases mem_range_lift_of_le fltq.le with ⟨fUdown, fUlift⟩
+  use fUdown
+  constructor
+  · simp_all only [lift_inj, mem_inter_iff, f]
+  · exact ⟨lift_lt.mp <| fUlift ▸ (this.1), lift_lt.mp (hq'.symm ▸ (fUlift ▸ this).2)⟩
+
+/--
+Given a limit ordinal `o` and a property on pairs of ordinals `P`, such that
+for any `p < o` there is a `q < o` above `p` so that `P p q`, we can construct
+an increasing `ω`-sequence below `o` that satisfies `P` between every 2 consecutive elements.
+Additionaly, the sequence can begin arbitrarily high in `o`. That is, above any `r < o`.
+-/
+theorem exists_omega0_seq_succ_prop (opos : 0 < o) {P : Ordinal → Ordinal → Prop}
+    (hP : ∀ p : Iio o, ∃ q, (p < q ∧ P p q)) (r : Iio o) : ∃ f : (Iio ω) → Iio o,
+    (∀ i, P (f i) (f (succ i))) ∧ (∀ i j, (i < j) → f i < f j)
+    ∧ r < f ⟨0, omega0_pos⟩ := by
+  have oLim : IsSuccLimit o := isSuccLimit_iff'.mpr <|
+      ⟨opos.ne.symm, fun a alto ↦ (hP ⟨a, alto⟩).casesOn fun r hr ↦
+    lt_of_le_of_lt (succ_le_of_lt hr.1) r.2⟩
+  classical
+  let H₂ : (p : Iio ω) → (Iio o) → (Iio o) := fun _ fp ↦ Classical.choose (hP fp)
+  let H₃ : (w : Iio ω) → IsSuccLimit w.1 → ((o' : Iio ω) → o' < w → (Iio o)) → (Iio o) :=
+    fun _ _ _ ↦ ⟨0, oLim.bot_lt⟩
+  let f : Iio ω → Iio o := fun x ↦ @boundedLimitRec' ω isSuccLimit_omega0 (fun _ ↦ Iio o) x
+    (succ r) H₂ H₃
+  -- Key relation: f at successor equals chosen witness
+  have f_succ_eq : ∀ n : Iio ω,
+      f ⟨Order.succ n.1, isSuccLimit_omega0.succ_lt n.2⟩ = Classical.choose (hP (f n)) := by
+    intro n
+    change boundedLimitRec' isSuccLimit_omega0 ⟨Order.succ n.1, _⟩ (succ r) H₂ H₃ =
+      Classical.choose (hP (f n))
+    rw [@boundedLimitRec'_succ ω isSuccLimit_omega0 (fun _ ↦ Iio o) n (succ r) H₂ H₃]
+  -- The successor in Iio ω
+  have succ_eq : ∀ n : Iio ω,
+      (succ n : Iio ω) = ⟨Order.succ n.1, isSuccLimit_omega0.succ_lt n.2⟩ := fun n ↦
+    succ_Iio isSuccLimit_omega0.isSuccPrelimit
+  have f_succ : ∀ n : Iio ω, f (succ n) = Classical.choose (hP (f n)) := fun n ↦ by
+    rw [succ_eq n, f_succ_eq n]
+  use f
+  refine ⟨?_, ?_, ?_⟩
+  · intro n
+    rw [f_succ n]
+    exact (Classical.choose_spec (hP (f n))).2
+  · have aux : ∀ i, f i < f (succ i) := fun i ↦ by
+      rw [f_succ i]
+      exact (Classical.choose_spec (hP (f i))).1
+    exact strictMono_of_succ_lt_omega0 f aux
+  · have hf0 : f ⟨0, omega0_pos⟩ = succ r :=
+      @boundedLimitRec'_zero ω isSuccLimit_omega0 ((fun _ ↦ Iio o)) (succ r) H₂ H₃
+    rw [hf0]
+    change r.1 < (Order.succ r : Iio o).1
+    rw [coe_succ_Iio oLim.isSuccPrelimit]
+    exact lt_succ r.1
+
+/-- If between every 2 consecutive elements of a weakly increasing `δ`-sequence
+  there is an element of `C`, and `δ` is a limit ordinal,
+  then the supremum of the sequence is an accumulation point of `C`. -/
+theorem isAcc_iSup_of_between {δ : Ordinal.{u}} (C : Set Ordinal) (δLim : IsSuccLimit δ)
+    (s : Iio δ → Ordinal.{max u v}) (sInc : ∀ o, s o < s (succ o))
+    (h : ∀ o, (C ∩ (Icc (s o) (s (succ o)))).Nonempty) :
+    IsAcc (iSup s) C := by
+  rw [isAcc_iff]
+  constructor
+  · rw [← pos_iff_ne_zero, Ordinal.lt_iSup_iff]
+    use ⟨1, one_lt_of_isSuccLimit δLim⟩
+    refine lt_of_le_of_lt (bot_le (a := s ⟨0, δLim.bot_lt⟩)) ?_
+    convert sInc ⟨0, δLim.bot_lt⟩
+    rw [coe_succ_Iio δLim.isSuccPrelimit]
+    exact (zero_add (1 : Ordinal)).symm
+  intro p hp
+  rw [Ordinal.lt_iSup_iff] at hp
+  obtain ⟨r, hr⟩ := hp
+  obtain ⟨q, hq⟩ := h r
+  use q
+  refine ⟨hq.1, ⟨hr.trans_le hq.2.1, ?_⟩⟩
+  rw [Ordinal.lt_iSup_iff]
+  exact ⟨succ (succ r), hq.2.2.trans_lt (sInc (succ r))⟩
+
+namespace IsClub
+
+/--
+The intersection of less than `o.cof` clubs in `o` is a club in `o`.
+-/
+theorem sInter (hCof : ℵ₀ < o.cof) (hS : ∀ C ∈ S, IsClub C o) (hSemp : S.Nonempty)
+    (Scard : #S < Cardinal.lift.{u + 1, u} o.cof) : IsClub (⋂₀ S) o := by
+  refine ⟨IsClosedBelow.sInter (fun C CmemS ↦ (hS C CmemS).1), (isAcc_iff _ _).mpr ?_⟩
+  have nonemptyS : Nonempty S := hSemp.to_subtype
+  have oLim : IsSuccLimit o := one_lt_cof_iff.mp (one_lt_aleph0.trans_le hCof.le)
+  use oLim.bot_lt.ne.symm
+  intro p plto
+  let P : Ordinal → Ordinal → Prop := fun p q ↦ ∀ C ∈ S, (C ∩ Ioo p q).Nonempty
+  have auxP : ∀ p : Iio o, ∃ q, p < q ∧ P p q := fun p ↦ by
+    rcases exists_above_of_lt_cof p.2 nonemptyS (fun U hU ↦ (hS U hU).2) Scard with ⟨q, hq⟩
+    use ⟨q, hq.1⟩, hq.2.1, hq.2.2
+  rcases exists_omega0_seq_succ_prop.{u, u} oLim.bot_lt auxP ⟨p, plto⟩ with ⟨f, hf⟩
+  let sup := iSup (fun n ↦ (f n).1)
+  use sup
+  have suplt : sup < o := by
+    apply iSup_Iio_lt_ord (fun n ↦ (f n).2)
+    rwa [Cardinal.lift_id, Cardinal.lift_id, card_omega0]
+  constructor
+  · intro s hs
+    apply (hS s hs).1.forall_lt sup suplt
+    apply isAcc_iSup_of_between
+    · exact isSuccLimit_omega0
+    · intro n
+      rw [@Subtype.coe_lt_coe]
+      convert hf.2.1 n (succ n) ?_
+      · apply Subtype.coe_lt_coe.mp
+        rw [coe_succ_of_mem]
+        · exact lt_succ n.1
+        exact isSuccLimit_omega0.succ_lt n.2
+    · intro n
+      apply (hf.1 n s hs).mono
+      exact inter_subset_inter_right _ Ioo_subset_Icc_self
+  · constructor
+    · rw [Ordinal.lt_iSup_iff]
+      exact ⟨⟨0, omega0_pos⟩, hf.2.2⟩
+    · exact suplt
+
+theorem iInter_lift {ι : Type v} {f : ι → Set Ordinal.{u}} [Nonempty ι] (hCof : ℵ₀ < o.cof)
+    (hf : ∀ i, IsClub (f i) o) (ιCard : Cardinal.lift.{u} #ι < Cardinal.lift.{v} o.cof) :
+    IsClub (⋂ i, f i) o := by
+  refine IsClub.sInter (S := range f) hCof (fun y ⟨x, hx⟩ ↦ hx ▸ hf x) (range_nonempty f) ?_
+  have := mk_range_le_lift (f := f)
+  rw [← Cardinal.lift_lt.{_, max v (u + 1)}]
+  have aux : Cardinal.lift.{max v (u + 1), u + 1} #↑(range f) =
+      Cardinal.lift.{max v, u + 1} #↑(range f) := by
+    convert (@lift_umax_eq.{u + 1, u + 1, v} #(range f) #(range f)).mpr rfl
+    exact Cardinal.lift_umax.symm
+  rw [aux]
+  apply this.trans_lt
+  convert lift_strictMono.{max u v, max (u + 1) v} ιCard
+  · rw [Cardinal.lift_lift, Cardinal.lift_umax.{v, u + 1}]
+  · rw [Cardinal.lift_lift, Cardinal.lift_lift]
+
+theorem iInter [Nonempty ι] (hCof : ℵ₀ < o.cof) (hf : ∀ i, IsClub (f i) o)
+    (ιCard : #ι < o.cof) : IsClub (⋂ i, f i) o :=
+  IsClub.iInter_lift hCof hf (Cardinal.lift_lt.mpr ιCard)
+
+theorem inter {Ϟ : Ordinal.{u}} (hCof : ℵ₀ < Ϟ.cof) {C D : Set Ordinal}
+    (hC : IsClub C Ϟ) (hD : IsClub D Ϟ) : IsClub (C ∩ D) Ϟ := by
+  rw [← sInter_pair C D]
+  refine IsClub.sInter hCof ?_ ⟨C, mem_insert C _⟩ ?_
+  · intro E hE
+    rcases hE with hE | hE
+    · exact hE ▸ hC
+    · rcases hE with rfl
+      exact hD
+  · by_cases h : C = D
+    · subst h
+      simp only [pair_eq_singleton, mk_singleton]
+      rw [show (1 : Cardinal.{u + 1}) = Cardinal.lift.{u + 1, u} 1 by simp, Cardinal.lift_lt]
+      exact one_lt_aleph0.trans hCof
+    · have hne : C ∉ ({D} : Set (Set Ordinal)) := by simp [h]
+      rw [show ({C, D} : Set (Set Ordinal)) = insert C {D} from rfl,
+        Cardinal.mk_insert hne, mk_singleton]
+      rw [show ((1 : Cardinal.{u + 1}) + 1) = Cardinal.lift.{u + 1, u} 2 by simp; norm_num,
+        Cardinal.lift_lt]
+      exact two_lt_aleph0.trans hCof
+
+theorem iInter_Iio {Ϟ o : Ordinal.{u}} {p : Iio o} {f : Iio p → Set Ordinal}
+    (hϞ : ℵ₀ < Ϟ.cof) (h : p.1.card < Ϟ.cof) (hf : ∀ x, IsClub (f x) Ϟ) :
+    IsClub (⋂ α, f α) Ϟ := by
+  by_cases h : 0 < p.1
+  · have : Nonempty (Iio p) := ⟨⟨0, h.trans p.2⟩, h⟩
+    apply IsClub.iInter_lift hϞ hf
+    · rwa [mk_Iio_subtype, Cardinal.mk_Iio_ordinal, Cardinal.lift_lift, Cardinal.lift_lt]
+  · have hp0 : p.1 = 0 := (eq_zero_or_pos p.1).resolve_right h
+    have : IsEmpty (Iio p) := isEmpty_iff.mpr fun ⟨x, h'⟩ ↦ by
+      have h'' : x.1 < p.1 := h'
+      rw [hp0] at h''
+      exact (bot_le (a := x.1)).not_gt h''
+    rw [iInter_of_empty]
+    convert isClub_univ <| one_lt_cof_iff.mp (one_lt_aleph0.trans_le hϞ.le)
+
+end IsClub
+
+
+namespace IsClub
+
+/-- Accumulation points of a club form a club. -/
+theorem derivedSet {α : Ordinal.{u}} {C : Set Ordinal} (hcof : ℵ₀ < α.cof) (h : IsClub C α) :
+    IsClub (derivedSet C) α := by
+  rw [isClub_iff]
+  refine ⟨?_, h.ne_zero, ?_⟩
+  · intro p pltα pacc
+    change IsAcc _ _
+    rw [isAcc_iff]
+    refine ⟨pacc.pos.ne.symm, ?_⟩
+    intro q qltp
+    obtain ⟨x, hx⟩ := pacc.forall_lt q qltp
+    exact ⟨x, ⟨h.mem_of_isAcc (hx.2.2.trans pltα) hx.1, hx.2⟩⟩
+  · intro p pltα
+    obtain ⟨f, hf⟩ := exists_omega0_seq_succ_prop.{_, 0} (bot_lt_of_lt pltα) (P := fun _ x ↦ x ∈ C)
+      (fun p ↦ by
+        obtain ⟨x, hx⟩ := h.forall_lt p p.2
+        exact ⟨⟨x, hx.2.2⟩, ⟨hx.2.1, hx.1⟩⟩)
+      ⟨p, pltα⟩
+    use iSup (fun x ↦ f x)
+    constructor
+    · apply isAcc_iSup (o := ω) (α := ⟨0, omega0_pos⟩) isSuccLimit_omega0
+      · exact hf.2.1
+      · intro n h
+        convert hf.1 ⟨pred n, (pred_le_self n.1).trans_lt n.2⟩
+        rw [succ_Iio isSuccLimit_omega0.isSuccPrelimit]
+        apply SetCoe.ext
+        exact (succ_pred_of_finite (bot_lt_of_lt h) n.2).symm
+    · constructor
+      · exact (lt_ciSup_iff bddAbove_of_small).mpr ⟨⟨0, omega0_pos⟩, hf.2.2⟩
+      · apply iSup_Iio_lt_ord (fun i ↦ (f i).2)
+        rwa [card_omega0, lift_aleph0, Cardinal.lift_id']
+
+end IsClub
+
+theorem exists_unbounded_Iio_cof {α : Ordinal} (hlim : IsSuccLimit α) : ∃ S, S ⊆ Iio α ∧ IsAcc α S
+    ∧ #S = Cardinal.lift.{u + 1, u} α.cof := by
+  have h_t_lim : IsSuccLimit (type (· < · : ↑(Iio α) → ↑(Iio α) → Prop)) := by
+    rw [type_lt_Iio]
+    exact isSuccLimit_lift.mpr hlim
+  obtain ⟨S, hUnb, hCard⟩ :=
+    Ordinal.cof_eq' (· < · : ↑(Iio α) → ↑(Iio α) → Prop) h_t_lim
+  refine ⟨Subtype.val '' S, ?_, ?_, ?_⟩
+  · exact Subtype.coe_image_subset (Iio α) S
+  · rw [isAcc_iff]
+    refine ⟨hlim.bot_lt.ne.symm, ?_⟩
+    intro β βltα
+    obtain ⟨x, hx⟩ := hUnb ⟨succ β, hlim.succ_lt βltα⟩
+    refine ⟨x.1, ⟨x, hx.1, rfl⟩, ?_, x.2⟩
+    have hx2 : succ β < x.1 := hx.2
+    exact (lt_succ β).trans hx2
+  · rw [Cardinal.mk_image_eq Subtype.val_injective, hCard, type_lt_Iio, lift_cof]
+
+theorem exists_club_card {o : Ordinal.{u}} (h : IsSuccLimit o) :
+    ∃ C : Club o, #C = Cardinal.lift.{u + 1, u} o.cof := by
+  obtain ⟨S, hS⟩ := exists_unbounded_Iio_cof h
+  let C := S ∪ (derivedSet S)
+  use ⟨C, ⟨isClosedBelow_derivedSet o, hS.2.1.mono subset_union_left⟩⟩
+  apply (hS.2.2 ▸ mk_le_mk_of_subset subset_union_left).antisymm'
+  calc
+    #C ≤ #S + #(derivedSet S) := mk_union_le _ _
+    _ ≤ #S + #S := by gcongr; exact mk_derivedSet_le S
+    _ = max #S #S := add_eq_max <| by
+      rw [hS.2.2, ← lift_aleph0.{u + 1, u}, Cardinal.lift_le]
+      exact aleph0_le_cof_iff.mpr (one_lt_cof_iff.mpr h)
+    _ = #S := max_self _
+    _ = Cardinal.lift.{u + 1, u} o.cof := hS.2.2
+
+/-- A set of ordinals is stationary below an ordinal if it intersects every club of it. -/
+def IsStationary (S : Set Ordinal) (o : Ordinal) : Prop :=
+  ∀ C, IsClub C o → (S ∩ C).Nonempty
+
+namespace IsStationary
+
+theorem inter_Iio {o : Ordinal} {S : Set Ordinal} (hS : IsStationary S o) :
+    IsStationary (S ∩ Iio o) o := by
+  intro C hC
+  convert hS _ hC.inter_Iio using 1
+  rw [inter_comm C, inter_assoc]
+
+theorem inter_isClub {o : Ordinal} {S C : Set Ordinal} (hS : IsStationary S o)
+    (hC : IsClub C o) : (S ∩ C ∩ (Iio o)).Nonempty := by
+  have := hS.inter_Iio C hC
+  rwa [inter_assoc, inter_comm C, ← inter_assoc]
+
+end IsStationary
+
+end Ordinal

--- a/LeanPool/PCFTheory/Background/Cofinality.lean
+++ b/LeanPool/PCFTheory/Background/Cofinality.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2026 YnirPaz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: YnirPaz
+-/
+
+import Mathlib.SetTheory.Cardinal.Cofinality
+import LeanPool.PCFTheory.Background.Ordinal
+
+/-!
+# Cofinality results for indexed suprema
+
+A more general universe version of `iSup_lt_ord_lift` and a related corollary
+phrased in terms of `Iio`.
+-/
+
+universe u v
+
+open Cardinal Set
+
+namespace Ordinal
+
+/-- A version of `lift_iSup_lt_of_lt_cof` with more general universes. -/
+theorem iSup_lt_ord_lift' {ι : Type v} {f : ι → Ordinal.{u}} {c : Ordinal.{u}}
+    (hι : Cardinal.lift.{u} #ι < Cardinal.lift.{v} c.cof) : (∀ i, f i < c) → iSup f < c :=
+  fun h ↦ lift_iSup_lt_of_lt_cof (by rw [← lift_cof]; exact hι) h
+
+theorem iSup_Iio_lt_ord {δ : Ordinal.{u}} {ℓ : Ordinal.{v}} {f : Iio ℓ → Ordinal.{u}}
+    (hf : ∀ i, f i < δ) (hcard : Cardinal.lift.{u} ℓ.card < Cardinal.lift.{v} δ.cof) :
+    iSup f < δ := by
+  refine iSup_lt_ord_lift' ?_ hf
+  · rw [Cardinal.mk_Iio_ordinal, Cardinal.lift_lift]
+    have aux1 : Cardinal.lift.{max (v + 1) u, v} ℓ.card =
+      Cardinal.lift.{v + 1} (Cardinal.lift.{u, v} ℓ.card) := (Cardinal.lift_lift _).symm
+    have aux2 : Cardinal.lift.{v + 1, u} δ.cof =
+      Cardinal.lift.{v + 1} (Cardinal.lift.{v, u} δ.cof) := (Cardinal.lift_lift _).symm
+    rwa [aux1, aux2, Cardinal.lift_lt]
+
+end Ordinal

--- a/LeanPool/PCFTheory/Background/Ordinal.lean
+++ b/LeanPool/PCFTheory/Background/Ordinal.lean
@@ -1,0 +1,198 @@
+/-
+Copyright (c) 2026 YnirPaz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: YnirPaz
+-/
+
+import Mathlib.SetTheory.Ordinal.Arithmetic
+import Mathlib.SetTheory.Cardinal.Cofinality
+import Mathlib.Order.SuccPred.Limit
+
+/-!
+# Background lemmas on ordinals
+
+Auxiliary results about ordinals and recursion on bounded ordinals used in the
+PCF-theory formalization.
+-/
+
+noncomputable section
+
+universe u v w
+
+open Set Order Cardinal
+
+namespace Ordinal
+
+instance : Nonempty (Iio omega0.{u}) := ⟨0, omega0_pos⟩
+
+theorem coe_succ_Iio {α : Type*} [PartialOrder α] [SuccOrder α] {a : α} (h : IsSuccPrelimit a)
+    {x : Iio a} : (succ x).1 = succ x.1 := by
+  apply coe_succ_of_mem
+  have := Subtype.mem x
+  rw [mem_Iio] at this ⊢
+  exact h.succ_lt this
+
+theorem succ_Iio {α : Type*} [PartialOrder α] [SuccOrder α] {a : α} (h : IsSuccPrelimit a)
+    {x : Iio a} : succ x = ⟨succ x.1, h.succ_lt x.2⟩ :=
+  Subtype.val_inj.mp <| coe_succ_Iio h
+
+/-- The order isomorphism between ℕ and the first ω ordinals. -/
+@[simps! apply]
+def relIso_nat_omega0 : ℕ ≃o Iio ω where
+  toFun n := ⟨n, natCast_lt_omega0 n⟩
+  invFun n := Classical.choose (lt_omega0.1 n.2)
+  left_inv n := by
+    have h : ∃ m : ℕ, n = (m : Ordinal) := ⟨n, rfl⟩
+    exact (Nat.cast_inj.1 (Classical.choose_spec h)).symm
+  right_inv n := Subtype.ext (Classical.choose_spec (lt_omega0.1 n.2)).symm
+  map_rel_iff' := by simp
+
+@[simp]
+theorem relIso_nat_omega0_coe_symm_apply (o : Iio ω) : relIso_nat_omega0.symm o = o.1 := by
+  obtain ⟨o, h⟩ := o
+  rcases lt_omega0.mp h with ⟨n, hn⟩
+  simp_rw [hn]
+  exact congrArg Nat.cast <| relIso_nat_omega0.symm_apply_apply n
+
+theorem strictMono_of_succ_lt_omega0 {α : Type*} [Preorder α] (f : Iio ω → α)
+    (hf : ∀ i, f i < f (succ i)) : StrictMono f := by
+  have mono := strictMono_nat_of_lt_succ fun n ↦
+    (succ_Iio isSuccLimit_omega0.isSuccPrelimit) ▸ hf ⟨n, natCast_lt_omega0 n⟩
+  convert mono.comp relIso_nat_omega0.symm.strictMono
+  ext
+  simp
+
+/-- The lift of a supremum is the supremum of the lifts. -/
+theorem lift_sSup {s : Set Ordinal} (hs : BddAbove s) :
+    lift.{u} (sSup s) = sSup (lift.{u} '' s) := by
+  apply ((le_csSup_iff' (Ordinal.bddAbove_image.{_,u} hs _)).2 fun c hc => _).antisymm (csSup_le' _)
+  · intro c hc
+    by_contra h
+    have := (not_le.1 h).le
+    obtain ⟨d, rfl⟩ := mem_range_lift_of_le this
+    simp_rw [lift_le] at h hc
+    rw [csSup_le_iff' hs] at h
+    exact h fun a ha => lift_le.1 <| hc (mem_image_of_mem _ ha)
+  · rintro i ⟨j, hj, rfl⟩
+    exact lift_le.2 (le_csSup hs hj)
+
+/-- The lift of a supremum is the supremum of the lifts. -/
+theorem lift_iSup {ι : Type v} {f : ι → Ordinal.{w}} (hf : BddAbove (range f)) :
+    lift.{u} (iSup f) = ⨆ i, lift.{u} (f i) := by
+  rw [iSup, iSup, lift_sSup hf, ← range_comp]
+  simp [Function.comp_def]
+
+
+/-- Strong recursion on `Iio l`: given a recursor that builds `C o` from values of `C` on
+all predecessors `o' : Iio o`, we get a function `(o : Iio l) → C o`. -/
+@[elab_as_elim]
+def boundedRec {l : Ordinal} {C : Iio l → Sort*}
+    (H : (o : Iio l) → ((o' : Iio o) → C o') → C o) (o : Iio l) : C o :=
+  lt_wf.fix (C := fun p ↦ (h : p < l) → C ⟨p, h⟩)
+    (fun o h h' ↦ H ⟨o, h'⟩ fun o' ↦ h o'.1 o'.2 (o'.2.trans h')) o o.2
+
+theorem boundedRec_eq {l} {C} (H o) :
+    @boundedRec l C H o = H o (fun o' ↦ @boundedRec l C H o') := by
+  rcases o with ⟨o, ho⟩
+  unfold boundedRec
+  rw [WellFounded.fix_eq]
+  rfl
+
+/-- Bounded version of `limitRecOn`: an `Iio l` version that mirrors the deprecated
+`boundedLimitRecOn` API used in PCF-theory. -/
+@[elab_as_elim]
+def boundedLimitRec' {l : Ordinal} (lLim : IsSuccLimit l) {motive : Iio l → Sort*} (o : Iio l)
+    (zero : motive ⟨0, lLim.bot_lt⟩)
+    (succAux : (o : Iio l) → motive o → motive ⟨Order.succ o.1, lLim.succ_lt o.2⟩)
+    (limit : (o : Iio l) → IsSuccLimit o.1 → (Π o' < o, motive o') → motive o) :
+    motive o := by
+  obtain ⟨o, ho⟩ := o
+  induction o using limitRecOn with
+  | zero => exact zero
+  | succ o IH =>
+    have ho' : o < l := (lt_succ o).trans ho
+    exact succAux ⟨o, ho'⟩ (IH ho')
+  | limit o ho' IH => exact limit ⟨o, ho⟩ ho' fun a ha ↦ IH a.1 ha (ha.trans (c := l) ho)
+
+theorem boundedLimitRec'_zero {l} (lLim : IsSuccLimit l) {motive} (H₁ H₂ H₃) :
+    @boundedLimitRec' l lLim motive ⟨0, lLim.bot_lt⟩ H₁ H₂ H₃ = H₁ := by
+  unfold boundedLimitRec'
+  dsimp
+  rw [limitRecOn_zero]
+
+theorem boundedLimitRec'_succ {l} (lLim : IsSuccLimit l) {motive} (o H₁ H₂ H₃) :
+    @boundedLimitRec' l lLim motive ⟨Order.succ o.1, lLim.succ_lt o.2⟩ H₁ H₂ H₃ = H₂ o
+    (@boundedLimitRec' l lLim motive o H₁ H₂ H₃) := by
+  unfold boundedLimitRec'
+  dsimp
+  rw [limitRecOn_succ]
+  rfl
+
+/-- There doesn't exist a chain of subsets of `S` of length longer than `#S`. -/
+theorem not_exists_ssubset_chain_lift {α : Type u} {S : Set α} {ℓ : Ordinal.{v}}
+    (hℓ : IsSuccLimit ℓ)
+    (h : Cardinal.lift.{v, u} #S < Cardinal.lift.{u, v} ℓ.card) :
+    ¬ ∃ f : Iio ℓ → Set α, (∀ o, f o ⊆ S) ∧ (∀ o p, o < p → f p ⊂ f o) := by
+  rintro ⟨f, hf⟩
+  have hsub : ∀ (o p : ↑(Iio ℓ)), o ≤ p → f p ⊆ f o := by
+    intro o p h
+    rcases h.lt_or_eq with h' | h'
+    · exact (hf.2 _ _ h').subset
+    · rw [h']
+  suffices g : Iio ℓ ↪ S by
+    have hle : Cardinal.lift.{u, v + 1} #(↑(Iio ℓ)) ≤ Cardinal.lift.{v + 1, u} #↑S :=
+      lift_mk_le'.mpr ⟨g⟩
+    have hnlt := hle.not_gt
+    rw [Cardinal.mk_Iio_ordinal, Cardinal.lift_lift] at hnlt
+    apply hnlt
+    have aux1 : Cardinal.lift.{v + 1, u} #↑S = Cardinal.lift.{v + 1} (Cardinal.lift.{v, u} #↑S) :=
+      (Cardinal.lift_lift _).symm
+    have aux2 : Cardinal.lift.{max (v + 1) u, v} ℓ.card =
+        Cardinal.lift.{v + 1} (Cardinal.lift.{u, v} ℓ.card) := (Cardinal.lift_lift _).symm
+    rwa [aux1, aux2, Cardinal.lift_lt]
+  use fun i ↦ by
+    have := hf.2 i (succ i) (by
+      change i.1 < (succ i).1
+      rw [coe_succ_Iio hℓ.isSuccPrelimit]
+      exact lt_succ _)
+    let x := Classical.choose <| exists_of_ssubset this
+    have xmemS : x ∈ S := hf.1 i (((exists_of_ssubset this).choose_spec).1)
+    exact ⟨x, xmemS⟩
+  intro i j
+  simp only [Subtype.mk.injEq]
+  intro h
+  generalize_proofs _ pfi pfj at h
+  have spec := Classical.choose_spec pfi
+  have spec' := h ▸ Classical.choose_spec pfj
+  refine ((lt_trichotomy i j).resolve_left ?_).resolve_right ?_
+  · intro ho
+    have : succ i ≤ j := succ_le_of_lt ho
+    exact spec.2 <| hsub _ _ this spec'.1
+  · intro ho
+    have : succ j ≤ i := succ_le_of_lt ho
+    exact spec'.2 <| hsub _ _ this spec.1
+
+theorem mk_Iio_subtype {o : Ordinal} {p : Iio o} : #(Iio p) = #(Iio p.1) := by
+  apply mk_congr
+  let f : Iio p → Iio p.1 := fun ⟨x, h⟩ ↦ ⟨x, h⟩
+  let g : Iio p.1 → Iio p := fun ⟨x, h⟩ ↦ ⟨⟨x,
+    have : p.1 < o := p.2
+    have := h.trans this
+    this⟩, h⟩
+  exact ⟨f, g, congrFun rfl, congrFun rfl⟩
+
+theorem two_lt_aleph0 : 2 < ℵ₀ := natCast_lt_aleph0
+
+theorem succ_pred_of_finite {o : Ordinal} (h : 0 < o) (h' : o < ω) : succ o.pred = o := by
+  apply succ_pred_eq_iff_not_isSuccPrelimit.mpr
+  intro hl
+  have hlim : IsSuccLimit o := ⟨by rw [isMin_iff_eq_bot]; exact h.ne_bot, hl⟩
+  exact (omega0_le_of_isSuccLimit hlim).not_gt h'
+
+theorem type_Iio (α : Ordinal.{u}) : type (· < · : Iio α → Iio α → Prop) = lift.{u + 1} α :=
+  type_lt_Iio α
+
+theorem isSuccLimit_iff' {o : Ordinal} : IsSuccLimit o ↔ o ≠ 0 ∧ ∀ x < o, succ x < o := by
+  rw [Ordinal.isSuccLimit_iff, isSuccPrelimit_iff_succ_lt]
+
+end Ordinal

--- a/LeanPool/PCFTheory/Background/Topology.lean
+++ b/LeanPool/PCFTheory/Background/Topology.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 YnirPaz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: YnirPaz
+-/
+
+import Mathlib.SetTheory.Ordinal.Topology
+import Mathlib.Topology.DerivedSet
+import LeanPool.PCFTheory.Background.Ordinal
+
+/-!
+# Topological results on ordinals
+
+A handful of order-topological facts used to set up the theory of clubs.
+-/
+
+open Set Order Cardinal
+
+universe u v
+
+namespace Ordinal
+
+-- Small.{u} → Small.{max u v} isn't properly synthed, so this instance is required.
+instance {o : Ordinal.{u}} : Small.{max u v} (Iio o) := small_lift (Iio o)
+
+/-- If `o` is a successor limit, `Iio o` has no maximal element. -/
+theorem instNoMaxOrderIio {o : Ordinal} (h : IsSuccLimit o) : NoMaxOrder (Iio o) := by
+  constructor
+  rintro ⟨a, ha⟩
+  refine ⟨⟨Order.succ a, h.succ_lt ha⟩, ?_⟩
+  exact Subtype.mk_lt_mk.mpr (lt_succ a)
+
+namespace IsAcc
+
+theorem inter_Ioi {o p : Ordinal} {S : Set Ordinal} (h : o.IsAcc S) (hp : p < o) :
+    o.IsAcc (S ∩ Ioi p) := by
+  rw [isAcc_iff]
+  refine ⟨h.pos.ne.symm, fun q hq ↦ ?_⟩
+  obtain ⟨x, xmem⟩ := h.forall_lt (max p q) (max_lt hp hq)
+  use x
+  exact ⟨⟨xmem.1, (max_lt_iff.mp xmem.2.1).1⟩, ⟨(max_lt_iff.mp xmem.2.1).2, xmem.2.2⟩⟩
+
+end IsAcc
+
+theorem isAcc_iSup {o : Ordinal.{u}} {α : Iio o} (ho : IsSuccLimit o) (f : Iio o → Ordinal.{v})
+    [Small.{v} (Iio o)] (hf : ∀ α β, α < β → f α < f β) {S : Set Ordinal}
+    (hp : ∀ β, α < β → f β ∈ S) :
+    (iSup f).IsAcc S := by
+  have hone : (1 : Ordinal) < o := one_lt_of_isSuccLimit ho
+  have : NoMaxOrder ↑(Iio o) := instNoMaxOrderIio ho
+  have : Nonempty (Iio o) := ⟨⟨0, ho.bot_lt⟩⟩
+  rw [isAcc_iff]
+  constructor
+  · have flt := hf ⟨0, ho.bot_lt⟩ ⟨1, hone⟩ (Subtype.mk_lt_mk.mpr zero_lt_one)
+    have lesup := le_ciSup (f := f) bddAbove_of_small ⟨1, hone⟩
+    intro h
+    have := h ▸ bot_lt_of_lt (flt.trans_le lesup)
+    exact not_lt_bot this
+  · intro β hβ
+    obtain ⟨γ, hγ⟩ := (lt_ciSup_iff bddAbove_of_small).mp hβ
+    use f (succ (max α γ))
+    constructor
+    · exact hp (succ (max α γ)) <| (le_max_left α γ).trans_lt (lt_succ (max α γ))
+    · constructor
+      · exact hγ.trans <| hf _ _ <| (le_max_right α γ).trans_lt (lt_succ (max α γ))
+      · apply (lt_ciSup_iff bddAbove_of_small).mpr
+        use succ (succ (max α γ))
+        exact hf _ _ (lt_succ _)
+
+open Classical in
+theorem mk_derivedSet_le (S : Set Ordinal) : #(derivedSet S) ≤ #S := by
+  by_cases hS : S.Finite
+  · exact mk_le_mk_of_subset <| (isClosed_iff_derivedSet_subset _).mp hS.isClosed
+  /- `f` sends each accumulation point of `S` to the smallest element of `S` above it,
+  if it exists. This is an injection from the accumulation points to `Option S`. -/
+  let f : derivedSet S → Option S := fun δ ↦ if h : (S ∩ Ioi δ).Nonempty then
+    some ⟨sInf (S ∩ Ioi δ.1), inter_subset_left (csInf_mem h)⟩
+    else none
+  suffices hf : Function.Injective f by
+    convert mk_le_of_injective hf using 1
+    rw [mk_option]
+    refine (add_one_of_aleph0_le ?_).symm
+    exact infinite_iff.mp (infinite_coe_iff.mpr hS)
+  intro a b hab
+  apply Subtype.ext
+  -- Helper: derive a contradiction when `a.1 < b.1` (in any LT instance) and `f a = f b`.
+  suffices aux : ∀ (a b : derivedSet S),
+      (a.1 < b.1 : Prop) → f a = f b → a.1 = b.1 by
+    rcases lt_trichotomy a.1 b.1 with h | h | h
+    · exact aux a b h hab
+    · exact h
+    · exact (aux b a h hab.symm).symm
+  clear hab a b
+  intro a b altb hab
+  exfalso
+  by_cases ha : (S ∩ Ioi a.1).Nonempty
+  · by_cases hb : (S ∩ Ioi b.1).Nonempty
+    · unfold f at hab
+      rw [dif_pos ha, dif_pos hb, Option.some_inj] at hab
+      have heq : sInf (S ∩ Ioi a.1) = sInf (S ∩ Ioi b.1) := congrArg Subtype.val hab
+      have blt : b.1 ≤ sInf (S ∩ Ioi b.1) := le_csInf hb fun _ ⟨_, h⟩ ↦ h.le
+      obtain ⟨x, hx⟩ := IsAcc.forall_lt b.2 a.1 altb
+      have hkey : sInf (S ∩ Ioi a.1) < b.1 :=
+        csInf_lt_of_lt (a := x) (OrderBot.bddBelow _) ⟨hx.1, hx.2.1⟩ hx.2.2
+      have hcontra : sInf (S ∩ Ioi b.1) < b.1 := heq ▸ hkey
+      exact lt_irrefl _ (lt_of_lt_of_le hcontra blt)
+    · unfold f at hab
+      rw [dif_pos ha, dif_neg hb] at hab
+      cases hab
+  · obtain ⟨x, hx⟩ := IsAcc.forall_lt b.2 a.1 altb
+    exact ha ⟨x, ⟨hx.1, hx.2.1⟩⟩
+
+
+theorem isClosedBelow_derivedSet {S : Set Ordinal} :
+    ∀ o, IsClosedBelow (S ∪ (derivedSet S)) o := fun o ↦ by
+  rw [isClosedBelow_iff]
+  intro p plto pacc
+  right
+  apply (isAcc_iff _ _).mpr
+  refine ⟨(IsAcc.pos pacc).ne.symm, ?_⟩
+  intro q qltp
+  obtain ⟨x, hx⟩ := IsAcc.forall_lt pacc q qltp
+  rcases hx.1 with xs | xds
+  · exact ⟨x, ⟨xs, hx.2⟩⟩
+  obtain ⟨y, hy⟩ := IsAcc.forall_lt xds q hx.2.1
+  exact ⟨y, ⟨hy.1, ⟨hy.2.1, hy.2.2.trans hx.2.2⟩⟩⟩
+
+end Ordinal

--- a/LeanPool/PCFTheory/ClubGuessing.lean
+++ b/LeanPool/PCFTheory/ClubGuessing.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2026 YnirPaz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: YnirPaz
+-/
+
+import LeanPool.PCFTheory.Background.Club
+
+/-!
+# Club guessing
+
+This file formalizes `theorem 2.17` in the chapter "Cardinal Arithmetic" in the "Handbook
+of set theory."
+
+For `δ` an ordinal, let `S ⊆ δ`, and `f : (α : S) → Club α` a function assigning a club
+to each element of `S`.
+Then `f` is said to be "club guessing" if for every club of `δ`, `C : Club δ`, there is some
+`α ∈ S` such that `f α ⊆ C`. That is, `f` guesses `C` at `α`.
+
+There are many existence results on club guessing sequences. The one we need is `theorem 2.17`:
+  Let `Ϟ` be an ordinal and let `S` be a stationary set below `Ϟ`, such that every
+  element of `S` has the same cofinality `κ`. Further assume `succ κ < Ϟ.cof`.
+  Then there exists a club guessing sequence on `S`.
+
+## Main definitions
+
+* `Ordinal.IsClubGuessing {S} f γ` says `f : (α : S) → Club α` is a club guessing sequence for `γ`.
+  Unlike in the typical definition, we don't assume `S ⊆ Iio γ`. This makes no mathematical
+  difference but allows us to have `IsClubGuessing f γ` for many different `γ`.
+
+## Main results
+
+* `Ordinal.exists_isClubGuessing_of_cof_uncountable`: Let `Ϟ` be an ordinal and `S` stationary below
+  `Ϟ`, such that `∀ α ∈ S, α.cof = κ`, for a constant `κ` satisfying `succ κ < Ϟ.cof`.
+  Assume also that `ℵ₀ < κ`. Then there exists `f : (α : S) → Club α` that is club guessing
+  below `Ϟ`.
+-/
+
+noncomputable section
+
+open Cardinal Order Set
+
+universe u
+
+namespace Ordinal
+
+/-- `f : (α : S) → Club α` is a *club-guessing sequence for `γ`* when every club of `γ`
+contains the carrier of `f α` for some `α ∈ S`. -/
+def IsClubGuessing {S : Set Ordinal} (f : (α : S) → Club α) (γ : Ordinal) : Prop :=
+  ∀ C : Club γ, ∃ δ, (f δ).carrier ⊆ C.carrier
+
+theorem exists_club_of_not_isClubGuessing {S : Set Ordinal} {γ : Ordinal} (f : (α : S) → Club α)
+    (h : ¬ IsClubGuessing f γ) : ∃ C : Club γ, ∀ δ, ¬ (f δ).carrier ⊆ C := by
+  dsimp [IsClubGuessing] at h
+  push Not at h
+  exact h
+
+namespace ClubGuessing
+
+/-- The assumptions of the theorem and `hCont`, which says the result is false. -/
+class Assumptions where
+  /-- The ambient ordinal `Ϟ` below which we build the club-guessing sequence. -/
+  Ϟ : Ordinal.{u}
+  /-- The common cofinality `κ` of all elements of the stationary set `S`. -/
+  κ : Cardinal.{u}
+  /-- Hypothesis: `κ` is uncountable. -/
+  hκ : ℵ₀ < κ
+  /-- Hypothesis: `succ κ < Ϟ.cof`. -/
+  hcof : succ κ < Ϟ.cof
+  /-- The stationary set on which we build the club-guessing sequence. -/
+  S : Set Ordinal.{u}
+  /-- Hypothesis: `S` is stationary below `Ϟ`. -/
+  hStat : IsStationary S Ϟ
+  /-- Hypothesis: `S` is a subset of `Iio Ϟ`. -/
+  hSub : S ⊆ Iio Ϟ
+  /-- Hypothesis: every element of `S` has cofinality `κ`. -/
+  hS : ∀ α ∈ S, α.cof = κ
+  /-- Contradictory hypothesis used for the proof by contradiction: there is no
+  club-guessing sequence. -/
+  hCont : ∀ f : (α : S) → Club.{u} α, ¬ IsClubGuessing f Ϟ
+
+namespace Assumptions
+variable [assumptions : Assumptions.{u}]
+
+instance : Nonempty (Iio (succ κ).ord) := ⟨0,
+  ord_zero ▸ (ord_lt_ord.mpr <| (aleph0_pos.trans hκ).trans (lt_succ κ))⟩
+
+theorem isSuccLimit_of_mem_S {α : S} : IsSuccLimit α.1 :=
+  one_lt_cof_iff.mp (one_lt_aleph0.trans_le (hS α α.2 ▸ hκ).le)
+
+theorem aleph0_lt_cof_Ϟ : ℵ₀ < Ϟ.cof := by
+    calc
+      ℵ₀ < κ := hκ
+      _ < succ κ := lt_succ _
+      _ < Ϟ.cof := hcof
+
+/-- A first attempt at a club-guessing sequence: pick an arbitrary club of cardinality `κ`
+below each element of `S`. -/
+def f : (α : S) → Club α := fun _ ↦ Classical.choose <| exists_club_card isSuccLimit_of_mem_S
+
+/-- Given a club `E` of `Ϟ` not guessed by `f`, we "force" `f` to guess `E` at every
+point in `S` that is an accumulation point of `E` by intersecting every `f α` with `E`. -/
+def restrict (E : Club Ϟ) : (α : S) → Club α := fun α ↦
+  open Classical in
+  if h : IsAcc α.1 E then
+    ⟨(f α).1 ∩ E,
+      IsClub.inter (hS α α.2 ▸ hκ) (f α).2 <| IsClub.isClub_of_isAcc (hSub α.2) E.2 h⟩
+  else univ_club isSuccLimit_of_mem_S
+
+/-- The sequence of clubs `E_α` obtained by repeatedly choosing a club not guessed by the
+current restriction of `f`. -/
+def F : Iio (succ κ).ord → Club Ϟ := by
+  refine @boundedRec (succ κ).ord (fun _ ↦ Club Ϟ) fun o ih ↦
+    Classical.choose <| exists_club_of_not_isClubGuessing _
+      ((hCont <| restrict ⟨⋂ α, ih α, ?_⟩))
+  apply IsClub.iInter_Iio aleph0_lt_cof_Ϟ
+  · exact (lt_ord.mp o.2).trans hcof
+  · exact fun x ↦ (ih x).isClub
+
+/-- Prefix intersections of `F`. -/
+def F' : Iio (succ κ).ord → Club Ϟ := fun δ ↦ ⟨⋂ α : Iio δ, F α,
+  IsClub.iInter_Iio aleph0_lt_cof_Ϟ ((lt_ord.mp δ.2).trans hcof) fun x ↦ (F x).2⟩
+
+/-- The intersection of all clubs `F α` for `α < succ κ`. -/
+def E : Club Ϟ := ⟨⋂ α : Iio (succ κ).ord, F α, by
+  apply IsClub.iInter_lift aleph0_lt_cof_Ϟ fun i ↦ (F i).2
+  rw [Cardinal.mk_Iio_ordinal, Cardinal.lift_lift, Cardinal.lift_lt, card_ord]
+  exact hcof⟩
+
+/-- Since `E` is a club and `S` is stationary, there is some `α ∈ S ∩ E'`; this is one
+such witness. -/
+def α : assumptions.S := by
+  have : Set.Nonempty _ := hStat.inter_isClub (E.2.derivedSet aleph0_lt_cof_Ϟ)
+  exact ⟨Classical.choose this, (Classical.choose_spec this).1.1⟩
+
+theorem isAcc_α : IsAcc α E := by
+  unfold α
+  generalize_proofs pf
+  exact (Classical.choose_spec pf).1.2
+
+theorem isAcc_α_F' (β : Iio (succ κ).ord) : IsAcc α (F' β) :=
+  isAcc_α.mono (by exact fun x hx y ⟨z, hz⟩ ↦ hx y ⟨z, hz⟩)
+
+theorem restrict_subset_α (β : Iio (succ κ).ord) : restrict (F' β) α ⊆ f α := by
+  rw [restrict, dif_pos (isAcc_α_F' _)]
+  exact inter_subset_left
+
+theorem restrict_subset_restrict {C D : Club Ϟ} (h : C ⊆ D) (ha : IsAcc α C) :
+    restrict C α ⊆ restrict D α := by
+  unfold restrict
+  rw [dif_pos ha, dif_pos (by exact ha.mono h)]
+  exact inter_subset_inter (fun _ H ↦ H) h
+
+theorem restrict_not_subset (β : Iio (succ κ).ord) :
+    ¬ (restrict (F' β) α).carrier ⊆ (F β).carrier := by
+  rw [F, boundedRec_eq]
+  generalize_proofs _ _ _ pf
+  exact Classical.choose_spec pf α
+
+theorem restrict_subset {β γ : Iio (succ κ).ord} (h : β < γ) :
+    (restrict (F' γ) α).carrier ⊆ (F β).carrier := by
+  rw [restrict, dif_pos (isAcc_α_F' γ)]
+  refine inter_subset_right.trans ?_
+  intro x xmem
+  exact xmem (F β).carrier ⟨⟨β, h⟩, rfl⟩
+
+/- At each of the `succ κ` steps, when we chose a club `C` that is not guessed so far,
+we shrunk the club we started with below `α`, `f α`.
+In fact we shrunk the club below every element of `S ∩ C'`, because no club guessed `C`.
+ -/
+theorem restrict_ssubset_restrict {β γ : Iio (succ κ).ord} (h : β < γ) :
+    restrict (F' γ) α ⊂ restrict (F' β) α := by
+  rw [ssubset_iff_subset_ne]
+  constructor
+  · apply restrict_subset_restrict
+    · exact fun x hx s ⟨z, hz⟩ ↦ hx s ⟨⟨z.1, z.2.trans h⟩, hz⟩
+    · exact isAcc_α_F' _
+  · exact fun heq ↦ restrict_not_subset β (heq ▸ (restrict_subset h))
+
+/- `f α` has cardinality `κ`, but we removed elements from it `succ κ` many times. -/
+theorem contradiction : False := by
+  have : Cardinal.lift.{u, u + 1} #(f α).carrier
+      < Cardinal.lift.{u + 1, u} (succ κ).ord.card := by
+    have : #↑(f α).carrier = Cardinal.lift.{u + 1, u} κ := by
+      unfold f
+      generalize_proofs pf
+      convert Classical.choose_spec pf
+      exact (hS α α.2).symm
+    rw [card_ord, this, Cardinal.lift_lift, Cardinal.lift_lt]
+    exact lt_succ κ
+  apply not_exists_ssubset_chain_lift (isSuccLimit_ord (hκ.trans (lt_succ κ)).le) this
+  use fun x ↦ restrict (F' x) α
+  constructor
+  · exact restrict_subset_α
+  · exact fun β γ ↦ restrict_ssubset_restrict
+
+end Assumptions
+end ClubGuessing
+
+theorem exists_isClubGuessing_of_cof_uncountable {Ϟ : Ordinal} {κ : Cardinal} (hκ : ℵ₀ < κ)
+    (hcof : succ κ < Ϟ.cof) {S : Set Ordinal} (hStat : IsStationary S Ϟ)
+    (hS : ∀ α ∈ S, α.cof = κ) : ∃ f : (α : S) → Club α, IsClubGuessing f Ϟ := by
+  by_contra! h
+  have : ClubGuessing.Assumptions := ⟨Ϟ, κ, hκ, hcof, S ∩ Iio Ϟ, hStat.inter_Iio,
+    inter_subset_right, (fun _ ⟨h, _⟩ ↦ hS _ h), ?_⟩
+  · exact ClubGuessing.Assumptions.contradiction
+  · intro f hf
+    let g : (α : S) → (Club α) := fun α ↦ if hα : α.1 ∈ (Iio Ϟ) then (f ⟨α.1, ⟨α.2, hα⟩⟩) else
+      univ_club (one_lt_cof_iff.mp (one_lt_aleph0.trans_le (hS α α.2 ▸ hκ).le))
+    refine h g fun C ↦ ?_
+    obtain ⟨δ, hδ⟩ := hf ⟨C.1 ∩ Iio Ϟ, C.2.inter_Iio⟩
+    use ⟨δ.1, δ.2.1⟩
+    unfold g
+    rw [dif_pos δ.2.2]
+    exact hδ.trans inter_subset_left
+
+end Ordinal

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -444,3 +444,27 @@ projects:
     msc:
       - "11E25"
       - "11H06"
+  - slug: pcf-theory
+    title: PCF Theory
+    summary: Formalizes foundational results from Shelah's Possible Cofinality theory, including the existence of club-guessing sequences.
+    branch: set theory
+    entry_module: LeanPool.PCFTheory
+    authors:
+      - YnirPaz
+    source:
+      url: https://github.com/YnirPaz/PCF-Theory
+      github_repo: YnirPaz/PCF-Theory
+    status: verified
+    main_declarations:
+      - Ordinal.exists_isClubGuessing_of_cof_uncountable
+    main_results:
+      - declaration: Ordinal.exists_isClubGuessing_of_cof_uncountable
+        informal: Proves the existence of a club-guessing sequence on a stationary set whose elements share a common uncountable cofinality bounded by the cofinality of the ambient ordinal.
+    tags:
+      - set-theory
+      - cardinal-arithmetic
+      - club-guessing
+    msc:
+      - "03E04"
+      - "03E10"
+      - "03E55"


### PR DESCRIPTION
Imported from https://github.com/YnirPaz/PCF-Theory.

**Slug:** `pcf-theory`
**Toolchain target:** `leanprover/lean4:v4.30.0-rc2`
**Branch:** `import/pcf-theory` (auto-generated by `scripts/import-formalization.sh`)
**Agent:** `claude` using `claude-opus-4-7` at effort `max`, exited with code `143`.

**Commits on this branch:**
- c16b101 Vendor PCF-Theory from YnirPaz/PCF-Theory

## Agent flagged this import as blocked

# Import guard failure

The wrapper found forbidden Lean tokens in added LeanPool lines:

- `LeanPool/PCFTheory/ClubGuessing.lean:   `Ϟ`, such that `∀ α ∈ S, α.cof = κ`, for a constant `κ` satisfying `succ κ < Ϟ.cof`.`

Remove these escape hatches or diagnostics before merging.

---
_Opened automatically by `scripts/import-formalization.sh`. Review the diff carefully before merging — the agent ran unattended._
