### PR TITLE
Import shannon-1948-formalization formalization

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -233,6 +233,17 @@ import LeanPool.Sensitivity.Main
 import LeanPool.Sensitivity.Multilinear
 import LeanPool.Sensitivity.Parity
 import LeanPool.Sensitivity.Subcube
+import LeanPool.Shannon1948Formalization
+import LeanPool.Shannon1948Formalization.Entropy
+import LeanPool.Shannon1948Formalization.Entropy.Approx
+import LeanPool.Shannon1948Formalization.Entropy.Converse
+import LeanPool.Shannon1948Formalization.Entropy.Core
+import LeanPool.Shannon1948Formalization.Entropy.Final
+import LeanPool.Shannon1948Formalization.Entropy.Gibbs
+import LeanPool.Shannon1948Formalization.Entropy.Joint
+import LeanPool.Shannon1948Formalization.Entropy.Properties
+import LeanPool.Shannon1948Formalization.Entropy.Rational
+import LeanPool.Shannon1948Formalization.Entropy.Uniform
 import LeanPool.SumsThreeSquares
 import LeanPool.SumsThreeSquares.MinkowskiConvex
 import LeanPool.SumsThreeSquares.SumThreeSquares

--- a/LeanPool/Shannon1948Formalization.lean
+++ b/LeanPool/Shannon1948Formalization.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+import LeanPool.Shannon1948Formalization.Entropy
+
+/-!
+# Shannon Entropy Characterization
+
+Source: url:https://github.com/SamuelSchlesinger/shannon-1948-formalization
+Authors: Samuel Schlesinger
+Status: verified
+Main declarations: `LeanPool.Shannon1948Formalization.entropyNat_unique`
+Tags: information-theory, entropy, probability
+MSC: 94A17, 60C05
+-/
+
+/-!
+# Shannon
+
+Project entrypoint.
+Re-exports the entropy characterization development.
+-/

--- a/LeanPool/Shannon1948Formalization/Entropy.lean
+++ b/LeanPool/Shannon1948Formalization/Entropy.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+import LeanPool.Shannon1948Formalization.Entropy.Properties
+import LeanPool.Shannon1948Formalization.Entropy.Converse
+
+/-!
+# Shannon.Entropy
+
+Facade module for the Shannon entropy formalization.
+
+Import this file to access the full development:
+- Characterization theorems (Appendix 2): `entropyNat_unique`, `entropyBase_unique`
+- Converse: `entropyNat_shannonAxioms` (entropy satisfies the axioms)
+- Section 6 properties: nonnegativity, maximum at uniform, subadditivity,
+  conditioning reduces entropy, chain rule, product additivity
+
+## Module chain
+
+`Core → Uniform → Rational → Approx → Final → Gibbs → Joint → Properties`
+                                                    ↘ Converse
+-/

--- a/LeanPool/Shannon1948Formalization/Entropy.lean
+++ b/LeanPool/Shannon1948Formalization/Entropy.lean
@@ -14,7 +14,7 @@ Facade module for the Shannon entropy formalization.
 
 Import this file to access the full development:
 - Characterization theorems (Appendix 2): `entropyNat_unique`, `entropyBase_unique`
-- Converse: `entropyNat_shannonAxioms` (entropy satisfies the axioms)
+- Converse: `entropyNat_shannonAxioms` (entropy satisfies the formal conditions)
 - Section 6 properties: nonnegativity, maximum at uniform, subadditivity,
   conditioning reduces entropy, chain rule, product additivity
 

--- a/LeanPool/Shannon1948Formalization/Entropy/Approx.lean
+++ b/LeanPool/Shannon1948Formalization/Entropy/Approx.lean
@@ -1,0 +1,305 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+import LeanPool.Shannon1948Formalization.Entropy.Rational
+
+/-!
+# Shannon.Entropy.Approx
+
+Phase 3 of the characterization: continuity extension.
+
+Constructs floor-count rational approximants `approxProb p N` and proves
+their convergence to `p`. This is the bridge from the rational formula to the
+full real-probability formula.
+-/
+namespace LeanPool.Shannon1948Formalization
+
+noncomputable section
+open Filter
+open scoped Topology
+
+/-! ## Phase 3: Continuity Extension by Rational Approximation -/
+
+/-- Integer count approximation used in the continuity-extension phase. -/
+def approxCount
+    {α : Type} [Fintype α]
+    (p : ProbDist α)
+    (N : ℕ)
+    (a : α) : ℕ :=
+  Nat.floor (((N + 1 : ℕ) : ℝ) * p a) + 1
+
+/-- Total count for `approxCount`; this is the denominator of the rational approximation. -/
+def approxTotal
+    {α : Type} [Fintype α]
+    (p : ProbDist α)
+    (N : ℕ) : ℕ :=
+  ∑ a, approxCount p N a
+
+lemma approxCount_pos
+    {α : Type} [Fintype α]
+    (p : ProbDist α)
+    (N : ℕ)
+    (a : α) :
+    0 < approxCount p N a := by
+  unfold approxCount
+  exact Nat.succ_pos _
+
+lemma approxTotal_pos
+    {α : Type} [Fintype α]
+    (p : ProbDist α)
+    (N : ℕ) :
+    0 < approxTotal p N := by
+  classical
+  obtain ⟨a0⟩ := nonempty_of_probDist p
+  unfold approxTotal
+  exact lt_of_lt_of_le
+    (approxCount_pos p N a0)
+    (Finset.single_le_sum
+      (fun b _ => Nat.zero_le (approxCount p N b))
+      (Finset.mem_univ a0))
+
+/-- Rational approximation of `p` obtained from floor counts. -/
+def approxProb
+    {α : Type} [Fintype α]
+    (p : ProbDist α)
+    (N : ℕ) : ProbDist α := by
+  let T : ℕ := approxTotal p N
+  have hT : 0 < T := by
+    simpa [T] using approxTotal_pos p N
+  refine ⟨fun a => (approxCount p N a : ℝ) / (T : ℝ), ?_⟩
+  constructor
+  · intro a
+    positivity
+  · have hT_ne : (T : ℝ) ≠ 0 := by exact_mod_cast (Nat.ne_of_gt hT)
+    calc
+      (∑ a, (approxCount p N a : ℝ) / (T : ℝ))
+          = (∑ a, (approxCount p N a : ℝ)) / (T : ℝ) := by
+              rw [Finset.sum_div]
+      _ = (T : ℝ) / (T : ℝ) := by
+            simp [T, approxTotal]
+      _ = 1 := by
+            field_simp [hT_ne]
+
+@[simp] lemma approxProb_apply
+    {α : Type} [Fintype α]
+    (p : ProbDist α)
+    (N : ℕ)
+    (a : α) :
+    approxProb p N a = (approxCount p N a : ℝ) / (approxTotal p N : ℝ) := by
+  unfold approxProb
+  simp
+
+lemma entropyNat_approxProb
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H)
+    {α : Type} [Fintype α]
+    (p : ProbDist α)
+    (N : ℕ) :
+    H (approxProb p N) = -K H * ∑ a, approxProb p N a * Real.log (approxProb p N a) := by
+  refine entropyNat_of_rational_counts H hH (approxProb p N) (approxCount p N) ?_ (approxTotal p N)
+    (approxTotal_pos p N) ?_ ?_
+  · intro a
+    exact approxCount_pos p N a
+  · simp [approxTotal]
+  · intro a
+    simp [approxProb_apply]
+
+lemma approxCount_mul_bounds
+    {α : Type} [Fintype α]
+    (p : ProbDist α)
+    (N : ℕ)
+    (a : α) :
+    let M : ℝ := ((N + 1 : ℕ) : ℝ)
+    0 ≤ (approxCount p N a : ℝ) - M * p a ∧
+      (approxCount p N a : ℝ) - M * p a ≤ 1 := by
+  intro M
+  have hp_nonneg : 0 ≤ p a := prob_nonneg p a
+  have hM_nonneg : 0 ≤ M := by
+    dsimp [M]
+    positivity
+  have hfloor_le : (Nat.floor (M * p a) : ℝ) ≤ M * p a := by
+    exact Nat.floor_le (mul_nonneg hM_nonneg hp_nonneg)
+  have hlt : M * p a < (Nat.floor (M * p a) : ℝ) + 1 := by
+    exact Nat.lt_floor_add_one (M * p a)
+  constructor
+  · calc
+      0 ≤ ((Nat.floor (M * p a) : ℝ) + 1) - M * p a := by
+            linarith [hlt]
+      _ = (approxCount p N a : ℝ) - M * p a := by
+            simp [approxCount, M, add_comm]
+  · calc
+      (approxCount p N a : ℝ) - M * p a
+          = ((Nat.floor (M * p a) : ℝ) + 1) - M * p a := by
+              simp [approxCount, M, add_comm]
+      _ ≤ (M * p a + 1) - M * p a := by
+            gcongr
+      _ = 1 := by ring
+
+lemma approxTotal_bounds
+    {α : Type} [Fintype α]
+    (p : ProbDist α)
+    (N : ℕ) :
+    let M : ℝ := ((N + 1 : ℕ) : ℝ)
+    0 ≤ (approxTotal p N : ℝ) - M ∧
+      (approxTotal p N : ℝ) - M ≤ Fintype.card α := by
+  intro M
+  have hsumDelta :
+      (∑ a, ((approxCount p N a : ℝ) - M * p a))
+        = (approxTotal p N : ℝ) - M := by
+    calc
+      (∑ a, ((approxCount p N a : ℝ) - M * p a))
+          = (∑ a, (approxCount p N a : ℝ)) - ∑ a, (M * p a) := by
+              rw [Finset.sum_sub_distrib]
+      _ = (approxTotal p N : ℝ) - (M * ∑ a, p a) := by
+            simp [approxTotal, Finset.mul_sum]
+      _ = (approxTotal p N : ℝ) - M := by
+            rw [prob_sum_eq_one p, mul_one]
+  have hnonneg :
+      0 ≤ ∑ a, ((approxCount p N a : ℝ) - M * p a) := by
+    refine Finset.sum_nonneg ?_
+    intro a _
+    exact (approxCount_mul_bounds p N a).1
+  have hupper :
+      (∑ a, ((approxCount p N a : ℝ) - M * p a))
+        ≤ ∑ _a : α, (1 : ℝ) := by
+    refine Finset.sum_le_sum ?_
+    intro a _
+    exact (approxCount_mul_bounds p N a).2
+  constructor
+  · simpa [hsumDelta]
+      using hnonneg
+  · calc
+      (approxTotal p N : ℝ) - M
+          = ∑ a, ((approxCount p N a : ℝ) - M * p a) := by
+              simp [hsumDelta]
+      _ ≤ ∑ _a : α, (1 : ℝ) := hupper
+      _ = Fintype.card α := by simp
+
+lemma approxProb_error_bound
+    {α : Type} [Fintype α]
+    (p : ProbDist α)
+    (N : ℕ)
+    (a : α) :
+    let M : ℝ := ((N + 1 : ℕ) : ℝ)
+    |approxProb p N a - p a|
+      ≤ ((Fintype.card α : ℝ) + 1) / M := by
+  intro M
+  have hM_pos : 0 < M := by
+    dsimp [M]
+    positivity
+  have hM_nonneg : 0 ≤ M := le_of_lt hM_pos
+  let T : ℝ := (approxTotal p N : ℝ)
+  have hT_bounds : 0 ≤ T - M ∧ T - M ≤ Fintype.card α := by
+    simpa [T, M] using approxTotal_bounds p N
+  have hM_le_T : M ≤ T := by
+    exact sub_nonneg.mp hT_bounds.1
+  have hT_pos : 0 < T := lt_of_lt_of_le hM_pos hM_le_T
+  have hT_ne : T ≠ 0 := ne_of_gt hT_pos
+  have habs_MT : |M - T| ≤ Fintype.card α := by
+    have habs_TM : |T - M| ≤ Fintype.card α := by
+      simpa [abs_of_nonneg hT_bounds.1] using hT_bounds.2
+    simpa [abs_sub_comm] using habs_TM
+  have hdelta :
+      0 ≤ (approxCount p N a : ℝ) - M * p a ∧
+      (approxCount p N a : ℝ) - M * p a ≤ 1 := by
+    simpa [M] using approxCount_mul_bounds p N a
+  have hdelta_abs : |(approxCount p N a : ℝ) - M * p a| ≤ 1 := by
+    simpa [abs_of_nonneg hdelta.1] using hdelta.2
+  have hp_le_one : p a ≤ 1 := prob_le_one p a
+  have hp_abs_le_one : |p a| ≤ 1 := by
+    simpa [abs_of_nonneg (prob_nonneg p a)] using hp_le_one
+  have hnum :
+      |(approxCount p N a : ℝ) - p a * T| ≤ (Fintype.card α : ℝ) + 1 := by
+    have hdecomp :
+        (approxCount p N a : ℝ) - p a * T
+          = ((approxCount p N a : ℝ) - M * p a) + p a * (M - T) := by
+      ring
+    have hmul_abs :
+        |p a * (M - T)| = |p a| * |M - T| := by
+      rw [abs_mul]
+    have hmul_le_one :
+        |p a| * |M - T| ≤ 1 * |M - T| := by
+      exact mul_le_mul_of_nonneg_right hp_abs_le_one (abs_nonneg (M - T))
+    have hMT_le_card :
+        1 * |M - T| ≤ 1 * (Fintype.card α : ℝ) := by
+      exact mul_le_mul_of_nonneg_left habs_MT (by positivity : (0 : ℝ) ≤ 1)
+    calc
+      |(approxCount p N a : ℝ) - p a * T|
+          = |((approxCount p N a : ℝ) - M * p a) + p a * (M - T)| := by
+              rw [hdecomp]
+      _ ≤ |(approxCount p N a : ℝ) - M * p a| + |p a * (M - T)| := by
+            exact abs_add_le _ _
+      _ = |(approxCount p N a : ℝ) - M * p a| + (|p a| * |M - T|) := by
+            rw [hmul_abs]
+      _ ≤ 1 + (|p a| * |M - T|) := by linarith [hdelta_abs]
+      _ ≤ 1 + (1 * |M - T|) := by linarith [hmul_le_one]
+      _ ≤ 1 + (1 * (Fintype.card α : ℝ)) := by linarith [hMT_le_card]
+      _ = (Fintype.card α : ℝ) + 1 := by ring
+  have hsub :
+      approxProb p N a - p a
+        = ((approxCount p N a : ℝ) - p a * T) / T := by
+    rw [approxProb_apply]
+    change (approxCount p N a : ℝ) / T - p a = ((approxCount p N a : ℝ) - p a * T) / T
+    field_simp [hT_ne]
+  calc
+    |approxProb p N a - p a|
+        = |((approxCount p N a : ℝ) - p a * T) / T| := by rw [hsub]
+    _ = |(approxCount p N a : ℝ) - p a * T| / T := by
+          rw [abs_div, abs_of_pos hT_pos]
+    _ ≤ (((Fintype.card α : ℝ) + 1) / T) := by
+          exact (div_le_div_of_nonneg_right hnum (le_of_lt hT_pos))
+    _ ≤ ((Fintype.card α : ℝ) + 1) / M := by
+          exact div_le_div_of_nonneg_left (by positivity) hM_pos hM_le_T
+
+lemma tendsto_approxProb_apply
+    {α : Type} [Fintype α]
+    (p : ProbDist α)
+    (a : α) :
+    Tendsto (fun N : ℕ => approxProb p N a) atTop (𝓝 (p a)) := by
+  have hbound_tendsto :
+      Tendsto (fun N : ℕ => ((Fintype.card α : ℝ) + 1) / (((N + 1 : ℕ) : ℝ))) atTop (𝓝 0) := by
+    have hone :
+        Tendsto (fun N : ℕ => (1 : ℝ) / ((N + 1 : ℕ))) atTop (𝓝 0) := by
+      simpa using
+        (tendsto_one_div_add_atTop_nhds_zero_nat :
+          Tendsto (fun N : ℕ => (1 : ℝ) / (N + 1)) atTop (𝓝 0))
+    have hone' :
+        Tendsto (fun N : ℕ => (1 : ℝ) / ((N : ℝ) + 1)) atTop (𝓝 0) := by
+      simpa [Nat.cast_add] using hone
+    have hmul :
+        Tendsto
+          (fun N : ℕ => ((Fintype.card α : ℝ) + 1) * ((1 : ℝ) / (N + 1)))
+          atTop
+          (𝓝 (((Fintype.card α : ℝ) + 1) * 0)) :=
+      tendsto_const_nhds.mul hone'
+    simpa [div_eq_mul_inv, mul_assoc, mul_comm, mul_left_comm] using hmul
+  have habs_tendsto :
+      Tendsto (fun N : ℕ => |approxProb p N a - p a|) atTop (𝓝 0) := by
+    refine squeeze_zero (fun N => abs_nonneg _) ?_ hbound_tendsto
+    intro N
+    simpa using approxProb_error_bound p N a
+  have hsub :
+      Tendsto (fun N : ℕ => approxProb p N a - p a) atTop (𝓝 (0 : ℝ)) := by
+    rw [tendsto_zero_iff_abs_tendsto_zero]
+    simpa using habs_tendsto
+  have hsub' :
+      Tendsto (fun N : ℕ => approxProb p N a - p a) atTop (𝓝 (p a - p a)) := by
+    simpa using hsub
+  exact (Filter.tendsto_sub_const_iff (b := p a)).1 hsub'
+
+lemma tendsto_approxProb
+    {α : Type} [Fintype α]
+    (p : ProbDist α) :
+    Tendsto (fun N : ℕ => approxProb p N) atTop (𝓝 p) := by
+  refine (tendsto_subtype_rng).2 ?_
+  rw [tendsto_pi_nhds]
+  intro a
+  simpa using tendsto_approxProb_apply p a
+
+
+end
+
+end LeanPool.Shannon1948Formalization

