### PR TITLE
Import duality formalization

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -74,6 +74,14 @@ import LeanPool.DeadEnds.PrimeTail
 import LeanPool.DeadEnds.RelevantPrimes
 import LeanPool.DeadEnds.Solution
 import LeanPool.DeadEnds.TailEstimates
+import LeanPool.Duality
+import LeanPool.Duality.Common
+import LeanPool.Duality.ExtendedFields
+import LeanPool.Duality.FarkasBartl
+import LeanPool.Duality.FarkasBasic
+import LeanPool.Duality.FarkasSpecial
+import LeanPool.Duality.LinearProgramming
+import LeanPool.Duality.LinearProgrammingB
 import LeanPool.Erdos1196
 import LeanPool.Erdos1196.Basic
 import LeanPool.Erdos1196.FirstEntryRowTerm

--- a/LeanPool/Duality.lean
+++ b/LeanPool/Duality.lean
@@ -18,11 +18,12 @@ import LeanPool.Duality.LinearProgrammingB
 Source: arxiv:2409.08119
 Authors: Martin Dvorak
 Status: verified
-Main declarations: `equalityFarkas`, `inequalityFarkas`, `extendedFarkas`,
-  `ValidELP.strongDuality`, `StandardLP.strongDuality`
+Main declarations: `extendedFarkas`, `StandardLP.strongDuality`
 Tags: linear-programming, optimization, farkas-lemma
 MSC: 90C05, 90C46
+-/
 
+/-!
 ## Mathematical overview
 
 Farkas established that a system of linear inequalities has a solution if and only if we cannot

--- a/LeanPool/Duality.lean
+++ b/LeanPool/Duality.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 Martin Dvorak. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Martin Dvorak
+-/
+
+import LeanPool.Duality.Common
+import LeanPool.Duality.ExtendedFields
+import LeanPool.Duality.FarkasBartl
+import LeanPool.Duality.FarkasBasic
+import LeanPool.Duality.FarkasSpecial
+import LeanPool.Duality.LinearProgramming
+import LeanPool.Duality.LinearProgrammingB
+
+/-!
+# Duality theory in linear optimization and its extensions
+
+Source: arxiv:2409.08119
+Authors: Martin Dvorak
+Status: verified
+Main declarations: `equalityFarkas`, `inequalityFarkas`, `extendedFarkas`,
+  `ValidELP.strongDuality`, `StandardLP.strongDuality`
+Tags: linear-programming, optimization, farkas-lemma
+MSC: 90C05, 90C46
+
+## Mathematical overview
+
+Farkas established that a system of linear inequalities has a solution if and only if we cannot
+obtain a contradiction by taking a linear combination of the inequalities. Several Farkas-like
+theorems are stated and formally proved in Lean 4. Furthermore, we consider a linearly ordered
+field extended with two special elements denoted by `⊥` and `⊤`, where `⊥` is below every
+element and `⊤` is above every element. We define `⊥ + a = ⊥ = a + ⊥` for all `a` and we
+define `⊤ + b = ⊤ = b + ⊤` for all `b ≠ ⊥`. Instead of multiplication, we define scalar
+action `c • ⊥ = ⊥` for every `c ≥ 0` but we define `d • ⊤ = ⊤` only for `d > 0` because
+`0 • ⊤ = 0`. We extend certain Farkas-like theorems to a setting where coefficients are from
+an extended linearly ordered field.
+
+Main corollaries:
+- `equalityFarkas`: Farkas for equalities,
+- `inequalityFarkas`: Farkas for inequalities,
+- `StandardLP.strongDuality`: strong duality for standard LP.
+
+Main results:
+- `finFarkasBartl` / `fintypeFarkasBartl`: Farkas–Bartl theorem,
+- `extendedFarkas`: extended Farkas theorem,
+- `ValidELP.strongDuality`: strong duality for extended LP.
+
+## Provenance
+
+Imported from <https://github.com/madvorak/duality> (originally Lean v4.18.0) and ported to
+Lean Pool's v4.30.0-rc2 / Mathlib v4.30.0-rc2 toolchain. Technical report:
+<https://arxiv.org/abs/2409.08119>.
+-/

--- a/LeanPool/Duality/Common.lean
+++ b/LeanPool/Duality/Common.lean
@@ -67,11 +67,6 @@ postfix:max ".→" => Iff.mp
 /-- The right-to-left direction of `↔`. -/
 postfix:max ".←" => Iff.mpr
 
-/-- The "left" or "top" variant (mostly used downstream by the VCSP project). -/
-prefix:max "◩" => Sum.inl
-
-/-- The "right" or "bottom" variant (mostly used downstream by the VCSP project). -/
-prefix:max "◪" => Sum.inr
 
 end notations
 

