### PR TITLE
Import sard formalization

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -224,6 +224,9 @@ import LeanPool.RlTheoryInLean.Probability.MarkovChain.Finite.Defs
 import LeanPool.RlTheoryInLean.Probability.MarkovChain.Trajectory
 import LeanPool.RlTheoryInLean.StochasticApproximation
 import LeanPool.RlTheoryInLean.StochasticApproximation.DiscreteGronwall
+import LeanPool.Sard
+import LeanPool.Sard.MeasureZero
+import LeanPool.Sard.ToSubset
 import LeanPool.Sensitivity
 import LeanPool.Sensitivity.Basic
 import LeanPool.Sensitivity.Consequences

--- a/LeanPool/Sard.lean
+++ b/LeanPool/Sard.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2026 Floris van Doorn, Michael Rothgang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn, Michael Rothgang
+-/
+
+import LeanPool.Sard.MeasureZero
+import LeanPool.Sard.ToSubset
+
+/-!
+# Towards the Sard-Smale theorem
+
+Source: url:https://github.com/fpvandoorn/sard
+Authors: Floris van Doorn, Michael Rothgang
+Status: verified
+Main declarations: `LeanPool.Sard.MeasureZero`, `LeanPool.Sard.MeasureZero.iUnion`
+Tags: differential-topology, measure-theory, manifolds
+MSC: 57R35, 28A75
+-/
+
+/-!
+## Provenance
+
+Imported from <https://github.com/fpvandoorn/sard> (Apache-2.0) and ported from
+Lean `v4.12.0` to Lean Pool's `v4.30.0-rc2`.
+
+This import preserves the completed measure-zero infrastructure for manifolds
+and small subtype-set helpers. The upstream repository also contains unfinished
+Sard theorem reductions and obsolete scratch helpers, which were not vendored
+because they still contain unresolved proof obligations.
+-/