--- a/LeanPool/Shannon1948Formalization/Entropy/Converse.lean
+++ b/LeanPool/Shannon1948Formalization/Entropy/Converse.lean
@@ -12,7 +12,7 @@ import LeanPool.Shannon1948Formalization.Entropy.Gibbs
 The converse direction: `entropyNat` satisfies `ShannonEntropyAxioms`.
 
 Combined with the characterization theorems in `Final.lean`, this gives a true
-"if and only if": a functional `H` satisfies the Shannon axioms iff it is a
+"if and only if": a functional `H` satisfies the Shannon conditions iff it is a
 positive multiple of `entropyNat`.
 
 ## Main results
@@ -95,11 +95,11 @@ theorem entropyNat_grouping
 
 /-! ## Main theorem -/
 
-/-- `entropyNat` satisfies the Shannon entropy axioms.
+/-- `entropyNat` satisfies the Shannon entropy conditions.
 
 This is the converse of the characterization: the characterization shows any `H`
-satisfying the axioms must be a positive multiple of `entropyNat`; this theorem
-shows `entropyNat` itself satisfies the axioms, proving the axiom system is
+satisfying the conditions must be a positive multiple of `entropyNat`; this theorem
+shows `entropyNat` itself satisfies the conditions, proving the specification is
 consistent and completing the "if and only if". -/
 theorem entropyNat_shannonAxioms : ShannonEntropyAxioms (fun {α} [Fintype α] => entropyNat) where
   continuous := continuous_entropyNat

--- a/LeanPool/Shannon1948Formalization/Entropy/Converse.lean
+++ b/LeanPool/Shannon1948Formalization/Entropy/Converse.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+import LeanPool.Shannon1948Formalization.Entropy.Gibbs
+
+/-!
+# Shannon.Entropy.Converse
+
+The converse direction: `entropyNat` satisfies `ShannonEntropyAxioms`.
+
+Combined with the characterization theorems in `Final.lean`, this gives a true
+"if and only if": a functional `H` satisfies the Shannon axioms iff it is a
+positive multiple of `entropyNat`.
+
+## Main results
+
+- `entropyNat_relabelInvariant`: relabeling outcomes preserves entropy
+- `entropyNat_grouping`: two-stage decomposition identity
+- `entropyNat_shannonAxioms`: `ShannonEntropyAxioms entropyNat`
+-/
+namespace LeanPool.Shannon1948Formalization
+
+noncomputable section
+open Finset Real
+
+/-! ## Relabel invariance -/
+
+/-- Entropy is invariant under relabeling outcomes by an equivalence. -/
+theorem entropyNat_relabelInvariant
+    {α β : Type} [Fintype α] [Fintype β]
+    (e : α ≃ β) (p : ProbDist α) :
+    entropyNat (relabelProb e p) = entropyNat p := by
+  unfold entropyNat relabelProb
+  simp only
+  show -∑ b, p (e.symm b) * log (p (e.symm b)) = -∑ a, p a * log (p a)
+  congr 1
+  exact e.symm.sum_comp (fun a => p a * log (p a))
+
+/-! ## Uniform monotonicity -/
+
+/-- Entropy on uniform distributions is strictly monotone in alphabet size. -/
+theorem entropyNat_uniformMonotone :
+    StrictMono fun n : ℕ+ => entropyNat (uniformPNat n) := by
+  intro m n hmn
+  change entropyNat (uniformPNat m) < entropyNat (uniformPNat n)
+  rw [entropyNat_uniformPNat, entropyNat_uniformPNat]
+  have hm_pos : (0 : ℝ) < m := by exact_mod_cast m.2
+  have hmn_real : (m : ℝ) < (n : ℝ) := by exact_mod_cast hmn
+  exact Real.log_lt_log hm_pos hmn_real
+
+/-! ## Grouping -/
+
+/-- Two-stage decomposition: `H(compose p q) = H(p) + ∑ a, p(a) * H(q a)`. -/
+theorem entropyNat_grouping
+    {α : Type} [Fintype α]
+    {β : α → Type} [∀ a, Fintype (β a)]
+    (p : ProbDist α) (q : (a : α) → ProbDist (β a)) :
+    entropyNat (composeProb p q) = entropyNat p + ∑ a, p a * entropyNat (q a) := by
+  unfold entropyNat
+  -- LHS: -∑ ⟨a,b⟩, p(a)*q_a(b) * log(p(a)*q_a(b))
+  -- RHS: (-∑ a, p(a)*log(p(a))) + ∑ a, p(a) * (-∑ b, q_a(b)*log(q_a(b)))
+  have hcomp : ∀ x : Sigma β, (composeProb p q) x = p x.1 * q x.1 x.2 := fun _ => rfl
+  simp_rw [hcomp]
+  -- Rewrite the sigma sum as a double sum
+  have hsum_sigma :
+      ∑ x : Sigma β, p x.1 * q x.1 x.2 * log (p x.1 * q x.1 x.2) =
+        ∑ a, ∑ b, p a * q a b * log (p a * q a b) := by
+    simpa using Fintype.sum_sigma
+      (f := fun x : Sigma β => p x.1 * q x.1 x.2 * log (p x.1 * q x.1 x.2))
+  rw [show -∑ x : Sigma β, p x.1 * q x.1 x.2 * log (p x.1 * q x.1 x.2) =
+      -(∑ a, ∑ b, p a * q a b * log (p a * q a b)) by rw [hsum_sigma]]
+  -- Split log(p(a) * q_a(b)) = log(p(a)) + log(q_a(b)) in nonzero cases
+  have key : ∀ a, ∑ b, p a * q a b * log (p a * q a b) =
+      p a * log (p a) + p a * ∑ b, q a b * log (q a b) := by
+    intro a
+    by_cases hpa : p a = 0
+    · simp [hpa]
+    · have hpa_pos : 0 < p a := lt_of_le_of_ne (prob_nonneg p a) (Ne.symm hpa)
+      have split : ∀ b, p a * q a b * log (p a * q a b) =
+          q a b * (p a * log (p a)) + p a * (q a b * log (q a b)) := by
+        intro b
+        by_cases hqb : q a b = 0
+        · simp [hqb]
+        · have hqb_pos : 0 < q a b := lt_of_le_of_ne (prob_nonneg (q a) b) (Ne.symm hqb)
+          rw [Real.log_mul (ne_of_gt hpa_pos) (ne_of_gt hqb_pos)]
+          ring
+      simp_rw [split, Finset.sum_add_distrib, ← Finset.sum_mul, ← Finset.mul_sum]
+      rw [prob_sum_eq_one (q a), one_mul]
+  simp_rw [key, Finset.sum_add_distrib]
+  simp [Finset.sum_neg_distrib]
+  linarith
+
+/-! ## Main theorem -/
+
+/-- `entropyNat` satisfies the Shannon entropy axioms.
+
+This is the converse of the characterization: the characterization shows any `H`
+satisfying the axioms must be a positive multiple of `entropyNat`; this theorem
+shows `entropyNat` itself satisfies the axioms, proving the axiom system is
+consistent and completing the "if and only if". -/
+theorem entropyNat_shannonAxioms : ShannonEntropyAxioms (fun {α} [Fintype α] => entropyNat) where
+  continuous := continuous_entropyNat
+  uniformMonotone := entropyNat_uniformMonotone
+  relabelInvariant := entropyNat_relabelInvariant
+  grouping := entropyNat_grouping
+
+end
+
+end LeanPool.Shannon1948Formalization

--- a/LeanPool/Shannon1948Formalization/Entropy/Core.lean
+++ b/LeanPool/Shannon1948Formalization/Entropy/Core.lean
@@ -18,7 +18,7 @@ import Mathlib.Tactic
 Foundational definitions for the Shannon characterization development:
 
 - finite probability distributions (`ProbDist`);
-- Shannon-style axiom bundle (`ShannonEntropyAxioms`);
+- Shannon-style condition bundle (`ShannonEntropyAxioms`);
 - basic constructions used in all later phases
   (`uniformPNat`, `composeProb`, `relabelProb`).
 
@@ -131,7 +131,7 @@ def relabelProb
   · simpa using (e.symm.sum_comp (fun a => p a)).trans (prob_sum_eq_one p)
 
 /--
-Shannon's three axioms for a finite-choice uncertainty functional `H`.
+Shannon's three conditions for a finite-choice uncertainty functional `H`.
 The final theorem will show any such `H` has entropy form up to a positive scale.
 -/
 structure ShannonEntropyAxioms