--- a/LeanPool/Duality/Common.lean
+++ b/LeanPool/Duality/Common.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2026 Martin Dvorak. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Martin Dvorak
+-/
+import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.Algebra.Order.Group.Defs
+
+
+section finset_sums
+variable {α β : Type*}
+
+lemma Finset.subtype_univ_sum_eq_subtype_univ_sum {p q : α → Prop} (hpq : p = q)
+    [Fintype { a : α // p a }] [Fintype { a : α // q a }] [AddCommMonoid β]
+    {f : { a : α // p a } → β} {g : { a : α // q a } → β}
+    (hfg : ∀ a : α, ∀ hpa : p a, ∀ hqa : q a, f ⟨a, hpa⟩ = g ⟨a, hqa⟩) :
+    Finset.univ.sum f = Finset.univ.sum g := by
+  subst hpq
+  convert rfl
+  ext
+  symm
+  apply hfg
+
+lemma Finset.univ_sum_of_zero_when_not [Fintype α] [AddCommMonoid β]
+    {f : α → β} (p : α → Prop) [DecidablePred p] (hpf : ∀ a : α, ¬(p a) → f a = 0) :
+    Finset.univ.sum f = Finset.univ.sum (fun a : { a : α // p a } => f a.val) := by
+  classical
+  trans (Finset.univ.filter p).sum f
+  · symm
+    apply Finset.sum_subset_zero_on_sdiff
+    · apply Finset.subset_univ
+    · simpa
+    · intros
+      rfl
+  · apply Finset.sum_subtype
+    simp
+
+end finset_sums
+
+
+section logic_with_neq
+variable {P Q : Prop}
+
+lemma or_of_neq (hpq : P ≠ Q) : P ∨ Q := by
+  tauto
+
+lemma not_and_of_neq (hpq : P ≠ Q) : ¬(P ∧ Q) := by
+  tauto
+
+lemma neq_of_iff_neg (hpq : P ↔ ¬Q) : P ≠ Q := by
+  tauto
+
+lemma neg_iff_neg (hpq : P ↔ Q) : ¬P ↔ ¬Q := by
+  tauto
+
+end logic_with_neq
+
+
+section notations
+
+/-- Writing `↓t` is slightly more general than writing `Function.const _ t`. -/
+notation:max "↓"t:arg => (fun _ => t)
+
+/-- The left-to-right direction of `↔`. -/
+postfix:max ".→" => Iff.mp
+
+/-- The right-to-left direction of `↔`. -/
+postfix:max ".←" => Iff.mpr
+
+/-- The "left" or "top" variant (mostly used downstream by the VCSP project). -/
+prefix:max "◩" => Sum.inl
+
+/-- The "right" or "bottom" variant (mostly used downstream by the VCSP project). -/
+prefix:max "◪" => Sum.inr
+
+end notations
+
+
+section miscellaneous
+
+lemma le_of_nneg_add {α : Type*} [AddCommGroup α] [PartialOrder α] [IsOrderedAddMonoid α]
+    {a b c : α} (habc : a + b = c) (ha : 0 ≤ a) : b ≤ c := by
+  aesop
+
+/-- `change h to t` rewrites the hypothesis `h` to the definitionally equal type `t`. -/
+macro "change " h:ident " to " t:term : tactic => `(tactic| change $t at $h:ident)
+
+/-- `aeply t` is shorthand for `intro <;> apply t <;> aesop`, useful for proving universally
+    quantified goals where each instance is dispatched by `aesop` after applying `t`. -/
+macro "aeply" t:term : tactic => `(tactic| intro <;> apply $t <;> aesop)
+
+end miscellaneous

--- a/LeanPool/Duality/ExtendedFields.lean
+++ b/LeanPool/Duality/ExtendedFields.lean
@@ -1,0 +1,280 @@
+/-
+Copyright (c) 2026 Martin Dvorak. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Martin Dvorak
+-/
+import Mathlib.Algebra.Order.Monoid.WithTop
+import Mathlib.Algebra.Order.Field.Basic
+import LeanPool.Duality.Common
+
+/-!
+This entire file is inspired by:
+https://github.com/leanprover-community/mathlib4/blob/333e2d79fdaee86489af73dee919bc4b66957a52/Mathlib/Data/Real/EReal.lean
+-/
+
+/-- `Extend F` is the type of values in `F ∪ {⊥, ⊤}` where, informally speaking,
+    `⊥` (negative infinity) is stronger than `⊤` (positive infinity). -/
+def Extend (F : Type*) := WithBot (WithTop F)
+
+
+variable {F : Type*} [Field F] [LinearOrder F] [IsStrictOrderedRing F]
+
+instance : AddCommMonoid (Extend F) :=
+  inferInstanceAs (AddCommMonoid (WithBot (WithTop F)))
+
+instance : LinearOrder (Extend F) :=
+  inferInstanceAs (LinearOrder (WithBot (WithTop F)))
+
+instance : IsOrderedAddMonoid (Extend F) :=
+  inferInstanceAs (IsOrderedAddMonoid (WithBot (WithTop F)))
+
+instance : AddCommMonoidWithOne (Extend F) :=
+  inferInstanceAs (AddCommMonoidWithOne (WithBot (WithTop F)))
+
+
+instance : ZeroLEOneClass (Extend F) := inferInstanceAs (ZeroLEOneClass (WithBot (WithTop F)))
+
+instance : CharZero (Extend F) := inferInstanceAs (CharZero (WithBot (WithTop F)))
+
+instance : BoundedOrder (Extend F) := inferInstanceAs (BoundedOrder (WithBot (WithTop F)))
+
+instance : DenselyOrdered (Extend F) := inferInstanceAs (DenselyOrdered (WithBot (WithTop F)))
+
+instance : DecidableRel ((· < ·) : Extend F → Extend F → Prop) := WithBot.decidableLT
+
+
+/-- The canonical inclusion from `F` to `Extend F` is registered as a coercion. -/
+@[coe] def toE : F → Extend F := some ∘ some
+
+instance : Coe F (Extend F) := ⟨toE⟩
+
+
+namespace EF
+
+/-! ### Coercion -/
+
+omit [Field F] [IsStrictOrderedRing F] in
+lemma coe_strictMono : StrictMono (toE (F := F)) :=
+  WithBot.coe_strictMono.comp WithTop.coe_strictMono
+
+omit [Field F] [IsStrictOrderedRing F] in
+lemma coe_injective : Function.Injective (toE (F := F)) :=
+  coe_strictMono.injective
+
+omit [Field F] [IsStrictOrderedRing F] in
+@[simp, norm_cast]
+lemma coe_le_coe_iff {x y : F} : (x : Extend F) ≤ (y : Extend F) ↔ x ≤ y :=
+  coe_strictMono.le_iff_le
+
+lemma coe_le_coe_iff_F (F : Type) [Field F] [LinearOrder F] [IsStrictOrderedRing F]
+    {x y : F} : (x : Extend F) ≤ (y : Extend F) ↔ x ≤ y :=
+  coe_strictMono.le_iff_le
+
+omit [Field F] [IsStrictOrderedRing F] in
+@[simp, norm_cast]
+lemma coe_lt_coe_iff {x y : F} : (x : Extend F) < (y : Extend F) ↔ x < y :=
+  coe_strictMono.lt_iff_lt
+
+omit [Field F] [IsStrictOrderedRing F] in
+@[simp, norm_cast]
+lemma coe_eq_coe_iff {x y : F} : (x : Extend F) = (y : Extend F) ↔ x = y :=
+  coe_injective.eq_iff
+
+omit [Field F] [IsStrictOrderedRing F] in
+lemma coe_neq_coe_iff {x y : F} : (x : Extend F) ≠ (y : Extend F) ↔ x ≠ y :=
+  coe_injective.ne_iff
+
+omit [LinearOrder F] [IsStrictOrderedRing F] in
+@[simp, norm_cast]
+lemma coe_zero : ((0 : F) : Extend F) = 0 := rfl
+
+omit [LinearOrder F] [IsStrictOrderedRing F] in
+@[simp, norm_cast]
+lemma coe_one : ((1 : F) : Extend F) = 1 := rfl
+
+omit [Field F] [IsStrictOrderedRing F] in
+@[simp]
+lemma bot_lt_coe (x : F) : (⊥ : Extend F) < x :=
+  WithBot.bot_lt_coe _
+
+omit [Field F] [IsStrictOrderedRing F] in
+@[simp]
+lemma coe_neq_bot (x : F) : (x : Extend F) ≠ ⊥ :=
+  (bot_lt_coe x).ne'
+
+omit [Field F] [IsStrictOrderedRing F] in
+@[simp]
+lemma bot_neq_coe (x : F) : (⊥ : Extend F) ≠ x :=
+  (bot_lt_coe x).ne
+
+omit [Field F] [IsStrictOrderedRing F] in
+@[simp]
+lemma coe_lt_top (x : F) : (x : Extend F) < ⊤ :=
+  WithBot.coe_lt_coe.← <| WithTop.coe_lt_top _
+
+omit [Field F] [IsStrictOrderedRing F] in
+@[simp]
+lemma coe_neq_top (x : F) : (x : Extend F) ≠ ⊤ :=
+  (coe_lt_top x).ne
+
+omit [Field F] [IsStrictOrderedRing F] in
+@[simp]
+lemma top_neq_coe (x : F) : (⊤ : Extend F) ≠ x :=
+  (coe_lt_top x).ne'
+
+omit [IsStrictOrderedRing F] in
+@[simp]
+lemma bot_lt_zero : (⊥ : Extend F) < 0 :=
+  bot_lt_coe 0
+
+omit [IsStrictOrderedRing F] in
+@[simp]
+lemma bot_neq_zero : (⊥ : Extend F) ≠ 0 :=
+  (coe_neq_bot 0).symm
+
+omit [IsStrictOrderedRing F] in
+@[simp]
+lemma zero_neq_bot : (0 : Extend F) ≠ ⊥ :=
+  coe_neq_bot 0
+
+omit [IsStrictOrderedRing F] in
+@[simp]
+lemma zero_lt_top : (0 : Extend F) < ⊤ :=
+  coe_lt_top 0
+
+omit [IsStrictOrderedRing F] in
+@[simp]
+lemma zero_neq_top : (0 : Extend F) ≠ ⊤ :=
+  coe_neq_top 0
+
+omit [IsStrictOrderedRing F] in
+@[simp]
+lemma top_neq_zero : (⊤ : Extend F) ≠ 0 :=
+  zero_neq_top.symm
+
+omit [LinearOrder F] [IsStrictOrderedRing F] in
+@[simp, norm_cast]
+lemma coe_add (x y : F) : toE (x + y) = toE x + toE y :=
+  rfl
+
+omit [IsStrictOrderedRing F] in
+@[simp, norm_cast]
+lemma coe_eq_zero {x : F} : (x : Extend F) = 0 ↔ x = 0 :=
+  coe_eq_coe_iff
+
+omit [IsStrictOrderedRing F] in
+@[simp, norm_cast]
+lemma coe_eq_one {x : F} : (x : Extend F) = 1 ↔ x = 1 :=
+  coe_eq_coe_iff
+
+omit [IsStrictOrderedRing F] in
+lemma coe_neq_zero {x : F} : (x : Extend F) ≠ 0 ↔ x ≠ 0 :=
+  coe_neq_coe_iff
+
+omit [IsStrictOrderedRing F] in
+lemma coe_neq_one {x : F} : (x : Extend F) ≠ 1 ↔ x ≠ 1 :=
+  coe_neq_coe_iff
+
+omit [IsStrictOrderedRing F] in
+@[simp, norm_cast]
+lemma coe_nonneg {x : F} : (0 : Extend F) ≤ x ↔ 0 ≤ x :=
+  coe_le_coe_iff
+
+omit [IsStrictOrderedRing F] in
+@[simp, norm_cast]
+lemma coe_nonpos {x : F} : x ≤ (0 : Extend F) ↔ x ≤ 0 :=
+  coe_le_coe_iff
+
+omit [IsStrictOrderedRing F] in
+@[simp, norm_cast]
+lemma coe_pos {x : F} : (0 : Extend F) < x ↔ 0 < x :=
+  coe_lt_coe_iff
+
+omit [IsStrictOrderedRing F] in
+@[simp, norm_cast]
+lemma coe_neg' {x : F} : x < (0 : Extend F) ↔ x < 0 :=
+  coe_lt_coe_iff
+
+/-! ### Addition -/
+
+omit [IsStrictOrderedRing F] in
+@[simp]
+lemma add_bot (x : Extend F) : x + ⊥ = ⊥ :=
+  WithBot.add_bot x
+
+omit [IsStrictOrderedRing F] in
+@[simp]
+lemma bot_add (x : Extend F) : ⊥ + x = ⊥ :=
+  WithBot.bot_add x
+
+omit [IsStrictOrderedRing F] in
+@[simp]
+lemma add_eq_bot_iff {x y : Extend F} : x + y = ⊥ ↔ x = ⊥ ∨ y = ⊥ :=
+  WithBot.add_eq_bot
+
+omit [IsStrictOrderedRing F] in
+@[simp]
+lemma top_add_top : (⊤ : Extend F) + ⊤ = ⊤ :=
+  rfl
+
+omit [IsStrictOrderedRing F] in
+@[simp]
+lemma top_add_coe (x : F) : (⊤ : Extend F) + x = ⊤ :=
+  rfl
+
+omit [IsStrictOrderedRing F] in
+@[simp]
+lemma coe_add_top (x : F) : (x : Extend F) + ⊤ = ⊤ :=
+  rfl
+
+/-! ### Negation -/
+
+/-- Negation on `Extend F`. -/
+def neg : Extend F → Extend F
+| ⊥ => ⊤
+| ⊤ => ⊥
+| (x : F) => toE (-x)
+
+instance : Neg (Extend F) := ⟨EF.neg⟩
+
+instance : SubNegZeroMonoid (Extend F) where
+  neg_zero := congr_arg toE neg_zero
+  zsmul := zsmulRec
+
+omit [IsStrictOrderedRing F] in
+@[simp]
+lemma neg_top : -(⊤ : Extend F) = ⊥ :=
+  rfl
+
+omit [IsStrictOrderedRing F] in
+@[simp]
+lemma neg_bot : -(⊥ : Extend F) = ⊤ :=
+  rfl
+
+omit [IsStrictOrderedRing F] in
+@[simp, norm_cast]
+lemma coe_neg (x : F) : toE (-x) = -(toE x) := rfl
+
+instance : InvolutiveNeg (Extend F) where
+  neg_neg a :=
+    match a with
+    | ⊥ => rfl
+    | ⊤ => rfl
+    | (a : F) => congr_arg toE (neg_neg a)
+
+omit [IsStrictOrderedRing F] in
+@[simp]
+lemma neg_eq_top_iff {x : Extend F} : -x = ⊤ ↔ x = ⊥ :=
+  neg_injective.eq_iff' rfl
+
+omit [IsStrictOrderedRing F] in
+@[simp]
+lemma neg_eq_bot_iff {x : Extend F} : -x = ⊥ ↔ x = ⊤ :=
+  neg_injective.eq_iff' rfl
+
+omit [IsStrictOrderedRing F] in
+@[simp]
+lemma neg_eq_zero_iff {x : Extend F} : -x = 0 ↔ x = 0 :=
+  neg_injective.eq_iff' neg_zero
+
+end EF

--- a/LeanPool/Duality/FarkasBartl.lean
+++ b/LeanPool/Duality/FarkasBartl.lean
@@ -1,0 +1,274 @@
+/-
+Copyright (c) 2026 Martin Dvorak. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Martin Dvorak
+-/
+import Mathlib.Algebra.Order.Module.Defs
+import Mathlib.Algebra.Module.LinearMap.Basic
+import Mathlib.Algebra.BigOperators.GroupWithZero.Action
+import Mathlib.Algebra.Module.Pi
+import Mathlib.Tactic.Abel
+import Mathlib.Tactic.Have
+import LeanPool.Duality.Common
+
+private def withoutLastMap {m : ℕ} {R W : Type*} [Semiring R] [AddCommMonoid W] [Module R W]
+    (A : W →ₗ[R] Fin m.succ → R) :
+    W →ₗ[R] Fin m → R :=
+  ⟨⟨
+    fun w : W => fun i : Fin m => A w i.castSucc,
+  by
+    intros
+    ext
+    simp
+  ⟩,
+  by
+    intros
+    ext
+    simp
+  ⟩
+
+/-- `▀A` is shorthand notation for `withoutLastMap A`, the restriction of `A` to its first
+    `m` coordinates (dropping the last). -/
+prefix:max "▀" => withoutLastMap
+
+private def auxLinMaps {m : ℕ} {R W : Type*} [Ring R] [AddCommMonoid W] [Module R W]
+    (A : W →ₗ[R] Fin m.succ → R) (y : W) :
+    W →ₗ[R] Fin m → R :=
+  ⟨⟨
+    ▀A - (A · ⟨m, m.lt_add_one⟩ • ▀A y),
+  by
+    intros
+    ext
+    simp only [withoutLastMap, LinearMap.coe_mk, AddHom.coe_mk, Pi.add_apply, Pi.sub_apply,
+      Pi.smul_apply, map_add, smul_eq_mul, add_mul]
+    abel
+  ⟩,
+  by
+    intros
+    ext
+    simp [withoutLastMap, mul_sub, mul_assoc]
+  ⟩
+
+private def auxLinMap {m : ℕ} {R V W : Type*} [Semiring R] [AddCommGroup V] [Module R V]
+    [AddCommMonoid W] [Module R W]
+    (A : W →ₗ[R] Fin m.succ → R) (b : W →ₗ[R] V) (y : W) : W →ₗ[R] V :=
+  ⟨⟨
+    b - (A · ⟨m, m.lt_add_one⟩ • b y),
+  by
+    intros
+    simp only [Pi.add_apply, Pi.sub_apply, map_add, add_smul]
+    abel
+  ⟩,
+  by
+    intros
+    -- note that `simp` does not work here
+    simp only [Pi.smul_apply, Pi.sub_apply, LinearMapClass.map_smul, RingHom.id_apply, smul_sub,
+      IsScalarTower.smul_assoc]
+  ⟩
+
+private lemma filter_yielding_singleton_attach_sum {m : ℕ} {R V : Type*} [Semiring R]
+    [AddCommMonoid V] [Module R V]
+    (f : Fin m.succ → R) (v : V) :
+    ∑ j ∈ (Finset.univ.filter (fun i : Fin m.succ => ¬(i.val < m))).attach, f j.val • v =
+    f ⟨m, m.lt_add_one⟩ • v := by
+  have singlet : Finset.univ.filter (fun i : Fin m.succ => ¬(i.val < m)) = {⟨m, m.lt_add_one⟩}
+  · rw [Finset.ext_iff]
+    intro i
+    constructor <;> rw [Finset.mem_singleton, Finset.mem_filter] <;> intro hi
+    · have him := hi.right
+      push Not at him
+      exact le_antisymm (Nat.le_of_lt_succ i.isLt) him
+    · refine ⟨Finset.mem_univ i, ?_⟩
+      rw [hi]
+      push Not
+      rfl
+  rw [singlet, Finset.sum_attach _ (fun j : Fin m.succ => f j • v), Finset.sum_singleton]
+
+private lemma impossible_index {m : ℕ} {i : Fin m.succ} (hi : ¬(i.val < m))
+    (i_neq_m : i ≠ ⟨m, m.lt_add_one⟩) : False := by
+  push Not at hi
+  exact i_neq_m (le_antisymm (Fin.succ_le_succ_iff.→ i.isLt) hi)
+
+variable {R V W : Type*}
+
+private lemma finishing_piece {m : ℕ} [Semiring R]
+    [AddCommMonoid V] [Module R V] [AddCommMonoid W] [Module R W]
+    {A : W →ₗ[R] Fin m.succ → R} {w : W} {x : Fin m → V} :
+    ∑ i : Fin m, ▀A w i • x i =
+    ∑ i : { j : Fin m.succ // j ∈ Finset.univ.filter (·.val < m) }, A w i.val •
+      x ⟨i.val.val, by aesop⟩ := by
+  apply
+    Finset.sum_bij'
+      (fun i : Fin m =>
+        ↓(⟨⟨i.val, by omega⟩, by aesop⟩ :
+          { a : Fin m.succ // a ∈ Finset.univ.filter (·.val < m) }))
+      (fun i' : { a : Fin m.succ // a ∈ Finset.univ.filter (·.val < m) } => ↓⟨i'.val.val, by aesop⟩)
+      (by aesop)
+      (by aesop)
+      (by aesop)
+      (by aesop)
+  intros
+  rfl
+
+lemma industepFarkasBartl {m : ℕ} [DivisionRing R] [LinearOrder R] [IsStrictOrderedRing R]
+    [AddCommGroup V] [LinearOrder V] [IsOrderedAddMonoid V] [Module R V] [PosSMulMono R V]
+    [AddCommGroup W] [Module R W]
+    (ih : ∀ A₀ : W →ₗ[R] Fin m → R, ∀ b₀ : W →ₗ[R] V,
+      (∀ y₀ : W, 0 ≤ A₀ y₀ → 0 ≤ b₀ y₀) →
+        (∃ x₀ : Fin m → V, 0 ≤ x₀ ∧ ∀ w₀ : W, ∑ i₀ : Fin m, A₀ w₀ i₀ • x₀ i₀ = b₀ w₀))
+    {A : W →ₗ[R] Fin m.succ → R} {b : W →ₗ[R] V} (hAb : ∀ y : W, 0 ≤ A y → 0 ≤ b y) :
+    ∃ x : Fin m.succ → V, 0 ≤ x ∧ ∀ w : W, ∑ i : Fin m.succ, A w i • x i = b w := by
+  if
+    is_easy : ∀ y : W, 0 ≤ ▀A y → 0 ≤ b y
+  then
+    obtain ⟨x, hx, hxb⟩ := ih ▀A b is_easy
+    use (fun i : Fin m.succ => if hi : i.val < m then x ⟨i.val, hi⟩ else 0)
+    constructor
+    · intro i
+      if hi : i.val < m then
+        clear * - hi hx
+        aesop
+      else
+        simp [hi]
+    · intro w
+      simp_rw [smul_dite, smul_zero]
+      rw [Finset.sum_dite, Finset.sum_const_zero, add_zero]
+      convert hxb w using 1
+      symm
+      apply finishing_piece
+  else
+    push Not at is_easy
+    obtain ⟨y', hay', hby'⟩ := is_easy
+    let M : Fin m.succ := ⟨m, lt_add_one m⟩ -- the last (new) index
+    let y : W := (A y' M)⁻¹ • y' -- rescaled `y'`
+    have hAy' : A y' M < 0
+    · by_contra! contr
+      exact (
+        (hAb y' (fun i : Fin m.succ =>
+          if hi : i.val < m then
+            hay' ⟨i, hi⟩
+          else if hiM : i = M then
+            hiM ▸ contr
+          else
+            (impossible_index hi hiM).elim
+        )).trans_lt hby'
+      ).false
+    have hAy : A y M = 1
+    · convert inv_mul_cancel₀ hAy'.ne
+      simp [y]
+    have hAA : ∀ w : W, A (w - (A w M • y)) M = 0
+    · intro w
+      simp [hAy]
+    have hbA : ∀ w : W, 0 ≤ ▀A (w - (A w M • y)) → 0 ≤ b (w - (A w M • y))
+    · intro w hw
+      apply hAb
+      intro i
+      if hi : i.val < m then
+        exact hw ⟨i, hi⟩
+      else if hiM : i = M then
+        rw [hiM, hAA, Pi.zero_apply]
+      else
+        exfalso
+        exact impossible_index hi hiM
+    have hbAb : ∀ w : W, 0 ≤ (▀A - (A · M • ▀A y)) w → 0 ≤ (b - (A · M • b y)) w
+    · simpa using hbA
+    obtain ⟨x', hx', hxb'⟩ := ih (auxLinMaps A y) (auxLinMap A b y) hbAb
+    use (fun i : Fin m.succ =>
+      if hi : i.val < m then x' ⟨i.val, hi⟩ else b y - ∑ i : Fin m, ▀A y i • x' i)
+    constructor
+    · intro i
+      if hi : i.val < m then
+        clear * - hi hx'
+        aesop
+      else
+        have hAy'' : (A y' M)⁻¹ ≤ 0
+        · exact (inv_lt_zero.mpr hAy').le
+        have hay : ▀A y ≤ 0
+        · simpa [y] using smul_nonpos_of_nonpos_of_nonneg hAy'' hay'
+        have hby : 0 ≤ b y
+        · simpa [y] using smul_nonneg_of_nonpos_of_nonpos hAy'' hby'.le
+        simpa [hi] using
+          (Finset.sum_nonpos
+            (fun i : Fin m => ↓(smul_nonpos_of_nonpos_of_nonneg (hay i) (hx' i)))).trans hby
+    · intro w
+      have haAa : ∑ i : Fin m, (▀A w i - A w M * ▀A y i) • x' i = b w - A w M • b y
+      · simpa using hxb' w
+      rw [←add_eq_of_eq_sub haAa]
+      simp_rw [smul_dite]
+      rw [Finset.sum_dite]
+      erw [filter_yielding_singleton_attach_sum]
+      simp_rw [sub_smul]
+      rw [Finset.sum_sub_distrib]
+      simp_rw [←smul_smul, ←Finset.smul_sum]
+      symm
+      rw [smul_sub, finishing_piece]
+      apply add_comm_sub
+
+theorem finFarkasBartl {n : ℕ} [DivisionRing R] [LinearOrder R] [IsStrictOrderedRing R]
+    [AddCommGroup V] [LinearOrder V] [IsOrderedAddMonoid V] [Module R V] [PosSMulMono R V]
+    [AddCommGroup W] [Module R W]
+    (A : W →ₗ[R] Fin n → R) (b : W →ₗ[R] V) :
+    (∃ x : Fin n → V, 0 ≤ x ∧ ∀ w : W, ∑ j : Fin n, A w j • x j = b w) ≠
+      (∃ y : W, 0 ≤ A y ∧ b y < 0) := by
+  apply neq_of_iff_neg
+  push Not
+  refine ⟨fun ⟨x, hx, hb⟩ y hy => hb y ▸
+    Finset.sum_nonneg (fun i : Fin n => ↓(smul_nonneg (hy i) (hx i))), ?_⟩
+  induction n generalizing b with -- note that `A` is "generalized" automatically
+  | zero =>
+    have A_tauto : ∀ w : W, 0 ≤ A w := ↓(Nat.not_lt_zero _ ·.isLt |>.elim)
+    intro hAb
+    refine ⟨0, le_refl 0, fun w : W => ?_⟩
+    simp_rw [Pi.zero_apply, smul_zero, Finset.sum_const_zero]
+    apply le_antisymm (hAb w (A_tauto w))
+    simpa using hAb (-w) (A_tauto (-w))
+  | succ m ih =>
+    exact industepFarkasBartl ih
+
+theorem fintypeFarkasBartl {J : Type*} [Fintype J]
+    [DivisionRing R] [LinearOrder R] [IsStrictOrderedRing R]
+    [AddCommGroup V] [LinearOrder V] [IsOrderedAddMonoid V] [Module R V] [PosSMulMono R V]
+    [AddCommGroup W] [Module R W]
+    (A : W →ₗ[R] J → R) (b : W →ₗ[R] V) :
+    (∃ x : J → V, 0 ≤ x ∧ ∀ w : W, ∑ j : J, A w j • x j = b w) ≠
+      (∃ y : W, 0 ≤ A y ∧ b y < 0) := by
+  convert
+    finFarkasBartl ⟨⟨(A · ∘ (Fintype.equivFin J).symm), by aesop⟩, by aesop⟩ b
+      using 1
+  · constructor <;> intro ⟨x, hx, hA⟩
+    · use x ∘ (Fintype.equivFin J).invFun
+      constructor
+      · intro j
+        simpa using hx ((Fintype.equivFin J).invFun j)
+      · intro w
+        convert hA w
+        apply Finset.sum_equiv (Fintype.equivFin J).symm <;>
+        · intros
+          simp
+    · use x ∘ (Fintype.equivFin J).toFun
+      constructor
+      · intro j
+        simpa using hx ((Fintype.equivFin J).toFun j)
+      · intro w
+        convert hA w
+        apply Finset.sum_equiv (Fintype.equivFin J) <;>
+        · intro
+          simp
+  · constructor <;> intro ⟨y, hAy, hby⟩ <;> refine ⟨y, fun j => ?_, hby⟩
+    · simpa using hAy ((Fintype.equivFin J).invFun j)
+    · simpa using hAy ((Fintype.equivFin J).toFun j)
+
+theorem almostFarkasBartl {J : Type*} [Fintype J]
+    [DivisionRing R] [LinearOrder R] [IsStrictOrderedRing R]
+    [AddCommGroup W] [Module R W]
+    (A : W →ₗ[R] J → R) (b : W →ₗ[R] R) :
+    (∃ x : J → R, 0 ≤ x ∧ ∀ w : W, ∑ j : J, A w j • x j = b w) ≠
+      (∃ y : W, 0 ≤ A y ∧ b y < 0) :=
+  fintypeFarkasBartl A b
+
+theorem coordinateFarkasBartl {I J : Type*} [Fintype J]
+    [DivisionRing R] [LinearOrder R] [IsStrictOrderedRing R]
+    (A : (I → R) →ₗ[R] J → R) (b : (I → R) →ₗ[R] R) :
+    (∃ x : J → R, 0 ≤ x ∧ ∀ w : I → R, ∑ j : J, A w j • x j = b w) ≠
+      (∃ y : I → R, 0 ≤ A y ∧ b y < 0) :=
+  almostFarkasBartl A b

--- a/LeanPool/Duality/FarkasBartl.lean
+++ b/LeanPool/Duality/FarkasBartl.lean
@@ -27,15 +27,12 @@ private def withoutLastMap {m : ℕ} {R W : Type*} [Semiring R] [AddCommMonoid W
     simp
   ⟩
 
-/-- `▀A` is shorthand notation for `withoutLastMap A`, the restriction of `A` to its first
-    `m` coordinates (dropping the last). -/
-prefix:max "▀" => withoutLastMap
 
 private def auxLinMaps {m : ℕ} {R W : Type*} [Ring R] [AddCommMonoid W] [Module R W]
     (A : W →ₗ[R] Fin m.succ → R) (y : W) :
     W →ₗ[R] Fin m → R :=
   ⟨⟨
-    ▀A - (A · ⟨m, m.lt_add_one⟩ • ▀A y),
+    withoutLastMap A - (A · ⟨m, m.lt_add_one⟩ • withoutLastMap A y),
   by
     intros
     ext
@@ -94,7 +91,7 @@ variable {R V W : Type*}
 private lemma finishing_piece {m : ℕ} [Semiring R]
     [AddCommMonoid V] [Module R V] [AddCommMonoid W] [Module R W]
     {A : W →ₗ[R] Fin m.succ → R} {w : W} {x : Fin m → V} :
-    ∑ i : Fin m, ▀A w i • x i =
+    ∑ i : Fin m, withoutLastMap A w i • x i =
     ∑ i : { j : Fin m.succ // j ∈ Finset.univ.filter (·.val < m) }, A w i.val •
       x ⟨i.val.val, by aesop⟩ := by
   apply
@@ -119,9 +116,9 @@ lemma industepFarkasBartl {m : ℕ} [DivisionRing R] [LinearOrder R] [IsStrictOr
     {A : W →ₗ[R] Fin m.succ → R} {b : W →ₗ[R] V} (hAb : ∀ y : W, 0 ≤ A y → 0 ≤ b y) :
     ∃ x : Fin m.succ → V, 0 ≤ x ∧ ∀ w : W, ∑ i : Fin m.succ, A w i • x i = b w := by
   if
-    is_easy : ∀ y : W, 0 ≤ ▀A y → 0 ≤ b y
+    is_easy : ∀ y : W, 0 ≤ withoutLastMap A y → 0 ≤ b y
   then
-    obtain ⟨x, hx, hxb⟩ := ih ▀A b is_easy
+    obtain ⟨x, hx, hxb⟩ := ih (withoutLastMap A) b is_easy
     use (fun i : Fin m.succ => if hi : i.val < m then x ⟨i.val, hi⟩ else 0)
     constructor
     · intro i
@@ -159,7 +156,7 @@ lemma industepFarkasBartl {m : ℕ} [DivisionRing R] [LinearOrder R] [IsStrictOr
     have hAA : ∀ w : W, A (w - (A w M • y)) M = 0
     · intro w
       simp [hAy]
-    have hbA : ∀ w : W, 0 ≤ ▀A (w - (A w M • y)) → 0 ≤ b (w - (A w M • y))
+    have hbA : ∀ w : W, 0 ≤ withoutLastMap A (w - (A w M • y)) → 0 ≤ b (w - (A w M • y))
     · intro w hw
       apply hAb
       intro i
@@ -170,11 +167,12 @@ lemma industepFarkasBartl {m : ℕ} [DivisionRing R] [LinearOrder R] [IsStrictOr
       else
         exfalso
         exact impossible_index hi hiM
-    have hbAb : ∀ w : W, 0 ≤ (▀A - (A · M • ▀A y)) w → 0 ≤ (b - (A · M • b y)) w
+    have hbAb : ∀ w : W,
+        0 ≤ (withoutLastMap A - (A · M • withoutLastMap A y)) w → 0 ≤ (b - (A · M • b y)) w
     · simpa using hbA
     obtain ⟨x', hx', hxb'⟩ := ih (auxLinMaps A y) (auxLinMap A b y) hbAb
     use (fun i : Fin m.succ =>
-      if hi : i.val < m then x' ⟨i.val, hi⟩ else b y - ∑ i : Fin m, ▀A y i • x' i)
+      if hi : i.val < m then x' ⟨i.val, hi⟩ else b y - ∑ i : Fin m, withoutLastMap A y i • x' i)
     constructor
     · intro i
       if hi : i.val < m then
@@ -183,7 +181,7 @@ lemma industepFarkasBartl {m : ℕ} [DivisionRing R] [LinearOrder R] [IsStrictOr
       else
         have hAy'' : (A y' M)⁻¹ ≤ 0
         · exact (inv_lt_zero.mpr hAy').le
-        have hay : ▀A y ≤ 0
+        have hay : withoutLastMap A y ≤ 0
         · simpa [y] using smul_nonpos_of_nonpos_of_nonneg hAy'' hay'
         have hby : 0 ≤ b y
         · simpa [y] using smul_nonneg_of_nonpos_of_nonpos hAy'' hby'.le
@@ -191,7 +189,8 @@ lemma industepFarkasBartl {m : ℕ} [DivisionRing R] [LinearOrder R] [IsStrictOr
           (Finset.sum_nonpos
             (fun i : Fin m => ↓(smul_nonpos_of_nonpos_of_nonneg (hay i) (hx' i)))).trans hby
     · intro w
-      have haAa : ∑ i : Fin m, (▀A w i - A w M * ▀A y i) • x' i = b w - A w M • b y
+      have haAa : ∑ i : Fin m, (withoutLastMap A w i - A w M * withoutLastMap A y i) • x' i =
+          b w - A w M • b y
       · simpa using hxb' w
       rw [←add_eq_of_eq_sub haAa]
       simp_rw [smul_dite]

--- a/LeanPool/Duality/FarkasBasic.lean
+++ b/LeanPool/Duality/FarkasBasic.lean
@@ -150,8 +150,8 @@ theorem inequalityFarkas (A : Matrix I J F) (b : I → F) :
     · intro k
       simp only [A', Matrix.transpose_fromCols, Matrix.transpose_one] at hAy
       apply hAy
-    refine ⟨y, fun i : I => ?_, fun j : J => h1Ay ◪j, hby⟩
-    simpa using h1Ay ◩i
+    refine ⟨y, fun i : I => ?_, fun j : J => h1Ay (Sum.inr j), hby⟩
+    simpa using h1Ay (Sum.inl i)
 
 /-- A system of linear inequalities over nonnegative variables has a solution if and only if
 we cannot obtain a contradiction by taking a nonnegative linear combination of the inequalities;

--- a/LeanPool/Duality/FarkasBasic.lean
+++ b/LeanPool/Duality/FarkasBasic.lean
@@ -1,0 +1,163 @@
+/-
+Copyright (c) 2026 Martin Dvorak. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Martin Dvorak
+-/
+import Mathlib.Algebra.Order.Sum
+import Mathlib.Algebra.Order.Group.PosPart
+import Mathlib.LinearAlgebra.Matrix.DotProduct
+import Mathlib.Data.Matrix.ColumnRowPartitioned
+import Mathlib.LinearAlgebra.Matrix.ToLin
+import LeanPool.Duality.FarkasBartl
+
+
+/- Let's move from linear maps to matrices, which give more familiar
+(albeit less general) formulations of the theorems of alternative. -/
+
+variable {I J F : Type*} [Fintype I] [Fintype J] [Field F] [LinearOrder F] [IsStrictOrderedRing F]
+
+open scoped Matrix
+
+/-- `finishit` is a helper tactic used by `equalityFarkas` to discharge the residual
+    matrix-vector equality after the main Farkas-Bartl bijection: it unfolds the matrix
+    products, swaps the order of summation, and closes the goal with `ring`. -/
+macro "finishit" : tactic => `(tactic| -- should be `private macro` which Lean does not allow
+  unfold Matrix.mulVec Matrix.vecMul dotProduct <;>
+  simp_rw [Finset.sum_mul] <;> rw [Finset.sum_comm] <;>
+  congr <;> ext <;> congr <;> ext <;> ring)
+
+/-- A system of linear equalities over nonnegative variables has a solution if and only if
+we cannot obtain a contradiction by taking a linear combination of the inequalities. -/
+theorem equalityFarkas (A : Matrix I J F) (b : I → F) :
+    (∃ x : J → F, 0 ≤ x ∧ A *ᵥ x = b) ≠ (∃ y : I → F, 0 ≤ Aᵀ *ᵥ y ∧ b ⬝ᵥ y < 0) := by
+  convert
+    coordinateFarkasBartl Aᵀ.mulVecLin ⟨⟨(b ⬝ᵥ ·), dotProduct_add b⟩, (dotProduct_smul · b)⟩
+      using 3
+  · constructor <;> intro ⟨hx, hAx⟩ <;> refine ⟨hx, ?_⟩
+    · intro
+      simp only [Matrix.mulVecLin_transpose, LinearMap.flip_apply, Matrix.vecMulBilin_apply,
+        smul_eq_mul, LinearMap.coe_mk, AddHom.coe_mk]
+      rw [←hAx]
+      finishit
+    · simp only [Matrix.mulVecLin_transpose, LinearMap.flip_apply, Matrix.vecMulBilin_apply,
+        smul_eq_mul, LinearMap.coe_mk, AddHom.coe_mk] at hAx
+      apply dotProduct_eq
+      intro w
+      rw [←hAx w]
+      finishit
+
+/- The following two theorems could be given in much more generality.
+In our work, however, this is the only setting we provide.
+This special case of the Fredholm alternative is not our main focus
+but a byproduct of the other theorems we prove.
+You can use `basicLinearAlgebra_lt` to gain intuition for understanding
+what `equalityFarkas` says. -/
+
+/-- A system of linear equalities has a solution if and only if
+we cannot obtain a contradiction by taking a linear combination of the equalities. -/
+theorem basicLinearAlgebra_lt (A : Matrix I J F) (b : I → F) :
+    (∃ x : J → F, A *ᵥ x = b) ≠ (∃ y : I → F, Aᵀ *ᵥ y = 0 ∧ b ⬝ᵥ y < 0) := by
+  convert equalityFarkas (Matrix.fromCols A (-A)) b using 1
+  · constructor
+    · intro ⟨x, hAx⟩
+      use Sum.elim x⁺ x⁻
+      constructor
+      · rw [Sum.nonneg_elim_iff]
+        exact ⟨posPart_nonneg x, negPart_nonneg x⟩
+      · rw [Matrix.fromCols_mulVec_sumElim, Matrix.neg_mulVec, ←Matrix.mulVec_neg,
+          ←Matrix.mulVec_add, ←sub_eq_add_neg]
+        convert hAx
+        aesop
+    · intro ⟨x, _, hAx⟩
+      use x ∘ Sum.inl - x ∘ Sum.inr
+      rw [Matrix.mulVec_sub]
+      rwa [←Sum.elim_comp_inl_inr x, Matrix.fromCols_mulVec_sumElim, Matrix.neg_mulVec,
+        ←sub_eq_add_neg] at hAx
+  · constructor
+    · intro ⟨y, hAy, hby⟩
+      refine ⟨y, ?_, hby⟩
+      rw [Matrix.transpose_fromCols, Matrix.fromRows_mulVec, Sum.nonneg_elim_iff]
+      constructor
+      · rw [hAy]
+      · rw [Matrix.transpose_neg, Matrix.neg_mulVec, hAy, neg_zero]
+    · intro ⟨y, hAy, hby⟩
+      refine ⟨y, ?_, hby⟩
+      rw [Matrix.transpose_fromCols, Matrix.fromRows_mulVec, Sum.nonneg_elim_iff] at hAy
+      obtain ⟨hAyp, hAyn⟩ := hAy
+      refine le_antisymm ?_ hAyp
+      intro i
+      specialize hAyn i
+      rwa [Matrix.transpose_neg, Matrix.neg_mulVec, Pi.zero_apply, Pi.neg_apply,
+        Right.nonneg_neg_iff] at hAyn
+
+/-- A system of linear equalities has a solution if and only if
+we cannot obtain a contradiction by taking a linear combination of the equalities;
+midly reformulated. -/
+theorem basicLinearAlgebra (A : Matrix I J F) (b : I → F) :
+    (∃ x : J → F, A *ᵥ x = b) ≠ (∃ y : I → F, Aᵀ *ᵥ y = 0 ∧ b ⬝ᵥ y ≠ 0) := by
+  convert basicLinearAlgebra_lt A b using 1
+  refine ⟨fun ⟨y, hAy, hby⟩ => ?_, by aesop⟩
+  if hlt : b ⬝ᵥ y < 0 then
+    aesop
+  else
+    use -y
+    rw [Matrix.mulVec_neg, hAy, neg_zero, dotProduct_neg, neg_lt_zero]
+    push Not at hlt
+    exact ⟨rfl, lt_of_le_of_ne hlt hby.symm⟩
+
+/- Let's move to the "symmetric" variants now. They will also be used in the upcoming extended
+setting and in the upcoming theory of linear programming. -/
+
+/-- A system of linear inequalities over nonnegative variables has a solution if and only if
+we cannot obtain a contradiction by taking a nonnegative linear combination of the inequalities. -/
+theorem inequalityFarkas (A : Matrix I J F) (b : I → F) :
+    (∃ x : J → F, 0 ≤ x ∧ A *ᵥ x ≤ b) ≠ (∃ y : I → F, 0 ≤ y ∧ 0 ≤ Aᵀ *ᵥ y ∧ b ⬝ᵥ y < 0) := by
+  classical
+  let A' : Matrix I (I ⊕ J) F := Matrix.fromCols 1 A
+  convert equalityFarkas A' b using 1 <;> constructor
+  · intro ⟨x, hx, hAxb⟩
+    use Sum.elim (b - A *ᵥ x) x
+    constructor
+    · rw [Sum.nonneg_elim_iff]
+      exact ⟨fun i : I => sub_nonneg_of_le (hAxb i), hx⟩
+    · aesop
+  · intro ⟨x, hx, hAxb⟩
+    use x ∘ Sum.inr
+    constructor
+    · intro
+      apply hx
+    · intro i
+      have hi := congr_fun hAxb i
+      simp only [A', Matrix.mulVec, dotProduct, Matrix.fromCols, Matrix.of_apply,
+        Sum.elim_inl, Sum.elim_inr, Fintype.sum_sum_type] at hi
+      apply le_of_nneg_add hi
+      apply Fintype.sum_nonneg
+      rw [Pi.le_def]
+      intro
+      rw [Pi.zero_apply]
+      apply mul_nonneg
+      · apply Matrix.zero_le_one_elem
+      · apply hx
+  · intro ⟨y, hy, hAy, hby⟩
+    refine ⟨y, ?_, hby⟩
+    intro k
+    cases k with
+    | inl i => simpa [A', Matrix.neg_mulVec] using
+      dotProduct_nonneg_of_nonneg (Matrix.zero_le_one_elem · i) hy
+    | inr j => apply hAy
+  · intro ⟨y, hAy, hby⟩
+    have h1Ay : 0 ≤ (Matrix.fromRows (1 : Matrix I I F) Aᵀ *ᵥ y)
+    · intro k
+      simp only [A', Matrix.transpose_fromCols, Matrix.transpose_one] at hAy
+      apply hAy
+    refine ⟨y, fun i : I => ?_, fun j : J => h1Ay ◪j, hby⟩
+    simpa using h1Ay ◩i
+
+/-- A system of linear inequalities over nonnegative variables has a solution if and only if
+we cannot obtain a contradiction by taking a nonnegative linear combination of the inequalities;
+midly reformulated. -/
+theorem inequalityFarkas_neg (A : Matrix I J F) (b : I → F) :
+    (∃ x : J → F, 0 ≤ x ∧ A *ᵥ x ≤ b) ≠ (∃ y : I → F, 0 ≤ y ∧ -Aᵀ *ᵥ y ≤ 0 ∧ b ⬝ᵥ y < 0) := by
+  convert inequalityFarkas A b using 5
+  rw [Matrix.neg_mulVec, ←neg_zero]
+  constructor <;> intro hAx i <;> simpa using hAx i

--- a/LeanPool/Duality/FarkasSpecial.lean
+++ b/LeanPool/Duality/FarkasSpecial.lean
@@ -1,0 +1,631 @@
+/-
+Copyright (c) 2026 Martin Dvorak. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Martin Dvorak
+-/
+import LeanPool.Duality.ExtendedFields
+import LeanPool.Duality.FarkasBasic
+
+
+section notation_EF
+
+/-- `F∞` is sugar for `Extend F`, the type of values in `F ∪ {⊥, ⊤}`. -/
+syntax:max ident noWs "∞" : term
+
+macro_rules
+| `($F:ident∞) => `(Extend $F)
+
+/-- Pretty-print `Extend F` back as `F∞`. -/
+@[app_unexpander Extend]
+def unexpandExtend : Lean.PrettyPrinter.Unexpander
+| `($(_) $F:ident) => `($F:ident∞)
+| _ => throw ()
+
+end notation_EF
+
+
+section nonnegative_subtype
+
+/-- `NNeg F` is the subtype of nonnegative elements of `F`. -/
+abbrev NNeg (F : Type*) [Zero F] [LE F] :=
+  { a : F // 0 ≤ a }
+
+/-- `F≥0` is sugar for `NNeg F`, the subtype of nonnegative elements of `F`. -/
+syntax:max ident noWs "≥0" : term
+
+macro_rules
+| `($F:ident≥0) => `(NNeg $F)
+
+/-- Pretty-print `NNeg F` back as `F≥0`. -/
+@[app_unexpander NNeg]
+def unexpandNNeg : Lean.PrettyPrinter.Unexpander
+| `($(_) $F:ident) => `($F:ident≥0)
+| _ => throw ()
+
+end nonnegative_subtype
+
+
+variable {F : Type*} [Field F] [LinearOrder F] [IsStrictOrderedRing F]
+
+section extras_EF
+
+/-- Scalar action of a nonnegative scalar on `F∞`: `c • ⊥ = ⊥`, `c • ⊤ = ⊤` when `c > 0`
+    (and `c • ⊤ = 0` when `c = 0`), and `c • (f : F) = c * f` on finite values. -/
+def EF.smulNN (c : F≥0) : F∞ → F∞
+| ⊥ => ⊥
+| ⊤ => if c = 0 then 0 else ⊤
+| (f : F) => toE (c.val * f)
+
+instance : SMulZeroClass F≥0 F∞ where
+  smul := EF.smulNN
+  smul_zero (c : F≥0) := EF.coe_eq_coe_iff.← (mul_zero c.val)
+
+omit [IsStrictOrderedRing F] in
+lemma EF.pos_smul_top {c : F≥0} (hc : 0 < c) : c • (⊤ : F∞) = ⊤ := by
+  change EF.smulNN c ⊤ = ⊤
+  change (if c = 0 then (0 : F∞) else ⊤) = ⊤
+  exact if_neg hc.ne.symm
+
+lemma EF.smul_top_neq_bot (c : F≥0) : c • (⊤ : F∞) ≠ ⊥ := by
+  change EF.smulNN c ⊤ ≠ ⊥
+  change (if c = 0 then (0 : F∞) else ⊤) ≠ ⊥
+  by_cases hc0 : c = 0
+  · simp [hc0]
+  · simp [hc0]
+
+omit [IsStrictOrderedRing F] in
+lemma EF.smul_coe_neq_bot (c : F≥0) (f : F) : c • toE f ≠ (⊥ : F∞) :=
+  EF.coe_neq_bot (c * f)
+
+omit [IsStrictOrderedRing F] in
+lemma EF.smul_bot (c : F≥0) : c • (⊥ : F∞) = ⊥ :=
+  rfl
+
+lemma EF.smul_nonbot_neq_bot (c : F≥0) {r : F∞} (hr : r ≠ ⊥) : c • r ≠ ⊥ := by
+  match r with
+  | ⊥ => simp at hr
+  | ⊤ => apply EF.smul_top_neq_bot
+  | (f : F) => apply EF.smul_coe_neq_bot
+
+omit [IsStrictOrderedRing F] in
+lemma EF.zero_smul_nonbot {r : F∞} (hr : r ≠ ⊥) : (0 : F≥0) • r = 0 := by
+  change EF.smulNN 0 r = 0
+  match r with
+  | ⊥ => simp at hr
+  | ⊤ => exact if_pos rfl
+  | (f : F) => exact congr_arg toE (zero_mul f)
+
+omit [IsStrictOrderedRing F] in
+lemma EF.zero_smul_coe (f : F) : (0 : F≥0) • toE f = 0 :=
+  EF.zero_smul_nonbot (EF.coe_neq_bot f)
+
+/-- The canonical inclusion `F → F∞` packaged as an additive homomorphism. -/
+def EF.AddHom : F →+ F∞ := ⟨⟨toE, EF.coe_zero⟩, EF.coe_add⟩
+
+omit [LinearOrder F] [IsStrictOrderedRing F] in
+lemma Finset.sum_toE {ι : Type*} (s : Finset ι) (f : ι → F) :
+    toE (s.sum f) = s.sum (fun i : ι => toE (f i)) :=
+  map_sum EF.AddHom f s
+
+lemma Multiset.sum_eq_EF_bot_iff (s : Multiset F∞) : s.sum = (⊥ : F∞) ↔ ⊥ ∈ s := by
+  constructor <;> intro hs
+  · induction s using Multiset.induction with
+    | empty =>
+      exfalso
+      rw [Multiset.sum_zero] at hs
+      exact EF.zero_neq_bot hs
+    | cons a m ih =>
+      rw [Multiset.mem_cons]
+      rw [Multiset.sum_cons] at hs
+      match a with
+      | ⊥ =>
+        left
+        rfl
+      | ⊤ =>
+        match hm : m.sum with
+        | ⊥ =>
+          right
+          exact ih hm
+        | ⊤ =>
+          exfalso
+          rw [hm] at hs
+          change hs to ⊤ + ⊤ = ⊥
+          rw [EF.top_add_top] at hs
+          exact top_ne_bot hs
+        | (f : F) =>
+          exfalso
+          rw [hm] at hs
+          change hs to ⊤ + toE f = ⊥
+          rw [EF.top_add_coe] at hs
+          exact top_ne_bot hs
+      | (f : F) =>
+        match hm : m.sum with
+        | ⊥ =>
+          right
+          exact ih hm
+        | ⊤ =>
+          exfalso
+          rw [hm] at hs
+          change hs to toE f + ⊤ = ⊥
+          rw [EF.coe_add_top] at hs
+          exact top_ne_bot hs
+        | (_ : F) =>
+          exfalso
+          rw [hm] at hs
+          exact EF.coe_neq_bot _ hs
+  · induction s using Multiset.induction with
+    | empty =>
+      exfalso
+      exact Multiset.notMem_zero ⊥ hs
+    | cons a m ih =>
+      rw [Multiset.sum_cons]
+      rw [Multiset.mem_cons] at hs
+      cases hs with
+      | inl ha => rw [←ha, EF.bot_add]
+      | inr hm => rw [ih hm, EF.add_bot]
+
+lemma Multiset.sum_eq_EF_top {s : Multiset F∞} (htop : ⊤ ∈ s) (hbot : ⊥ ∉ s) :
+    s.sum = (⊤ : F∞) := by
+  induction s using Multiset.induction with
+  | empty =>
+    exfalso
+    exact Multiset.notMem_zero ⊤ htop
+  | cons a m ih =>
+    rw [Multiset.sum_cons]
+    rw [Multiset.mem_cons] at htop
+    cases htop with
+    | inl ha =>
+      rw [←ha]
+      match hm : m.sum with
+      | (f : F) => rfl
+      | ⊤ => rfl
+      | ⊥ =>
+        exfalso
+        apply hbot
+        rw [Multiset.mem_cons]
+        right
+        rw [←Multiset.sum_eq_EF_bot_iff]
+        exact hm
+    | inr hm =>
+      rw [ih hm ((hbot ∘ Multiset.mem_cons_of_mem) ·)]
+      match a with
+      | (f : F) => rfl
+      | ⊤ => rfl
+      | ⊥ => simp at hbot
+
+end extras_EF
+
+
+open scoped Matrix
+variable {I J : Type*} [Fintype I] [Fintype J]
+
+
+section hetero_matrix_products_defs
+variable {α γ : Type*} [AddCommMonoid α] [SMul γ α]
+  -- elements come from `α` but weights (coefficients) from `γ`
+
+/-- `dotWeig v w` is the sum of the element-wise products `w i • v i` akin the dot product
+    but heterogeneous (mnemonic: "vector times weights").
+    Note that the order of arguments (also with the infix notation) is opposite than in the
+    `SMul` it builds upon. -/
+def dotWeig (v : I → α) (w : I → γ) : α := ∑ i : I, w i • v i
+
+@[inherit_doc dotWeig]
+infixl:72 " ᵥ⬝ " => dotWeig
+
+/-- `Matrix.mulWeig M w` is the heterogeneous analogue of the matrix-vector product
+    `Matrix.mulVec M w` (mnemonic: "matrix times weights").
+    Note that the order of arguments (also with the infix notation) is opposite than in the
+    `SMul` it builds upon. -/
+def Matrix.mulWeig (M : Matrix I J α) (w : J → γ) (i : I) : α :=
+  M i ᵥ⬝ w
+
+@[inherit_doc Matrix.mulWeig]
+infixr:73 " ₘ* " => Matrix.mulWeig
+
+end hetero_matrix_products_defs
+
+
+section hetero_matrix_products_EF
+
+omit [IsStrictOrderedRing F] in
+lemma no_bot_dotWeig_zero {v : I → F∞} (hv : ∀ i, v i ≠ ⊥) :
+    v ᵥ⬝ (0 : I → F≥0) = (0 : F∞) :=
+  Finset.sum_eq_zero (fun (i : I) _ =>
+    match hvi : v i with
+    | ⊤ => show EF.smulNN 0 ⊤ = 0 from if_pos rfl
+    | ⊥ => (hv i hvi).elim
+    | (f : F) => EF.zero_smul_coe f)
+
+lemma has_bot_dotWeig_nneg {v : I → F∞} {i : I} (hvi : v i = ⊥) (w : I → F≥0) :
+    v ᵥ⬝ w = (⊥ : F∞) := by
+  simp only [dotWeig, Finset.sum, Multiset.sum_eq_EF_bot_iff, Multiset.mem_map, Finset.mem_val,
+    Finset.mem_univ, true_and]
+  use i
+  rewrite [hvi]
+  rfl
+
+lemma no_bot_dotWeig_nneg {v : I → F∞} (hv : ∀ i, v i ≠ ⊥) (w : I → F≥0) :
+    v ᵥ⬝ w ≠ (⊥ : F∞) := by
+  simp only [dotWeig, Finset.sum]
+  intro contr
+  simp only [Multiset.sum_eq_EF_bot_iff, Multiset.mem_map, Finset.mem_val, Finset.mem_univ,
+    true_and] at contr
+  obtain ⟨i, hi⟩ := contr
+  exact match hvi : v i with
+  | ⊥ => hv i hvi
+  | ⊤ => EF.smul_top_neq_bot (w i) ((congr_arg _ hvi.symm).trans hi)
+  | (f : F) => EF.smul_coe_neq_bot (w i) f ((congr_arg _ hvi.symm).trans hi)
+
+lemma no_bot_has_top_dotWeig_pos {v : I → F∞} (hv : ∀ a, v a ≠ ⊥) {i : I} (hvi : v i = ⊤)
+    (w : I → F≥0) (hwi : 0 < w i) :
+    v ᵥ⬝ w = ⊤ := by
+  apply Multiset.sum_eq_EF_top
+  · rw [Multiset.mem_map]
+    use i
+    constructor
+    · rw [Finset.mem_val]
+      apply Finset.mem_univ
+    · rw [hvi]
+      exact EF.pos_smul_top hwi
+  · intro contr
+    rw [Multiset.mem_map] at contr
+    obtain ⟨b, -, hb⟩ := contr
+    exact EF.smul_nonbot_neq_bot (w b) (hv b) hb
+
+lemma no_bot_has_top_dotWeig_le {v : I → F∞} (hv : ∀ a, v a ≠ ⊥) {i : I} (hvi : v i = ⊤)
+    (w : I → F≥0) {f : F} (hq : v ᵥ⬝ w ≤ f) :
+    w i ≤ 0 := by
+  by_contra! contr
+  rw [no_bot_has_top_dotWeig_pos hv hvi w contr, top_le_iff] at hq
+  exact EF.coe_neq_top f hq
+
+lemma no_bot_has_top_dotWeig_nneg_le {v : I → F∞} (hv : ∀ a, v a ≠ ⊥) {i : I} (hvi : v i = ⊤)
+    (w : I → F≥0) {f : F} (hq : v ᵥ⬝ w ≤ f) :
+    w i = 0 :=
+  le_antisymm (no_bot_has_top_dotWeig_le hv hvi w hq) (w i).property
+
+lemma dotWeig_zero_le_zero (v : I → F∞) :
+    v ᵥ⬝ (0 : I → F≥0) ≤ (0 : F∞) := by
+  if hv : ∀ i, v i ≠ ⊥ then
+    rw [no_bot_dotWeig_zero hv]
+  else
+    push Not at hv
+    rw [has_bot_dotWeig_nneg]
+    · apply bot_le
+    · exact hv.choose_spec
+
+omit [Fintype I] in
+lemma Matrix.mulWeig_zero_le_zero (M : Matrix I J F∞) :
+    M ₘ* (0 : J → F≥0) ≤ (0 : I → F∞) := by
+  intro i
+  apply dotWeig_zero_le_zero
+
+end hetero_matrix_products_EF
+
+
+section extended_Farkas
+
+/-! The proof of `extendedFarkas` below is split across several private helpers so that no
+single proof body exceeds the LeanPool 200-line cap, and so the elaborator does not run out
+of heartbeats. -/
+
+private abbrev extendedFarkas.I' (A : Matrix I J F∞) (b : I → F∞) : Type _ :=
+  { i : I // b i ≠ ⊤ ∧ ∀ j : J, A i j ≠ ⊥ }
+
+private abbrev extendedFarkas.J' (A : Matrix I J F∞) (b : I → F∞) : Type _ :=
+  { j : J // ∀ i' : extendedFarkas.I' A b, A i'.val j ≠ ⊤ }
+
+private def extendedFarkas.A' (A : Matrix I J F∞) (b : I → F∞) :
+    Matrix (extendedFarkas.I' A b) (extendedFarkas.J' A b) F :=
+  Matrix.of (fun i' : extendedFarkas.I' A b => fun j' : extendedFarkas.J' A b =>
+    match matcha : A i'.val j'.val with
+    | (f : F) => f
+    | ⊥ => (i'.property.right j' matcha).elim
+    | ⊤ => (j'.property i' matcha).elim)
+
+private def extendedFarkas.b' {A : Matrix I J F∞} {b : I → F∞} (hbot : ¬ ∃ i : I, b i = ⊥) :
+    extendedFarkas.I' A b → F :=
+  fun i' : extendedFarkas.I' A b =>
+    match hbi : b i'.val with
+    | (f : F) => f
+    | ⊥ => (hbot ⟨i', hbi⟩).elim
+    | ⊤ => (i'.property.left hbi).elim
+
+private lemma extendedFarkas.fwd_solution {A : Matrix I J F∞} {b : I → F∞}
+    (hbot : ¬ ∃ i : I, b i = ⊥)
+    (x : J → F≥0) (ineqalities : A ₘ* x ≤ b) :
+    ∃ x' : extendedFarkas.J' A b → F, 0 ≤ x' ∧
+      extendedFarkas.A' A b *ᵥ x' ≤ extendedFarkas.b' (A := A) hbot := by
+  refine ⟨(x ·.val), (x ·.val |>.property), fun i' : extendedFarkas.I' A b => ?_⟩
+  rw [←EF.coe_le_coe_iff]
+  convert ineqalities i'.val; swap
+  · simp only [extendedFarkas.b']
+    split <;> rename_i hbi
+    · exact hbi.symm
+    · exact (hbot ⟨i', hbi⟩).elim
+    · exact (i'.property.left hbi).elim
+  simp only [Matrix.mulVec, dotProduct, Matrix.mulWeig, dotWeig]
+  rw [Finset.sum_toE, Finset.univ_sum_of_zero_when_not (fun j : J =>
+    ∀ i' : extendedFarkas.I' A b, A i'.val j ≠ ⊤)]
+  · congr
+    ext j'
+    rw [mul_comm]
+    simp only [extendedFarkas.A', Matrix.of_apply]
+    split <;> rename_i hAij
+    · exact congr_arg (x j'.val • ·) hAij.symm
+    · exact (i'.property.right _ hAij).elim
+    · exact (j'.property _ hAij).elim
+  · intro j where_top
+    push Not at where_top
+    obtain ⟨t, ht⟩ := where_top
+    have hxj : x j = 0
+    · obtain ⟨e, he⟩ : ∃ e : F, b t = e :=
+        match hbt : b t.val with
+        | (f : F) => ⟨_, rfl⟩
+        | ⊥ => (hbot ⟨t, hbt⟩).elim
+        | ⊤ => (t.property.left hbt).elim
+      exact no_bot_has_top_dotWeig_nneg_le (t.property.right) ht x (he ▸ ineqalities t.val)
+    rw [hxj]
+    apply EF.zero_smul_nonbot
+    apply i'.property.right
+
+private lemma extendedFarkas.bwd_solution {A : Matrix I J F∞} {b : I → F∞}
+    (hbot : ¬ ∃ i : I, b i = ⊥)
+    (x : extendedFarkas.J' A b → F) (hx : 0 ≤ x)
+    (ineqalities : extendedFarkas.A' A b *ᵥ x ≤ extendedFarkas.b' (A := A) hbot) :
+    ∃ x' : J → F≥0, A ₘ* x' ≤ b := by
+  use (fun j : J => if hj : (∀ i' : extendedFarkas.I' A b, A i'.val j ≠ ⊤) then
+    ⟨x ⟨j, hj⟩, hx ⟨j, hj⟩⟩ else 0)
+  intro i
+  if hi : (b i ≠ ⊤ ∧ ∀ j : J, A i j ≠ ⊥) then
+    convert EF.coe_le_coe_iff.← (ineqalities ⟨i, hi⟩)
+    · unfold Matrix.mulVec dotProduct Matrix.mulWeig dotWeig
+      simp_rw [dite_smul]
+      rw [Finset.sum_dite]
+      convert add_zero _
+      · apply Finset.sum_eq_zero
+        intro j _
+        apply EF.zero_smul_nonbot
+        exact hi.right j.val
+      · erw [←Finset.sum_coe_sort_eq_attach]
+        rw [Finset.sum_toE]
+        apply Finset.subtype_univ_sum_eq_subtype_univ_sum
+        · ext
+          simp
+        · intro j hj _
+          rw [mul_comm]
+          simp only [extendedFarkas.A', Matrix.of_apply]
+          split <;> rename_i hAij
+          · exact hAij ▸ rfl
+          · exact (hi.right _ hAij).elim
+          · exact (hj ⟨i, hi⟩ hAij).elim
+    · simp only [extendedFarkas.b']
+      split <;> rename_i hbi
+      · exact hbi
+      · exact (hbot ⟨i, hbi⟩).elim
+      · exact (hi.left hbi).elim
+  else
+    push Not at hi
+    if hbi : b i = ⊤ then
+      rw [hbi]
+      apply le_top
+    else
+      obtain ⟨j, hAij⟩ := hi hbi
+      convert_to ⊥ ≤ b i
+      · apply has_bot_dotWeig_nneg hAij
+      apply bot_le
+
+private lemma extendedFarkas.fwd_witness {A : Matrix I J F∞} {b : I → F∞}
+    (hbot : ¬ ∃ i : I, b i = ⊥)
+    (hAi : ¬ ∃ i : I, (∃ j : J, A i j = ⊥) ∧ (∃ j : J, A i j = ⊤))
+    (hAj : ¬ ∃ j : J, (∃ i : I, A i j = ⊥) ∧ (∃ i : I, A i j = ⊤))
+    (hAb : ¬ ∃ i : I, (∃ j : J, A i j = ⊤) ∧ b i = ⊤)
+    (y : I → F≥0)
+    (ineqalities : -Aᵀ ₘ* y ≤ 0) (sharpine : b ᵥ⬝ y < 0) :
+    ∃ y' : extendedFarkas.I' A b → F, 0 ≤ y' ∧
+      -(extendedFarkas.A' A b)ᵀ *ᵥ y' ≤ 0 ∧ extendedFarkas.b' (A := A) hbot ⬝ᵥ y' < 0 := by
+  use (fun i' : extendedFarkas.I' A b => y i'.val)
+  constructor
+  · intro i'
+    exact (y i'.val).property
+  have h0 : ∀ i : I, ¬ (b i ≠ ⊤ ∧ ∀ j : J, A i j ≠ ⊥) → y i = 0
+  · intro i i_not_I'
+    by_contra contr
+    have hyi : 0 < y i
+    · cases lt_or_eq_of_le (y i).property with
+      | inl hpos =>
+        exact hpos
+      | inr h0 =>
+        exfalso
+        apply contr
+        ext
+        exact h0.symm
+    if bi_top : b i = ⊤ then
+      have impos : b ᵥ⬝ y = ⊤
+      · push Not at hbot
+        exact no_bot_has_top_dotWeig_pos hbot bi_top y hyi
+      rw [impos] at sharpine
+      exact not_top_lt sharpine
+    else
+      push Not at i_not_I'
+      obtain ⟨j, Aij_eq_bot⟩ := i_not_I' bi_top
+      have htop : ((-Aᵀ) j) ᵥ⬝ y = ⊤
+      · refine no_bot_has_top_dotWeig_pos ?_ (by simpa using Aij_eq_bot) y hyi
+        intro k hk
+        exact hAj ⟨j, ⟨i, Aij_eq_bot⟩, ⟨k, by simpa using hk⟩⟩
+      have ineqality : ((-Aᵀ) j) ᵥ⬝ y ≤ 0 := ineqalities j
+      rw [htop, top_le_iff] at ineqality
+      exact EF.zero_neq_top ineqality
+  constructor
+  · have hnb : ∀ i : I, ¬ (b i ≠ ⊤ ∧ ∀ j : J, A i j ≠ ⊥) → ∀ j : J, (-Aᵀ) j i ≠ ⊥
+    · intro i i_not_I' j contr
+      have btop : ∃ j : J, A i j = ⊤
+      · use j
+        simpa using contr
+      refine hAi ⟨i, ?_, btop⟩
+      push Not at i_not_I'
+      apply i_not_I'
+      intro bi_eq_top
+      apply hAb
+      use i
+    intro j'
+    have inequality : ∑ i : I, y i • (-Aᵀ) j'.val i ≤ 0 := ineqalities j'
+    rw [Finset.univ_sum_of_zero_when_not
+      (fun i : I => b i ≠ ⊤ ∧ ∀ (j : J), A i j ≠ ⊥)] at inequality
+    · rw [←EF.coe_le_coe_iff]
+      convert inequality
+      simp only [Matrix.mulVec, dotProduct]
+      rw [Finset.sum_toE]
+      congr
+      ext i'
+      simp only [extendedFarkas.A', Matrix.neg_apply, Matrix.transpose_apply, Matrix.of_apply]
+      split <;> rename_i hAij
+      · rewrite [hAij, mul_comm]
+        rfl
+      · exfalso
+        apply i'.property.right
+        exact hAij
+      · exfalso
+        apply j'.property
+        exact hAij
+    · intro i hi
+      rw [h0 i hi]
+      apply EF.zero_smul_nonbot
+      apply hnb
+      exact hi
+  · unfold dotWeig at sharpine
+    rw [Finset.univ_sum_of_zero_when_not
+      (fun i : I => b i ≠ ⊤ ∧ ∀ (j : J), A i j ≠ ⊥)] at sharpine
+    · unfold dotProduct
+      rw [←EF.coe_lt_coe_iff, Finset.sum_toE]
+      convert sharpine with i'
+      simp only [extendedFarkas.b']
+      split <;> rename_i hbi
+      · rewrite [hbi, mul_comm]
+        rfl
+      · exfalso
+        apply hbot
+        use i'
+        exact hbi
+      · exfalso
+        apply i'.property.left
+        exact hbi
+    · intro i hi
+      rw [h0 i hi]
+      apply EF.zero_smul_nonbot
+      intro contr
+      exact hbot ⟨i, contr⟩
+
+private lemma extendedFarkas.bwd_witness {A : Matrix I J F∞} {b : I → F∞}
+    (hbot : ¬ ∃ i : I, b i = ⊥)
+    (y : extendedFarkas.I' A b → F) (hy : 0 ≤ y)
+    (ineqalities : -(extendedFarkas.A' A b)ᵀ *ᵥ y ≤ 0)
+    (sharpine : extendedFarkas.b' (A := A) hbot ⬝ᵥ y < 0) :
+    ∃ y' : I → F≥0, -Aᵀ ₘ* y' ≤ 0 ∧ b ᵥ⬝ y' < 0 := by
+  use (fun i : I => if hi : (b i ≠ ⊤ ∧ ∀ j : J, A i j ≠ ⊥) then ⟨y ⟨i, hi⟩, hy ⟨i, hi⟩⟩ else 0)
+  constructor
+  · intro j
+    if hj : (∀ i : I, A i j ≠ ⊤) then
+      convert EF.coe_le_coe_iff.← (ineqalities ⟨j, (hj ·.val)⟩)
+      simp only [Matrix.mulWeig]
+      simp only [dotWeig, dite_smul]
+      rw [Finset.sum_dite]
+      convert add_zero _
+      · apply Finset.sum_eq_zero
+        intro i _
+        apply EF.zero_smul_nonbot
+        intro contr
+        rw [Matrix.neg_apply, EF.neg_eq_bot_iff] at contr
+        exact hj i contr
+      · simp only [Matrix.mulVec, dotProduct, Matrix.neg_apply, Matrix.transpose_apply]
+        rw [Finset.sum_toE]
+        apply Finset.subtype_univ_sum_eq_subtype_univ_sum
+        · ext
+          simp
+        · intro i hi hif
+          rw [mul_comm]
+          simp only [extendedFarkas.A', Matrix.of_apply]
+          split <;> rename_i hAij
+          · exact hAij ▸ rfl
+          · exact (hi.right _ hAij).elim
+          · exact (hj _ hAij).elim
+    else
+      push Not at hj
+      obtain ⟨i, Aij_eq_top⟩ := hj
+      unfold Matrix.mulWeig
+      rw [has_bot_dotWeig_nneg]
+      · apply bot_le
+      · rwa [Matrix.neg_apply, Matrix.transpose_apply, EF.neg_eq_bot_iff]
+  · convert EF.coe_lt_coe_iff.← sharpine
+    unfold dotProduct dotWeig
+    simp_rw [dite_smul]
+    rw [Finset.sum_dite]
+    convert add_zero _
+    · apply Finset.sum_eq_zero
+      intro j _
+      apply EF.zero_smul_nonbot
+      exact (hbot ⟨j.val, ·⟩)
+    · erw [←Finset.sum_coe_sort_eq_attach]
+      rw [Finset.sum_toE]
+      apply Finset.subtype_univ_sum_eq_subtype_univ_sum
+      · ext
+        simp
+      · intro i hi _
+        rw [mul_comm]
+        simp only [extendedFarkas.b']
+        split <;> rename_i hbi
+        · simp_rw [hbi]; exact rfl
+        · exact (hbot ⟨i, hbi⟩).elim
+        · exact (hi.left hbi).elim
+
+/-- Just like `inequalityFarkas_neg` but for `A` and `b` over `F∞`. -/
+theorem extendedFarkas
+    -- The matrix (LHS)
+    (A : Matrix I J F∞)
+    -- The upper-bounding vector (RHS)
+    (b : I → F∞)
+    -- `A` must not have both `⊥` and `⊤` in the same row
+    (hAi : ¬∃ i : I, (∃ j : J, A i j = ⊥) ∧ (∃ j : J, A i j = ⊤))
+    -- `A` must not have both `⊥` and `⊤` in the same column
+    (hAj : ¬∃ j : J, (∃ i : I, A i j = ⊥) ∧ (∃ i : I, A i j = ⊤))
+    -- `A` must not have `⊤` on any row where `b` has `⊤`
+    (hAb : ¬∃ i : I, (∃ j : J, A i j = ⊤) ∧ b i = ⊤)
+    -- `A` must not have `⊥` on any row where `b` has `⊥`
+    (hbA : ¬∃ i : I, (∃ j : J, A i j = ⊥) ∧ b i = ⊥) :
+    (∃ x : J → F≥0, A ₘ* x ≤ b) ≠ (∃ y : I → F≥0, -Aᵀ ₘ* y ≤ 0 ∧ b ᵥ⬝ y < 0) := by
+  classical
+  if hbot : ∃ i : I, b i = ⊥ then
+    obtain ⟨i, hi⟩ := hbot
+    if hi' : (∀ j : J, A i j ≠ ⊥) then
+      convert false_ne_true
+      · rw [iff_false, not_exists]
+        intro x hAxb
+        specialize hAxb i
+        rw [hi, le_bot_iff] at hAxb
+        exact no_bot_dotWeig_nneg hi' x hAxb
+      · rw [iff_true]
+        use 0
+        constructor
+        · apply Matrix.mulWeig_zero_le_zero
+        · rw [has_bot_dotWeig_nneg hi]
+          exact EF.bot_lt_zero
+    else
+      push Not at hi'
+      exfalso
+      apply hbA
+      exact ⟨i, hi', hi⟩
+  else
+    convert inequalityFarkas_neg (extendedFarkas.A' A b) (extendedFarkas.b' (A := A) hbot)
+    · constructor
+      · intro ⟨x, ineqalities⟩
+        exact extendedFarkas.fwd_solution hbot x ineqalities
+      · intro ⟨x, hx, ineqalities⟩
+        exact extendedFarkas.bwd_solution hbot x hx ineqalities
+    · constructor
+      · intro ⟨y, ineqalities, sharpine⟩
+        exact extendedFarkas.fwd_witness hbot hAi hAj hAb y ineqalities sharpine
+      · intro ⟨y, hy, ineqalities, sharpine⟩
+        exact extendedFarkas.bwd_witness hbot y hy ineqalities sharpine
+
+end extended_Farkas

--- a/LeanPool/Duality/LinearProgramming.lean
+++ b/LeanPool/Duality/LinearProgramming.lean
@@ -1,0 +1,1162 @@
+/-
+Copyright (c) 2026 Martin Dvorak. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Martin Dvorak
+-/
+import Mathlib.Tactic.Linarith
+import LeanPool.Duality.FarkasSpecial
+
+
+/-- Linear program over `F∞` in the standard form (i.e.,
+    a system of linear inequalities with nonnegative variables).
+    Variables are of type `J`. Conditions are indexed by type `I`.
+    The objective function is intended to be minimized. -/
+@[ext]
+structure ExtendedLP (I J F : Type*) [Field F] [LinearOrder F] [IsStrictOrderedRing F] where
+  /-- The left-hand-side matrix. -/
+  A : Matrix I J F∞
+  /-- The right-hand-side vector. -/
+  b : I → F∞
+  /-- The objective function coefficients. -/
+  c : J → F∞
+
+/-- Extended linear program with properties that are needed for duality theorems. -/
+structure ValidELP (I J F : Type*) [Field F] [LinearOrder F] [IsStrictOrderedRing F]
+    extends ExtendedLP I J F where
+  /-- No `⊥` and `⊤` in the same row. -/
+  hAi : ¬∃ i : I, (∃ j : J, A i j = ⊥) ∧ (∃ j : J, A i j = ⊤)
+  /-- No `⊥` and `⊤` in the same column. -/
+  hAj : ¬∃ j : J, (∃ i : I, A i j = ⊥) ∧ (∃ i : I, A i j = ⊤)
+  /-- No `⊥` in the row where the right-hand-side vector has `⊥`. -/
+  hbA : ¬∃ i : I, (∃ j : J, A i j = ⊥) ∧ b i = ⊥
+  /-- No `⊤` in the column where the objective function has `⊥`. -/
+  hcA : ¬∃ j : J, (∃ i : I, A i j = ⊤) ∧ c j = ⊥
+  /-- No `⊤` in the row where the right-hand-side vector has `⊤`. -/
+  hAb : ¬∃ i : I, (∃ j : J, A i j = ⊤) ∧ b i = ⊤
+  /-- No `⊥` in the column where the objective function has `⊤`. -/
+  hAc : ¬∃ j : J, (∃ i : I, A i j = ⊥) ∧ c j = ⊤
+
+open scoped Matrix
+
+variable {I J F : Type*} [Field F] [LinearOrder F] [IsStrictOrderedRing F]
+
+section extended_LP_definitions
+
+/-- A nonnegative vector `x` is a solution to a linear program `P` iff
+    its multiplication by matrix `A` from the left yields a vector whose
+    all entries are less or equal to corresponding entries of the vector `b`. -/
+def ExtendedLP.IsSolution [Fintype J] (P : ExtendedLP I J F) (x : J → F≥0) : Prop :=
+  P.A ₘ* x ≤ P.b
+
+/-- Linear program `P` reaches objective value `r` iff there is a solution `x` such that,
+    when its entries are elementwise multiplied by the the coefficients `c` and summed up,
+    the result is the value `r`. -/
+def ExtendedLP.Reaches [Fintype J] (P : ExtendedLP I J F) (r : F∞) : Prop :=
+  ∃ x : J → F≥0, P.IsSolution x ∧ P.c ᵥ⬝ x = r
+
+/-- Linear program `P` is feasible iff `P` reaches a value that is not `⊤`. -/
+def ExtendedLP.IsFeasible [Fintype J] (P : ExtendedLP I J F) : Prop :=
+  ∃ p : F∞, P.Reaches p ∧ p ≠ ⊤
+
+/-- Linear program `P` is bounded by `r` iff every value reached by `P` is
+    greater or equal to `r` (i.e., `P` is bounded by `r` from below). -/
+def ExtendedLP.IsBoundedBy [Fintype J] (P : ExtendedLP I J F) (r : F) : Prop :=
+  ∀ p : F∞, P.Reaches p → r ≤ p
+
+/-- Linear program `P` is unbounded iff values reached by `P` have no finite lower bound. -/
+def ExtendedLP.IsUnbounded [Fintype J] (P : ExtendedLP I J F) : Prop :=
+  ¬∃ r : F, P.IsBoundedBy r
+
+open scoped Classical in
+/-- Extended notion of "optimum" of "minimization LP" (the less the better). -/
+noncomputable def ExtendedLP.optimum [Fintype J] (P : ExtendedLP I J F) : Option F∞ :=
+  if ¬P.IsFeasible then
+    some ⊤ -- infeasible means that the minimum is `⊤`
+  else
+    if P.IsUnbounded then
+      some ⊥ -- unbounded means that the minimum is `⊥`
+    else
+      if hr : ∃ r : F, P.Reaches (toE r) ∧ P.IsBoundedBy r then
+        some (toE hr.choose) -- the minimum is finite
+      else
+        none -- invalid finite value (infimum is not attained)
+
+/-- `OppositesOpt p q` essentially says `none ≠ p = -q`. -/
+def OppositesOpt : Option F∞ → Option F∞ → Prop
+| (p : F∞), (q : F∞) => p = -q  -- opposite values; includes `⊥ = -⊤` and `⊤ = -⊥`
+| _       , _        => False   -- namely `OppositesOpt none none` is `False`
+
+/-- Dualize an extended linear program in the standard form.
+    The matrix gets transposed and its values flip signs.
+    The original objective function becomes the new right-hand-side vector.
+    The original right-hand-side vector becomes the new objective function.
+    Both linear programs are intended to be minimized. -/
+abbrev ExtendedLP.dualize (P : ExtendedLP I J F) : ExtendedLP J I F :=
+  ⟨-P.Aᵀ, P.c, P.b⟩
+
+/-- Dualize a valid extended linear program. -/
+def ValidELP.dualize (P : ValidELP I J F) : ValidELP J I F where
+  toExtendedLP := P.toExtendedLP.dualize
+  hAi := by aeply P.hAj
+  hAj := by aeply P.hAi
+  hbA := by aeply P.hcA
+  hcA := by aeply P.hbA
+  hAb := by aeply P.hAc
+  hAc := by aeply P.hAb
+
+end extended_LP_definitions
+
+
+section weak_duality
+
+lemma EF.one_smul (r : F∞) : (1 : F≥0) • r = r := by
+  match r with
+  | ⊥ => rfl
+  | ⊤ =>
+    change EF.smulNN 1 ⊤ = ⊤
+    change (if (1 : F≥0) = 0 then (0 : F∞) else ⊤) = ⊤
+    exact if_neg (by norm_num)
+  | (q : F) => exact congr_arg toE (one_mul q)
+
+lemma EF.sub_nonpos_iff (r s : F∞) : r + (-s) ≤ 0 ↔ r ≤ s := by
+  match r with
+  | ⊥ => convert_to True ↔ True <;> simp
+  | ⊤ => match s with
+    | ⊥ => convert_to False ↔ False <;> simp
+    | ⊤ => convert_to True ↔ True <;> simp
+    | (_ : F) => convert_to False ↔ False <;> simp [←EF.coe_neg]
+  | (_ : F) => match s with
+    | ⊥ => convert_to False ↔ False <;> simp
+    | ⊤ => convert_to True ↔ True <;> simp
+    | (_ : F) => simp [←EF.coe_neg, ←EF.coe_add]
+
+lemma EF.vec_sub_nonpos_iff (u v : I → F∞) : u + (-v) ≤ 0 ↔ u ≤ v := by
+  constructor <;> intro huv i <;> simpa [EF.sub_nonpos_iff] using huv i
+
+omit [IsStrictOrderedRing F] in
+lemma sumElim_dotWeig_sumElim [Fintype I] [Fintype J] (u : I → F∞) (v : J → F∞)
+    (x : I → F≥0) (y : J → F≥0) :
+    Sum.elim u v ᵥ⬝ Sum.elim x y = u ᵥ⬝ x + v ᵥ⬝ y := by
+  simp [dotWeig]
+
+omit [IsStrictOrderedRing F] in
+lemma Matrix.fromRows_mulWeig [Fintype J] {I₁ I₂ : Type*} (M₁ : Matrix I₁ J F∞)
+    (M₂ : Matrix I₂ J F∞) (w : J → F≥0) :
+    Matrix.fromRows M₁ M₂ ₘ* w = Sum.elim (M₁ ₘ* w) (M₂ ₘ* w) := by
+  ext (_|_) <;> rfl
+
+omit [IsStrictOrderedRing F] in
+lemma Matrix.fromCols_mulWeig_sumElim {J₁ J₂ : Type*} [Fintype J₁] [Fintype J₂]
+    (M₁ : Matrix I J₁ F∞) (M₂ : Matrix I J₂ F∞) (w₁ : J₁ → F≥0) (w₂ : J₂ → F≥0) :
+    Matrix.fromCols M₁ M₂ ₘ* Sum.elim w₁ w₂ = M₁ ₘ* w₁ + M₂ ₘ* w₂ := by
+  ext
+  simp [Matrix.fromCols, Matrix.mulWeig, dotWeig]
+
+lemma dotWeig_eq_bot [Fintype J] {v : J → F∞} {w : J → F≥0} :
+    (∃ j : J, v j = ⊥) ↔ v ᵥ⬝ w = ⊥ := by
+  constructor
+  · intro ⟨j, hvj⟩
+    apply has_bot_dotWeig_nneg hvj
+  · intro hvw
+    by_contra! contr
+    exact no_bot_dotWeig_nneg contr w hvw
+
+lemma ValidELP.weakDuality_of_no_bot [Fintype I] [Fintype J]
+    (P : ValidELP I J F) (hb : ¬∃ i : I, P.b i = ⊥) (hc : ¬∃ j : J, P.c j = ⊥)
+    {p : F∞} (hP : P.Reaches p) {q : F∞} (hQ : P.dualize.Reaches q) :
+    0 ≤ p + q := by
+  classical
+  obtain ⟨x, hx, rfl⟩ := hP
+  obtain ⟨y, hy, rfl⟩ := hQ
+  by_contra contr
+  apply
+    not_and_of_neq
+      (extendedFarkas
+        (Matrix.fromRows P.A (Matrix.replicateRow Unit P.c))
+        (Sum.elim P.b ↓(P.c ᵥ⬝ x))
+        (by
+          intro ⟨i, ⟨s, his⟩, ⟨t, hit⟩⟩
+          cases i with
+          | inl i' => exact P.hAi ⟨i', ⟨s, his⟩, ⟨t, hit⟩⟩
+          | inr => exact hc ⟨s, his⟩
+        )
+        (by
+          intro ⟨j, ⟨s, hjs⟩, ⟨t, hjt⟩⟩
+          cases s with
+          | inl iₛ =>
+            cases t with
+            | inl iₜ => exact P.hAj ⟨j, ⟨iₛ, hjs⟩, ⟨iₜ, hjt⟩⟩
+            | inr => exact P.hAc ⟨j, ⟨iₛ, hjs⟩, hjt⟩
+          | inr =>
+            cases t with
+            | inl iₜ => exact P.hcA ⟨j, ⟨iₜ, hjt⟩, hjs⟩
+            | inr => simp_all
+        )
+        (by
+          intro ⟨i, ⟨j, hij⟩, hi⟩
+          cases i with
+          | inl i' => exact P.hAb ⟨i', ⟨j, hij⟩, hi⟩
+          | inr =>
+            rw [Sum.elim_inr] at hi
+            push Not at contr
+            rw [hi] at contr
+            match hby : P.b ᵥ⬝ y with
+            | ⊥ =>
+              change hby to P.b ᵥ⬝ y = ⊥
+              rw [←dotWeig_eq_bot] at hby
+              exact hb hby
+            | ⊤ =>
+              dsimp only [ValidELP.dualize] at contr
+              rw [hby] at contr
+              change contr to ⊤ + ⊤ < 0
+              simp at contr
+            | (q : F) =>
+              dsimp only [ValidELP.dualize] at contr
+              rw [hby] at contr
+              change contr to ⊤ + toE q < 0
+              simp at contr
+        )
+        (by
+          intro ⟨i, ⟨j, hij⟩, hi⟩
+          cases i with
+          | inl i' => exact P.hbA ⟨i', ⟨j, hij⟩, hi⟩
+          | inr => exact hc ⟨j, hij⟩
+        )
+      )
+  constructor
+  · use x
+    rw [Matrix.fromRows_mulWeig, Sum.elim_le_elim_iff]
+    exact ⟨hx, by rfl⟩
+  · use Sum.elim y 1
+    constructor
+    · rw [Matrix.transpose_fromRows, Matrix.fromCols_neg, Matrix.fromCols_mulWeig_sumElim]
+      have hle0 : (-P.Aᵀ) ₘ* y + (-P.c) ≤ 0
+      · rwa [EF.vec_sub_nonpos_iff]
+      convert hle0
+      ext
+      simp [Matrix.mulWeig, dotWeig, EF.one_smul]
+    · have hlt0 : P.b ᵥ⬝ y + P.c ᵥ⬝ x < 0
+      · push Not at contr
+        rwa [add_comm]
+      rw [sumElim_dotWeig_sumElim]
+      have h1 : (↓(P.c ᵥ⬝ x) : Unit → F∞) ᵥ⬝ (1 : Unit → F≥0) = P.c ᵥ⬝ x := by
+        simp only [dotWeig, Fintype.sum_unique, EF.one_smul, Pi.one_apply]
+      rw [h1]
+      exact hlt0
+
+lemma ValidELP.no_bot_of_reaches [Fintype J] (P : ValidELP I J F) {p : F∞} (hP : P.Reaches p)
+    (i : I) : P.b i ≠ ⊥ := by
+  intro contr
+  obtain ⟨x, hx, -⟩ := hP
+  have impos : P.A i ᵥ⬝ x ≤ ⊥ := contr ▸ hx i
+  rw [le_bot_iff, ←dotWeig_eq_bot] at impos
+  exact P.hbA ⟨i, impos, contr⟩
+
+theorem ValidELP.weakDuality [Fintype I] [Fintype J]
+    (P : ValidELP I J F)
+    {p : F∞} (hP : P.Reaches p) {q : F∞} (hQ : P.dualize.Reaches q) :
+    0 ≤ p + q := by
+  by_cases hb : ∃ i : I, P.b i = ⊥
+  · exfalso
+    obtain ⟨i, hi⟩ := hb
+    exact P.no_bot_of_reaches hP i hi
+  by_cases hc : ∃ j : J, P.c j = ⊥
+  · exfalso
+    obtain ⟨j, hj⟩ := hc
+    exact P.dualize.no_bot_of_reaches hQ j hj
+  exact P.weakDuality_of_no_bot hb hc hP hQ
+
+end weak_duality
+
+
+section strong_duality
+
+section nneg_vs_zero
+
+omit [IsStrictOrderedRing F] in
+lemma eq_zero_of_zero_eq_val {k : F≥0} (hk : 0 = k.val) :
+    k = 0 :=
+  Subtype.ext hk.symm
+
+omit [IsStrictOrderedRing F] in
+lemma pos_of_NN_not_zero {k : F≥0} (hk : ¬(k = 0)) :
+    0 < k := by
+  apply lt_of_le_of_ne k.property
+  exact hk ∘ eq_zero_of_zero_eq_val
+
+end nneg_vs_zero
+
+section misc_EF_properties
+
+lemma EF.smul_nonpos {r : F∞} (hr : r ≤ 0) (k : F≥0) :
+    k • r ≤ 0 := by
+  match r with
+  | ⊥ => apply bot_le
+  | ⊤ => exact absurd hr (not_le.mpr EF.zero_lt_top)
+  | (f : F) =>
+    change (toE (k.val * f) : F∞) ≤ (0 : F∞)
+    exact (EF.coe_le_coe_iff (x := k.val * f) (y := 0)).←
+      (mul_nonpos_of_nonneg_of_nonpos k.property (EF.coe_nonpos.→ hr))
+
+lemma EF.smul_lt_smul_left {k : F≥0} (hk : 0 < k) (r s : F∞) :
+    k • r < k • s ↔ r < s := by
+  match s with
+  | ⊥ =>
+    convert_to False ↔ False
+    · rw [iff_false]
+      apply not_lt_bot
+    · simp
+    rfl
+  | ⊤ =>
+    match r with
+    | ⊥ =>
+      convert_to True ↔ True
+      · rw [EF.pos_smul_top hk, iff_true]
+        apply bot_lt_top
+      · simp
+      rfl
+    | ⊤ =>
+      convert_to False ↔ False
+      · apply lt_self_iff_false
+      · apply lt_self_iff_false
+      rfl
+    | (_ : F) =>
+      convert_to True ↔ True
+      · rw [EF.pos_smul_top hk, iff_true]
+        apply EF.coe_lt_top
+      · simp
+      rfl
+  | (q : F) =>
+    match r with
+    | ⊥ =>
+      convert_to True ↔ True
+      · rw [iff_true]
+        apply EF.bot_lt_coe
+      · simp
+      rfl
+    | ⊤ =>
+      convert_to False ↔ False
+      · rw [EF.pos_smul_top hk, iff_false]
+        apply not_top_lt
+      · simp
+      rfl
+    | (p : F) =>
+      rw [EF.coe_lt_coe_iff]
+      change (toE (k.val * p) < toE (k.val * q) : Prop) ↔ p < q
+      rw [EF.coe_lt_coe_iff]
+      have hk' : (0 : F) < k.val := hk
+      exact mul_lt_mul_iff_right₀ hk'
+
+lemma EF.smul_le_smul_left {k : F≥0} (hk : 0 < k) (r s : F∞) :
+    k • r ≤ k • s ↔ r ≤ s := by
+  convert neg_iff_neg (EF.smul_lt_smul_left hk s r) <;> exact Iff.symm not_lt
+
+lemma EF.smul_neg {k : F≥0} {r : F∞} (hkr : k = 0 → r ≠ ⊥ ∧ r ≠ ⊤) :
+    k • (-r) = -(k • r) := by
+  match r with
+  | ⊥ =>
+    rw [EF.neg_bot]
+    if hk : 0 < k then
+      rewrite [EF.pos_smul_top hk]
+      rfl
+    else
+      exfalso
+      simp_all
+  | ⊤ =>
+    rw [EF.neg_top]
+    if hk : 0 < k then
+      rewrite [EF.pos_smul_top hk, EF.neg_top]
+      rfl
+    else
+      exfalso
+      simp_all
+  | (f : F) =>
+    rw [←EF.coe_neg]
+    change toE (k * (-f)) = toE (-(k * f))
+    rw [mul_neg]
+
+lemma EF.pos_smul_neg {k : F≥0} (hk : 0 < k) (r : F∞) :
+    k • (-r) = -(k • r) := by
+  apply EF.smul_neg
+  intro h0
+  exfalso
+  exact (h0 ▸ hk).false
+
+lemma EF.smul_smul {k : F≥0} (hk : 0 < k) (l : F≥0) (r : F∞) :
+    l • (k • r) = k • (l • r) := by
+  match r with
+  | ⊥ =>
+    rw [EF.smul_bot, EF.smul_bot, EF.smul_bot]
+  | ⊤ =>
+    rw [EF.pos_smul_top hk]
+    if hl : 0 < l then
+      rw [EF.pos_smul_top hl, EF.pos_smul_top hk]
+    else if hl0 : l = 0 then
+      rw [hl0, EF.zero_smul_nonbot top_ne_bot, smul_zero]
+    else
+      exfalso
+      simp_all only [not_lt, nonpos_iff_eq_zero]
+  | (f : F) =>
+    exact EF.coe_eq_coe_iff.← (mul_left_comm l.val k.val f)
+
+lemma EF.add_smul (k l : F≥0) (r : F∞) :
+    (k + l) • r = k • r + l • r := by
+  match r with
+  | ⊥ =>
+    rewrite [EF.smul_bot, EF.smul_bot, EF.smul_bot]
+    rfl
+  | ⊤ =>
+    if k_eq_0 : k = 0 then
+      rw [k_eq_0, EF.zero_smul_nonbot top_ne_bot, zero_add, zero_add]
+    else
+      have k_pos : 0 < k
+      · exact pos_of_NN_not_zero k_eq_0
+      rw [EF.pos_smul_top (add_pos_of_pos_of_nonneg k_pos l.property)]
+      rw [EF.pos_smul_top k_pos]
+      if l_eq_0 : l = 0 then
+        rw [l_eq_0, EF.zero_smul_nonbot top_ne_bot, add_zero]
+      else
+        rw [EF.pos_smul_top (pos_of_NN_not_zero l_eq_0)]
+        rfl
+  | (f : F) =>
+    change toE ((k.val + l.val) * f) = toE (k.val * f) + toE (l.val * f)
+    rw [←EF.coe_add, add_mul]
+
+omit [IsStrictOrderedRing F] in
+lemma EF.smul_add {k : F≥0} (hk : 0 < k) (r s : F∞) :
+    k • (r + s) = k • r + k • s := by
+  match r, s with
+  | ⊥, _ =>
+    rw [EF.bot_add, EF.smul_bot, EF.bot_add]
+  | _, ⊥ =>
+    rw [EF.add_bot, EF.smul_bot, EF.add_bot]
+  | (p : F), (q : F) =>
+    change toE (k * (p + q)) = toE (k * p) + toE (k * q)
+    rewrite [mul_add]
+    rfl
+  | (p : F), ⊤ =>
+    rw [EF.coe_add_top, EF.pos_smul_top hk]
+    change ⊤ = toE (k * p) + ⊤
+    rw [EF.coe_add_top]
+  | ⊤, (q : F) =>
+    rw [EF.top_add_coe, EF.pos_smul_top hk]
+    change ⊤ = ⊤ + toE (k * q)
+    rw [EF.top_add_coe]
+  | ⊤, ⊤ =>
+    rw [EF.top_add_top, EF.pos_smul_top hk, EF.top_add_top]
+
+lemma EF.mul_smul (k l : F≥0) (r : F∞) :
+    (k * l) • r = k • (l • r) := by
+  match r with
+  | ⊥ =>
+    iterate 3 rw [EF.smul_bot]
+  | ⊤ =>
+    if l_eq_0 : l = 0 then
+      rw [l_eq_0, EF.zero_smul_nonbot top_ne_bot, mul_zero, EF.zero_smul_nonbot top_ne_bot,
+        smul_zero]
+    else
+      have l_pos : 0 < l
+      · apply lt_of_le_of_ne l.property
+        exact l_eq_0 ∘ eq_zero_of_zero_eq_val
+      rw [EF.pos_smul_top l_pos]
+      if k_eq_0 : k = 0 then
+        rw [k_eq_0, EF.zero_smul_nonbot top_ne_bot, zero_mul, EF.zero_smul_nonbot top_ne_bot]
+      else
+        have c_pos : 0 < k
+        · exact pos_of_NN_not_zero k_eq_0
+        rw [EF.pos_smul_top c_pos, EF.pos_smul_top (mul_pos c_pos l_pos)]
+  | (f : F) =>
+    change toE ((k * l) * f) = toE (k * (l * f))
+    rw [mul_assoc]
+
+lemma EF.one_smul_vec (v : J → F∞) :
+    (1 : F≥0) • v = v := by
+  ext
+  apply EF.one_smul
+
+omit [IsStrictOrderedRing F] in
+lemma EF.smul_add_vec {k : F≥0} (hk : 0 < k) (v w : J → F∞) :
+    k • (v + w) = k • v + k • w := by
+  ext
+  apply EF.smul_add hk
+
+lemma EF.mul_smul_vec (k l : F≥0) (v : J → F∞) :
+    (k * l) • v = k • (l • v) := by
+  ext
+  apply EF.mul_smul
+
+lemma EF.vec_smul_le_smul_left {k : F≥0} (hk : 0 < k) (u v : I → F∞) :
+    k • u ≤ k • v ↔ u ≤ v := by
+  simp [Pi.le_def, EF.smul_le_smul_left, hk]
+
+lemma Multiset.sum_neq_EF_top {s : Multiset F∞} (hs : ⊤ ∉ s) :
+    s.sum ≠ ⊤ := by
+  induction s using Multiset.induction with
+  | empty => simp
+  | cons a m ih =>
+    rw [Multiset.sum_cons]
+    match a with
+    | ⊥ => simp
+    | ⊤ => simp at hs
+    | (_ : F) => match hm : m.sum with
+      | ⊥ => simp
+      | ⊤ => exact (ih (by simpa using hs) hm).elim
+      | (_ : F) => simp [←EF.coe_add]
+
+omit [IsStrictOrderedRing F] in
+lemma Multiset.smul_EF_sum {k : F≥0} (hk : 0 < k) (s : Multiset F∞) :
+    (s.map (k • ·)).sum = k • s.sum := by
+  induction s using Multiset.induction with
+  | empty => simp
+  | cons a m ih => simp [EF.smul_add hk, ←ih]
+
+omit [IsStrictOrderedRing F] in
+lemma Finset.smul_EF_sum [Fintype J] {k : F≥0} (hk : 0 < k) (v : J → F∞) :
+    ∑ j : J, k • v j = k • ∑ j : J, v j := by
+  convert Multiset.smul_EF_sum hk (Finset.univ.val.map v)
+  simp
+
+end misc_EF_properties
+
+section dotWeig_EF_properties
+
+omit [IsStrictOrderedRing F] in
+lemma zero_dotWeig [Fintype J] (w : J → F≥0) : (0 : J → F∞) ᵥ⬝ w = 0 := by
+  apply Finset.sum_eq_zero
+  intro j _
+  exact smul_zero (w j)
+
+lemma dotWeig_add [Fintype J] (x : J → F∞) (v w : J → F≥0) :
+    x ᵥ⬝ (v + w) = x ᵥ⬝ v + x ᵥ⬝ w := by
+  simp [dotWeig, EF.add_smul, Finset.sum_add_distrib]
+
+lemma dotWeig_smul [Fintype J] {k : F≥0} (hk : 0 < k) (x : J → F∞) (v : J → F≥0) :
+    x ᵥ⬝ (k • v) = k • (x ᵥ⬝ v) := by
+  change ∑ j : J, (k * v j) • x j = k • ∑ j : J, v j • x j
+  rw [←Finset.smul_EF_sum hk]
+  apply congr_arg
+  ext
+  apply EF.mul_smul
+
+lemma no_top_dotWeig_nneg [Fintype J] {v : J → F∞} (hv : ∀ j, v j ≠ ⊤) (w : J → F≥0) :
+    v ᵥ⬝ w ≠ (⊤ : F∞) := by
+  apply Multiset.sum_neq_EF_top
+  rw [Multiset.mem_map]
+  intro ⟨i, _, hi⟩
+  match hvi : v i with
+  | ⊥ => exact bot_ne_top (hvi ▸ hi)
+  | ⊤ => exact false_of_ne (hvi ▸ hv i)
+  | (_ : F) => exact EF.coe_neq_top _ (hvi ▸ hi)
+
+end dotWeig_EF_properties
+
+section matrix_EF_properties
+
+omit [IsStrictOrderedRing F] in
+lemma Matrix.EF_neg_zero : -(0 : Matrix I J F∞) = 0 := by
+  ext
+  apply neg_zero
+
+omit [IsStrictOrderedRing F] in
+lemma Matrix.EF_neg_neg (M : Matrix I J F∞) : -(-M) = M := by
+  ext
+  apply neg_neg
+
+omit [IsStrictOrderedRing F] in
+lemma Matrix.zero_mulWeig [Fintype J] (v : J → F≥0) : (0 : Matrix I J F∞) ₘ* v = 0 := by
+  ext
+  simp [Matrix.mulWeig, dotWeig]
+
+lemma Matrix.mulWeig_add [Fintype J] (M : Matrix I J F∞) (v w : J → F≥0) :
+    M ₘ* (v + w) = M ₘ* v + M ₘ* w := by
+  ext
+  apply dotWeig_add
+
+lemma Matrix.mulWeig_smul [Fintype J] {k : F≥0} (hk : 0 < k) (M : Matrix I J F∞) (v : J → F≥0) :
+    M ₘ* (k • v) = k • (M ₘ* v) := by
+  ext
+  apply dotWeig_smul hk
+
+end matrix_EF_properties
+
+section extended_LP_properties
+
+lemma ValidELP.dualize_dualize (P : ValidELP I J F) : P = P.dualize.dualize := by
+  obtain ⟨⟨_, _, _⟩⟩ := P
+  simp [ValidELP.dualize]
+
+lemma ValidELP.no_bot_of_feasible [Fintype J] (P : ValidELP I J F) (hP : P.IsFeasible) (i : I) :
+    P.b i ≠ ⊥ :=
+  P.no_bot_of_reaches hP.choose_spec.left i
+
+variable [Fintype J]
+
+lemma ValidELP.isUnbounded_iff (P : ValidELP I J F) :
+    P.IsUnbounded ↔ ∀ r : F, ∃ p : F∞, P.Reaches p ∧ p < r := by
+  simp [ExtendedLP.IsUnbounded, ExtendedLP.IsBoundedBy]
+
+lemma ValidELP.unbounded_of_reaches_le (P : ValidELP I J F)
+    (hP : ∀ r : F, ∃ p : F∞, P.Reaches p ∧ p ≤ r) :
+    P.IsUnbounded := by
+  rw [ValidELP.isUnbounded_iff]
+  intro r
+  obtain ⟨p, hPp, hpr⟩ := hP (r-1)
+  exact ⟨p, hPp, hpr.trans_lt (EF.coe_lt_coe_iff.← (sub_one_lt r))⟩
+
+lemma ValidELP.unbounded_of_feasible_of_neg (P : ValidELP I J F) (hP : P.IsFeasible)
+    {x₀ : J → F≥0} (hx₀ : P.c ᵥ⬝ x₀ < 0) (hAx₀ : P.A ₘ* x₀ + (0 : F≥0) • (-P.b) ≤ 0) :
+    P.IsUnbounded := by
+  have nobot := P.no_bot_of_feasible hP
+  obtain ⟨e, ⟨xₚ, hxₚ, hce⟩, he⟩ := hP
+  apply P.unbounded_of_reaches_le
+  intro s
+  if hs : e ≤ s then
+    refine ⟨e, ⟨xₚ, hxₚ, hce⟩, ?_⟩
+    simpa using hs
+  else
+    push Not at hs
+    match e with
+    | ⊥ => simp at hs
+    | ⊤ => simp at he
+    | (e : F) =>
+      clear he
+      match hcx₀ : P.c ᵥ⬝ x₀ with
+      | ⊥ =>
+        refine ⟨⊥, ⟨xₚ, hxₚ, ?_⟩, bot_le⟩
+        change hcx₀ to P.c ᵥ⬝ x₀ = ⊥
+        rwa [←dotWeig_eq_bot] at hcx₀ ⊢
+      | ⊤ =>
+        exfalso
+        rw [hcx₀] at hx₀
+        exact (hx₀.trans_le le_top).false
+      | (d : F) =>
+        rw [hcx₀] at hx₀
+        have coef_pos : 0 < (s - e) / d
+        · apply div_pos_of_neg_of_neg
+          · rwa [sub_neg, ←EF.coe_lt_coe_iff]
+          · rwa [←EF.coe_neg']
+        let k : F≥0 := ⟨((s - e) / d), coef_pos.le⟩
+        let k_pos : 0 < k := coef_pos
+        refine ⟨s, ⟨xₚ + k • x₀, ?_, ?_⟩, by rfl⟩
+        · intro i
+          match hi : P.b i with
+          | ⊥ =>
+            exfalso
+            exact nobot i hi
+          | ⊤ =>
+            apply le_top
+          | (bᵢ : F) =>
+            specialize hAx₀ i
+            rw [Pi.add_apply, Pi.smul_apply, Pi.neg_apply, hi] at hAx₀
+            have zeros : (P.A ₘ* x₀) i + (0 : F∞) ≤ 0
+            · convert hAx₀
+              change 0 = 0 • -(toE bᵢ)
+              rw [←EF.coe_neg, EF.zero_smul_coe]
+            rw [add_zero] at zeros
+            rw [Matrix.mulWeig_add, Matrix.mulWeig_smul k_pos, Pi.add_apply]
+            apply add_le_of_le_of_nonpos
+            · convert_to (P.A ₘ* xₚ) i ≤ P.b i
+              · exact hi.symm
+              exact hxₚ i
+            · exact EF.smul_nonpos zeros k
+        · rw [dotWeig_add, hce, dotWeig_smul k_pos, hcx₀]
+          change toE (e + ((s - e) / d) * d) = toE s
+          rw [EF.coe_eq_coe_iff, div_mul_cancel_of_imp]
+          · exact add_sub_cancel e s
+          · intro d_eq_0
+            exfalso
+            rw [d_eq_0] at hx₀
+            exact hx₀.false
+
+variable [Fintype I]
+
+lemma ValidELP.unbounded_of_feasible_of_infeasible (P : ValidELP I J F)
+    (hP : P.IsFeasible) (hQ : ¬P.dualize.IsFeasible) :
+    P.IsUnbounded := by
+  let I' : Type _ := { i : I // P.b i ≠ ⊤ }
+  let A' : Matrix I' J F∞ := Matrix.of (fun i' : I' => P.A i'.val)
+  let b' : I' → F∞ := (fun i' : I' => P.b i'.val)
+  cases or_of_neq (extendedFarkas (-A'ᵀ) P.c
+      (by aeply P.hAj) (by aeply P.hAi) (by aeply P.hAc) (by aeply P.hcA)) with
+  | inl caseI =>
+    exfalso
+    obtain ⟨y, hy⟩ := caseI
+    match hby : b' ᵥ⬝ y with
+    | ⊥ => exact no_bot_dotWeig_nneg (P.no_bot_of_feasible hP ·.val ·) y hby
+    | ⊤ => exact no_top_dotWeig_nneg (·.property) y hby
+    | (q : F) =>
+      apply hQ
+      refine ⟨toE q, ⟨fun i : I => if hi : (P.b i ≠ ⊤) then y ⟨i, hi⟩ else 0, ?_⟩,
+        EF.coe_neq_top q⟩
+      constructor
+      · unfold ValidELP.dualize ExtendedLP.IsSolution Matrix.mulWeig
+        convert hy
+        simp only [Matrix.mulWeig, dotWeig, dite_not, dite_smul]
+        rw [Finset.sum_dite]
+        convert zero_add _ using 1
+        apply congr_arg₂
+        · apply Finset.sum_eq_zero
+          intro i _
+          apply EF.zero_smul_nonbot
+          intro contr
+          exact P.hAb ⟨i.val, by aesop, by aesop⟩
+        · erw [←Finset.sum_coe_sort_eq_attach]
+          apply Finset.subtype_univ_sum_eq_subtype_univ_sum
+          · ext
+            simp
+          · intros
+            rfl
+      · simp only [dotWeig, dite_not, dite_smul]
+        rw [Finset.sum_dite]
+        convert zero_add _
+        · apply Finset.sum_eq_zero
+          intro i _
+          apply EF.zero_smul_nonbot
+          exact P.no_bot_of_feasible hP i.val
+        · change hby to b' ᵥ⬝ y = toE q
+          erw [←Finset.sum_coe_sort_eq_attach]
+          rw [←hby]
+          apply Finset.subtype_univ_sum_eq_subtype_univ_sum
+          · ext
+            simp
+          · intros
+            rfl
+  | inr caseJ =>
+    obtain ⟨x, hAx, hcx⟩ := caseJ
+    apply P.unbounded_of_feasible_of_neg hP hcx
+    rw [Matrix.transpose_neg, Matrix.transpose_transpose, Matrix.EF_neg_neg] at hAx
+    intro i
+    match hbi : P.b i with
+    | ⊥ =>
+      exfalso
+      exact P.no_bot_of_feasible hP i hbi
+    | ⊤ =>
+      change hbi to P.b i = ⊤
+      rw [Pi.add_apply, Pi.smul_apply, Pi.neg_apply, hbi, EF.neg_top, EF.smul_bot, EF.add_bot]
+      apply bot_le
+    | (f : F) =>
+      change hbi to P.b i = toE f
+      have hf : -(toE f) ≠ (⊥ : F∞)
+      · rw [←EF.coe_neg]
+        apply EF.coe_neq_bot
+      rw [Pi.add_apply, Pi.smul_apply, Pi.neg_apply, hbi, EF.zero_smul_nonbot hf, add_zero]
+      exact hAx ⟨i, hbi ▸ EF.coe_neq_top f⟩
+
+lemma ValidELP.infeasible_of_unbounded (P : ValidELP I J F) (hP : P.IsUnbounded) :
+    ¬P.dualize.IsFeasible := by
+  intro ⟨q, hPq, hq⟩
+  rw [ValidELP.isUnbounded_iff] at hP
+  match q with
+  | ⊥ =>
+    obtain ⟨p, hp, -⟩ := hP 0
+    simpa using P.weakDuality hp hPq
+  | ⊤ =>
+    exact hq rfl
+  | (f : F) =>
+    obtain ⟨p, hp, hpq⟩ := hP (-f)
+    have wd := P.weakDuality hp hPq
+    match p with
+    | ⊥ => simp at wd
+    | ⊤ => simp at hpq
+    | (_ : F) =>
+      rw [←EF.coe_add, ←EF.coe_zero, EF.coe_le_coe_iff] at wd
+      rw [EF.coe_lt_coe_iff] at hpq
+      linarith
+
+/-! The strong duality auxiliary proof is split because the original single proof exceeded the
+LeanPool 200-line cap. We dispatch on the two cases coming from `extendedFarkas` and finish
+each in its own helper. -/
+
+private lemma ValidELP.strongDuality_aux_caseX (P : ValidELP I J F)
+    (hP : P.IsFeasible) (hQ : P.dualize.IsFeasible)
+    {X : J ⊕ I → F≥0}
+    (hX :
+      Matrix.fromRows
+        (Matrix.fromBlocks P.A 0 0 (-P.Aᵀ))
+        (Matrix.replicateRow Unit (Sum.elim P.c P.b)) ₘ* X ≤
+      Sum.elim (Sum.elim P.b P.c) 0) :
+    ∃ p q : F, P.Reaches p ∧ P.dualize.Reaches q ∧ p + q ≤ 0 := by
+  rw [
+    Matrix.fromRows_mulWeig, Sum.elim_le_elim_iff,
+    ←Matrix.fromRows_fromCols_eq_fromBlocks, Matrix.fromRows_mulWeig, Sum.elim_le_elim_iff,
+    ←Sum.elim_comp_inl_inr X, Matrix.fromCols_mulWeig_sumElim, Matrix.fromCols_mulWeig_sumElim,
+    Matrix.zero_mulWeig, add_zero, Matrix.zero_mulWeig, zero_add
+  ] at hX
+  set x := X ∘ Sum.inl
+  set y := X ∘ Sum.inr
+  obtain ⟨⟨hx, hy⟩, hxy⟩ := hX
+  specialize hxy 0
+  change hxy to Sum.elim P.c P.b ᵥ⬝ Sum.elim x y ≤ 0
+  rw [sumElim_dotWeig_sumElim] at hxy
+  match hcx : P.c ᵥ⬝ x with
+  | ⊥ =>
+    exfalso
+    obtain ⟨j, hj⟩ := dotWeig_eq_bot.← hcx
+    exact P.dualize.no_bot_of_feasible hQ j hj
+  | ⊤ =>
+    exfalso
+    match hby : P.b ᵥ⬝ y with
+    | ⊥ =>
+      obtain ⟨i, hi⟩ := dotWeig_eq_bot.← hby
+      exact P.no_bot_of_feasible hP i hi
+    | ⊤ =>
+      rw [hcx, hby] at hxy
+      exact (hxy.trans_lt EF.zero_lt_top).false
+    | (_ : F) =>
+      rw [hcx, hby] at hxy
+      exact (hxy.trans_lt EF.zero_lt_top).false
+  | (p : F) =>
+    match hby : P.b ᵥ⬝ y with
+    | ⊥ =>
+      exfalso
+      obtain ⟨i, hi⟩ := dotWeig_eq_bot.← hby
+      exact P.no_bot_of_feasible hP i hi
+    | ⊤ =>
+      exfalso
+      rw [hcx, hby] at hxy
+      exact (hxy.trans_lt EF.zero_lt_top).false
+    | (q : F) =>
+      refine ⟨p, q, ⟨x, hx, hcx⟩, ⟨y, hy, hby⟩, ?_⟩
+      rw [←EF.coe_le_coe_iff]
+      rwa [hcx, hby] at hxy
+
+private lemma ValidELP.strongDuality_aux_caseY (P : ValidELP I J F)
+    (hP : P.IsFeasible) (hQ : P.dualize.IsFeasible)
+    {Y : (I ⊕ J) ⊕ Unit → F≥0}
+    (hAY :
+      -(Matrix.fromRows
+          (Matrix.fromBlocks P.A 0 0 (-P.Aᵀ))
+          (Matrix.replicateRow Unit (Sum.elim P.c P.b)))ᵀ ₘ* Y ≤ 0)
+    (hbc : Sum.elim (Sum.elim P.b P.c) 0 ᵥ⬝ Y < 0) :
+    ∃ p q : F, P.Reaches p ∧ P.dualize.Reaches q ∧ p + q ≤ 0 := by
+  rw [
+    Matrix.transpose_fromRows, Matrix.fromBlocks_transpose, Matrix.transpose_zero,
+    Matrix.transpose_zero, Matrix.transpose_neg, Matrix.transpose_transpose,
+    Matrix.transpose_replicateRow, Matrix.fromCols_neg,
+    ←Sum.elim_comp_inl_inr Y, Matrix.fromCols_mulWeig_sumElim,
+    Matrix.fromBlocks_neg, Matrix.EF_neg_neg, Matrix.EF_neg_zero, Matrix.EF_neg_zero,
+    ←Matrix.fromRows_fromCols_eq_fromBlocks, Matrix.fromRows_mulWeig,
+    ←Sum.elim_comp_inl_inr (Y ∘ Sum.inl), Matrix.fromCols_mulWeig_sumElim,
+    Matrix.fromCols_mulWeig_sumElim,
+    Matrix.zero_mulWeig, add_zero, Matrix.zero_mulWeig, zero_add,
+  ] at hAY
+  rw [←Sum.elim_comp_inl_inr Y, ←Sum.elim_comp_inl_inr (Y ∘ Sum.inl)] at hbc
+  set x := (Y ∘ Sum.inl) ∘ Sum.inr
+  set y := (Y ∘ Sum.inl) ∘ Sum.inl
+  set z := (Y ∘ Sum.inr) 0
+  have hAyx : Sum.elim (-P.Aᵀ ₘ* y) (P.A ₘ* x) + z • (-Sum.elim P.c P.b) ≤ 0
+  · convert hAY
+    ext
+    simp [Matrix.replicateCol, Matrix.mulWeig, dotWeig, z]
+  have hAyx' :
+      Sum.elim (-P.Aᵀ ₘ* y) (P.A ₘ* x) + Sum.elim (z • (-P.c)) (z • (-P.b)) ≤ 0
+  · convert hAyx
+    aesop
+  clear hAY hAyx
+  rw [←Sum.elim_add_add, Sum.elim_nonpos_iff] at hAyx'
+  obtain ⟨hy, hx⟩ := hAyx'
+  rw [sumElim_dotWeig_sumElim, zero_dotWeig, add_zero, sumElim_dotWeig_sumElim] at hbc
+  have z_pos : 0 < z
+  · by_contra contr
+    have z_eq_0 : z = 0
+    · push Not at contr
+      exact nonpos_iff_eq_zero.→ contr
+    rw [z_eq_0] at hx hy
+    clear contr z_eq_0 z
+    if hxc : P.c ᵥ⬝ x < 0 then
+      exact P.infeasible_of_unbounded (P.unbounded_of_feasible_of_neg hP hxc hx) hQ
+    else
+      have hyb : P.b ᵥ⬝ y < 0
+      · push Not at hxc
+        by_contra! contr
+        exact (hbc.trans_le (add_nonneg contr hxc)).false
+      exact P.dualize.infeasible_of_unbounded
+        (P.dualize.unbounded_of_feasible_of_neg hQ hyb hy) (P.dualize_dualize ▸ hP)
+  match hcx : P.c ᵥ⬝ x with
+  | ⊥ =>
+    exfalso
+    obtain ⟨j, hj⟩ := dotWeig_eq_bot.← hcx
+    exact P.dualize.no_bot_of_feasible hQ j hj
+  | ⊤ =>
+    exfalso
+    match hby : P.b ᵥ⬝ y with
+    | ⊥ =>
+      obtain ⟨i, hi⟩ := dotWeig_eq_bot.← hby
+      exact P.no_bot_of_feasible hP i hi
+    | ⊤ =>
+      rw [hcx, hby] at hbc
+      exact (hbc.trans EF.zero_lt_top).false
+    | (_ : F) =>
+      rw [hcx, hby] at hbc
+      exact (hbc.trans EF.zero_lt_top).false
+  | (p : F) =>
+    match hby : P.b ᵥ⬝ y with
+    | ⊥ =>
+      exfalso
+      obtain ⟨i, hi⟩ := dotWeig_eq_bot.← hby
+      exact P.no_bot_of_feasible hP i hi
+    | ⊤ =>
+      exfalso
+      rw [hcx, hby] at hbc
+      exact (hbc.trans EF.zero_lt_top).false
+    | (q : F) =>
+      have z_inv_pos : 0 < z⁻¹
+      · exact inv_pos_of_pos z_pos
+      refine ⟨z⁻¹ * p, z⁻¹ * q, ⟨z⁻¹ • x, ?_, ?_⟩, ⟨z⁻¹ • y, ?_, ?_⟩, ?_⟩
+      · rwa [
+          ←EF.vec_smul_le_smul_left z_inv_pos, smul_zero,
+          EF.smul_add_vec z_inv_pos, ←Matrix.mulWeig_smul z_inv_pos, ←EF.mul_smul_vec,
+          inv_mul_cancel₀ (ne_of_lt z_pos).symm, EF.one_smul_vec, EF.vec_sub_nonpos_iff
+        ] at hx
+      · rewrite [dotWeig_smul z_inv_pos, hcx]
+        rfl
+      · rwa [
+          ←EF.vec_smul_le_smul_left z_inv_pos, smul_zero,
+          EF.smul_add_vec z_inv_pos, ←Matrix.mulWeig_smul z_inv_pos, ←EF.mul_smul_vec,
+          inv_mul_cancel₀ (ne_of_lt z_pos).symm, EF.one_smul_vec, EF.vec_sub_nonpos_iff
+        ] at hy
+      · dsimp only [ValidELP.dualize]
+        rewrite [dotWeig_smul z_inv_pos, hby]
+        rfl
+      rw [hcx, hby] at hbc
+      rw [←mul_add]
+      have hpq : p + q < 0
+      · rwa [←EF.coe_lt_coe_iff, add_comm]
+      exact mul_nonpos_of_nonneg_of_nonpos z_inv_pos.le hpq.le
+
+lemma ValidELP.strongDuality_aux (P : ValidELP I J F)
+    (hP : P.IsFeasible) (hQ : P.dualize.IsFeasible) :
+    ∃ p q : F, P.Reaches p ∧ P.dualize.Reaches q ∧ p + q ≤ 0 := by
+  cases
+    or_of_neq
+      (extendedFarkas
+        (Matrix.fromRows
+          (Matrix.fromBlocks P.A 0 0 (-P.Aᵀ))
+          (Matrix.replicateRow Unit (Sum.elim P.c P.b)))
+        (Sum.elim (Sum.elim P.b P.c) 0)
+        (by
+          intro ⟨k, ⟨s, hks⟩, ⟨t, hkt⟩⟩
+          cases k with
+          | inl k' =>
+            cases k' with
+            | inl i =>
+              cases s with
+              | inl jₛ =>
+                cases t with
+                | inl jₜ =>
+                  exact P.hAi
+                    ⟨i, ⟨⟨jₛ, by simpa using hks⟩, ⟨jₜ, by simpa using hkt⟩⟩⟩
+                | inr iₜ => simp at hkt
+              | inr iₛ => simp at hks
+            | inr j =>
+              cases t with
+              | inl jₜ => simp at hkt
+              | inr iₜ =>
+                cases s with
+                | inl jₛ => simp at hks
+                | inr iₛ =>
+                  exact P.hAj
+                    ⟨j, ⟨iₜ, by simpa using hkt⟩, ⟨iₛ, by simpa using hks⟩⟩
+          | inr =>
+            cases s with
+            | inl jₛ => exact P.dualize.no_bot_of_feasible hQ jₛ hks
+            | inr iₛ => exact P.no_bot_of_feasible hP iₛ hks
+        )
+        (by
+          intro ⟨k, ⟨s, hks⟩, ⟨t, hkt⟩⟩
+          cases k with
+          | inl j =>
+            cases s with
+            | inl s' =>
+              cases s' with
+              | inl iₛ =>
+                cases t with
+                | inl t' =>
+                  cases t' with
+                  | inl iₜ => exact P.hAj ⟨j, ⟨⟨iₛ, hks⟩, ⟨iₜ, hkt⟩⟩⟩
+                  | inr jₜ => simp at hkt
+                | inr => exact P.hAc ⟨j, ⟨iₛ, hks⟩, hkt⟩
+              | inr jₛ => simp at hks
+            | inr => exact P.dualize.no_bot_of_feasible hQ j hks
+          | inr i =>
+            cases s with
+            | inl s' =>
+              cases s' with
+              | inl iₛ => simp at hks
+              | inr jₛ =>
+                cases t with
+                | inl t' =>
+                  cases t' with
+                  | inl iₜ => simp at hkt
+                  | inr jₜ =>
+                    exact P.hAi
+                      ⟨i, ⟨jₜ, by simpa using hkt⟩, ⟨jₛ, by simpa using hks⟩⟩
+                | inr => exact P.hAb ⟨i, ⟨jₛ, by simpa using hks⟩, hkt⟩
+            | inr => exact P.no_bot_of_feasible hP i hks
+        )
+        (by
+          intro ⟨k, ⟨t, hkt⟩, hk⟩
+          cases k with
+          | inl k' =>
+            cases k' with
+            | inl i =>
+              cases t with
+              | inl jₜ => exact P.hAb ⟨i, ⟨jₜ, hkt⟩, hk⟩
+              | inr iₜ => simp at hkt
+            | inr j =>
+              cases t with
+              | inl jₜ => simp at hkt
+              | inr iₜ => exact P.hAc ⟨j, ⟨iₜ, by simpa using hkt⟩, hk⟩
+          | inr => simp at hk
+        )
+        (by
+          intro ⟨k, ⟨s, hks⟩, hk⟩
+          cases k with
+          | inl k' =>
+            cases k' with
+            | inl i =>
+              cases s with
+              | inl jₛ => exact P.no_bot_of_feasible hP i hk
+              | inr iₛ => simp at hks
+            | inr j =>
+              cases s with
+              | inl jₛ => simp at hks
+              | inr iₛ => exact P.dualize.no_bot_of_feasible hQ j hk
+          | inr => simp at hk
+        )
+      ) with
+  | inl case_X =>
+    obtain ⟨X, hX⟩ := case_X
+    exact P.strongDuality_aux_caseX hP hQ hX
+  | inr case_Y =>
+    obtain ⟨Y, hAY, hbc⟩ := case_Y
+    exact P.strongDuality_aux_caseY hP hQ hAY hbc
+
+lemma ValidELP.strongDuality_of_both_feasible (P : ValidELP I J F)
+    (hP : P.IsFeasible) (hQ : P.dualize.IsFeasible) :
+    ∃ r : F, P.Reaches (toE (-r)) ∧ P.dualize.Reaches (toE r) := by
+  obtain ⟨p, q, hp, hq, hpq⟩ := P.strongDuality_aux hP hQ
+  have h0pq : 0 ≤ p + q
+  · rw [←EF.coe_le_coe_iff, EF.coe_add, EF.coe_zero]
+    exact P.weakDuality hp hq
+  have hqp : -q = p
+  · rw [neg_eq_iff_add_eq_zero, add_comm]
+    exact le_antisymm hpq h0pq
+  exact ⟨q, hqp ▸ hp, hq⟩
+
+end extended_LP_properties
+
+section extended_LP_optima
+
+lemma ExtendedLP.optimum_unique [Fintype J] {P : ExtendedLP I J F} {r s : F}
+    (hPr : P.Reaches (toE r) ∧ P.IsBoundedBy r) (hPs : P.Reaches (toE s) ∧ P.IsBoundedBy s) :
+    r = s := by
+  rw [←EF.coe_eq_coe_iff]
+  apply le_antisymm
+  · apply hPr.right
+    exact hPs.left
+  · apply hPs.right
+    exact hPr.left
+
+lemma ExtendedLP.optimum_eq_of_reaches_bounded [Fintype J] {P : ExtendedLP I J F} {r : F}
+    (reaches : P.Reaches (toE r)) (bounded : P.IsBoundedBy r) :
+    P.optimum = some r := by
+  have hP : P.IsFeasible
+  · obtain ⟨x, hx⟩ := reaches
+    exact ⟨toE r, ⟨x, hx⟩, EF.coe_neq_top r⟩
+  have hPP : ∃ r : F, P.Reaches (toE r) ∧ P.IsBoundedBy r
+  · use r
+  have hPb : ¬P.IsUnbounded
+  · exact (· ⟨r, bounded⟩)
+  have hopt : P.optimum = some (toE hPP.choose) := by
+    unfold ExtendedLP.optimum
+    rw [if_neg (not_not.mpr hP), if_neg hPb, dif_pos hPP]
+  rw [hopt]
+  exact congr_arg (some <| toE ·) (ExtendedLP.optimum_unique hPP.choose_spec ⟨reaches, bounded⟩)
+
+omit [IsStrictOrderedRing F] in
+lemma oppositesOpt_comm (p q : Option F∞) : OppositesOpt p q ↔ OppositesOpt q p := by
+  cases p with
+  | none =>
+    convert_to False ↔ False
+    · simp [OppositesOpt]
+    rfl
+  | some r =>
+    cases q with
+    | none => trivial
+    | some s =>
+      if hrs : r = -s then
+        convert_to True ↔ True
+        · simpa [OppositesOpt]
+        · simpa [OppositesOpt, neg_eq_iff_eq_neg] using hrs.symm
+        rfl
+      else
+        convert_to False ↔ False
+        · simpa [OppositesOpt]
+        · simpa [OppositesOpt, neg_eq_iff_eq_neg] using Ne.symm hrs
+        rfl
+
+variable [Fintype I] [Fintype J]
+
+lemma ValidELP.strongDuality_of_prim_feasible (P : ValidELP I J F) (hP : P.IsFeasible) :
+    OppositesOpt P.optimum P.dualize.optimum := by
+  if hQ : P.dualize.IsFeasible then
+    obtain ⟨r, hPr, hQr⟩ := P.strongDuality_of_both_feasible hP hQ
+    have hPopt : P.optimum = some (toE (-r))
+    · apply ExtendedLP.optimum_eq_of_reaches_bounded hPr
+      intro p hPp
+      have Pwd := P.weakDuality hPp hQr
+      match p with
+      | ⊥ => simp at Pwd
+      | ⊤ => apply le_top
+      | (_ : F) =>
+        rw [←EF.coe_add, ←EF.coe_zero] at Pwd
+        rw [EF.coe_le_coe_iff] at Pwd ⊢
+        rwa [neg_le_iff_add_nonneg]
+    have hQopt : P.dualize.optimum = some (toE r)
+    · apply ExtendedLP.optimum_eq_of_reaches_bounded hQr
+      intro q hQq
+      have Qwd := P.weakDuality hPr hQq
+      match q with
+      | ⊥ => simp at Qwd
+      | ⊤ => apply le_top
+      | (_ : F) =>
+        rw [←EF.coe_add, ←EF.coe_zero, add_comm] at Qwd
+        rw [EF.coe_le_coe_iff] at Qwd ⊢
+        rwa [le_add_neg_iff_le] at Qwd
+    rewrite [hPopt, hQopt]
+    rfl
+  else
+    have hPopt : P.optimum = some ⊥
+    · simp only [ExtendedLP.optimum, hP, P.unbounded_of_feasible_of_infeasible hP hQ]
+      rfl
+    have hQopt : P.dualize.optimum = some ⊤
+    · simp only [ExtendedLP.optimum, hQ]
+      rfl
+    rw [hPopt, hQopt]
+    exact EF.neg_top
+
+omit [Fintype I] in
+theorem ValidELP.optimum_neq_none [Finite I] (P : ValidELP I J F) : P.optimum ≠ none := by
+  letI : Fintype I := Fintype.ofFinite I
+  if hP : P.IsFeasible then
+    intro contr
+    simpa [contr, OppositesOpt] using P.strongDuality_of_prim_feasible hP
+  else
+    simp [ExtendedLP.optimum, hP]
+
+lemma ValidELP.strongDuality_of_dual_feasible (P : ValidELP I J F) (hP : P.dualize.IsFeasible) :
+    OppositesOpt P.optimum P.dualize.optimum := by
+  rw [oppositesOpt_comm]
+  nth_rw 2 [P.dualize_dualize]
+  exact P.dualize.strongDuality_of_prim_feasible hP
+
+theorem ValidELP.strongDuality (P : ValidELP I J F) (hP : P.IsFeasible ∨ P.dualize.IsFeasible) :
+    OppositesOpt P.optimum P.dualize.optimum :=
+  hP.casesOn
+    (P.strongDuality_of_prim_feasible ·)
+    (P.strongDuality_of_dual_feasible ·)
+
+end extended_LP_optima
+
+end strong_duality

--- a/LeanPool/Duality/LinearProgrammingB.lean
+++ b/LeanPool/Duality/LinearProgrammingB.lean
@@ -46,23 +46,23 @@ def StandardLP.IsSolution [Semiring R] [PartialOrder R]
 /-- Linear program `P` reaches objective value `r` iff there is a solution `x` such that,
     when its entries are elementwise multiplied by the the coefficients `c` and summed up,
     the result is the value `r`. -/
-def StandardLP.Reaches [Semiring R] [PartialOrder R] [IsOrderedRing R]
+def StandardLP.Reaches [Semiring R] [PartialOrder R]
     (P : StandardLP I J R) (r : R) : Prop :=
   ∃ x : J → R≥0, P.IsSolution x ∧ P.c ⬝ᵥ x = r
 
 /-- Linear program `P` is feasible iff there exists a solution to `P`. -/
-def StandardLP.IsFeasible [Semiring R] [PartialOrder R] [IsOrderedRing R]
+def StandardLP.IsFeasible [Semiring R] [PartialOrder R]
     (P : StandardLP I J R) : Prop :=
   ∃ r : R, P.Reaches r
 
 /-- Linear program `P` is bounded by `r` iff every value reached by `P` is
     greater or equal to `r` (i.e., `P` is bounded by `r` from below). -/
-def StandardLP.IsBoundedBy [Semiring R] [PartialOrder R] [IsOrderedRing R]
+def StandardLP.IsBoundedBy [Semiring R] [PartialOrder R]
     (P : StandardLP I J R) (r : R) : Prop :=
   ∀ p : R, P.Reaches p → r ≤ p
 
 /-- Linear program `P` is unbounded iff values reached by `P` have no lower bound. -/
-def StandardLP.IsUnbounded [Semiring R] [PartialOrder R] [IsOrderedRing R]
+def StandardLP.IsUnbounded [Semiring R] [PartialOrder R]
     (P : StandardLP I J R) : Prop :=
   ¬∃ r : R, P.IsBoundedBy r
 

--- a/LeanPool/Duality/LinearProgrammingB.lean
+++ b/LeanPool/Duality/LinearProgrammingB.lean
@@ -1,0 +1,239 @@
+/-
+Copyright (c) 2026 Martin Dvorak. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Martin Dvorak
+-/
+import Mathlib.Tactic.Peel
+import LeanPool.Duality.LinearProgramming
+
+/-!
+We prove properties of "normal" linear programs as a corollary of properties of extended
+linear programs. The only exception is the weak duality theorem, which is proved separately,
+to allow weaker assumptions.
+-/
+
+
+/-- Linear program in the standard form. Variables are of type `J`. Conditions are indexed by
+    type `I`. The objective function is intended to be minimized. -/
+structure StandardLP (I J R : Type*) where
+  /-- The left-hand-side matrix -/
+  A : Matrix I J R
+  /-- The right-hand-side vector -/
+  b : I → R
+  /-- The objective function coefficients -/
+  c : J → R
+
+
+variable {I R : Type*}
+
+/-- Coerce a vector of nonnegative values into a vector of the underlying ring. -/
+@[coe] def coeNN [Zero R] [LE R] : (I → R≥0) → (I → R) := (Subtype.val ∘ ·)
+
+instance [Zero R] [LE R] : Coe (I → R≥0) (I → R) :=
+  ⟨coeNN⟩
+
+open scoped Matrix
+
+variable {J : Type*} [Fintype J]
+
+/-- A nonnegative vector `x` is a solution to a linear program `P` iff
+    its multiplication by matrix `A` from the left yields a vector whose
+    all entries are less or equal to corresponding entries of the vector `b`. -/
+def StandardLP.IsSolution [Semiring R] [PartialOrder R]
+    (P : StandardLP I J R) (x : J → R≥0) : Prop :=
+  P.A *ᵥ x ≤ P.b
+
+/-- Linear program `P` reaches objective value `r` iff there is a solution `x` such that,
+    when its entries are elementwise multiplied by the the coefficients `c` and summed up,
+    the result is the value `r`. -/
+def StandardLP.Reaches [Semiring R] [PartialOrder R] [IsOrderedRing R]
+    (P : StandardLP I J R) (r : R) : Prop :=
+  ∃ x : J → R≥0, P.IsSolution x ∧ P.c ⬝ᵥ x = r
+
+/-- Linear program `P` is feasible iff there exists a solution to `P`. -/
+def StandardLP.IsFeasible [Semiring R] [PartialOrder R] [IsOrderedRing R]
+    (P : StandardLP I J R) : Prop :=
+  ∃ r : R, P.Reaches r
+
+/-- Linear program `P` is bounded by `r` iff every value reached by `P` is
+    greater or equal to `r` (i.e., `P` is bounded by `r` from below). -/
+def StandardLP.IsBoundedBy [Semiring R] [PartialOrder R] [IsOrderedRing R]
+    (P : StandardLP I J R) (r : R) : Prop :=
+  ∀ p : R, P.Reaches p → r ≤ p
+
+/-- Linear program `P` is unbounded iff values reached by `P` have no lower bound. -/
+def StandardLP.IsUnbounded [Semiring R] [PartialOrder R] [IsOrderedRing R]
+    (P : StandardLP I J R) : Prop :=
+  ¬∃ r : R, P.IsBoundedBy r
+
+/-- Dualize a linear program in the standard form.
+    The matrix gets transposed and its values flip signs.
+    The original objective function becomes the new right-hand-side vector.
+    The original right-hand-side vector becomes the new objective function.
+    Both linear programs are intended to be minimized. -/
+def StandardLP.dualize [Ring R] (P : StandardLP I J R) : StandardLP J I R :=
+  ⟨-P.Aᵀ, P.c, P.b⟩
+
+
+lemma Matrix.transpose_mulVec_dotProduct [Fintype I] [CommSemiring R] (M : Matrix I J R)
+    (v : I → R) (w : J → R) :
+    Mᵀ *ᵥ v ⬝ᵥ w = M *ᵥ w ⬝ᵥ v := by
+  rw [dotProduct_comm, Matrix.dotProduct_mulVec, Matrix.vecMul_transpose]
+
+theorem StandardLP.weakDuality [Fintype I] [CommRing R] [PartialOrder R] [IsOrderedRing R]
+    {P : StandardLP I J R}
+    {p : R} (hP : P.Reaches p) {q : R} (hQ : P.dualize.Reaches q) :
+    0 ≤ p + q := by
+  obtain ⟨x, hxb, rfl⟩ := hP
+  obtain ⟨y, hyc, rfl⟩ := hQ
+  have hyxx : (-P.Aᵀ) *ᵥ ↑y ⬝ᵥ ↑x ≤ P.c ⬝ᵥ ↑x :=
+    dotProduct_le_dotProduct_of_nonneg_right hyc (x ·|>.property)
+  have hxyy : P.A *ᵥ ↑x ⬝ᵥ ↑y ≤ P.b ⬝ᵥ ↑y :=
+    dotProduct_le_dotProduct_of_nonneg_right hxb (y ·|>.property)
+  rw [←neg_le_iff_add_nonneg']
+  rw [Matrix.neg_mulVec, neg_dotProduct, neg_le, Matrix.transpose_mulVec_dotProduct] at hyxx
+  exact (hyxx.trans hxyy)
+
+
+variable [Field R] [LinearOrder R] [IsStrictOrderedRing R]
+
+open scoped Classical in
+/-- The "optimum" of "minimization LP" (the less the better). -/
+noncomputable def StandardLP.optimum (P : StandardLP I J R) : Option R∞ :=
+  if ¬P.IsFeasible then
+    some ⊤ -- infeasible means that the minimum is `⊤`
+  else
+    if P.IsUnbounded then
+      some ⊥ -- unbounded means that the minimum is `⊥`
+    else
+      if hr : ∃ r : R, P.Reaches r ∧ P.IsBoundedBy r then
+        some (toE hr.choose) -- the minimum exists
+      else
+        none -- invalid finite value (infimum is not attained)
+
+
+private def StandardLP.toValidELP (P : StandardLP I J R) : ValidELP I J R :=
+  ⟨⟨P.A.map toE, toE ∘ P.b, toE ∘ P.c⟩, by aesop, by aesop, by aesop, by aesop, by aesop, by aesop⟩
+
+omit [IsStrictOrderedRing R] in
+private lemma StandardLP.toE_dotProduct_apply (P : StandardLP I J R) (x : J → R≥0) :
+    toE (P.c ⬝ᵥ x) = (toE ∘ P.c ᵥ⬝ x) := by
+  simp_rw [dotProduct, dotWeig, mul_comm]
+  apply Finset.sum_toE
+
+omit [IsStrictOrderedRing R] in
+private lemma StandardLP.toE_mulVec_apply (P : StandardLP I J R) (x : J → R≥0) (i : I) :
+    toE ((P.A *ᵥ x) i) = (P.A.map toE ₘ* x) i := by
+  simp_rw [Matrix.mulVec, Matrix.mulWeig, Matrix.map, dotProduct, dotWeig, Matrix.of_apply,
+    mul_comm]
+  apply Finset.sum_toE
+
+private lemma StandardLP.toValidELP.isSolution_iff (P : StandardLP I J R) (x : J → R≥0) :
+    P.toValidELP.IsSolution x ↔ P.IsSolution x := by
+  change P.A.map toE ₘ* x ≤ toE ∘ P.b ↔ P.A *ᵥ x ≤ P.b
+  constructor
+  · intro h i
+    have := h i
+    rw [Function.comp_apply, ←StandardLP.toE_mulVec_apply, EF.coe_le_coe_iff] at this
+    exact this
+  · intro h i
+    rw [Function.comp_apply, ←StandardLP.toE_mulVec_apply, EF.coe_le_coe_iff]
+    exact h i
+
+private lemma StandardLP.toValidELP_reaches_iff (P : StandardLP I J R) (r : R) :
+    P.toValidELP.Reaches r ↔ P.Reaches r := by
+  peel with x
+  apply and_congr
+  · apply StandardLP.toValidELP.isSolution_iff
+  · exact P.toE_dotProduct_apply x ▸ EF.coe_eq_coe_iff
+
+private lemma StandardLP.toValidELP_isFeasible_iff (P : StandardLP I J R) :
+    P.toValidELP.IsFeasible ↔ P.IsFeasible := by
+  constructor
+  · intro ⟨r, ⟨x, hx, hxr⟩, hr⟩
+    match r with
+    | ⊥ =>
+      exfalso
+      rw [←dotWeig_eq_bot] at hxr
+      simp [StandardLP.toValidELP] at hxr
+    | ⊤ =>
+      exfalso
+      exact hr rfl
+    | (p : R) =>
+      refine ⟨p, x, ?_, ?_⟩
+      · rwa [StandardLP.toValidELP.isSolution_iff] at hx
+      · rwa [←EF.coe_eq_coe_iff, P.toE_dotProduct_apply]
+  · intro ⟨r, x, hx, hxr⟩
+    refine ⟨toE r, ⟨x, ?_, ?_⟩, EF.coe_neq_top r⟩
+    · rwa [StandardLP.toValidELP.isSolution_iff]
+    · rwa [←EF.coe_eq_coe_iff, P.toE_dotProduct_apply] at hxr
+
+private lemma StandardLP.toValidELP_isBoundedBy_iff (P : StandardLP I J R) (r : R) :
+    P.toValidELP.IsBoundedBy r ↔ P.IsBoundedBy r := by
+  unfold StandardLP.IsBoundedBy ExtendedLP.IsBoundedBy
+  constructor <;> intro hP p hPp
+  · simpa [EF.coe_le_coe_iff] using
+      hP (toE p) (by simpa [StandardLP.toValidELP_reaches_iff] using hPp)
+  · match p with
+    | ⊥ =>
+      exfalso
+      obtain ⟨_, -, impos⟩ := hPp
+      rw [←dotWeig_eq_bot] at impos
+      simp [StandardLP.toValidELP] at impos
+    | ⊤ =>
+      apply le_top
+    | (_ : R) =>
+      rw [EF.coe_le_coe_iff]
+      apply hP
+      simpa [StandardLP.toValidELP_reaches_iff] using hPp
+
+private lemma StandardLP.toValidELP_isUnbounded_iff (P : StandardLP I J R) :
+    P.toValidELP.IsUnbounded ↔ P.IsUnbounded := by
+  constructor <;> intro hP hr <;> apply hP <;>
+    simpa only [P.toValidELP_isBoundedBy_iff] using hr
+
+private theorem StandardLP.toValidELP_optimum_eq (P : StandardLP I J R) :
+    P.toValidELP.optimum = P.optimum := by
+  if feas : P.IsFeasible then
+    if unbo : P.IsUnbounded then
+      convert Eq.refl (some (⊥ : R∞))
+      · simp [ExtendedLP.optimum, feas, unbo, P.toValidELP_isFeasible_iff,
+          P.toValidELP_isUnbounded_iff]
+      · simp [StandardLP.optimum, feas, unbo]
+    else
+      simp only [StandardLP.optimum, ExtendedLP.optimum, feas, unbo,
+        P.toValidELP_isFeasible_iff, P.toValidELP_isUnbounded_iff]
+      if hr : ∃ r : R, P.Reaches r ∧ P.IsBoundedBy r then
+        convert Eq.refl (some (toE hr.choose))
+        · simp [hr, P.toValidELP_reaches_iff, P.toValidELP_isBoundedBy_iff]
+        · simp [hr]
+      else
+        convert Eq.refl none
+        · simp [hr, P.toValidELP_reaches_iff, P.toValidELP_isBoundedBy_iff]
+        · simp [hr]
+  else
+    convert Eq.refl (some (⊤ : R∞))
+    · simp [ExtendedLP.optimum, feas, P.toValidELP_isFeasible_iff]
+    · simp [StandardLP.optimum, feas]
+
+omit [Fintype J] in
+private lemma StandardLP.toValidELP_dualize_eq (P : StandardLP I J R) :
+    P.toValidELP.dualize = P.dualize.toValidELP :=
+  rfl
+
+
+variable [Fintype I]
+
+omit [Fintype I] in
+theorem StandardLP.optimum_neq_none [Finite I] (P : StandardLP I J R) :
+    P.optimum ≠ none := by
+  letI : Fintype I := Fintype.ofFinite I
+  exact P.toValidELP_optimum_eq ▸ P.toValidELP.optimum_neq_none
+
+theorem StandardLP.strongDuality (P : StandardLP I J R)
+    (hP : P.IsFeasible ∨ P.dualize.IsFeasible) :
+    OppositesOpt P.optimum P.dualize.optimum := by
+  simpa [StandardLP.toValidELP_optimum_eq, P.toValidELP_dualize_eq] using
+    P.toValidELP.strongDuality (by
+      simpa [StandardLP.toValidELP_isFeasible_iff, P.toValidELP_dualize_eq] using
+        hP)

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -419,6 +419,41 @@ projects:
       - "28A75"
       - "52A40"
       - "49Q20"
+  - slug: duality
+    title: Duality theory in linear optimization and its extensions
+    summary: Formalizes Farkas-like theorems and strong LP duality, including extensions to a linearly ordered field with bot and top.
+    branch: linear optimization
+    entry_module: LeanPool.Duality
+    authors:
+      - Martin Dvorak
+    source:
+      arxiv: "2409.08119"
+      github_repo: madvorak/duality
+    status: verified
+    main_declarations:
+      - equalityFarkas
+      - inequalityFarkas
+      - extendedFarkas
+      - ValidELP.strongDuality
+      - StandardLP.strongDuality
+    main_results:
+      - declaration: equalityFarkas
+        informal: Farkas' lemma for linear equalities over nonnegative variables.
+      - declaration: inequalityFarkas
+        informal: Farkas' lemma for linear inequalities over nonnegative variables.
+      - declaration: extendedFarkas
+        informal: Extended Farkas theorem for matrices and vectors over a linearly ordered field with bot and top.
+      - declaration: ValidELP.strongDuality
+        informal: Strong duality theorem for extended linear programs.
+      - declaration: StandardLP.strongDuality
+        informal: Strong duality theorem for linear programs in standard form.
+    tags:
+      - linear-programming
+      - optimization
+      - farkas-lemma
+    msc:
+      - "90C05"
+      - "90C46"
   - slug: sumsthreesquares
     title: Sums of Three Squares
     summary: Formalizes a blueprint step in the three-squares theorem using quadratic forms and geometry of numbers.

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -431,10 +431,7 @@ projects:
       github_repo: madvorak/duality
     status: verified
     main_declarations:
-      - equalityFarkas
-      - inequalityFarkas
       - extendedFarkas
-      - ValidELP.strongDuality
       - StandardLP.strongDuality
     main_results:
       - declaration: equalityFarkas


### PR DESCRIPTION
Imported from https://github.com/madvorak/duality.

**Slug:** `duality`
**Toolchain target:** `leanprover/lean4:v4.30.0-rc2`
**Branch:** `import/duality` (auto-generated by `scripts/import-formalization.sh`)
**Agent:** `claude` using `claude-opus-4-7` at effort `max`, exited with code `143`.

**Commits on this branch:**
- e70be06 WIP: agent partial progress on duality import

---
_Opened automatically by `scripts/import-formalization.sh`. Review the diff carefully before merging — the agent ran unattended._