--- a/LeanPool/Sard/MeasureZero.lean
+++ b/LeanPool/Sard/MeasureZero.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2026 Michael Rothgang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Rothgang
+-/
+
+import Mathlib.Geometry.Manifold.IsManifold.Basic
+import Mathlib.MeasureTheory.Measure.Haar.Basic
+
+namespace LeanPool.Sard
+
+/-!
+# Measure zero subsets of a manifold
+
+Defines the notion of measure-zero subsets on a finite-dimensional topological manifold.
+
+While such a manifold has no canonical measure, a subset can be called
+measure zero when its image in every preferred chart is null for every additive
+Haar measure on the model vector space.
+
+This file preserves the completed closure properties from the upstream Sard
+development.
+
+## References
+See [Hirsch76], chapter 3.1 for the definition of measure zero subsets in a manifold.
+-/
+
+open MeasureTheory Measure Function TopologicalSpace Set
+
+variable
+  -- Let `M` be a finite-dimensional topological manifold over `(E, H)`.
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {H : Type*} [TopologicalSpace H]
+  (I : ModelWithCorners ℝ E H) {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  [MeasurableSpace E]
+variable {I}
+
+variable (I) in
+/-- A measure zero subset of an n-dimensional manifold $M$ is a subset $S ⊆ M$ such that
+for all charts $(φ, U)$ of $M$, $φ(U ∩ S) ⊆ ℝ^n$ has measure zero. -/
+-- xxx: show that my spelling implies the same for all charts!
+def MeasureZero (s : Set M) : Prop :=
+  ∀ (μ : Measure E) [IsAddHaarMeasure μ] (x : M),
+    μ (I ∘ (chartAt H x) '' ((chartAt H x).source ∩ s)) = 0
+
+namespace MeasureZero
+/-- Having measure zero is monotone: a subset of a set with measure zero has measure zero. -/
+protected lemma mono {s t : Set M} (hst : s ⊆ t) (ht : MeasureZero I t) :
+    (MeasureZero I s) := by
+  intro μ _ x
+  let e := chartAt H x
+  have : I ∘ e '' (e.source ∩ s) ⊆  I ∘ e '' (e.source ∩ t) := by
+    exact image_mono (inter_subset_inter_right e.source hst)
+  exact measure_mono_null this (ht μ x)
+
+/-- The empty set has measure zero. -/
+protected lemma empty : MeasureZero I (∅: Set M) := by
+  intro μ _ x
+  simp only [comp_apply, inter_empty, image_empty, measure_empty]
+
+/-- The countable index union of measure zero sets has measure zero. -/
+protected lemma iUnion {ι : Type*} [Encodable ι] {s : ι → Set M}
+    (hs : ∀ n : ι, MeasureZero I (s n)) : MeasureZero I (⋃ (n : ι),  s n) := by
+  intro μ _ x
+  let e := chartAt H x
+  have :
+      I ∘ e '' (e.source ∩ (⋃ (n : ι), s n)) =
+        ⋃ (n : ι), I ∘ e '' (e.source ∩ s n) := by
+    rw [inter_iUnion]
+    exact image_iUnion
+  -- union of null sets is a null set
+  simp_all only [comp_apply, measure_iUnion_null_iff, e]
+  intro i
+  apply hs
+
+/-- The finite union of measure-zero sets has measure zero. -/
+protected lemma union {s t : Set M} (hs : MeasureZero I s) (ht : MeasureZero I t) :
+    MeasureZero I (s ∪ t) := by
+  let u : Bool → Set M := fun b ↦ cond b s t
+  have : ∀ i : Bool, MeasureZero I (u i) := by
+    intro i
+    cases i
+    · exact ht
+    · exact hs
+  rw [union_eq_iUnion]
+  exact MeasureZero.iUnion this
+end MeasureZero
+
+end LeanPool.Sard

--- a/LeanPool/Sard/ToSubset.lean
+++ b/LeanPool/Sard/ToSubset.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 Michael Rothgang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Rothgang
+-/
+
+import Mathlib.Data.Set.Functor
+import Mathlib.Topology.Compactness.Compact
+import Mathlib.Topology.Constructions
+
+namespace LeanPool.Sard
+
+/-!
+# Coercions between sets and subtypes
+
+Auxiliary API for viewing an intersection `s ∩ t` as a subset of the subtype `t`.
+-/
+-- Coercion of sets and subsets.
+-- Based on a Zulip discussion about casting sets to subsets.
+
+namespace Set
+variable {X : Type*} (s t : Set X)
+
+-- first variant uses a proof of inclusion: is not as nice to work with
+/-- If two subsets `s` and `t` satisfy `s ⊆ t` and `h` is a proof of this inclusion,
+`toSubset' s t h` is the set `s` as a subset of `t`. -/
+def toSubset' (h : s ≤ t) : Set t := Set.range (Set.inclusion h)
+
+@[simp]
+lemma mem_toSubset' (h : s ≤ t)
+    (x : t) : x ∈ toSubset' s t h ↔ ↑x ∈ s := by
+  rw [toSubset', Set.range_inclusion, Set.mem_setOf_eq]
+
+/-- Given sets `s t : Set X`, `Set.toSubset s t` is `s ∩ t` realized as a term of `Set t`. -/
+def toSubset : Set t := (Subtype.val · ∈ s)
+
+@[simp]
+lemma mem_toSubset (x : t) : x ∈ toSubset s t ↔ ↑x ∈ s := Iff.rfl
+
+@[simp]
+lemma coe_toSubset : (Set.toSubset s t : Set X) = s ∩ t := by
+  ext
+  simp
+end Set
+
+open Set
+
+/-- The image of `s ∩ w` agrees with the image of `s` viewed inside the subtype `w`. -/
+lemma toSubset_aux1 {X Y : Type*} (f : X → Y) {s w : Set X} (hsw : s ⊆ w) :
+    f '' (s ∩ w) = (w.restrict f) '' (Set.toSubset s w) := by
+  ext y
+  constructor
+  · rintro ⟨x, hx, rfl⟩
+    exact ⟨⟨x, hsw hx.1⟩, by simpa using hx.1, rfl⟩
+  · rintro ⟨x, hx, rfl⟩
+    exact ⟨x, ⟨by simpa using hx, x.2⟩, rfl⟩
+
+/-- `toSubset` commutes with countable unions. -/
+lemma toSubset_iUnion {X : Type*} {t : Set X} (S : ℕ → Set X) :
+    Set.toSubset (⋃ n, S n) t = ⋃ n, Set.toSubset (S n) t := by
+  ext
+  simp
+
+/-- If `s` is compact and `s ⊆ t`, then `s` is compact as a subset of the subtype `t`. -/
+lemma toSubset_compact {X : Type*} [TopologicalSpace X] {s t : Set X} (hsw : s ⊆ t)
+    (hs : IsCompact s) : IsCompact (Set.toSubset s t) := by
+  have h_univ : IsCompact (Set.univ : Set s) := isCompact_iff_isCompact_univ.mp hs
+  have h_image : IsCompact (Set.inclusion hsw '' (Set.univ : Set s)) :=
+    h_univ.image (continuous_inclusion hsw)
+  convert h_image
+  ext x
+  constructor
+  · intro hx
+    refine ⟨⟨x, hx⟩, trivial, ?_⟩
+    ext
+    rfl
+  · rintro ⟨a, _, ha⟩
+    have h_value : (a : X) = x := congrArg Subtype.val ha
+    simp [← h_value, a.property]
+
+end LeanPool.Sard

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -444,3 +444,34 @@ projects:
     msc:
       - "11E25"
       - "11H06"
+  - slug: sard
+    title: Towards the Sard-Smale theorem
+    summary: Develops measure-zero and subtype-set infrastructure used in work toward Sard and Sard-Smale theorems.
+    branch: differential topology
+    entry_module: LeanPool.Sard
+    authors:
+      - Floris van Doorn
+      - Michael Rothgang
+    source:
+      url: https://github.com/fpvandoorn/sard
+      github_repo: fpvandoorn/sard
+    status: verified
+    main_declarations:
+      - LeanPool.Sard.MeasureZero
+      - LeanPool.Sard.MeasureZero.iUnion
+    main_results:
+      - declaration: LeanPool.Sard.MeasureZero
+        informal: Defines measure-zero subsets of a finite-dimensional manifold by requiring null chart images for every preferred chart.
+      - declaration: LeanPool.Sard.MeasureZero.mono
+        informal: Proves that the manifold measure-zero predicate is monotone under taking subsets.
+      - declaration: LeanPool.Sard.MeasureZero.iUnion
+        informal: Proves closure of manifold measure-zero sets under countable indexed unions.
+      - declaration: LeanPool.Sard.toSubset_compact
+        informal: Shows that a compact subset remains compact when viewed inside a containing subtype.
+    tags:
+      - differential-topology
+      - measure-theory
+      - manifolds
+    msc:
+      - "57R35"
+      - "28A75"


### PR DESCRIPTION
Imported from https://github.com/fpvandoorn/sard.

**Slug:** `sard`
**Toolchain target:** `leanprover/lean4:v4.30.0-rc2`
**Branch:** `import/sard` (auto-generated by `scripts/import-formalization.sh`)
**Agent:** `codex` using `gpt-5.5` at effort `xhigh`, exited with code `0`.

**Commits on this branch:**
- 153b970 Vendor sard from fpvandoorn/sard

## Import notes (from agent)

# sard import notes

Source: https://github.com/fpvandoorn/sard
Target: LeanPool.Sard

Vendored files:

- `Sard/MeasureZero.lean`: ported as `LeanPool/Sard/MeasureZero.lean`.
- `Sard/ToSubset.lean`: ported as `LeanPool/Sard/ToSubset.lean`.

Excluded files and blockers:

- `Sard/MainTheorem.lean`: contains the unfinished local and global Sard theorem development, including unresolved Hausdorff-measure identification, convexity, finite-dimensional Hausdorff-dimension, chart-domain, and hard-case Sard proof obligations. These are mathematical gaps in the upstream file rather than Lean-version drift.
- `Sard/Stuff.lean`: contains experimental lemmas for null images under `C¹` maps and the dimension-increase case, with unresolved Haar/Hausdorff-measure equivalence and factorization proof obligations.
- `Sard/LocallyLipschitz.lean`: most of the useful API has since moved into Mathlib (`ContDiff.locallyLipschitz`, `LocallyLipschitzOn.restrict`, and related Lipschitz API). The remaining scalar-multiplication proof in the upstream file relies on unfinished ENNReal coercion lemmas.
- `Sard/LocallyLipschitzMeasureZero.lean`: the global locally Lipschitz null-set image theorem is close to Mathlib's current Hausdorff-measure API, but the open-set specialization and `C¹` open-set theorem still require a nontrivial decomposition of arbitrary open sets into countably many local convex/Lipschitz pieces. The upstream file uses a false placeholder convexity assumption for an arbitrary open set.
- `Sard/ManifoldAux.lean`: much of the chart smoothness API was upstreamed or renamed in Mathlib by Lean `v4.30.0-rc2`. The remaining differential-bijectivity helpers depend on older manifold API spellings and include an explicitly unused lemma with an unresolved inverse-image equality; importing this module would duplicate current Mathlib lemmas and require a separate modernization pass.
- later `Sard/MeasureZero.lean` lemmas after the countable-union API: these depend on old chart internals and on manifold API that has since been reorganized around `IsManifold`; the imported file keeps the completed definition and closure lemmas.
- `Sard/ObsoleteHelpers.lean`: marked obsolete upstream and contains incomplete topological helper proofs.

No source file was excluded for licensing reasons; the source repository is Apache-2.0.

---
_Opened automatically by `scripts/import-formalization.sh`. Review the diff carefully before merging — the agent ran unattended._