--- a/LeanPool/Shannon1948Formalization/Entropy/Core.lean
+++ b/LeanPool/Shannon1948Formalization/Entropy/Core.lean
@@ -1,0 +1,182 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+import Mathlib.Analysis.Convex.DoublyStochasticMatrix
+import Mathlib.Analysis.SpecialFunctions.Log.Base
+import Mathlib.Analysis.SpecialFunctions.Log.NegMulLog
+import Mathlib.Data.Fintype.BigOperators
+import Mathlib.Data.Fintype.EquivFin
+import Mathlib.Logic.Equiv.Fin.Basic
+import Mathlib.Tactic
+
+/-!
+# Shannon.Entropy.Core
+
+Foundational definitions for the Shannon characterization development:
+
+- finite probability distributions (`ProbDist`);
+- Shannon-style axiom bundle (`ShannonEntropyAxioms`);
+- basic constructions used in all later phases
+  (`uniformPNat`, `composeProb`, `relabelProb`).
+
+Global roadmap (matching Shannon Appendix 2):
+1. Equiprobable case: `Apos H (n * m) = Apos H n + Apos H m`, then `Apos H n = K * log n`.
+2. Rational case: grouped equiprobable refinement implies
+   `H p = -K * ∑ p_i log p_i` for rational probabilities.
+3. Real case: floor-count rational approximants `approxProb p N` converge to `p`;
+   continuity upgrades the rational formula to all real probabilities.
+-/
+namespace LeanPool.Shannon1948Formalization
+
+noncomputable section
+open Filter
+open scoped Topology
+
+/-- `p` has nonnegative masses that sum to one. -/
+def IsProbDist {α : Type} [Fintype α] (p : α → ℝ) : Prop :=
+  (∀ a, 0 ≤ p a) ∧ (∑ a, p a) = 1
+
+/--
+A probability distribution over a finite type `α`, bundled with simplex proofs.
+This keeps API signatures clean (no separate `IsProbDist` assumptions everywhere).
+-/
+abbrev ProbDist (α : Type) [Fintype α] := {p : α → ℝ // IsProbDist p}
+
+instance {α : Type} [Fintype α] : CoeFun (ProbDist α) (fun _ => α → ℝ) where
+  coe p := p.1
+
+lemma prob_nonneg {α : Type} [Fintype α] (p : ProbDist α) (a : α) : 0 ≤ p a :=
+  p.2.1 a
+
+lemma prob_sum_eq_one {α : Type} [Fintype α] (p : ProbDist α) : (∑ a, p a) = 1 :=
+  p.2.2
+
+lemma prob_le_one {α : Type} [Fintype α] (p : ProbDist α) (a : α) : p a ≤ 1 := by
+  have hsingle : p a ≤ ∑ b, p b := by
+    simpa using (Finset.single_le_sum (fun b _ => prob_nonneg p b) (Finset.mem_univ a))
+  linarith [hsingle, prob_sum_eq_one p]
+
+/-- Uniform distribution on `Fin (n + 1)`. -/
+def uniformFin (n : ℕ) : ProbDist (Fin (n + 1)) := by
+  refine ⟨fun _ => 1 / (n + 1 : ℝ), ?_⟩
+  constructor
+  · intro _
+    positivity
+  · have h : (n + 1 : ℝ) ≠ 0 := by exact_mod_cast (Nat.succ_ne_zero n)
+    simp [Finset.card_univ, h]
+
+/--
+Uniform distribution on `Fin n` for positive natural `n : ℕ+`.
+This avoids `n + 1` index gymnastics when formalizing Appendix 2.
+-/
+def uniformPNat (n : ℕ+) : ProbDist (Fin n) := by
+  refine ⟨fun _ => 1 / (n : ℝ), ?_⟩
+  constructor
+  · intro _
+    positivity
+  · have h : (n : ℝ) ≠ 0 := by
+      exact_mod_cast (show (n : ℕ) ≠ 0 from Nat.ne_of_gt n.2)
+    simp [Finset.card_univ, h]
+
+/-- Composite distribution for a two-stage random choice. -/
+def composeProb
+    {α : Type} [Fintype α]
+    {β : α → Type} [∀ a, Fintype (β a)]
+    (p : ProbDist α)
+    (q : (a : α) → ProbDist (β a)) :
+    ProbDist (Sigma β) := by
+  refine ⟨fun x => p x.1 * q x.1 x.2, ?_⟩
+  constructor
+  · intro x
+    exact mul_nonneg (prob_nonneg p x.1) (prob_nonneg (q x.1) x.2)
+  · classical
+    calc
+      (∑ x : Sigma β, p x.1 * q x.1 x.2)
+          = ∑ a, ∑ b, p a * q a b := by
+              simpa using
+                (Fintype.sum_sigma (f := fun x : Sigma β => p x.1 * q x.1 x.2))
+      _ = ∑ a, p a * (∑ b, q a b) := by
+            refine Finset.sum_congr rfl ?_
+            intro a _
+            rw [Finset.mul_sum]
+      _ = ∑ a, p a * 1 := by
+            refine Finset.sum_congr rfl ?_
+            intro a _
+            rw [prob_sum_eq_one (q a)]
+      _ = ∑ a, p a := by simp
+      _ = 1 := prob_sum_eq_one p
+
+/-- Equivalence between two-stage finite outcomes and `Fin (n * m)`. -/
+def sigmaConstFinEquivFinMul (n m : ℕ+) :
+    Sigma (fun _ : Fin n => Fin m) ≃ Fin (n * m : ℕ+) :=
+  (Equiv.sigmaEquivProdOfEquiv (fun _ : Fin n => (Equiv.refl (Fin m)))).trans
+    finProdFinEquiv
+
+/--
+Relabel a distribution along an equivalence of finite types.
+This is the formal "event names do not matter" transport map.
+-/
+def relabelProb
+    {α β : Type} [Fintype α] [Fintype β]
+    (e : α ≃ β)
+    (p : ProbDist α) :
+    ProbDist β := by
+  refine ⟨fun b => p (e.symm b), ?_⟩
+  constructor
+  · intro b
+    exact prob_nonneg p (e.symm b)
+  · simpa using (e.symm.sum_comp (fun a => p a)).trans (prob_sum_eq_one p)
+
+/--
+Shannon's three axioms for a finite-choice uncertainty functional `H`.
+The final theorem will show any such `H` has entropy form up to a positive scale.
+-/
+structure ShannonEntropyAxioms
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ) : Prop where
+  /-- Continuity in probabilities (for each finite alphabet). -/
+  continuous :
+    ∀ {α : Type} [Fintype α], Continuous fun p : ProbDist α => H p
+
+  /-- On uniform distributions, uncertainty is monotone in alphabet size. -/
+  uniformMonotone :
+    StrictMono fun n : ℕ+ => H (uniformPNat n)
+
+  /-- Invariance under relabeling outcomes by a finite equivalence. -/
+  relabelInvariant :
+    ∀ {α β : Type} [Fintype α] [Fintype β]
+      (e : α ≃ β)
+      (p : ProbDist α),
+      H (relabelProb e p) = H p
+
+  /-- Grouping (recursivity): a two-stage choice decomposes additively. -/
+  grouping :
+    ∀ {α : Type} [Fintype α]
+      {β : α → Type} [∀ a, Fintype (β a)]
+      (p : ProbDist α)
+      (q : (a : α) → ProbDist (β a)),
+      H (composeProb p q) = H p + ∑ a, p a * H (q a)
+
+/--
+`A_H(n)` is Shannon's notation for uncertainty on the uniform distribution
+with `n + 1` equiprobable outcomes.
+-/
+def A
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (n : ℕ) : ℝ :=
+  H (uniformFin n)
+
+/--
+`Apos H n` is uncertainty for exactly `n` equiprobable outcomes (`n : ℕ+`).
+-/
+def Apos
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (n : ℕ+) : ℝ :=
+  H (uniformPNat n)
+
+
+end
+
+end LeanPool.Shannon1948Formalization

--- a/LeanPool/Shannon1948Formalization/Entropy/Final.lean
+++ b/LeanPool/Shannon1948Formalization/Entropy/Final.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+import LeanPool.Shannon1948Formalization.Entropy.Approx
+
+/-!
+# Shannon.Entropy.Final
+
+Final theorem layer.
+
+Combines the rational characterization and continuity extension to prove:
+- natural-log uniqueness (`entropyNat_unique`);
+- base-parametric uniqueness (`entropyBase_unique`).
+-/
+namespace LeanPool.Shannon1948Formalization
+
+noncomputable section
+open Filter
+open scoped Topology
+
+/-! ## Final Characterization Theorems -/
+
+/-! ### Theorem Index
+
+- `entropyNat_unique`
+- `entropyBase_unique`
+-/
+
+/--
+Uniqueness in natural-log units:
+every `H` satisfying the axiom bundle agrees with Shannon entropy up to the
+positive multiplicative constant `K H`.
+-/
+theorem entropyNat_unique
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H)
+    {α : Type} [Fintype α]
+    (p : ProbDist α) :
+    H p = -K H * ∑ a, p a * Real.log (p a) := by
+  have hseq :
+      ∀ N : ℕ, H (approxProb p N) = K H * entropyNat (approxProb p N) := by
+    intro N
+    have hN := entropyNat_approxProb H hH p N
+    simpa [entropyNat, mul_assoc, mul_left_comm, mul_comm] using hN
+  have hleft :
+      Tendsto (fun N : ℕ => H (approxProb p N)) atTop (𝓝 (H p)) := by
+    exact (hH.continuous (α := α)).continuousAt.tendsto.comp (tendsto_approxProb p)
+  have hright :
+      Tendsto (fun N : ℕ => K H * entropyNat (approxProb p N)) atTop (𝓝 (K H * entropyNat p)) := by
+    have hcont : Continuous (fun q : ProbDist α => K H * entropyNat q) :=
+      continuous_const.mul continuous_entropyNat
+    exact hcont.continuousAt.tendsto.comp (tendsto_approxProb p)
+  have hright' :
+      Tendsto (fun N : ℕ => H (approxProb p N)) atTop (𝓝 (K H * entropyNat p)) := by
+    convert hright using 1
+    funext N
+    exact hseq N
+  have hlim : H p = K H * entropyNat p := tendsto_nhds_unique hleft hright'
+  simpa [entropyNat, mul_assoc, mul_left_comm, mul_comm] using hlim
+
+/--
+Base-parametric uniqueness:
+for each base `b > 1`, there is a positive constant `Kb` with
+`H p = -Kb * ∑ p_i log_b p_i`.
+-/
+theorem entropyBase_unique
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H)
+    (b : ℝ)
+    (hb : 1 < b) :
+    ∃ Kb : ℝ, 0 < Kb ∧
+      ∀ {α : Type} [Fintype α] (p : ProbDist α),
+        H p = -Kb * ∑ a, p a * Real.logb b (p a) := by
+  refine ⟨K H * Real.log b, ?_, ?_⟩
+  · exact mul_pos (K_pos H hH) (Real.log_pos hb)
+  · intro α _ p
+    have hb0 : b ≠ 0 := ne_of_gt (lt_trans (show (0 : ℝ) < 1 by norm_num) hb)
+    have hb1 : b ≠ 1 := ne_of_gt hb
+    have hb_pos : 0 < b := lt_trans (show (0 : ℝ) < 1 by norm_num) hb
+    have hlogb_ne : Real.log b ≠ 0 := Real.log_ne_zero_of_pos_of_ne_one hb_pos hb1
+    calc
+      H p = -K H * ∑ a, p a * Real.log (p a) := entropyNat_unique H hH p
+      _ = -(K H * Real.log b) * ∑ a, p a * Real.logb b (p a) := by
+            have hsum :
+                (∑ a, p a * Real.log (p a))
+                  = Real.log b * (∑ a, p a * Real.logb b (p a)) := by
+              calc
+                (∑ a, p a * Real.log (p a))
+                    = ∑ a, p a * (Real.log b * Real.logb b (p a)) := by
+                        refine Finset.sum_congr rfl ?_
+                        intro a _
+                        have hterm :
+                            Real.log (p a) = Real.log b * Real.logb b (p a) := by
+                          unfold Real.logb
+                          field_simp [hlogb_ne]
+                        rw [hterm]
+                _ = Real.log b * (∑ a, p a * Real.logb b (p a)) := by
+                      rw [Finset.mul_sum]
+                      refine Finset.sum_congr rfl ?_
+                      intro a _
+                      ring
+            rw [hsum]
+            ring
+
+
+end
+
+end LeanPool.Shannon1948Formalization

--- a/LeanPool/Shannon1948Formalization/Entropy/Final.lean
+++ b/LeanPool/Shannon1948Formalization/Entropy/Final.lean
@@ -31,8 +31,8 @@ open scoped Topology
 
 /--
 Uniqueness in natural-log units:
-every `H` satisfying the axiom bundle agrees with Shannon entropy up to the
-positive multiplicative constant `K H`.
+every `H` satisfying the condition bundle agrees with Shannon entropy up to the
+positive multiplicative scale factor `K H`.
 -/
 theorem entropyNat_unique
     (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
@@ -63,7 +63,7 @@ theorem entropyNat_unique
 
 /--
 Base-parametric uniqueness:
-for each base `b > 1`, there is a positive constant `Kb` with
+for each base `b > 1`, there is a positive scale factor `Kb` with
 `H p = -Kb * ∑ p_i log_b p_i`.
 -/
 theorem entropyBase_unique

--- a/LeanPool/Shannon1948Formalization/Entropy/Gibbs.lean
+++ b/LeanPool/Shannon1948Formalization/Entropy/Gibbs.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+import LeanPool.Shannon1948Formalization.Entropy.Final
+
+/-!
+# Shannon.Entropy.Gibbs
+
+Gibbs inequality and single-variable entropy bounds.
+
+The Gibbs inequality (`∑ pᵢ log(qᵢ/pᵢ) ≤ 0`) is the analytical workhorse for
+deriving the properties of Shannon entropy listed in Section 6 of Shannon (1948).
+It follows from `log x ≤ x - 1` and the fact that probability masses sum to one.
+
+We also connect `entropyNat` to Mathlib's `Real.negMulLog`, giving access to
+Mathlib's concavity infrastructure for later proofs.
+
+## Main results
+
+- `entropyNat_eq_sum_negMulLog`: bridge between `entropyNat` and `Real.negMulLog`
+- `gibbs_inequality`: `∑ pᵢ log(qᵢ/pᵢ) ≤ 0`
+- `entropyNat_nonneg`: `H(p) ≥ 0`
+- `entropyNat_uniformPNat`: `H(uniform n) = log n`
+- `entropyNat_le_log_card`: `H(p) ≤ log |α|`
+-/
+namespace LeanPool.Shannon1948Formalization
+
+noncomputable section
+open Finset Real
+
+/-! ## Bridge to negMulLog -/
+
+/-- `entropyNat p = ∑ a, negMulLog (p a)`, connecting our definition to Mathlib's
+`Real.negMulLog` which carries concavity and differentiability lemmas. -/
+lemma entropyNat_eq_sum_negMulLog {α : Type} [Fintype α] (p : ProbDist α) :
+    entropyNat p = ∑ a, Real.negMulLog (p a) := by
+  unfold entropyNat Real.negMulLog
+  simp [Finset.sum_neg_distrib, neg_mul]
+
+/-! ## Gibbs inequality -/
+
+/-- **Gibbs inequality**: for probability distributions `p` and `q` where `q` covers
+the support of `p`, we have `∑ pᵢ log(qᵢ/pᵢ) ≤ 0`. Equivalently, the
+Kullback-Leibler divergence `D(p ‖ q) ≥ 0`.
+
+The proof uses `log x ≤ x - 1` on each ratio `qᵢ/pᵢ`, then telescopes via
+`∑ qᵢ = ∑ pᵢ = 1`. -/
+theorem gibbs_inequality {α : Type} [Fintype α]
+    (p q : ProbDist α) (hsupp : ∀ a, 0 < p a → 0 < q a) :
+    ∑ a, p a * Real.log (q a / p a) ≤ 0 := by
+  have key : ∀ a, p a * Real.log (q a / p a) ≤ q a - p a := by
+    intro a
+    by_cases hp : p a = 0
+    · simp [hp, prob_nonneg q a]
+    · have hpa : 0 < p a := lt_of_le_of_ne (prob_nonneg p a) (Ne.symm hp)
+      have hqa : 0 < q a := hsupp a hpa
+      calc p a * Real.log (q a / p a)
+          ≤ p a * (q a / p a - 1) :=
+            mul_le_mul_of_nonneg_left (Real.log_le_sub_one_of_pos (div_pos hqa hpa)) hpa.le
+        _ = q a - p a := by field_simp
+  calc ∑ a, p a * Real.log (q a / p a)
+      ≤ ∑ a, (q a - p a) := Finset.sum_le_sum (fun a _ => key a)
+    _ = (∑ a, q a) - (∑ a, p a) := by
+        simp_rw [sub_eq_add_neg]; rw [Finset.sum_add_distrib, Finset.sum_neg_distrib]
+    _ = 0 := by rw [prob_sum_eq_one q, prob_sum_eq_one p, sub_self]
+
+/-! ## Single-variable entropy bounds -/
+
+/-- Entropy is nonnegative: each `negMulLog(pᵢ) ≥ 0` for `pᵢ ∈ [0, 1]`. -/
+theorem entropyNat_nonneg {α : Type} [Fintype α] (p : ProbDist α) :
+    0 ≤ entropyNat p := by
+  rw [entropyNat_eq_sum_negMulLog]
+  exact Finset.sum_nonneg fun a _ => Real.negMulLog_nonneg (prob_nonneg p a) (prob_le_one p a)
+
+/-- Entropy of the uniform distribution on `n` outcomes equals `log n`. -/
+theorem entropyNat_uniformPNat (n : ℕ+) :
+    entropyNat (uniformPNat n) = Real.log n := by
+  have hn_pos : (0 : ℝ) < n := by exact_mod_cast n.2
+  have hn_ne : (n : ℝ) ≠ 0 := ne_of_gt hn_pos
+  rw [entropyNat_eq_sum_negMulLog]
+  have hval : ∀ a : Fin n, (uniformPNat n : Fin n → ℝ) a = 1 / (n : ℝ) := fun _ => rfl
+  simp_rw [hval, Real.negMulLog, Finset.sum_const, Finset.card_univ, Fintype.card_fin]
+  rw [Real.log_div one_ne_zero hn_ne, Real.log_one, zero_sub]
+  simp [nsmul_eq_mul]
+
+/-- Entropy is at most `log |α|`, with equality at the uniform distribution.
+The proof applies `gibbs_inequality` with `q = uniform`. -/
+theorem entropyNat_le_log_card {α : Type} [Fintype α] [Nonempty α]
+    (p : ProbDist α) :
+    entropyNat p ≤ Real.log (Fintype.card α) := by
+  have hcard_pos : (0 : ℝ) < Fintype.card α := by exact_mod_cast Fintype.card_pos (α := α)
+  have hcard_ne : (Fintype.card α : ℝ) ≠ 0 := ne_of_gt hcard_pos
+  let q : ProbDist α := ⟨fun _ => 1 / (Fintype.card α : ℝ), by
+    constructor
+    · intro _; positivity
+    · simp [Finset.card_univ, hcard_ne]⟩
+  have hq_val : ∀ a, q a = 1 / (Fintype.card α : ℝ) := fun _ => rfl
+  have hsupp : ∀ a, 0 < p a → 0 < q a := fun a _ => by rw [hq_val]; positivity
+  have hgibbs := gibbs_inequality p q hsupp
+  suffices h : ∑ a, p a * Real.log (q a / p a) =
+      entropyNat p - Real.log (Fintype.card α) by linarith
+  have hterm : ∀ a, p a * Real.log (q a / p a) =
+      p a * Real.log (q a) - p a * Real.log (p a) := by
+    intro a
+    by_cases hp : p a = 0
+    · simp [hp]
+    · have hpa : 0 < p a := lt_of_le_of_ne (prob_nonneg p a) (Ne.symm hp)
+      rw [Real.log_div (ne_of_gt (hsupp a hpa)) (ne_of_gt hpa), mul_sub]
+  simp_rw [hterm, sub_eq_add_neg]
+  rw [Finset.sum_add_distrib]
+  have hlogq : ∑ a, p a * Real.log (q a) = -Real.log (Fintype.card α) := by
+    simp_rw [hq_val, Real.log_div one_ne_zero hcard_ne, Real.log_one, zero_sub]
+    rw [← Finset.sum_mul, prob_sum_eq_one p, one_mul]
+  rw [hlogq, Finset.sum_neg_distrib]
+  unfold entropyNat; ring
+
+end
+
+end LeanPool.Shannon1948Formalization

--- a/LeanPool/Shannon1948Formalization/Entropy/Joint.lean
+++ b/LeanPool/Shannon1948Formalization/Entropy/Joint.lean
@@ -1,0 +1,193 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+import LeanPool.Shannon1948Formalization.Entropy.Gibbs
+
+/-!
+# Shannon.Entropy.Joint
+
+Joint distributions on product types, marginals, conditional entropy,
+and the chain rule for Shannon entropy.
+
+These definitions and theorems support the Section 6 properties by providing
+the infrastructure for multi-variable entropy identities.
+
+## Main definitions
+
+- `marginalFst`, `marginalSnd`: marginal distributions from a joint distribution
+- `prodDist`: product (independent) distribution from two marginals
+- `IsIndependent`: predicate for independence of a joint distribution
+- `condEntropy`: conditional entropy `H_X(Y) = -∑ p(x,y) log(p(x,y)/p(x))`
+- `mutualInfo`: mutual information `I(X;Y) = H(X) + H(Y) - H(X,Y)`
+
+## Main results
+
+- `chain_rule`: `H(X,Y) = H(X) + H_X(Y)`
+- `entropyNat_prodDist`: `H(X × Y) = H(X) + H(Y)` for independent distributions
+- `marginalFst_prodDist`, `marginalSnd_prodDist`: marginals of product distributions
+-/
+namespace LeanPool.Shannon1948Formalization
+
+noncomputable section
+open Finset Real
+
+/-! ## Marginals and product distributions -/
+
+/-- First marginal: `(marginalFst p)(a) = ∑_b p(a, b)`. -/
+def marginalFst {α β : Type} [Fintype α] [Fintype β]
+    (p : ProbDist (α × β)) : ProbDist α := by
+  refine ⟨fun a => ∑ b, p (a, b), ?_⟩
+  constructor
+  · intro a
+    exact Finset.sum_nonneg fun b _ => prob_nonneg p (a, b)
+  · calc ∑ a, ∑ b, p (a, b)
+        = ∑ ab : α × β, p ab := (Fintype.sum_prod_type _).symm
+      _ = 1 := prob_sum_eq_one p
+
+/-- Second marginal: `(marginalSnd p)(b) = ∑_a p(a, b)`. -/
+def marginalSnd {α β : Type} [Fintype α] [Fintype β]
+    (p : ProbDist (α × β)) : ProbDist β := by
+  refine ⟨fun b => ∑ a, p (a, b), ?_⟩
+  constructor
+  · intro b
+    exact Finset.sum_nonneg fun a _ => prob_nonneg p (a, b)
+  · calc ∑ b, ∑ a, p (a, b)
+        = ∑ ab : α × β, p ab := (Fintype.sum_prod_type_right _).symm
+      _ = 1 := prob_sum_eq_one p
+
+/-- Product distribution: `(prodDist p q)(a, b) = p(a) * q(b)`. -/
+def prodDist {α β : Type} [Fintype α] [Fintype β]
+    (p : ProbDist α) (q : ProbDist β) : ProbDist (α × β) := by
+  refine ⟨fun ab => p ab.1 * q ab.2, ?_⟩
+  constructor
+  · intro ab
+    exact mul_nonneg (prob_nonneg p ab.1) (prob_nonneg q ab.2)
+  · calc ∑ ab : α × β, p ab.1 * q ab.2
+        = ∑ a, ∑ b, p a * q b := Fintype.sum_prod_type _
+      _ = ∑ a, p a * (∑ b, q b) := by
+          apply Finset.sum_congr rfl; intro a _; rw [Finset.mul_sum]
+      _ = ∑ a, p a * 1 := by rw [prob_sum_eq_one q]
+      _ = 1 := by simp [mul_one, prob_sum_eq_one p]
+
+/-! ## Independence, conditional entropy, mutual information -/
+
+/-- A joint distribution is independent when it factors as the product of its marginals. -/
+def IsIndependent {α β : Type} [Fintype α] [Fintype β]
+    (p : ProbDist (α × β)) : Prop :=
+  ∀ a b, p (a, b) = marginalFst p a * marginalSnd p b
+
+/-- Conditional entropy `H_X(Y) = -∑_{x,y} p(x,y) log(p(x,y) / p_X(x))`.
+
+This measures the average remaining uncertainty in `Y` once `X` is known.
+The formula uses Lean's `0 / 0 = 0` and `log 0 = 0` conventions: when
+`p_X(x) = 0` we also have `p(x,y) = 0`, so the term vanishes. -/
+def condEntropy {α β : Type} [Fintype α] [Fintype β]
+    (p : ProbDist (α × β)) : ℝ :=
+  -∑ ab : α × β, p ab * Real.log (p ab / marginalFst p ab.1)
+
+/-- Mutual information `I(X;Y) = H(X) + H(Y) - H(X,Y)`. -/
+def mutualInfo {α β : Type} [Fintype α] [Fintype β]
+    (p : ProbDist (α × β)) : ℝ :=
+  entropyNat (marginalFst p) + entropyNat (marginalSnd p) - entropyNat p
+
+/-! ## Support lemmas -/
+
+/-- If a first marginal is zero, every joint probability with that first
+coordinate is zero (since the marginal is a sum of nonnegative terms). -/
+lemma prob_eq_zero_of_marginalFst_eq_zero {α β : Type} [Fintype α] [Fintype β]
+    (p : ProbDist (α × β)) (a : α) (ha : marginalFst p a = 0) (b : β) :
+    p (a, b) = 0 := by
+  have hterms : ∀ b' ∈ Finset.univ, 0 ≤ p (a, b') := fun b' _ => prob_nonneg p (a, b')
+  exact (Finset.sum_eq_zero_iff_of_nonneg hterms).mp ha b (Finset.mem_univ b)
+
+/-- A positive joint probability implies a positive first marginal. -/
+lemma marginalFst_pos_of_prob_pos {α β : Type} [Fintype α] [Fintype β]
+    (p : ProbDist (α × β)) (a : α) (b : β) (h : 0 < p (a, b)) :
+    0 < marginalFst p a :=
+  lt_of_lt_of_le h
+    (Finset.single_le_sum (fun b' _ => prob_nonneg p (a, b')) (Finset.mem_univ b))
+
+/-! ## Marginals of product distributions -/
+
+/-- The first marginal of a product distribution recovers the first factor. -/
+theorem marginalFst_prodDist {α β : Type} [Fintype α] [Fintype β]
+    (p : ProbDist α) (q : ProbDist β) :
+    marginalFst (prodDist p q) = p := by
+  ext a
+  change ∑ b, p a * q b = p a
+  rw [← Finset.mul_sum, prob_sum_eq_one q, mul_one]
+
+/-- The second marginal of a product distribution recovers the second factor. -/
+theorem marginalSnd_prodDist {α β : Type} [Fintype α] [Fintype β]
+    (p : ProbDist α) (q : ProbDist β) :
+    marginalSnd (prodDist p q) = q := by
+  ext b
+  change ∑ a, p a * q b = q b
+  rw [← Finset.sum_mul, prob_sum_eq_one p, one_mul]
+
+/-! ## Chain rule -/
+
+/-- **Chain rule for entropy**: `H(X,Y) = H(X) + H_X(Y)`.
+
+The proof expands `H(X)` over the product type by distributing the marginal
+weight, then combines termwise using `log(p/m) = log p - log m`. -/
+theorem chain_rule {α β : Type} [Fintype α] [Fintype β]
+    (p : ProbDist (α × β)) :
+    entropyNat p = entropyNat (marginalFst p) + condEntropy p := by
+  unfold entropyNat condEntropy
+  suffices h : ∑ ab : α × β, p ab * Real.log (p ab) =
+      (∑ a, marginalFst p a * Real.log (marginalFst p a)) +
+      (∑ ab : α × β, p ab * Real.log (p ab / marginalFst p ab.1)) by linarith
+  have hmargsplit : ∑ a, marginalFst p a * Real.log (marginalFst p a) =
+      ∑ ab : α × β, p ab * Real.log (marginalFst p ab.1) := by
+    have hsplit : ∀ a, marginalFst p a * Real.log (marginalFst p a) =
+        ∑ b, p (a, b) * Real.log (marginalFst p a) := by
+      intro a; rw [← Finset.sum_mul]; rfl
+    simp_rw [hsplit]
+    exact (Fintype.sum_prod_type
+      (fun (ab : α × β) => p ab * Real.log (marginalFst p ab.1))).symm
+  rw [hmargsplit, ← Finset.sum_add_distrib]
+  apply Finset.sum_congr rfl
+  intro ab _
+  by_cases hp : p ab = 0
+  · simp [hp]
+  · have hpab : 0 < p ab := lt_of_le_of_ne (prob_nonneg p ab) (Ne.symm hp)
+    have hm : 0 < marginalFst p ab.1 := marginalFst_pos_of_prob_pos p ab.1 ab.2 hpab
+    rw [Real.log_div (ne_of_gt hpab) (ne_of_gt hm)]; ring
+
+/-! ## Product distribution entropy -/
+
+/-- **Additivity for independent distributions**: `H(X × Y) = H(X) + H(Y)`.
+
+The proof uses `log(p(a) * q(b)) = log p(a) + log q(b)` for each nonzero term,
+then separates the double sum using `∑ qᵢ = 1` and `∑ pᵢ = 1`. -/
+theorem entropyNat_prodDist {α β : Type} [Fintype α] [Fintype β]
+    (p : ProbDist α) (q : ProbDist β) :
+    entropyNat (prodDist p q) = entropyNat p + entropyNat q := by
+  unfold entropyNat
+  suffices h : ∑ ab : α × β, (prodDist p q) ab * Real.log ((prodDist p q) ab) =
+      (∑ a, p a * Real.log (p a)) + (∑ b, q b * Real.log (q b)) by linarith
+  have hprod : ∀ ab : α × β, (prodDist p q) ab = p ab.1 * q ab.2 := fun _ => rfl
+  simp_rw [hprod]
+  rw [Fintype.sum_prod_type]
+  have key : ∀ a b, p a * q b * Real.log (p a * q b) =
+      q b * (p a * Real.log (p a)) + p a * (q b * Real.log (q b)) := by
+    intro a b
+    by_cases hpa : p a = 0
+    · simp [hpa]
+    · by_cases hqb : q b = 0
+      · simp [hqb]
+      · rw [Real.log_mul (ne_of_gt (lt_of_le_of_ne (prob_nonneg p a) (Ne.symm hpa)))
+              (ne_of_gt (lt_of_le_of_ne (prob_nonneg q b) (Ne.symm hqb)))]
+        ring
+  simp_rw [key, Finset.sum_add_distrib, ← Finset.sum_mul, ← Finset.mul_sum]
+  rw [prob_sum_eq_one q, one_mul]
+  congr 1
+  rw [← Finset.sum_mul, prob_sum_eq_one p, one_mul]
+
+end
+
+end LeanPool.Shannon1948Formalization

--- a/LeanPool/Shannon1948Formalization/Entropy/Properties.lean
+++ b/LeanPool/Shannon1948Formalization/Entropy/Properties.lean
@@ -1,0 +1,293 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+import LeanPool.Shannon1948Formalization.Entropy.Joint
+
+/-!
+# Shannon.Entropy.Properties
+
+The fundamental properties of Shannon entropy from Section 6 of Shannon (1948,
+pp. 11-12). These are consequences of the entropy formula, proved using the
+Gibbs inequality and concavity of `negMulLog`.
+
+## Main results
+
+1. `entropyNat_eq_zero_iff` — `H(p) = 0` iff `p` is deterministic
+2. `entropyNat_eq_log_card_iff` — `H(p) = log |α|` iff `p` is uniform
+3. `entropyNat_joint_le_add` — subadditivity: `H(X,Y) ≤ H(X) + H(Y)`
+4. `entropyNat_doublyStochastic_le` — Schur-concavity: doubly stochastic averaging
+5. `condEntropy_le_entropyNat` — conditioning reduces entropy: `H_X(Y) ≤ H(Y)`
+6. `condEntropy_nonneg` — conditional entropy is nonnegative
+-/
+namespace LeanPool.Shannon1948Formalization
+
+noncomputable section
+open Finset Real
+
+/-! ## Property 1: H = 0 iff deterministic -/
+
+/-- A distribution is deterministic if some outcome has probability one. -/
+def IsDeterministic {α : Type} [Fintype α] (p : ProbDist α) : Prop :=
+  ∃ a₀, p a₀ = 1
+
+/-- If every probability is 0 or 1 and the total is 1, exactly one is 1. -/
+private lemma deterministic_of_all_zero_or_one {α : Type} [Fintype α]
+    (p : ProbDist α) (h : ∀ a, p a = 0 ∨ p a = 1) :
+    IsDeterministic p := by
+  by_contra hnd
+  unfold IsDeterministic at hnd
+  push Not at hnd
+  have hall0 : ∀ a, p a = 0 := by
+    intro a
+    cases h a with
+    | inl h0 => exact h0
+    | inr h1 => exact absurd (hnd a) (not_not.mpr h1)
+  linarith [prob_sum_eq_one p, show (∑ a, p a) = 0 from
+    Finset.sum_eq_zero fun a _ => hall0 a]
+
+/-- **Property 1**: `H(p) = 0` if and only if `p` is deterministic.
+
+Forward: `H = 0` means each `negMulLog(pᵢ) = 0`, forcing each `pᵢ ∈ {0, 1}`;
+the sum constraint `∑ pᵢ = 1` then gives exactly one `pᵢ = 1`.
+Backward: `1 · log 1 = 0` and `0 · log 0 = 0`. -/
+theorem entropyNat_eq_zero_iff {α : Type} [Fintype α]
+    (p : ProbDist α) :
+    entropyNat p = 0 ↔ IsDeterministic p := by
+  classical
+  constructor
+  · intro hH
+    rw [entropyNat_eq_sum_negMulLog] at hH
+    have hterms : ∀ a, Real.negMulLog (p a) = 0 := by
+      have hnonneg : ∀ a ∈ Finset.univ, 0 ≤ Real.negMulLog (p a) :=
+        fun a _ => Real.negMulLog_nonneg (prob_nonneg p a) (prob_le_one p a)
+      exact fun a => (Finset.sum_eq_zero_iff_of_nonneg hnonneg).mp hH a (Finset.mem_univ a)
+    have h01 : ∀ a, p a = 0 ∨ p a = 1 := by
+      intro a
+      have hpa := hterms a
+      unfold Real.negMulLog at hpa
+      have hmul : p a * Real.log (p a) = 0 := by linarith
+      rcases mul_eq_zero.mp hmul with h0 | hlog
+      · left; linarith [prob_nonneg p a]
+      · rw [Real.log_eq_zero] at hlog
+        rcases hlog with h0 | h1 | hneg1
+        · left; exact h0
+        · right; exact h1
+        · linarith [prob_nonneg p a]
+    exact deterministic_of_all_zero_or_one p h01
+  · intro ⟨a₀, ha₀⟩
+    rw [entropyNat_eq_sum_negMulLog]
+    apply Finset.sum_eq_zero
+    intro a _
+    by_cases haa : a = a₀
+    · rw [haa, ha₀]; exact Real.negMulLog_one
+    · have : p a = 0 := by
+        have hrest : ∑ b ∈ Finset.univ.erase a₀, p b = 0 := by
+          have h1 := prob_sum_eq_one p
+          rw [← Finset.add_sum_erase _ _ (Finset.mem_univ a₀)] at h1
+          linarith
+        exact le_antisymm
+          ((Finset.sum_eq_zero_iff_of_nonneg (fun b _ => prob_nonneg p b)).mp
+            hrest a (Finset.mem_erase.mpr ⟨haa, Finset.mem_univ a⟩)).le
+          (prob_nonneg p a)
+      rw [this]; exact Real.negMulLog_zero
+
+/-! ## Property 2: H maximized at uniform -/
+
+/-- **Property 2**: `H(p) = log |α|` if and only if `p` is uniform.
+
+The forward direction uses strict concavity of `negMulLog` (strict Jensen):
+if any `pᵢ ≠ 1/|α|`, then `H(p) < log |α|`, contradicting `H(p) = log |α|`. -/
+theorem entropyNat_eq_log_card_iff {α : Type} [Fintype α] [Nonempty α]
+    (p : ProbDist α) :
+    entropyNat p = Real.log (Fintype.card α) ↔
+    ∀ a, p a = 1 / Fintype.card α := by
+  constructor
+  · intro hH
+    have hcard_pos : (0 : ℝ) < Fintype.card α := by exact_mod_cast Fintype.card_pos (α := α)
+    have hcard_ne : (Fintype.card α : ℝ) ≠ 0 := ne_of_gt hcard_pos
+    by_contra hne
+    push Not at hne
+    obtain ⟨a₀, ha₀⟩ := hne
+    have hlt : entropyNat p < Real.log (Fintype.card α) := by
+      rw [entropyNat_eq_sum_negMulLog]
+      have hlogcard : Real.log (Fintype.card α) =
+          Fintype.card α * Real.negMulLog (1 / Fintype.card α) := by
+        unfold Real.negMulLog
+        rw [Real.log_div one_ne_zero hcard_ne, Real.log_one, zero_sub]; field_simp
+      rw [hlogcard]
+      -- Not all p_i equal: if all were equal to p(a₀), then p(a₀) = 1/|α|
+      have hexists : ∃ k ∈ Finset.univ, (fun a => p a) a₀ ≠ (fun a => p a) k := by
+        by_contra h_all_eq
+        push Not at h_all_eq
+        have hall : ∀ k, p k = p a₀ := fun k => (h_all_eq k (Finset.mem_univ k)).symm
+        have hsum : (∑ a, p a) = Fintype.card α * p a₀ := by
+          simp_rw [hall]; rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul]
+        rw [prob_sum_eq_one p] at hsum
+        exact ha₀ (by field_simp at hsum ⊢; linarith)
+      -- Apply strict Jensen for concave negMulLog with uniform weights
+      have hscjensen := Real.strictConcaveOn_negMulLog.lt_map_sum
+        (t := Finset.univ) (w := fun _ => 1 / (Fintype.card α : ℝ)) (p := fun a => p a)
+        (fun _ _ => by positivity)
+        (by simp [Finset.card_univ, hcard_ne])
+        (fun _ _ => prob_nonneg p _)
+        ⟨a₀, Finset.mem_univ a₀, hexists⟩
+      rw [show ∑ a, (1 / (Fintype.card α : ℝ)) • p a = 1 / Fintype.card α from by
+        simp [smul_eq_mul, ← Finset.mul_sum, prob_sum_eq_one p]] at hscjensen
+      calc ∑ a, Real.negMulLog (p a)
+          = Fintype.card α * ∑ a, (1 / (Fintype.card α : ℝ)) • Real.negMulLog (p a) := by
+            simp only [smul_eq_mul]; rw [← Finset.mul_sum]; field_simp
+        _ < Fintype.card α * Real.negMulLog (1 / ↑(Fintype.card α)) :=
+            mul_lt_mul_of_pos_left hscjensen hcard_pos
+    linarith
+  · intro hunif
+    rw [entropyNat_eq_sum_negMulLog]
+    have hcard_pos : (0 : ℝ) < Fintype.card α := by exact_mod_cast Fintype.card_pos (α := α)
+    have hcard_ne : (Fintype.card α : ℝ) ≠ 0 := ne_of_gt hcard_pos
+    simp_rw [hunif, Finset.sum_const, Finset.card_univ]
+    unfold Real.negMulLog
+    rw [Real.log_div one_ne_zero hcard_ne, Real.log_one, zero_sub]
+    simp [nsmul_eq_mul]
+
+/-! ## Property 3: Subadditivity -/
+
+/-- **Property 3** (subadditivity): `H(X,Y) ≤ H(X) + H(Y)`.
+
+The proof applies `gibbs_inequality` with `q = prodDist (marginalFst p) (marginalSnd p)`,
+i.e., the product of marginals. The Gibbs sum telescopes to
+`H(X,Y) - H(X) - H(Y) ≤ 0`. -/
+theorem entropyNat_joint_le_add {α β : Type} [Fintype α] [Fintype β]
+    (p : ProbDist (α × β)) :
+    entropyNat p ≤ entropyNat (marginalFst p) + entropyNat (marginalSnd p) := by
+  let q := prodDist (marginalFst p) (marginalSnd p)
+  have hsupp : ∀ ab, 0 < p ab → 0 < q ab := by
+    intro ⟨a, b⟩ hab
+    change 0 < marginalFst p a * marginalSnd p b
+    exact mul_pos (marginalFst_pos_of_prob_pos p a b hab)
+      (lt_of_lt_of_le hab
+        (Finset.single_le_sum (fun a' _ => prob_nonneg p (a', b)) (Finset.mem_univ a)))
+  have hgibbs := gibbs_inequality p q hsupp
+  suffices h : ∑ ab, p ab * Real.log (q ab / p ab) =
+      entropyNat p - entropyNat (marginalFst p) - entropyNat (marginalSnd p) by linarith
+  unfold entropyNat
+  have hqval : ∀ ab : α × β, q ab = marginalFst p ab.1 * marginalSnd p ab.2 := fun _ => rfl
+  have hterm : ∀ ab : α × β,
+      p ab * Real.log (q ab / p ab) =
+      p ab * Real.log (marginalFst p ab.1) +
+      p ab * Real.log (marginalSnd p ab.2) -
+      p ab * Real.log (p ab) := by
+    intro ab
+    by_cases hp : p ab = 0
+    · simp [hp]
+    · have hpab : 0 < p ab := lt_of_le_of_ne (prob_nonneg p ab) (Ne.symm hp)
+      have hm1 : 0 < marginalFst p ab.1 := marginalFst_pos_of_prob_pos p ab.1 ab.2 hpab
+      have hm2 : 0 < marginalSnd p ab.2 :=
+        lt_of_lt_of_le hpab
+          (Finset.single_le_sum (fun a' _ => prob_nonneg p (a', ab.2)) (Finset.mem_univ ab.1))
+      rw [hqval, Real.log_div (ne_of_gt (mul_pos hm1 hm2)) (ne_of_gt hpab),
+          Real.log_mul (ne_of_gt hm1) (ne_of_gt hm2)]
+      ring
+  simp_rw [hterm, sub_eq_add_neg]
+  rw [Finset.sum_add_distrib, Finset.sum_add_distrib]
+  have hm1sum : ∑ ab : α × β, p ab * Real.log (marginalFst p ab.1) =
+      ∑ a, marginalFst p a * Real.log (marginalFst p a) := by
+    calc ∑ ab : α × β, p ab * Real.log (marginalFst p ab.1)
+        = ∑ a, ∑ b, p (a, b) * Real.log (marginalFst p a) := Fintype.sum_prod_type _
+      _ = ∑ a, (∑ b, p (a, b)) * Real.log (marginalFst p a) := by
+          apply Finset.sum_congr rfl; intro a _; rw [Finset.sum_mul]
+      _ = ∑ a, marginalFst p a * Real.log (marginalFst p a) := rfl
+  have hm2sum : ∑ ab : α × β, p ab * Real.log (marginalSnd p ab.2) =
+      ∑ b, marginalSnd p b * Real.log (marginalSnd p b) := by
+    calc ∑ ab : α × β, p ab * Real.log (marginalSnd p ab.2)
+        = ∑ b, ∑ a, p (a, b) * Real.log (marginalSnd p b) := Fintype.sum_prod_type_right _
+      _ = ∑ b, (∑ a, p (a, b)) * Real.log (marginalSnd p b) := by
+          apply Finset.sum_congr rfl; intro b _; rw [Finset.sum_mul]
+      _ = ∑ b, marginalSnd p b * Real.log (marginalSnd p b) := rfl
+  rw [hm1sum, hm2sum, Finset.sum_neg_distrib]; linarith
+
+/-! ## Property 4: Schur-concavity (doubly stochastic averaging) -/
+
+open Matrix in
+/-- Apply a doubly stochastic matrix `A` to a probability distribution `p`,
+yielding the distribution with `(Ap)_i = ∑_j A_{ij} p_j`. -/
+def doublyStochasticApply {n : Type} [Fintype n] [DecidableEq n]
+    (A : Matrix n n ℝ) (hA : A ∈ doublyStochastic ℝ n) (p : ProbDist n) : ProbDist n := by
+  refine ⟨fun i => ∑ j, A i j * p j, ?_⟩
+  constructor
+  · intro i
+    exact Finset.sum_nonneg fun j _ =>
+      mul_nonneg (nonneg_of_mem_doublyStochastic hA) (prob_nonneg p j)
+  · calc ∑ i, ∑ j, A i j * p j
+        = ∑ j, (∑ i, A i j) * p j := by rw [Finset.sum_comm]; simp_rw [Finset.sum_mul]
+      _ = ∑ j, 1 * p j := by
+          congr 1; ext j; congr 1; exact sum_col_of_mem_doublyStochastic hA j
+      _ = 1 := by simp [prob_sum_eq_one p]
+
+open Matrix in
+/-- **Property 4** (Schur-concavity): `H(p) ≤ H(Ap)` for doubly stochastic `A`.
+
+The proof applies Jensen's inequality for `negMulLog` row-by-row with weights
+`A_{ij}`, then sums over rows and uses column-stochasticity to collapse. -/
+theorem entropyNat_doublyStochastic_le {n : Type} [Fintype n] [DecidableEq n]
+    (A : Matrix n n ℝ) (hA : A ∈ doublyStochastic ℝ n) (p : ProbDist n) :
+    entropyNat p ≤ entropyNat (doublyStochasticApply A hA p) := by
+  rw [entropyNat_eq_sum_negMulLog, entropyNat_eq_sum_negMulLog]
+  -- Per-row Jensen: ∑_j A_{ij} * negMulLog(p_j) ≤ negMulLog(∑_j A_{ij} * p_j)
+  have hrow : ∀ i, ∑ j, A i j * negMulLog (p j) ≤
+      negMulLog (doublyStochasticApply A hA p i) := by
+    intro i
+    change ∑ j, A i j * negMulLog (p j) ≤ negMulLog (∑ j, A i j * p j)
+    have := Real.concaveOn_negMulLog.le_map_sum
+      (t := Finset.univ) (w := fun j => A i j) (p := fun j => (p j : ℝ))
+      (fun j _ => nonneg_of_mem_doublyStochastic hA)
+      (sum_row_of_mem_doublyStochastic hA i)
+      (fun j _ => prob_nonneg p j)
+    simp_rw [smul_eq_mul] at this
+    exact this
+  -- Sum over rows: ∑_i ∑_j A_{ij} * negMulLog(p_j) ≤ ∑_i negMulLog((Ap)_i)
+  have hsum : ∑ i, ∑ j, A i j * negMulLog (p j) ≤
+      ∑ i, negMulLog (doublyStochasticApply A hA p i) :=
+    Finset.sum_le_sum fun i _ => hrow i
+  -- Collapse LHS: swap sums, use column-stochasticity ∑_i A_{ij} = 1
+  have hlhs : ∑ i, ∑ j, A i j * negMulLog (p j) = ∑ j, negMulLog (p j) := by
+    rw [Finset.sum_comm]; congr 1; ext j
+    rw [← Finset.sum_mul, sum_col_of_mem_doublyStochastic hA j, one_mul]
+  linarith
+
+/-! ## Properties 5-6: Conditioning reduces entropy -/
+
+/-- **Property 6**: conditional entropy is nonnegative.
+
+Each ratio `p(x,y)/p_X(x) ≤ 1` (since `p(x,y) ≤ ∑_y p(x,y) = p_X(x)`),
+so `log(p(x,y)/p_X(x)) ≤ 0` and each summand is nonpositive. -/
+theorem condEntropy_nonneg {α β : Type} [Fintype α] [Fintype β]
+    (p : ProbDist (α × β)) :
+    0 ≤ condEntropy p := by
+  unfold condEntropy
+  rw [neg_nonneg]
+  apply Finset.sum_nonpos
+  intro ab _
+  by_cases hp : p ab = 0
+  · simp [hp]
+  · have hpab : 0 < p ab := lt_of_le_of_ne (prob_nonneg p ab) (Ne.symm hp)
+    have hm : 0 < marginalFst p ab.1 := marginalFst_pos_of_prob_pos p ab.1 ab.2 hpab
+    exact mul_nonpos_of_nonneg_of_nonpos hpab.le
+      (Real.log_nonpos (div_pos hpab hm).le
+        ((div_le_one hm).mpr
+          (Finset.single_le_sum (fun b _ => prob_nonneg p (ab.1, b)) (Finset.mem_univ ab.2))))
+
+/-- **Property 5**: conditioning reduces entropy, `H_X(Y) ≤ H(Y)`.
+
+From the chain rule `H(X,Y) = H(X) + H_X(Y)` and subadditivity
+`H(X,Y) ≤ H(X) + H(Y)`, we get `H_X(Y) ≤ H(Y)`. -/
+theorem condEntropy_le_entropyNat {α β : Type} [Fintype α] [Fintype β]
+    (p : ProbDist (α × β)) :
+    condEntropy p ≤ entropyNat (marginalSnd p) :=
+  le_of_add_le_add_left (a := entropyNat (marginalFst p))
+    ((chain_rule p).symm ▸ entropyNat_joint_le_add p)
+
+end
+
+end LeanPool.Shannon1948Formalization

--- a/LeanPool/Shannon1948Formalization/Entropy/Rational.lean
+++ b/LeanPool/Shannon1948Formalization/Entropy/Rational.lean
@@ -12,7 +12,7 @@ import LeanPool.Shannon1948Formalization.Entropy.Uniform
 Phase 2 of the characterization: rational probabilities.
 
 This module derives the entropy formula for distributions of the form
-`p_i = n_i / N` via grouped equiprobable refinement and the grouping axiom.
+`p_i = n_i / N` via grouped equiprobable refinement and the grouping condition.
 It also includes a worked decomposition corresponding to Shannon's
 `(1/2, 1/3, 1/6)` narrative.
 -/

--- a/LeanPool/Shannon1948Formalization/Entropy/Rational.lean
+++ b/LeanPool/Shannon1948Formalization/Entropy/Rational.lean
@@ -1,0 +1,244 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+import LeanPool.Shannon1948Formalization.Entropy.Uniform
+
+/-!
+# Shannon.Entropy.Rational
+
+Phase 2 of the characterization: rational probabilities.
+
+This module derives the entropy formula for distributions of the form
+`p_i = n_i / N` via grouped equiprobable refinement and the grouping axiom.
+It also includes a worked decomposition corresponding to Shannon's
+`(1/2, 1/3, 1/6)` narrative.
+-/
+namespace LeanPool.Shannon1948Formalization
+
+noncomputable section
+open Filter
+open scoped Topology
+
+/-! ## Phase 2: Rational Probabilities via Grouping -/
+
+lemma relabel_compose_rational_eq_uniform
+    {α : Type} [Fintype α]
+    (p : ProbDist α)
+    (n : α → ℕ)
+    (hpos : ∀ a, 0 < n a)
+    (N : ℕ)
+    (hN : 0 < N)
+    (hp : ∀ a, p a = (n a : ℝ) / (N : ℝ))
+    (e : Sigma (fun a : α => Fin (n a)) ≃ Fin N) :
+    relabelProb e
+      (composeProb p (fun a => uniformPNat ⟨n a, hpos a⟩))
+    = uniformPNat ⟨N, hN⟩ := by
+  ext x
+  have hN_ne : (N : ℝ) ≠ 0 := by exact_mod_cast (Nat.ne_of_gt hN)
+  have hn_ne : (n (e.symm x).1 : ℝ) ≠ 0 := by
+    exact_mod_cast (Nat.ne_of_gt (hpos (e.symm x).1))
+  simp [relabelProb, composeProb, uniformPNat, hp]
+  field_simp [hN_ne, hn_ne]
+
+lemma grouping_on_rational_counts
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H)
+    {α : Type} [Fintype α]
+    (p : ProbDist α)
+    (n : α → ℕ)
+    (hpos : ∀ a, 0 < n a)
+    (N : ℕ)
+    (hN : 0 < N)
+    (hsum : (∑ a, n a) = N)
+    (hp : ∀ a, p a = (n a : ℝ) / (N : ℝ)) :
+    Apos H ⟨N, hN⟩ = H p + ∑ a, p a * Apos H ⟨n a, hpos a⟩ := by
+  let q : (a : α) → ProbDist (Fin (n a)) := fun a => uniformPNat ⟨n a, hpos a⟩
+  have hgroup := hH.grouping p q
+  have hcard : Fintype.card (Sigma (fun a : α => Fin (n a))) = N := by
+    calc
+      Fintype.card (Sigma (fun a : α => Fin (n a)))
+          = ∑ a, Fintype.card (Fin (n a)) := by simp
+      _ = ∑ a, n a := by simp
+      _ = N := hsum
+  let e : Sigma (fun a : α => Fin (n a)) ≃ Fin N := Fintype.equivFinOfCardEq hcard
+  have hrelab : H (relabelProb e (composeProb p q)) = H (composeProb p q) :=
+    hH.relabelInvariant e (composeProb p q)
+  have hident :
+      relabelProb e (composeProb p q) = uniformPNat ⟨N, hN⟩ := by
+    simpa [q] using relabel_compose_rational_eq_uniform p n hpos N hN hp e
+  have hsumA :
+      (∑ a, p a * H (q a))
+        = ∑ a, p a * Apos H ⟨n a, hpos a⟩ := by
+    refine Finset.sum_congr rfl ?_
+    intro a _
+    rfl
+  calc
+    Apos H ⟨N, hN⟩ = H (composeProb p q) := by
+      simpa [Apos, hident] using hrelab
+    _ = H p + ∑ a, p a * H (q a) := hgroup
+    _ = H p + ∑ a, p a * Apos H ⟨n a, hpos a⟩ := by rw [hsumA]
+
+lemma entropyNat_of_rational_counts_aux
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H)
+    {α : Type} [Fintype α]
+    (p : ProbDist α)
+    (n : α → ℕ)
+    (hpos : ∀ a, 0 < n a)
+    (N : ℕ)
+    (hN : 0 < N)
+    (hsum : (∑ a, n a) = N)
+    (hp : ∀ a, p a = (n a : ℝ) / (N : ℝ)) :
+    H p
+      = K H * Real.log (N : ℝ)
+        - ∑ a, p a * (K H * Real.log (n a : ℝ)) := by
+  have hgroup :
+      Apos H ⟨N, hN⟩ = H p + ∑ a, p a * Apos H ⟨n a, hpos a⟩ :=
+    grouping_on_rational_counts H hH p n hpos N hN hsum hp
+  have hA_N : Apos H ⟨N, hN⟩ = K H * Real.log (N : ℝ) :=
+    Apos_eq_K_mul_log H hH ⟨N, hN⟩
+  have hA_n :
+      (∑ a, p a * Apos H ⟨n a, hpos a⟩)
+        = ∑ a, p a * (K H * Real.log (n a : ℝ)) := by
+    refine Finset.sum_congr rfl ?_
+    intro a _
+    simpa using congrArg (fun t => p a * t) (Apos_eq_K_mul_log H hH ⟨n a, hpos a⟩)
+  linarith [hgroup, hA_N, hA_n]
+
+lemma entropyNat_of_rational_counts
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H)
+    {α : Type} [Fintype α]
+    (p : ProbDist α)
+    (n : α → ℕ)
+    (hpos : ∀ a, 0 < n a)
+    (N : ℕ)
+    (hN : 0 < N)
+    (hsum : (∑ a, n a) = N)
+    (hp : ∀ a, p a = (n a : ℝ) / (N : ℝ)) :
+    H p = -K H * ∑ a, p a * Real.log (p a) := by
+  have hN_ne : (N : ℝ) ≠ 0 := by exact_mod_cast (Nat.ne_of_gt hN)
+  have h_main :
+      H p = K H * Real.log (N : ℝ) - ∑ a, p a * (K H * Real.log (n a : ℝ)) :=
+    entropyNat_of_rational_counts_aux H hH p n hpos N hN hsum hp
+  have hsum_scale :
+      (∑ a, p a * (K H * Real.log (n a : ℝ)))
+        = K H * (∑ a, p a * Real.log (n a : ℝ)) := by
+    calc
+      (∑ a, p a * (K H * Real.log (n a : ℝ)))
+          = ∑ a, K H * (p a * Real.log (n a : ℝ)) := by
+              refine Finset.sum_congr rfl ?_
+              intro a _
+              ring
+      _ = K H * (∑ a, p a * Real.log (n a : ℝ)) := by
+            rw [Finset.mul_sum]
+  have hlogp :
+      (∑ a, p a * Real.log (p a))
+        = (∑ a, p a * Real.log (n a : ℝ)) - Real.log (N : ℝ) := by
+    calc
+      (∑ a, p a * Real.log (p a))
+          = ∑ a, p a * (Real.log (n a : ℝ) - Real.log (N : ℝ)) := by
+              refine Finset.sum_congr rfl ?_
+              intro a _
+              rw [hp a]
+              have hn_ne : (n a : ℝ) ≠ 0 := by
+                exact_mod_cast (Nat.ne_of_gt (hpos a))
+              rw [Real.log_div hn_ne hN_ne]
+      _ = ∑ a, (p a * Real.log (n a : ℝ) - p a * Real.log (N : ℝ)) := by
+            refine Finset.sum_congr rfl ?_
+            intro a _
+            ring
+      _ = (∑ a, p a * Real.log (n a : ℝ)) - ∑ a, p a * Real.log (N : ℝ) := by
+            rw [Finset.sum_sub_distrib]
+      _ = (∑ a, p a * Real.log (n a : ℝ)) - (∑ a, p a) * Real.log (N : ℝ) := by
+            rw [Finset.sum_mul]
+      _ = (∑ a, p a * Real.log (n a : ℝ)) - Real.log (N : ℝ) := by
+            rw [prob_sum_eq_one p, one_mul]
+  calc
+    H p = K H * Real.log (N : ℝ) - ∑ a, p a * (K H * Real.log (n a : ℝ)) := h_main
+    _ = K H * Real.log (N : ℝ) - K H * (∑ a, p a * Real.log (n a : ℝ)) := by
+          rw [hsum_scale]
+    _ = -K H * ((∑ a, p a * Real.log (n a : ℝ)) - Real.log (N : ℝ)) := by ring
+    _ = -K H * (∑ a, p a * Real.log (p a)) := by rw [hlogp]
+
+/-- First-stage split used in the `(1/2, 1/3, 1/6)` worked decomposition. -/
+def workedP : ProbDist Bool := by
+  refine ⟨fun _ => (1 : ℝ) / 2, ?_⟩
+  constructor
+  · intro _
+    positivity
+  · simp
+
+/-- Second-stage alphabets for the worked decomposition:
+`true` has one outcome; `false` has two outcomes. -/
+def workedFib : Bool → Type
+  | true => Fin 1
+  | false => Fin 2
+
+instance : ∀ b : Bool, Fintype (workedFib b)
+  | true => by simpa [workedFib] using (inferInstance : Fintype (Fin 1))
+  | false => by simpa [workedFib] using (inferInstance : Fintype (Fin 2))
+
+/-- Second-stage conditional probabilities for the worked decomposition. -/
+def workedQ : (b : Bool) → ProbDist (workedFib b)
+  | true => by
+      change ProbDist (Fin 1)
+      simpa using (uniformPNat (1 : ℕ+))
+  | false => by
+      change ProbDist (Fin 2)
+      refine ⟨fun i : Fin 2 => if i = 0 then (2 : ℝ) / 3 else (1 : ℝ) / 3, ?_⟩
+      constructor
+      · intro i
+        by_cases hi : i = 0
+        · simp only [hi, ↓reduceIte]
+          positivity
+        · simp only [hi, ↓reduceIte]
+          norm_num
+      · norm_num [Fin.sum_univ_two]
+
+/-- The composed distribution in the worked `(1/2, 1/3, 1/6)` example. -/
+def workedCompose : ProbDist (Sigma workedFib) :=
+  composeProb workedP workedQ
+
+/--
+Masses in the worked decomposition:
+`(true, 0)` has mass `1/2`, `(false, 0)` has mass `1/3`,
+and `(false, 1)` has mass `1/6`.
+-/
+lemma workedCompose_masses :
+    workedCompose ⟨true, (0 : Fin 1)⟩ = (1 : ℝ) / 2 ∧
+      workedCompose ⟨false, (0 : Fin 2)⟩ = (1 : ℝ) / 3 ∧
+      workedCompose ⟨false, (1 : Fin 2)⟩ = (1 : ℝ) / 6 := by
+  constructor
+  · norm_num [workedCompose, composeProb, workedP, workedQ, workedFib, uniformPNat]
+  constructor
+  · norm_num [workedCompose, composeProb, workedP, workedQ, workedFib, uniformPNat]
+  · norm_num [workedCompose, composeProb, workedP, workedQ, workedFib, uniformPNat]
+
+/--
+Worked grouping identity corresponding to Shannon's `(1/2, 1/3, 1/6)` narrative:
+first choose `true/false` with probabilities `(1/2, 1/2)`, then if `false`
+choose between two outcomes with probabilities `(2/3, 1/3)`.
+-/
+theorem worked_grouping_identity
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H) :
+    H workedCompose = H workedP + (1 / 2 : ℝ) * H (workedQ false) := by
+  have hqTrue_zero : H (workedQ true) = 0 := by
+    simpa [workedQ, workedFib, Apos] using Apos_one_zero H hH
+  have hsum :
+      (∑ b : Bool, workedP b * H (workedQ b))
+        = (1 / 2 : ℝ) * H (workedQ false) := by
+    simp [workedP, hqTrue_zero]
+  calc
+    H workedCompose = H workedP + ∑ b : Bool, workedP b * H (workedQ b) := by
+      simpa [workedCompose] using hH.grouping workedP workedQ
+    _ = H workedP + (1 / 2 : ℝ) * H (workedQ false) := by rw [hsum]
+
+
+end
+
+end LeanPool.Shannon1948Formalization

--- a/LeanPool/Shannon1948Formalization/Entropy/Uniform.lean
+++ b/LeanPool/Shannon1948Formalization/Entropy/Uniform.lean
@@ -14,7 +14,7 @@ Phase 1 of the characterization: equiprobable distributions.
 Main outputs:
 - multiplicative/additive behavior on uniform choices (`Apos_mul`, `Apos_pow`);
 - logarithmic characterization `Apos H n = K H * log n`;
-- positivity of the scale constant `K`.
+- positivity of the scale factor `K`.
 -/
 namespace LeanPool.Shannon1948Formalization
 
@@ -135,7 +135,7 @@ lemma abs_sub_le_of_mem_interval
     linarith
   exact abs_le.mpr ⟨hleft, hright⟩
 
-/-- The canonical positive scaling constant from the two-outcome uniform case. -/
+/-- The canonical positive scale factor from the two-outcome uniform case. -/
 def K
     (H : {α : Type} → [Fintype α] → ProbDist α → ℝ) : ℝ :=
   Apos H 2 / Real.log 2

--- a/LeanPool/Shannon1948Formalization/Entropy/Uniform.lean
+++ b/LeanPool/Shannon1948Formalization/Entropy/Uniform.lean
@@ -1,0 +1,376 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+import LeanPool.Shannon1948Formalization.Entropy.Core
+
+/-!
+# Shannon.Entropy.Uniform
+
+Phase 1 of the characterization: equiprobable distributions.
+
+Main outputs:
+- multiplicative/additive behavior on uniform choices (`Apos_mul`, `Apos_pow`);
+- logarithmic characterization `Apos H n = K H * log n`;
+- positivity of the scale constant `K`.
+-/
+namespace LeanPool.Shannon1948Formalization
+
+noncomputable section
+open Filter
+open scoped Topology
+
+/-! ## Phase 1: Equiprobable Characterization -/
+
+lemma relabel_compose_uniform_eq_uniform_mul (n m : ℕ+) :
+    relabelProb (sigmaConstFinEquivFinMul n m)
+      (composeProb (uniformPNat n) (fun _ : Fin n => uniformPNat m))
+    = uniformPNat (n * m) := by
+  ext x
+  simp [relabelProb, composeProb, uniformPNat, sigmaConstFinEquivFinMul]
+  have hn : (n : ℝ) ≠ 0 := by
+    exact_mod_cast (show (n : ℕ) ≠ 0 from Nat.ne_of_gt n.2)
+  have hm : (m : ℝ) ≠ 0 := by
+    exact_mod_cast (show (m : ℕ) ≠ 0 from Nat.ne_of_gt m.2)
+  field_simp [hn, hm]
+
+lemma Apos_mul
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H)
+    (n m : ℕ+) :
+    Apos H (n * m) = Apos H n + Apos H m := by
+  let p : ProbDist (Fin n) := uniformPNat n
+  let q : (a : Fin n) → ProbDist (Fin m) := fun _ => uniformPNat m
+  have hgroup := hH.grouping p q
+  have hsum : (∑ a : Fin n, p a * H (q a)) = H (uniformPNat m) := by
+    change (∑ a : Fin n, p a * H (uniformPNat m)) = H (uniformPNat m)
+    calc
+      (∑ a : Fin n, p a * H (uniformPNat m))
+          = (∑ a : Fin n, p a) * H (uniformPNat m) := by
+              rw [Finset.sum_mul]
+      _ = 1 * H (uniformPNat m) := by rw [prob_sum_eq_one p]
+      _ = H (uniformPNat m) := by ring
+  have hrelab :=
+    hH.relabelInvariant (sigmaConstFinEquivFinMul n m) (composeProb p q)
+  have hident :
+      relabelProb (sigmaConstFinEquivFinMul n m) (composeProb p q) = uniformPNat (n * m) := by
+    simpa [p, q] using relabel_compose_uniform_eq_uniform_mul n m
+  have hrelab' : H (uniformPNat (n * m)) = H (composeProb p q) := by
+    rw [← hident]
+    exact hrelab
+  calc
+    Apos H (n * m) = H (composeProb p q) := by
+      simpa [Apos] using hrelab'
+    _ = H p + (∑ a : Fin n, p a * H (q a)) := hgroup
+    _ = H p + H (uniformPNat m) := by rw [hsum]
+    _ = Apos H n + Apos H m := by simp [Apos, p]
+
+lemma Apos_one_zero
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H) :
+    Apos H 1 = 0 := by
+  have h11 := Apos_mul H hH 1 1
+  have : Apos H 1 = Apos H 1 + Apos H 1 := by simpa using h11
+  linarith
+
+lemma Apos_pow
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H)
+    (n : ℕ+)
+    (k : ℕ) :
+    Apos H (n ^ k) = (k : ℝ) * Apos H n := by
+  induction k with
+  | zero =>
+      simpa using Apos_one_zero H hH
+  | succ k ih =>
+      calc
+        Apos H (n ^ (k + 1)) = Apos H (n ^ k * n) := by simp [pow_succ]
+        _ = Apos H (n ^ k) + Apos H n := Apos_mul H hH (n ^ k) n
+        _ = (k : ℝ) * Apos H n + Apos H n := by simp [ih]
+        _ = (k : ℝ) * Apos H n + (1 : ℝ) * Apos H n := by ring
+        _ = ((k : ℝ) + 1) * Apos H n := by ring
+        _ = (((k + 1 : ℕ) : ℝ) * Apos H n) := by
+              norm_num [Nat.cast_add]
+
+lemma Apos_nonneg
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H)
+    (n : ℕ+) :
+    0 ≤ Apos H n := by
+  have h1n : (1 : ℕ+) ≤ n := Nat.succ_le_of_lt n.2
+  have hmono : Apos H 1 ≤ Apos H n := hH.uniformMonotone.monotone h1n
+  linarith [hmono, Apos_one_zero H hH]
+
+lemma Apos_pos_two
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H) :
+    0 < Apos H 2 := by
+  have h12 : (1 : ℕ+) < 2 := by decide
+  have hmono : Apos H 1 < Apos H 2 := hH.uniformMonotone h12
+  linarith [hmono, Apos_one_zero H hH]
+
+/-- Strict monotonicity gives positivity of `Apos` for any alphabet size `> 1`. -/
+lemma Apos_pos_of_one_lt
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H)
+    {n : ℕ+}
+    (hn : 1 < n) :
+    0 < Apos H n := by
+  have hmono : Apos H 1 < Apos H n := hH.uniformMonotone hn
+  linarith [hmono, Apos_one_zero H hH]
+
+/-- If two reals are in the same closed interval, their distance is interval width. -/
+lemma abs_sub_le_of_mem_interval
+    {a b l u : ℝ}
+    (haL : l ≤ a)
+    (haU : a ≤ u)
+    (hbL : l ≤ b)
+    (hbU : b ≤ u) :
+    |a - b| ≤ u - l := by
+  have hright : a - b ≤ u - l := sub_le_sub haU hbL
+  have hleft : -(u - l) ≤ a - b := by
+    have hba : b - a ≤ u - l := sub_le_sub hbU haL
+    linarith
+  exact abs_le.mpr ⟨hleft, hright⟩
+
+/-- The canonical positive scaling constant from the two-outcome uniform case. -/
+def K
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ) : ℝ :=
+  Apos H 2 / Real.log 2
+
+lemma K_pos
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H) :
+    0 < K H := by
+  unfold K
+  have hA : 0 < Apos H 2 := Apos_pos_two H hH
+  have hlog : 0 < Real.log 2 := by
+    exact Real.log_pos (by norm_num : (1 : ℝ) < 2)
+  exact div_pos hA hlog
+
+lemma Apos_ratio_logb_close
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H)
+    {s t n : ℕ+}
+    (hs : 1 < s) :
+    |Apos H t / Apos H s - Real.logb (s : ℝ) (t : ℝ)| ≤ 1 / (n : ℝ) := by
+  let m : ℕ := Nat.log (s : ℕ) ((t : ℕ) ^ (n : ℕ))
+  have htn_ne_zero : ((t : ℕ) ^ (n : ℕ)) ≠ 0 := by
+    exact pow_ne_zero _ (Nat.ne_of_gt t.2)
+  have hs_nat : 1 < (s : ℕ) := hs
+  have hs_real : 1 < (s : ℝ) := by exact_mod_cast hs
+  have hpow_le_nat : (s : ℕ) ^ m ≤ (t : ℕ) ^ (n : ℕ) := by
+    simpa [m] using Nat.pow_log_le_self (s : ℕ) htn_ne_zero
+  have hpow_lt_nat : (t : ℕ) ^ (n : ℕ) < (s : ℕ) ^ (m + 1) := by
+    simpa [m] using Nat.lt_pow_succ_log_self hs_nat ((t : ℕ) ^ (n : ℕ))
+  have hpow_le : s ^ m ≤ t ^ (n : ℕ) := by
+    exact_mod_cast hpow_le_nat
+  have hpow_lt : t ^ (n : ℕ) < s ^ (m + 1) := by
+    exact_mod_cast hpow_lt_nat
+  have hA_le : Apos H (s ^ m) ≤ Apos H (t ^ (n : ℕ)) :=
+    hH.uniformMonotone.monotone hpow_le
+  have hA_lt : Apos H (t ^ (n : ℕ)) < Apos H (s ^ (m + 1)) :=
+    hH.uniformMonotone hpow_lt
+  have hAs_pos : 0 < Apos H s := Apos_pos_of_one_lt H hH hs
+  have hAs_ne : Apos H s ≠ 0 := ne_of_gt hAs_pos
+  have hn_pos : 0 < ((n : ℕ) : ℝ) := by exact_mod_cast n.2
+  have hn_ne : ((n : ℕ) : ℝ) ≠ 0 := ne_of_gt hn_pos
+  let ratioA : ℝ := Apos H t / Apos H s
+  let ratioL : ℝ := Real.logb (s : ℝ) (t : ℝ)
+  let nR : ℝ := (n : ℕ)
+  have hA_left : (m : ℝ) / nR ≤ ratioA := by
+    have hmul : (m : ℝ) * Apos H s ≤ ((n : ℕ) : ℝ) * Apos H t := by
+      calc
+        (m : ℝ) * Apos H s = Apos H (s ^ m) := (Apos_pow H hH s m).symm
+        _ ≤ Apos H (t ^ (n : ℕ)) := hA_le
+        _ = ((n : ℕ) : ℝ) * Apos H t := Apos_pow H hH t (n : ℕ)
+    have hdiv : (m : ℝ) ≤ (((n : ℕ) : ℝ) * Apos H t) / Apos H s := by
+      exact (le_div_iff₀ hAs_pos).2 (by simpa [mul_assoc] using hmul)
+    have hmul' : (m : ℝ) ≤ nR * ratioA := by
+      simpa [ratioA, nR, div_eq_mul_inv, mul_assoc, mul_comm, mul_left_comm] using hdiv
+    exact (div_le_iff₀ hn_pos).2 (by simpa [nR, mul_assoc, mul_comm, mul_left_comm] using hmul')
+  have hA_right : ratioA ≤ ((m + 1 : ℕ) : ℝ) / nR := by
+    have hmul : ((n : ℕ) : ℝ) * Apos H t ≤ ((m + 1 : ℕ) : ℝ) * Apos H s := by
+      calc
+        ((n : ℕ) : ℝ) * Apos H t = Apos H (t ^ (n : ℕ)) := (Apos_pow H hH t (n : ℕ)).symm
+        _ ≤ Apos H (s ^ (m + 1)) := hA_lt.le
+        _ = ((m + 1 : ℕ) : ℝ) * Apos H s := Apos_pow H hH s (m + 1)
+    have hdiv : (((n : ℕ) : ℝ) * Apos H t) / Apos H s ≤ ((m + 1 : ℕ) : ℝ) := by
+      exact (div_le_iff₀ hAs_pos).2 (by simpa [mul_assoc] using hmul)
+    have hmul' : nR * ratioA ≤ ((m + 1 : ℕ) : ℝ) := by
+      simpa [ratioA, nR, div_eq_mul_inv, mul_assoc, mul_comm, mul_left_comm] using hdiv
+    exact (le_div_iff₀ hn_pos).2 (by simpa [mul_comm, mul_left_comm, mul_assoc] using hmul')
+  have hs_pow_pos : 0 < ((s : ℝ) ^ m) := by positivity
+  have ht_pow_pos : 0 < ((t : ℝ) ^ (n : ℕ)) := by positivity
+  have hs_pow_next_pos : 0 < ((s : ℝ) ^ (m + 1)) := by positivity
+  have hlog_le :
+      Real.logb (s : ℝ) ((s : ℝ) ^ m) ≤ Real.logb (s : ℝ) ((t : ℝ) ^ (n : ℕ)) :=
+    (Real.logb_le_logb hs_real hs_pow_pos ht_pow_pos).2 (by exact_mod_cast hpow_le_nat)
+  have hlog_lt :
+      Real.logb (s : ℝ) ((t : ℝ) ^ (n : ℕ)) < Real.logb (s : ℝ) ((s : ℝ) ^ (m + 1)) :=
+    (Real.logb_lt_logb_iff hs_real ht_pow_pos hs_pow_next_pos).2 (by exact_mod_cast hpow_lt_nat)
+  have hL_left : (m : ℝ) / nR ≤ ratioL := by
+    have hmul : (m : ℝ) ≤ ((n : ℕ) : ℝ) * ratioL := by
+      calc
+        (m : ℝ) = Real.logb (s : ℝ) ((s : ℝ) ^ m) := by
+          rw [Real.logb_pow, Real.logb_self_eq_one hs_real, mul_one]
+        _ ≤ Real.logb (s : ℝ) ((t : ℝ) ^ (n : ℕ)) := hlog_le
+        _ = ((n : ℕ) : ℝ) * ratioL := by
+          simp [ratioL, Real.logb_pow]
+    exact (div_le_iff₀ hn_pos).2 (by simpa [nR, mul_comm, mul_left_comm, mul_assoc] using hmul)
+  have hL_right : ratioL ≤ ((m + 1 : ℕ) : ℝ) / nR := by
+    have hmul : ((n : ℕ) : ℝ) * ratioL ≤ ((m + 1 : ℕ) : ℝ) := by
+      calc
+        ((n : ℕ) : ℝ) * ratioL = Real.logb (s : ℝ) ((t : ℝ) ^ (n : ℕ)) := by
+          simp [ratioL, Real.logb_pow]
+        _ ≤ Real.logb (s : ℝ) ((s : ℝ) ^ (m + 1)) := hlog_lt.le
+        _ = ((m + 1 : ℕ) : ℝ) := by
+          rw [Real.logb_pow, Real.logb_self_eq_one hs_real, mul_one]
+    exact (le_div_iff₀ hn_pos).2 (by simpa [nR, mul_comm, mul_left_comm, mul_assoc] using hmul)
+  have hwidth :
+      (((m + 1 : ℕ) : ℝ) / nR) - ((m : ℝ) / nR) = 1 / nR := by
+    have hnR_ne : nR ≠ 0 := by
+      unfold nR
+      exact hn_ne
+    field_simp [hnR_ne]
+    norm_num
+  have habs :
+      |ratioA - ratioL|
+        ≤ (((m + 1 : ℕ) : ℝ) / nR) - ((m : ℝ) / nR) :=
+    abs_sub_le_of_mem_interval hA_left hA_right hL_left hL_right
+  have habs' : |ratioA - ratioL| ≤ 1 / nR := habs.trans_eq hwidth
+  simpa [ratioA, ratioL, nR] using habs'
+
+lemma Apos_ratio_eq_logb
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H)
+    {s t : ℕ+}
+    (hs : 1 < s) :
+    Apos H t / Apos H s = Real.logb (s : ℝ) (t : ℝ) := by
+  by_contra hneq
+  have hpos : 0 < |Apos H t / Apos H s - Real.logb (s : ℝ) (t : ℝ)| := by
+    exact abs_pos.mpr (sub_ne_zero.mpr hneq)
+  rcases exists_nat_one_div_lt hpos with ⟨N, hN⟩
+  let n : ℕ+ := Nat.succPNat N
+  have hbound := Apos_ratio_logb_close H hH (s := s) (t := t) (n := n) hs
+  have hsmall :
+      1 / ((n : ℕ) : ℝ) <
+        |Apos H t / Apos H s - Real.logb (s : ℝ) (t : ℝ)| := by
+    simpa [n, Nat.succPNat_coe] using hN
+  exact (not_lt_of_ge hbound) hsmall
+
+lemma Apos_eq_K_mul_log
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H)
+    (n : ℕ+) :
+    Apos H n = K H * Real.log (n : ℝ) := by
+  have hratio : Apos H n / Apos H 2 = Real.logb (2 : ℝ) (n : ℝ) :=
+    Apos_ratio_eq_logb H hH (s := 2) (t := n) (by decide)
+  have hA2_ne : Apos H 2 ≠ 0 := ne_of_gt (Apos_pos_two H hH)
+  have hlog2_ne : Real.log 2 ≠ 0 := by
+    apply Real.log_ne_zero.mpr
+    norm_num
+  have hmain : Apos H n = Real.logb (2 : ℝ) (n : ℝ) * Apos H 2 := by
+    exact (div_eq_iff hA2_ne).1 hratio
+  calc
+    Apos H n = Real.logb (2 : ℝ) (n : ℝ) * Apos H 2 := hmain
+    _ = (Real.log (n : ℝ) / Real.log 2) * Apos H 2 := by
+          rw [← Real.log_div_log]
+    _ = (Apos H 2 / Real.log 2) * Real.log (n : ℝ) := by
+          field_simp [hlog2_ne]
+    _ = K H * Real.log (n : ℝ) := by
+          rfl
+
+lemma Apos_pow_two_eq_K_log_pow
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H)
+    (k : ℕ) :
+    Apos H (2 ^ k) = K H * Real.log ((2 : ℝ) ^ k) := by
+  unfold K
+  calc
+    Apos H (2 ^ k) = (k : ℝ) * Apos H 2 := by
+      simpa using Apos_pow H hH 2 k
+    _ = (Apos H 2 / Real.log 2) * ((k : ℝ) * Real.log 2) := by
+          have hlogne : Real.log 2 ≠ 0 := by
+            apply Real.log_ne_zero.mpr
+            norm_num
+          field_simp [hlogne]
+    _ = (Apos H 2 / Real.log 2) * Real.log ((2 : ℝ) ^ k) := by
+          rw [Real.log_pow]
+
+lemma A_monotone
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H) :
+    Monotone (A H) := by
+  intro n m hnm
+  have hnm' : Nat.succPNat n ≤ Nat.succPNat m :=
+    Nat.succPNat_mono hnm
+  have hApos : Apos H (Nat.succPNat n) ≤ Apos H (Nat.succPNat m) :=
+    hH.uniformMonotone.monotone hnm'
+  simpa [A, Apos, uniformFin, uniformPNat] using hApos
+
+lemma Apos_monotone
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H) :
+    Monotone (Apos H) := by
+  exact hH.uniformMonotone.monotone
+
+/-- Entropy-form expression with natural logarithm. -/
+def entropyNat
+    {α : Type} [Fintype α]
+    (p : ProbDist α) : ℝ :=
+  -∑ a, p a * Real.log (p a)
+
+/-- Entropy-form expression with logarithm base `b`. -/
+def entropyBase
+    {α : Type} [Fintype α]
+    (b : ℝ)
+    (p : ProbDist α) : ℝ :=
+  -∑ a, p a * Real.logb b (p a)
+
+lemma continuous_entropyNat
+    {α : Type} [Fintype α] :
+    Continuous (fun p : ProbDist α => entropyNat p) := by
+  classical
+  unfold entropyNat
+  refine (continuous_finset_sum (s := Finset.univ)
+    (f := fun a => fun p : ProbDist α => p a * Real.log (p a)) ?_).neg
+  intro a _
+  have hcont_eval : Continuous (fun p : ProbDist α => (p : α → ℝ) a) :=
+    (continuous_apply a).comp continuous_subtype_val
+  simpa using Real.Continuous.mul_log hcont_eval
+
+lemma nonempty_of_probDist
+    {α : Type} [Fintype α]
+    (p : ProbDist α) :
+    Nonempty α := by
+  by_contra h
+  haveI : IsEmpty α := not_nonempty_iff.mp h
+  have hsum0 : (∑ a, p a) = 0 := by simp
+  linarith [hsum0, prob_sum_eq_one p]
+
+lemma Apos_eq_K_mul_logb
+    (H : {α : Type} → [Fintype α] → ProbDist α → ℝ)
+    (hH : ShannonEntropyAxioms H)
+    (b : ℝ)
+    (hb : 1 < b)
+    (n : ℕ+) :
+    Apos H n = (K H * Real.log b) * Real.logb b (n : ℝ) := by
+  have hb1 : b ≠ 1 := ne_of_gt hb
+  have hb_pos : 0 < b := lt_trans (show (0 : ℝ) < 1 by norm_num) hb
+  have hlogb_ne : Real.log b ≠ 0 := Real.log_ne_zero_of_pos_of_ne_one hb_pos hb1
+  have hlog :
+      Real.log (n : ℝ) = Real.log b * Real.logb b (n : ℝ) := by
+    unfold Real.logb
+    field_simp [hlogb_ne]
+  calc
+    Apos H n = K H * Real.log (n : ℝ) := Apos_eq_K_mul_log H hH n
+    _ = K H * (Real.log b * Real.logb b (n : ℝ)) := by rw [hlog]
+    _ = (K H * Real.log b) * Real.logb b (n : ℝ) := by ring
+
+
+end
+
+end LeanPool.Shannon1948Formalization

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -444,3 +444,34 @@ projects:
     msc:
       - "11E25"
       - "11H06"
+  - slug: shannon-1948-formalization
+    title: Shannon Entropy Characterization
+    summary: Formalizes Shannon's finite-alphabet characterization theorem for entropy from the 1948 paper.
+    branch: information theory
+    entry_module: LeanPool.Shannon1948Formalization
+    authors:
+      - Samuel Schlesinger
+    source:
+      url: https://github.com/SamuelSchlesinger/shannon-1948-formalization
+      github_repo: SamuelSchlesinger/shannon-1948-formalization
+    status: verified
+    main_declarations:
+      - LeanPool.Shannon1948Formalization.entropyNat_unique
+    main_results:
+      - declaration: LeanPool.Shannon1948Formalization.entropyNat_unique
+        informal: Proves that any finite-alphabet uncertainty functional satisfying Shannon's axioms equals natural-log entropy up to a positive scale.
+      - declaration: LeanPool.Shannon1948Formalization.entropyBase_unique
+        informal: Restates the characterization for any logarithm base greater than one.
+      - declaration: LeanPool.Shannon1948Formalization.entropyNat_shannonAxioms
+        informal: Proves the converse, showing that Shannon entropy satisfies the formal axiom bundle.
+      - declaration: LeanPool.Shannon1948Formalization.chain_rule
+        informal: Proves the finite joint-entropy chain rule.
+      - declaration: LeanPool.Shannon1948Formalization.entropyNat_joint_le_add
+        informal: Proves subadditivity of finite joint entropy.
+    tags:
+      - information-theory
+      - entropy
+      - probability
+    msc:
+      - "94A17"
+      - "60C05"

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -459,11 +459,11 @@ projects:
       - LeanPool.Shannon1948Formalization.entropyNat_unique
     main_results:
       - declaration: LeanPool.Shannon1948Formalization.entropyNat_unique
-        informal: Proves that any finite-alphabet uncertainty functional satisfying Shannon's axioms equals natural-log entropy up to a positive scale.
+        informal: Proves that any finite-alphabet uncertainty functional satisfying Shannon's conditions equals natural-log entropy up to a positive scale.
       - declaration: LeanPool.Shannon1948Formalization.entropyBase_unique
         informal: Restates the characterization for any logarithm base greater than one.
       - declaration: LeanPool.Shannon1948Formalization.entropyNat_shannonAxioms
-        informal: Proves the converse, showing that Shannon entropy satisfies the formal axiom bundle.
+        informal: Proves the converse, showing that Shannon entropy satisfies the formal condition bundle.
       - declaration: LeanPool.Shannon1948Formalization.chain_rule
         informal: Proves the finite joint-entropy chain rule.
       - declaration: LeanPool.Shannon1948Formalization.entropyNat_joint_le_add


### PR DESCRIPTION
Imported from https://github.com/SamuelSchlesinger/shannon-1948-formalization.

**Slug:** `shannon-1948-formalization`
**Toolchain target:** `leanprover/lean4:v4.30.0-rc2`
**Branch:** `import/shannon-1948-formalization` (auto-generated by `scripts/import-formalization.sh`)
**Agent:** `codex` using `gpt-5.5` at effort `xhigh`, exited with code `0`.

**Commits on this branch:**
- 4b7a1c1 Vendor Shannon entropy formalization
- 6de3d9b Clarify Shannon import comments

**Local verification:**
- `lake build LeanPool.Shannon1948Formalization`
- `lake build LeanPool`
- `lake exe lint-style LeanPool`
- `uv run python -m lean_pool.quality --repo ..`

---
_Opened automatically by `scripts/import-formalization.sh`. Review the diff carefully before merging — the agent ran unattended._
