### PR TITLE
Import zflean formalization

### DIFF
--- a/LeanPool/ZFLean.lean
+++ b/LeanPool/ZFLean.lean
@@ -1,0 +1,12 @@
+/-
+Copyright (c) 2026 Vincent Trélat. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vincent Trélat
+-/
+
+import LeanPool.ZFLean.Booleans
+import LeanPool.ZFLean.Integers
+import LeanPool.ZFLean.Rationals
+import LeanPool.ZFLean.Embeddings
+import LeanPool.ZFLean.Isomorphisms
+import LeanPool.ZFLean.Tactics

--- a/LeanPool/ZFLean/Basic.lean
+++ b/LeanPool/ZFLean/Basic.lean
@@ -1,0 +1,211 @@
+/-
+Copyright (c) 2026 Vincent Trélat. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vincent Trélat
+-/
+
+import Mathlib.SetTheory.ZFC.Basic
+noncomputable section
+
+namespace ZFSet
+
+theorem nonempty_exists_iff {n : ZFSet} : n ≠ ∅ ↔ ∃ m, m ∈ n := by
+  simp [ZFSet.ext_iff]
+
+@[simp] theorem subset_of_empty {x : ZFSet} (h : x ⊆ ∅) : x = ∅ := by
+  ext1 z
+  constructor
+  · intro hz
+    exact h hz
+  · intro hz
+    nomatch notMem_empty z hz
+
+theorem sep_subset_self {P : ZFSet → Prop} {a : ZFSet} : a.sep P ⊆ a := by
+  intros x hx
+  rw [mem_sep] at hx
+  exact hx.left
+
+theorem sUnion_insert {x : ZFSet} : (⋃₀ (insert x x) : ZFSet) = x ∪ (⋃₀ x : ZFSet) := by
+  ext1
+  simp only [mem_sUnion, mem_insert_iff, exists_eq_or_imp, mem_union]
+
+theorem singleton_subset_mem_iff {x y : ZFSet} : {x} ⊆ y ↔ x ∈ y := by
+  simp [subset_def]
+
+theorem sInter_pair {a b : ZFSet} : ⋂₀ {a, b} = a ∩ b := by
+  ext1 x
+  constructor
+  · intro h
+    rw [mem_sInter (by simp only [nonempty_def, mem_insert_iff, exists_or_eq_left])] at h
+    simp only [mem_insert_iff, mem_singleton, forall_eq_or_imp, forall_eq] at h
+    rwa [← mem_inter] at h
+  · intro h
+    rw [mem_sInter (by simp only [nonempty_def, mem_insert_iff, exists_or_eq_left])]
+    simp only [mem_insert_iff, mem_singleton, forall_eq_or_imp, forall_eq]
+    rwa [← mem_inter]
+
+@[simp]
+theorem sep_empty_iff {A : ZFSet} {P : ZFSet → Prop} : A.sep P = ∅ ↔ (A = ∅ ∨ ∀ x ∈ A, ¬ P x) where
+  mp h := by classical
+    by_cases A_emp : A = ∅
+    · left; assumption
+    · right
+      intros x mem_x_A
+      by_contra contr
+      have : x ∈ A.sep P := by
+        rw [mem_sep]
+        exact ⟨mem_x_A, contr⟩
+      rw [h] at this
+      nomatch this, notMem_empty _
+  mpr h := by classical
+    rcases h with rfl | h
+    · exact sep_empty P
+    · ext1 z
+      constructor
+      · intro hz
+        rw [mem_sep] at hz
+        nomatch h _ hz.left, hz.right
+      · intro hz
+        nomatch notMem_empty z, hz
+
+theorem insert_prod {A B x : ZFSet} : (insert x A).prod B = A.prod B ∪ ({x} : ZFSet).prod B := by
+  ext1 z
+  simp only [mem_prod, mem_insert_iff, exists_eq_or_imp, mem_union, mem_singleton, exists_eq_left]
+  constructor
+  · rintro (⟨b, bB, rfl⟩ | ⟨a, aA, b, bB, rfl⟩)
+    · simp only [pair_inj, exists_eq_right_right', true_and, exists_eq_right']
+      right
+      exact bB
+    · simp only [pair_inj, exists_eq_right_right']
+      left
+      exact ⟨aA, bB⟩
+  · rintro (⟨a, aA, b, bB, rfl⟩ | ⟨b, bB, rfl⟩)
+    · simp only [pair_inj, exists_eq_right_right']
+      right
+      exact ⟨aA, bB⟩
+    · simp only [pair_inj, true_and, exists_eq_right', exists_eq_right_right']
+      left
+      exact bB
+
+theorem prod_insert {A B x : ZFSet} : A.prod (insert x B) = A.prod B ∪ A.prod {x} := by
+  ext1 z
+  simp only [mem_prod, mem_insert_iff, exists_eq_or_imp, mem_union, mem_singleton, exists_eq_left]
+  constructor
+  · rintro ⟨a, aA, rfl | ⟨b, bB, rfl⟩⟩
+    · simp only [pair_inj, exists_eq_right_right', and_true, exists_eq_right']
+      right
+      exact aA
+    · simp only [pair_inj, exists_eq_right_right', existsAndEq, true_and]
+      left
+      exact ⟨aA, bB⟩
+  · rintro (⟨a, aA, b, bB, rfl⟩ | ⟨a, aA, rfl⟩)
+    · simp only [pair_inj, exists_eq_right_right']
+      exists a, aA
+      rw [eq_self, and_true, true_and]
+      right
+      exact bB
+    · simp only [pair_inj, and_true, exists_eq_right_right']
+      exists a, aA
+      left
+      rfl
+
+theorem union_empty {A : ZFSet} : A ∪ ∅ = A := by
+  ext1
+  simp_rw [mem_union, notMem_empty, or_false]
+
+theorem inter_comm {A B : ZFSet} : A ∩ B = B ∩ A := by
+  ext1
+  simp_rw [mem_inter]
+  exact and_comm
+
+theorem union_comm {A B : ZFSet} : A ∪ B = B ∪ A := by
+  ext1
+  simp_rw [mem_union]
+  exact or_comm
+
+theorem empty_union {A : ZFSet} : ∅ ∪ A = A := by
+  rw [union_comm]
+  exact union_empty
+
+@[simp]
+theorem mem_powerset_self {x : ZFSet} : x ∈ x.powerset := mem_powerset.mpr fun _ => id
+
+theorem inter_self {A : ZFSet} : A ∩ A = A := by
+  ext1
+  rw [mem_inter]
+  exact and_iff_left_of_imp id
+theorem inter_empty {A : ZFSet} : A ∩ ∅ = ∅ := by
+  ext1
+  simp
+theorem empty_inter {A : ZFSet} : ∅ ∩ A = ∅ := by
+  ext1
+  simp
+theorem union_self {A : ZFSet} : A ∪ A = A := by
+  ext1
+  rw [mem_union]
+  exact or_iff_left_of_imp id
+theorem sep_true {A : ZFSet} : A.sep (fun _ => True) = A := by
+  ext1
+  rw [mem_sep, and_true]
+
+theorem powerset_mono {x y : ZFSet} : x ⊆ y → x.powerset ⊆ y.powerset := by
+  intro hxy z hz
+  rw [mem_powerset] at hz ⊢
+  exact fun _ => (hxy <| hz ·)
+
+@[simp]
+theorem prod_empty_right {x : ZFSet} : x.prod ∅ = ∅ := by
+  ext z; simp
+@[simp]
+theorem prod_empty_left {x : ZFSet} : ZFSet.prod ∅ x = ∅ := by
+  ext z; simp
+
+notation " ε " => (Classical.epsilon fun z ↦ z ∈ ·)
+
+theorem eq_of_subset_subset {A B : ZFSet} (hAB : A ⊆ B) (hBA : B ⊆ A) : A = B := by
+  ext1 x
+  constructor <;> intro h
+  · exact hAB (hBA (hAB h))
+  · exact hBA (hAB (hBA h))
+
+theorem powerset_inj {A B : ZFSet} (h : A.powerset = B.powerset) : A = B := by
+  have A_sub := @ZFSet.mem_powerset_self A
+  have B_sub := @ZFSet.mem_powerset_self B
+  rw [h, ZFSet.mem_powerset] at A_sub
+  rw [←h, ZFSet.mem_powerset] at B_sub
+  apply ZFSet.eq_of_subset_subset <;> assumption
+
+theorem prod_inj {A B C D : ZFSet} (h : A.prod B = C.prod D) (hA : A ≠ ∅) (hB : B ≠ ∅) :
+    A = C ∧ B = D := by
+  obtain ⟨a, ha⟩ := nonempty_exists_iff.mp hA
+  obtain ⟨b, hb⟩ := nonempty_exists_iff.mp hB
+  obtain ⟨aC, bD⟩ : a ∈ C ∧ b ∈ D := by
+    rw [←pair_mem_prod, ←h, pair_mem_prod]
+    exact ⟨ha, hb⟩
+  rw [ZFSet.ext_iff, ZFSet.ext_iff]
+  suffices ∀ x y, (x ∈ A ↔ x ∈ C) ∧ (y ∈ B ↔ y ∈ D) by
+    and_intros
+    · intro z
+      specialize this z b
+      exact this.1
+    · intro z
+      specialize this a z
+      exact this.2
+  rw [ZFSet.ext_iff] at h
+  simp only [mem_prod] at h
+  intro x y
+  and_intros
+  · specialize h (x.pair b)
+    simp only [pair_inj, exists_eq_right_right'] at h
+    constructor <;> intro hx
+    · exact (h.mp ⟨hx, hb⟩).1
+    · exact (h.mpr ⟨hx, bD⟩).1
+  · specialize h (a.pair y)
+    simp only [pair_inj, exists_eq_right_right'] at h
+    constructor <;> intro hy
+    · exact (h.mp ⟨ha, hy⟩).2
+    · exact (h.mpr ⟨aC, hy⟩).2
+
+end ZFSet
+
+end

--- a/LeanPool/ZFLean/Booleans.lean
+++ b/LeanPool/ZFLean/Booleans.lean
@@ -1,0 +1,544 @@
+/-
+Copyright (c) 2026 Vincent Trélat. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vincent Trélat
+-/
+
+import LeanPool.ZFLean.Basic
+
+/-!
+# Boolean algebra on `ZFSet`
+
+This file defines the boolean algebra on `ZFSet` and the type of booleans `ZFBool`.
+It defines the following operations:
+- `not` : negation
+- `and` : conjunction
+- `or` : disjunction
+- `true` : ZF true value
+- `false` : ZF false value
+- `𝔹` : set of ZF booleans
+- `toBool` : conversion from `ZFBool` to `Bool`
+- `ofBool` : conversion from `Bool` to `ZFBool`
+
+-/
+
+noncomputable section
+
+/-! ## Preliminary definitions -/
+
+namespace ZFSet
+
+/-- Symmetric difference of two sets, denoted by `Δ`. -/
+def symmDiff (p q : ZFSet) : ZFSet := (p \ q) ∪ (q \ p)
+infix:70 " Δ " => symmDiff
+
+@[simp]
+theorem mem_symmDiff (x p q : ZFSet) : x ∈ p Δ q ↔ (x ∈ p ∧ x ∉ q) ∨ (x ∈ q ∧ x ∉ p) := by
+  simp only [symmDiff, mem_union, mem_diff]
+
+@[simp]
+theorem symmDiff_empty (p : ZFSet) : p Δ ∅ = p := by
+  ext x
+  simp only [mem_symmDiff, notMem_empty, not_false_eq_true, and_true, false_and, or_false]
+
+theorem symmDiff_comm (p q : ZFSet) : p Δ q = q Δ p := by
+  ext x
+  simp only [mem_symmDiff]
+  exact Or.comm
+
+@[simp]
+theorem symmDiff_self (p : ZFSet) : p Δ p = ∅ := by
+  ext x
+  simp only [mem_symmDiff, and_not_self, or_self, notMem_empty]
+
+section Booleans
+
+/-! ## ZF Boolean Algebra -/
+
+/-- False value defined as the empty set. -/
+abbrev zffalse : ZFSet := ∅
+/-- True value defined as the singleton containing the empty set. -/
+abbrev zftrue : ZFSet := {zffalse}
+/-- Set of ZF booleans, defined as the set containing `zffalse` and `zftrue`. -/
+abbrev 𝔹 : ZFSet := {zffalse,zftrue}
+/-- Type of ZF booleans. -/
+abbrev ZFBool := { x // x ∈ 𝔹 }
+
+theorem zftrue_ne_zffalse : zftrue ≠ zffalse := by
+  intro h
+  rw [ZFSet.ext_iff, zffalse, zftrue] at h
+  specialize h ∅
+  rw [mem_singleton] at h
+  nomatch h.mp rfl
+
+namespace ZFBool
+
+theorem zftrue_mem_𝔹 : zftrue ∈ 𝔹 := by
+  rw [mem_insert_iff, mem_singleton]
+  exact Or.inr rfl
+
+theorem zffalse_mem_𝔹 : zffalse ∈ 𝔹 := by
+  rw [mem_insert_iff, mem_singleton]
+  exact Or.inl rfl
+
+lemma 𝔹.nonempty : ZFSet.𝔹 ≠ ∅ := by
+  intro h
+  rw [ZFSet.ext_iff] at h
+  simp only [ZFSet.notMem_empty, iff_false] at h
+  nomatch h ZFSet.zffalse (ZFSet.ZFBool.zffalse_mem_𝔹)
+
+/-- False value, lifted on `ZFBool`. -/
+abbrev false : ZFBool := ⟨zffalse, zffalse_mem_𝔹⟩
+/-- True value, lifted on `ZFBool`. -/
+abbrev true : ZFBool := ⟨zftrue, zftrue_mem_𝔹⟩
+instance Bool_top : Top ZFBool := ⟨true⟩
+instance Bool_bot : Bot ZFBool := ⟨false⟩
+@[simp] theorem top_eq_true : ⊤ = true := rfl
+@[simp] theorem bot_eq_false : ⊥ = false := rfl
+theorem true_ne_false : (⊤ : ZFBool) ≠ ⊥ := by
+  intro h
+  rw [top_eq_true, bot_eq_false] at h
+  injection h with h
+  nomatch zftrue_ne_zffalse h
+
+@[simp]
+theorem mem_𝔹_iff (p : ZFSet) : p ∈ 𝔹 ↔ p = zffalse ∨ p = zftrue := by
+  rw [mem_insert_iff, mem_singleton]
+
+@[simp]
+theorem powerset_false : zffalse.powerset = zftrue := by
+  unfold zftrue zffalse
+  ext x
+  simp only [mem_powerset, mem_singleton]
+  apply Iff.intro
+  · exact subset_of_empty
+  · exact (subset_of_subset_of_eq (fun _ a => a) ·)
+
+/--
+The enumeration of the powerset of `𝔹`.
+-/
+theorem powerset_𝔹_def :
+  ZFSet.𝔹.powerset = {∅, {ZFSet.zffalse}, {ZFSet.zftrue}, {ZFSet.zffalse, ZFSet.zftrue}} := by
+  ext1 x
+  constructor
+  · intro h
+    rw [ZFSet.mem_powerset, ZFSet.𝔹] at h
+    simp_rw [ZFSet.mem_insert_iff, ZFSet.mem_singleton]
+    by_cases hx : x = ∅
+    · left; exact hx
+    · right
+      by_cases hx' : ZFSet.zffalse ∈ x
+      · rw [← or_assoc, or_comm, ← or_assoc]
+        left
+        by_cases hx'' : ZFSet.zftrue ∈ x
+        · left
+          ext1 s
+          constructor
+          · intro hs; exact h hs
+          · intro hs; rcases (ZFSet.ZFBool.mem_𝔹_iff s).mp hs with rfl | rfl <;> assumption
+        · right
+          ext1 s
+          constructor
+          · intro hs
+            rw [ZFSet.mem_singleton]
+            rcases ZFSet.ZFBool.mem_𝔹_iff s |>.mp (h hs) with rfl | rfl <;> trivial
+          · intro hs
+            rcases ZFSet.mem_singleton.mp hs
+            exact hx'
+      · by_cases hx'' : ZFSet.zftrue ∈ x
+        · right
+          left
+          ext1 s
+          constructor
+          · intro hs
+            rw [ZFSet.mem_singleton]
+            rcases (ZFSet.ZFBool.mem_𝔹_iff s).mp (h hs) with rfl | rfl <;> trivial
+          · intro hs
+            rcases ZFSet.mem_singleton.mp hs
+            exact hx''
+        · simp_rw [ZFSet.subset_def, ZFSet.ZFBool.mem_𝔹_iff] at h
+          obtain ⟨w, hw⟩ := nonempty_exists_iff.mp hx
+          rcases h hw with rfl | rfl <;> contradiction
+  · intro hx
+    simp_rw [ZFSet.mem_insert_iff, ZFSet.mem_singleton] at hx
+    rcases hx with rfl | rfl | rfl | rfl <;> rw [ZFSet.mem_powerset]
+    · exact ZFSet.empty_subset ZFSet.𝔹
+    · intro _ hx
+      rw [ZFSet.ZFBool.mem_𝔹_iff]
+      rcases ZFSet.mem_singleton.mp hx
+      left; rfl
+    · intro _ hx
+      rw [ZFSet.ZFBool.mem_𝔹_iff]
+      rcases ZFSet.mem_singleton.mp hx
+      right; rfl
+
+/-- Boolean negation, defined as the symmetric difference with `true`. -/
+protected abbrev not (p : ZFBool) : ZFBool := ⟨true Δ p.1, by
+  let ⟨p, hp⟩ := p
+  rw [mem_𝔹_iff] at hp ⊢
+  rcases hp with rfl | rfl
+  · right
+    exact symmDiff_empty _
+  · left
+    exact symmDiff_self _⟩
+
+/-- Cases elimination for `ZFBool`. -/
+@[cases_eliminator]
+def casesOn {motive : ZFBool → Sort _}
+  (p : ZFBool)
+  (false : motive ⊥)
+  (true : motive ⊤) : motive p := by
+  obtain ⟨P, hP⟩ := p
+  have := mem_𝔹_iff P |>.mp hP
+  by_cases h : P = zffalse
+  · subst h
+    exact false
+  · have := Or.resolve_left this h
+    subst this
+    exact true
+
+/-- Boolean conjunction, defined as set intersection. -/
+protected abbrev and (p q : ZFBool) : ZFBool :=
+  let ⟨P, hP⟩ := p
+  let ⟨Q, hQ⟩ := q
+  ⟨P ∩ Q, by
+    rw [mem_𝔹_iff]
+    rw [mem_𝔹_iff] at hP hQ
+    cases hP <;> cases hQ <;> subst_eqs
+    · apply Or.inl
+      ext1
+      rw [mem_inter, and_self]
+    · apply Or.inl
+      ext1
+      simp only [mem_inter, notMem_empty, false_and]
+    · apply Or.inl
+      ext1
+      simp only [mem_inter,  notMem_empty, and_false]
+    · apply Or.inr
+      ext1
+      simp only [mem_inter, and_self]⟩
+
+infixl:55 " ⋀ " => ZFBool.and
+
+protected abbrev or (p q : ZFBool) : ZFBool :=
+  let ⟨P, hP⟩ := p
+  let ⟨Q, hQ⟩ := q
+  ⟨P ∪ Q,
+    by
+    rw [mem_𝔹_iff]
+    rw [mem_𝔹_iff] at hP hQ
+    cases hP <;> cases hQ <;> subst_eqs
+    · apply Or.inl
+      ext1
+      rw [mem_union, or_self]
+    · apply Or.inr
+      ext1
+      simp only [mem_union, notMem_empty, mem_singleton, false_or]
+    · apply Or.inr
+      ext1
+      simp only [mem_union, notMem_empty, or_false]
+    · apply Or.inr
+      ext1
+      simp only [mem_union, or_self]⟩
+
+infixl:55 " ⋁ " => ZFBool.or
+
+/-! ### Boolean algebra -/
+
+@[simp]
+theorem not_true_eq_false : ZFBool.not ⊤ = ⊥ := by
+  rw [Subtype.mk.injEq]
+  ext1
+  rw [mem_symmDiff]
+  constructor
+  · rintro (⟨l, r⟩ | ⟨l, r⟩) <;> nomatch r l
+  · intro h
+    nomatch notMem_empty _ h
+
+@[simp]
+theorem not_false_eq_true : ZFBool.not ⊥ = ⊤ := by
+  rw [Subtype.mk.injEq]
+  ext1
+  rw [mem_symmDiff]
+  constructor
+  · rintro (⟨l, r⟩ | ⟨l, r⟩)
+    · exact l
+    · nomatch notMem_empty _ l
+  · intro h
+    left
+    exact ⟨h, notMem_empty _⟩
+
+theorem and_comm (p q : ZFBool) : p ⋀ q = q ⋀ p := by
+  obtain ⟨P, hP⟩ := p
+  obtain ⟨Q, hQ⟩ := q
+  rw [Subtype.mk.injEq]
+  ext1
+  repeat rw [mem_inter]
+  exact And.comm
+
+theorem and_assoc (p q r : ZFBool) : p ⋀ q ⋀ r = p ⋀ (q ⋀ r) := by
+  obtain ⟨P, hP⟩ := p
+  obtain ⟨Q, hQ⟩ := q
+  obtain ⟨R, hR⟩ := r
+  rw [Subtype.mk.injEq]
+  ext1
+  repeat rw [mem_inter]
+  exact _root_.and_assoc
+
+@[simp]
+theorem and_true (p : ZFBool) : p ⋀ ⊤ = p := by
+  obtain ⟨P, hP⟩ := p
+  rw [Subtype.mk.injEq]
+  ext1
+  rw [mem_inter]
+  rw [mem_𝔹_iff] at hP
+  rw [and_iff_left_iff_imp]
+  intro h
+  cases hP
+  · subst_eqs
+    simp only [notMem_empty] at h
+  · subst_eqs
+    assumption
+
+@[simp]
+theorem and_false (p : ZFBool) : p ⋀ ⊥ = ⊥ := by
+  obtain ⟨P, hP⟩ := p
+  ext
+  rw [mem_inter]
+  rw [mem_𝔹_iff] at hP
+  rcases hP with rfl | rfl
+  · exact and_iff_left_of_imp id
+  · constructor
+    · rintro ⟨_, h⟩
+      exact h
+    · intro h
+      nomatch notMem_empty _ h
+
+theorem and_iff (p q : ZFBool) : p ⋀ q = ⊤ ↔ p = ⊤ ∧ q = ⊤ := by
+  constructor
+  · intro h
+    cases q using casesOn with
+    | false =>
+      rw [and_false] at h
+      nomatch true_ne_false h.symm
+    | true => exact ⟨and_true p ▸ h, rfl⟩
+  · rintro (⟨rfl,rfl⟩)
+    rw [and_true]
+
+abbrev and_intro p q := and_iff p q |>.mpr
+
+theorem or_comm (p q : ZFBool) : p ⋁ q = q ⋁ p := by
+  obtain ⟨P, hP⟩ := p
+  obtain ⟨Q, hQ⟩ := q
+  rw [Subtype.mk.injEq]
+  ext1
+  repeat rw [mem_union]
+  exact Or.comm
+
+theorem or_assoc (p q r : ZFBool) : p ⋁ q ⋁ r = p ⋁ (q ⋁ r) := by
+  obtain ⟨P, hP⟩ := p
+  obtain ⟨Q, hQ⟩ := q
+  obtain ⟨R, hR⟩ := r
+  rw [Subtype.mk.injEq]
+  ext1
+  repeat rw [mem_union]
+  exact _root_.or_assoc
+
+theorem or_true (p : ZFBool) : p ⋁ ⊤ = ⊤ := by
+  obtain ⟨P, hP⟩ := p
+  rw [Subtype.mk.injEq]
+  ext1
+  rw [mem_union]
+  rw [mem_𝔹_iff] at hP
+  cases hP <;> subst_eqs
+  · simp only [notMem_empty, mem_singleton, false_or, top_eq_true]
+  · exact or_iff_left_of_imp id
+
+theorem or_false (p : ZFBool) : p ⋁ ⊥ = p := by
+  obtain ⟨P, hP⟩ := p
+  rw [Subtype.mk.injEq]
+  ext1
+  rw [mem_union]
+  rw [mem_𝔹_iff] at hP
+  cases hP <;> subst_eqs
+  · rw [or_self]
+  · simp only [notMem_empty, _root_.or_false]
+
+theorem or_iff (p q : ZFBool) : p ⋁ q = ⊤ ↔ p = ⊤ ∨ q = ⊤ := by
+  constructor
+  · intro h
+    cases p using casesOn with
+    | false =>
+      rw [or_comm, or_false] at h
+      exact Or.inr h
+    | true => exact Or.inl rfl
+  · intro h
+    rcases h with rfl | rfl
+    · rw [or_comm, or_true]
+    · rw [or_true]
+
+abbrev or_intro p q := or_iff p q |>.mpr
+
+open Classical in
+/-- Conversion of `ZFBool` to `Lean.Bool`. -/
+def toBool : ZFBool → Bool
+  | ⟨b, hb⟩ =>
+    if h : b = zftrue then Bool.true
+    else if h' : b = zffalse then Bool.false
+    else False.elim (by rcases (ZFBool.mem_𝔹_iff b |>.mp hb) <;> contradiction)
+
+theorem toBool_false : toBool ⊥ = Bool.false := by
+  rw [toBool]
+  split_ifs with h h'
+  · nomatch zftrue_ne_zffalse h.symm
+  · rfl
+  · nomatch h'
+
+theorem toBool_true : toBool ⊤ = Bool.true := by
+  rw [toBool]
+  split_ifs with h h'
+  · rfl
+  · nomatch h rfl
+  · nomatch h'
+
+theorem toBool_and (p q : ZFBool) : (p ⋀ q).toBool = (p.toBool && q.toBool) := by
+  cases p <;> cases q
+  · rw [and_false, toBool_false, Bool.false_and]
+  · rw [and_true, toBool_true, toBool_false, Bool.false_and]
+  · rw [and_false, toBool_true, toBool_false, Bool.and_false]
+  · rw [and_true, toBool_true, Bool.true_and]
+
+theorem toBool_or (p q : ZFBool) : (p ⋁ q).toBool = (p.toBool || q.toBool) := by
+  cases p <;> cases q
+  · rw [or_false, toBool_false, Bool.false_or]
+  · rw [or_true, toBool_true, toBool_false, Bool.or_true]
+  · rw [or_false, toBool_true, toBool_false, Bool.true_or]
+  · rw [or_true, toBool_true, Bool.true_or]
+
+theorem toBool_not (p : ZFBool) : toBool p.not = ¬ p.toBool := by
+  cases p
+  · rw [not_false_eq_true, toBool_true, toBool_false, Bool.false_eq_true, Bool.coe_sort_true]
+    exact _root_.not_false_eq_true.symm
+  · rw [not_true_eq_false, toBool_false, toBool_true, Bool.coe_false]
+    exact eq_false (fun h => h rfl) |>.symm
+
+theorem not_top_iff_bot {P : ZFBool} : P ≠ ⊤ ↔ P = ⊥ := by
+  constructor
+  · intro
+    cases P <;> trivial
+  · intro _ h
+    subst P
+    injections h
+    nomatch zftrue_ne_zffalse h.symm
+
+theorem not_bot_iff_top {P : ZFBool} : P ≠ ⊥ ↔ P = ⊤ := by
+  constructor
+  · intro
+    cases P <;> trivial
+  · intro _ h
+    subst P
+    injections h
+    nomatch zftrue_ne_zffalse h
+
+/-- Conversion of `Lean.Bool` to `ZFBool` -/
+def ofBool : Bool → ZFBool
+  | .true  => ⟨zftrue, ZFBool.zftrue_mem_𝔹⟩
+  | .false => ⟨zffalse, ZFBool.zffalse_mem_𝔹⟩
+
+theorem mem_ofBool_𝔹 (b : Bool) : (ofBool b).val ∈ 𝔹 := by
+  unfold 𝔹
+  rcases b <;> simp [ofBool]
+
+theorem sub_ofBool_singleton_𝔹 (b : Bool) : {(ofBool b).val} ⊆ 𝔹 := by
+  intro
+  rw [mem_singleton]
+  rintro rfl
+  exact mem_ofBool_𝔹 b
+
+theorem to_Bool_ofBool (b : Bool) : ZFBool.toBool (ofBool b) = b := by
+  cases b <;> rw [ofBool, ZFBool.toBool]
+  · split_ifs with h
+    · nomatch zftrue_ne_zffalse.symm h
+    · rfl
+    · generalize_proofs
+      contradiction
+  · split_ifs with h
+    · rfl
+    · contradiction
+    · generalize_proofs
+      contradiction
+
+theorem of_Bool_toBool (b : ZFBool) : ofBool b.toBool = b := by
+  obtain ⟨b, hb⟩ := b
+  rw [ZFBool.toBool, ofBool.eq_def]
+  split_ifs with h <;> (first | subst b | contradiction) <;> trivial
+
+theorem ofBool_decide_eq_true_iff {P : Prop} [Decidable P] : ofBool (decide P) = ⊤ ↔ P := by
+  constructor
+  · intro h
+    cases hP : decide P with
+    | false =>
+      rw [hP] at h
+      unfold ofBool at h
+      injection h with h
+      nomatch zftrue_ne_zffalse h.symm
+    | true => exact decide_eq_true_eq.mp hP
+  · intro h
+    cases hP : decide P with
+    | false =>
+      rw [Bool.decide_false_iff] at hP
+      contradiction
+    | true => rfl
+
+theorem ofBool_decide_eq_false_iff {P : Prop} [Decidable P] : ofBool (decide P) = ⊥ ↔ ¬P := by
+  constructor
+  · intro h
+    cases hP : decide P with
+    | false => exact decide_eq_false_iff_not.mp hP
+    | true =>
+      rw [hP] at h
+      unfold ofBool at h
+      injection h with h
+      nomatch zftrue_ne_zffalse h
+  · intro h
+    cases hP : decide P with
+    | false => rfl
+    | true =>
+      rw [Bool.decide_iff] at hP
+      contradiction
+
+instance : ZFBool ≃ Bool where
+  toFun := toBool
+  invFun := ofBool
+  left_inv := of_Bool_toBool
+  right_inv := to_Bool_ofBool
+
+instance : Coe Bool ZFBool := ⟨ofBool⟩
+instance : Coe ZFBool Bool := ⟨toBool⟩
+
+end ZFBool
+
+end Booleans
+
+section AdditionnalLemmas
+
+namespace ZFBool
+
+theorem and_coe (p q : ZFBool) : p ⋀ q = ((p : Bool) && (q : Bool)) := by
+  rw [← toBool_and, of_Bool_toBool]
+theorem or_coe (p q : ZFBool) : p ⋁ q = ((p : Bool) || (q : Bool)) := by
+  rw [← toBool_or, of_Bool_toBool]
+theorem not_coe (p : ZFBool) : ZFBool.not p = ¬(p : Bool) := by
+  rw [← toBool_not]
+
+theorem and_or_distrib_left (p q r : ZFBool) : p ⋀ (q ⋁ r) = (p ⋀ q) ⋁ (p ⋀ r) := by
+  rw [and_coe, or_coe, and_coe, and_coe, or_coe]
+  iterate 3 rw [to_Bool_ofBool]
+  rw [Bool.and_or_distrib_left]
+
+end ZFBool
+end AdditionnalLemmas
+
+end ZFSet
+
+end

--- a/LeanPool/ZFLean/Embeddings.lean
+++ b/LeanPool/ZFLean/Embeddings.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 Vincent Trélat. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vincent Trélat
+-/
+
+import LeanPool.ZFLean.Functions
+
+namespace ZFSet
+section Embeddings
+
+def hasEmbedding (A B : ZFSet) : Prop :=
+  ∃ (f : ZFSet) (hf : A.IsFunc B f), IsInjective f
+
+infix:50 " ↪ᶻ " => hasEmbedding
+infix:50 " ↩ᶻ " => fun A B ↦ B ↪ᶻ A
+
+theorem embedding_symm {A B : ZFSet} : A ↪ᶻ B ↔ B ↩ᶻ A := id Iff.rfl
+
+theorem embedding_singleton {x y : ZFSet} : {x} ↪ᶻ {y} := by
+  use {x.pair y}, ?_
+  · intro a b c ha hb hc ac bc
+    rw [mem_singleton] at ha hb hc
+    subst a b c
+    rfl
+  · and_intros
+    · intro z hz
+      rw [mem_singleton] at hz
+      subst z
+      rw [pair_mem_prod, mem_singleton, mem_singleton]
+      exact ⟨rfl, rfl⟩
+    · intro z hz
+      rw [mem_singleton] at hz
+      subst z
+      use y
+      and_intros
+      · beta_reduce
+        rw [mem_singleton]
+      · intro z hz
+        rw [mem_singleton, pair_inj] at hz
+        obtain ⟨_, rfl⟩ := hz
+        rfl
+
+theorem embedding_pair (a b c d : ZFSet) (hab_cd : a = b ↔ c = d) : {a, b} ↪ᶻ {c, d} := by
+  use {a.pair c, b.pair d}, ?_
+  · intro x y z hx hy hz xy yz
+    rw [mem_pair] at hx hy hz xy yz
+    simp_rw [pair_inj] at xy yz
+    rcases hx with rfl | rfl <;> rcases hy with rfl | rfl <;> rcases hz with rfl | rfl <;> try rfl
+    · rcases xy with ⟨⟨⟩, ⟨⟩⟩ | ⟨⟨⟩, ⟨⟩⟩ <;> rcases yz with ⟨⟨⟩, ⟨⟩⟩ | ⟨⟨⟩, ⟨⟩⟩ <;> try rfl
+      rw [hab_cd]
+    · rcases xy with ⟨⟨⟩, ⟨⟩⟩ | ⟨⟨⟩, ⟨⟩⟩ <;> rcases yz with ⟨⟨⟩, ⟨⟩⟩ | ⟨⟨⟩, ⟨⟩⟩ <;> try rfl
+      rw [hab_cd]
+    · rcases xy with ⟨⟨⟩, ⟨⟩⟩ | ⟨⟨⟩, ⟨⟩⟩ <;> rcases yz with ⟨⟨⟩, ⟨⟩⟩ | ⟨⟨⟩, ⟨⟩⟩ <;> try rfl
+      symm
+      rw [hab_cd]
+    · rcases xy with ⟨⟨⟩, ⟨⟩⟩ | ⟨⟨⟩, ⟨⟩⟩ <;> rcases yz with ⟨⟨⟩, ⟨⟩⟩ | ⟨⟨⟩, ⟨⟩⟩ <;> try rfl
+      symm
+      rw [hab_cd]
+  · and_intros
+    · intro z hz
+      rw [mem_pair] at hz
+      rcases hz with rfl | rfl
+      · simp_rw [pair_mem_prod, mem_pair]
+        and_intros <;> (left; trivial)
+      · simp_rw [pair_mem_prod, mem_pair]
+        and_intros <;> (right; trivial)
+    · intro z hz
+      rw [mem_pair] at hz
+      rcases hz with rfl | rfl
+      · by_cases hc : c = d
+        · subst c
+          rw [eq_self, iff_true] at hab_cd
+          subst z
+          simp only [pair_eq_singleton, mem_singleton, pair_inj, true_and, existsUnique_eq]
+        · simp only [hc, iff_false] at hab_cd
+          use c
+          and_intros
+          · beta_reduce
+            rw [mem_pair]
+            left
+            rfl
+          · intro y hy
+            rw [mem_pair, pair_inj] at hy
+            rcases hy with ⟨_, rfl⟩ | eq
+            · rfl
+            · rw [pair_inj] at eq
+              obtain ⟨rfl, rfl⟩ := eq
+              nomatch hab_cd rfl
+      · by_cases hc : c = d
+        · subst c
+          rw [eq_self, iff_true] at hab_cd
+          subst z
+          simp only [pair_eq_singleton, mem_singleton, pair_inj, true_and, existsUnique_eq]
+        · simp only [hc, iff_false] at hab_cd
+          use d
+          and_intros
+          · beta_reduce
+            rw [mem_pair]
+            right
+            rfl
+          · intro y hy
+            rw [mem_pair, pair_inj] at hy
+            rcases hy with ⟨rfl, _⟩ | eq
+            · nomatch hab_cd rfl
+            · rw [pair_inj] at eq
+              exact eq.2
+
+theorem embedding_refl (A : ZFSet) : A ↪ᶻ A := by
+  use A.Id, Id.IsFunc
+  intro x y z hx hy hz xz yz
+  rw [pair_mem_Id_iff] at xz yz
+  · subst x y
+    rfl
+  · exact hy
+  · exact hx
+
+theorem embedding_trans {A B C : ZFSet} (hAB : A ↪ᶻ B) (hBC : B ↪ᶻ C) : A ↪ᶻ C := by
+  obtain ⟨f, hf, injf⟩ := hAB
+  obtain ⟨g, hg, injg⟩ := hBC
+  use composition g f A B C, IsFunc_of_composition_IsFunc hg hf
+  intro x y z hx hy hz xz yz
+  simp only [mem_composition, pair_inj, existsAndEq, and_true,
+    exists_and_left, exists_eq_left'] at xz yz
+  obtain ⟨xA, zC, w, wB, xw, wz⟩ := xz
+  obtain ⟨-, -, w', w'B, xw', w'z⟩ := yz
+  obtain rfl := injg _ _ _ wB w'B hz wz w'z
+  obtain rfl := injf _ _ _ hx hy wB xw xw'
+  rfl
+
+end Embeddings
+end ZFSet

--- a/LeanPool/ZFLean/Functions.lean
+++ b/LeanPool/ZFLean/Functions.lean
@@ -1,0 +1,2832 @@
+/-
+Copyright (c) 2026 Vincent Trélat. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vincent Trélat
+-/
+
+import LeanPool.ZFLean.Rationals
+import LeanPool.ZFLean.Booleans
+import LeanPool.ZFLean.Tactics
+
+namespace ZFSet
+set_option linter.unusedVariables false
+
+section Relations
+
+-- syntax "zrel" : tactic
+-- macro_rules | `(tactic| zrel) => `(tactic| (
+--   change ?R ⊆ ZFSet.prod ?A ?B
+--   try
+--     have : ZFSet.IsFunc ?A ?B ?R := by try assumption
+--     obtain ⟨_,_⟩ := this
+--   exact ‹?R ⊆ ZFSet.prod ?A ?B›))
+
+/--
+Inverse of a (binary) relation. A proof that `R` is a relation is needed and tried to be
+automatically inferred.
+-/
+def inv (R : ZFSet) {A B : ZFSet} (isRel : R ⊆ A.prod B := by zrel) : ZFSet :=
+  (B.prod A).sep fun yx ↦
+    let x := yx.π₂
+    let y := yx.π₁
+    x.pair y ∈ R
+
+postfix:max "⁻¹" => inv
+
+theorem mem_inv {x y R A B : ZFSet} (hR : R ⊆ A.prod B) :
+    y.pair x ∈ R⁻¹ ↔ x.pair y ∈ R where
+  mp := by
+    intro h
+    dsimp [inv] at h
+    rw [mem_sep, pair_mem_prod, π₁_pair, π₂_pair] at h
+    exact h.2
+  mpr := by
+    intro h
+    rw [inv, mem_sep, pair_mem_prod, π₁_pair, π₂_pair]
+    dsimp
+    and_intros
+    · exact hR h |> pair_mem_prod.mp |>.2
+    · exact hR h |> pair_mem_prod.mp |>.1
+    · exact h
+
+@[zrel]
+theorem subset_prod_inv {R A B : ZFSet} (hR : R ⊆ A.prod B) : R⁻¹ ⊆ B.prod A := by
+  intro z hz
+  rw [inv, mem_sep] at hz
+  exact hz.1
+
+-- macro_rules | `(tactic| zrel) => `(tactic| apply subset_prod_inv; done)
+
+theorem inv_involutive {R A B : ZFSet} (hR : R ⊆ A.prod B) : (R⁻¹)⁻¹ = R := by
+  ext1 z
+  constructor
+  · intro h
+    obtain ⟨a, ha, b, hb, rfl⟩ := (subset_prod_inv <| subset_prod_inv hR) h |> mem_prod.mp
+    rwa [mem_inv, mem_inv] at h
+  · intro h
+    obtain ⟨a, ha, b, hb, rfl⟩ := hR h |> mem_prod.mp
+    rwa [mem_inv, mem_inv]
+
+/--
+Domain of a (binary) relation. A proof that `f` is a relation is needed and tried to be
+automatically inferred.
+-/
+-- abbrev Dom   (f : ZFSet) {A B : ZFSet} (hf : f ⊆ A.prod B := by zrel) :=
+--   ⋃₀ (A.powerset.sep λ 𝒟 => IsFunc 𝒟 B f) --NOTE: this def was specific to functions
+abbrev Dom (f : ZFSet) {A B : ZFSet} (hf : f ⊆ A.prod B := by zrel) :=
+  A.sep (fun x => ∃ y ∈ B, pair x y ∈ f)
+
+abbrev Range (f : ZFSet) {A B : ZFSet} (hf : f ⊆ A.prod B := by zrel) :=
+  B.sep (fun y => ∃ x ∈ Dom f hf, pair x y ∈ f)
+
+end Relations
+
+section Functions
+
+theorem funs.nonempty {A B : ZFSet} (hB : B ≠ ∅) : ZFSet.funs A B ≠ ∅ := by
+  obtain ⟨b, hb⟩ := nonempty_exists_iff.mp hB
+  letI f := (A.prod B).sep fun z ↦ ∃ x ∈ A, z = x.pair b
+  have hf : ZFSet.IsFunc A B f := by
+    unfold IsFunc
+    and_intros
+    · exact sep_subset_self
+    · intro x hx
+      exists b
+      and_intros
+      · beta_reduce
+        rw [mem_sep, pair_mem_prod]
+        exact ⟨⟨hx,hb⟩,x, ⟨hx, rfl⟩⟩
+      · intro y hy
+        rw [mem_sep, pair_mem_prod] at hy
+        obtain ⟨⟨xA, yB⟩, z, z_A, eq⟩ := hy
+        rw [pair_inj] at eq
+        exact eq.2
+  intro contr
+  rw [← mem_funs, contr] at hf
+  nomatch notMem_empty f hf
+
+/--
+`IsPFunc f A B` is the assertion that `f` is a partial function from `A` to `B`,
+i.e. that if `pair x y ∈ f` and `pair x z ∈ f` then `y = z`.
+-/
+def IsPFunc (f A B : ZFSet) := f ⊆ prod A B ∧ ∀ x y :
+  ZFSet, pair x y ∈ f → ∀ z, pair x z ∈ f → y = z
+
+-- syntax "zpfun" : tactic
+-- macro_rules | `(tactic| zpfun) => `(tactic| assumption; done)
+
+-- syntax "zfun" : tactic
+-- macro_rules | `(tactic| zfun) => `(tactic| assumption; done)
+
+-- macro_rules | `(tactic| zrel) => `(tactic| first | zfun | zpfun)
+
+@[zrel]
+theorem is_rel_of_is_pfunc {f A B : ZFSet} (hf : f.IsPFunc A B) : f ⊆ A.prod B := hf.1
+
+-- macro_rules | `(tactic| zrel) => `(tactic| (
+--   change ?R ⊆ ZFSet.prod ?A ?B
+--   try
+--     have : IsPFunc ?R ?A ?B := by try assumption
+--     obtain ⟨_,_⟩ := this
+--   exact ‹?R ⊆ ZFSet.prod ?A ?B›))
+
+-- macro_rules | `(tactic| zrel) => `(tactic| apply is_rel_of_is_pfunc; assumption; done)
+
+theorem pfunc_weaken {f A B C D : ZFSet} (hf : f.IsPFunc C D) (hAB : C ⊆ A) (hCD : D ⊆ B) :
+    f.IsPFunc A B := by
+  rcases hf with ⟨sub, unique⟩
+  and_intros
+  · intro _ hz
+    obtain ⟨a,ha,b,hb,rfl⟩ := mem_prod.mp <| sub hz
+    rw [mem_prod]
+    exact ⟨a, hAB ha, b, hCD hb, rfl⟩
+  · intros x y pair_x_y z pair_x_z
+    exact unique x y pair_x_y z pair_x_z
+
+-- macro_rules | `(tactic| zpfun) =>
+--   `(tactic| (apply pfunc_weaken <;> first | (assumption; done) | zpfun))
+
+@[zpfun]
+theorem is_func_is_pfunc {f A B : ZFSet} (hf : A.IsFunc B f) : f.IsPFunc A B := by
+  obtain ⟨sub, func⟩ := hf
+  and_intros
+  · assumption
+  · intros x y pair_x_y z pair_x_z
+    obtain ⟨_, x_A, b, b_B, eq⟩ := mem_prod.mp <| sub pair_x_y
+    rw [pair_inj] at eq; rcases eq with ⟨rfl, rfl⟩
+    obtain ⟨w, pair_x_w, unique⟩ := func x x_A
+    rw [unique z pair_x_z, unique y pair_x_y]
+
+-- macro_rules | `(tactic| zpfun) => `(tactic| apply is_func_is_pfunc; zfun; done)
+
+@[zrel]
+theorem is_rel_of_is_func {f A B : ZFSet} (hf : A.IsFunc B f) : f ⊆ A.prod B := hf.1
+
+-- macro_rules | `(tactic| zrel) => `(tactic| apply is_rel_of_is_func; zfun; done)
+
+theorem is_func_extend_range {f D E : ZFSet} (hf : IsFunc D E f) {F : ZFSet} (sub_E_F : E ⊆ F) :
+    IsFunc D F f := by
+  rcases hf with ⟨sub, func⟩
+  and_intros
+  · intro _ hz
+    obtain ⟨a, ha, b, hb, rfl⟩ := mem_prod.mp <| sub hz
+    rw [mem_prod]
+    exact ⟨a, ha, b, sub_E_F hb, rfl⟩
+  · exact func
+
+-- macro_rules | `(tactic| zpfun) =>
+--   `(tactic| apply is_func_extend_range <;> first | (assumption;done) | zpfun)
+
+@[simp, zfun]
+theorem is_func_empty : IsFunc ∅ ∅ ∅ :=
+  ⟨empty_subset (prod ∅ ∅), fun _ h ↦ nomatch h, notMem_empty _⟩
+
+theorem is_pfunc_func_exists {f A B : ZFSet} :
+    f.IsPFunc A B → ∃ A' B', IsFunc A' B' f ∧ A' ⊆ A ∧ B' ⊆ B := by
+  classical
+  rintro ⟨sub_AB, func⟩
+  by_cases hf : f = ∅
+  · subst f
+    exact ⟨∅, ∅, is_func_empty, empty_subset A, empty_subset B⟩
+  · let A' := A.sep (fun x ↦ ∃ y, pair x y ∈ f)
+    let B' := B.sep (fun y ↦ ∃ x ∈ A', pair x y ∈ f)
+    exists A', B'
+    and_intros
+    · intro z hz
+      obtain ⟨a, ha, b, hb, rfl⟩ := mem_prod.mp <| sub_AB hz
+      rw [mem_prod]
+      unfold A' B'
+      simp only [mem_sep]
+      exists a
+      and_intros
+      · exact ha
+      · exact ⟨b, hz⟩
+      · exact ⟨b, ⟨hb, a, mem_sep.mpr ⟨ha, b, hz⟩, hz⟩, rfl⟩
+    · intro x x_A
+      rw [mem_sep] at x_A
+      obtain ⟨x_A, y, pair⟩ := x_A
+      have y_B : y ∈ B := by
+        obtain ⟨_,_,_,_,h⟩ := mem_prod.mp <| sub_AB pair
+        rw [pair_inj] at h
+        rcases h with ⟨rfl, rfl⟩
+        assumption
+      exact ⟨y, pair, fun z hz ↦ func x z hz y pair⟩
+    repeat (intro z hz; exact mem_sep.mp hz |>.left)
+
+theorem pfun_dom_subset (f : ZFSet) {A B} (hf : f.IsPFunc A B) : f.Dom ⊆ A := by
+  rintro x x_dom
+  rw [mem_sep] at x_dom
+  exact x_dom.1
+
+theorem mem_dom {f A B : ZFSet} (hf : f.IsPFunc A B) {x y : ZFSet} :
+    pair x y ∈ f → x ∈ f.Dom := by classical
+  intro mem_pair
+  obtain ⟨D, C, is_func_DC, Dsub, Csub⟩ := is_pfunc_func_exists hf
+  rcases hf with ⟨sub, unique⟩
+  obtain ⟨a, ha, b, hb, eq⟩ := mem_prod.mp <| sub mem_pair
+  rw [pair_inj] at eq
+  rcases eq with ⟨rfl, rfl⟩
+  rw [mem_sep]
+  and_intros
+  · exact ha
+  · use y
+
+theorem is_func_dom_range (f : ZFSet) {A B} (hf : f.IsPFunc A B) :
+    IsFunc f.Dom f.Range f := by
+  classical
+  rcases hf with ⟨sub, unique⟩
+  and_intros
+  · intro _ h
+    obtain ⟨a,a_A,b,b_B,rfl⟩ := mem_prod.mp <| sub h
+    rw [pair_mem_prod]
+    and_intros
+    · rw [mem_sep]
+      and_intros
+      · exact a_A
+      · use b
+    · unfold Range
+      rw [mem_sep]
+      and_intros
+      · exact b_B
+      · exists a
+        and_intros
+        · exact mem_dom ⟨sub, unique⟩ h
+        · exact h
+  · intro z z_dom
+    rw [mem_sep] at z_dom
+    obtain ⟨zA, w, hw, zw_f⟩ := z_dom
+    use w
+    and_intros
+    · exact zw_f
+    · intro w' zw'_f
+      exact unique z w' zw'_f w zw_f
+
+theorem is_func_of_pfunc (f : ZFSet) {A B} (hf : f.IsPFunc A B) : IsFunc f.Dom B f := by
+  obtain ⟨ftot, uniq⟩ := is_func_dom_range f hf
+  obtain ⟨fsub, ispfun⟩ := hf
+  and_intros
+  · intro z hz
+    obtain ⟨x, xA, y, yB, rfl⟩ := mem_prod.mp <| fsub hz
+    obtain ⟨u, u_dom, v, v_dom, eq⟩ := mem_prod.mp <| ftot hz
+    rcases pair_inj.mp eq with ⟨rfl, rfl⟩
+    clear eq
+    rw [pair_mem_prod]
+    exact ⟨u_dom, yB⟩
+  · exact uniq
+
+def IsInjective (f : ZFSet) {A B : ZFSet} (hf : IsFunc A B f := by zfun) :=
+  ∀ x y z, x ∈ A → y ∈ A → z ∈ B → x.pair z ∈ f → y.pair z ∈ f → x = y
+
+def IsSurjective (f : ZFSet) {A B : ZFSet} (hf : IsFunc A B f := by zfun) :=
+  ∀ y ∈ B, ∃ x ∈ A, x.pair y ∈ f
+
+def IsBijective (f : ZFSet) {A B : ZFSet} (hf : IsFunc A B f := by zfun) :=
+  f.IsInjective ∧ f.IsSurjective
+
+theorem IsInjective.ofBijective {f A B C : ZFSet} {hf : IsFunc A B f}
+  (f_bij : f.IsBijective hf) (B_sub_C : B ⊆ C) :
+    f.IsInjective (is_func_extend_range hf B_sub_C) :=
+  fun _ _ z hx hy _ hxy hxz ↦
+    f_bij.1 _ _ z hx hy (pair_mem_prod.mp (hf.1 hxy)).2 hxy hxz
+
+theorem bijective_exists1_iff {f A B : ZFSet} (hf : IsFunc A B f) :
+  f.IsBijective ↔ ∀ y ∈ B, ∃! x ∈ A, x.pair y ∈ f := by
+  constructor
+  · intro bij y y_B
+    obtain ⟨inj, surj⟩ := bij
+    obtain ⟨x, x_A, x_pair_y⟩ := surj y y_B
+    apply ExistsUnique.intro x ⟨x_A, x_pair_y⟩
+    rintro z ⟨z_A, z_pair_y⟩
+    exact inj x z y x_A z_A y_B x_pair_y z_pair_y |>.symm
+  · intro exists1
+    constructor
+    · intro x z y x_A z_A y_B x_pair_y z_pair_y
+      obtain ⟨w, ⟨w_A, w_pair_y⟩, unique⟩ := exists1 y y_B
+      rw [unique x ⟨x_A, x_pair_y⟩, unique z ⟨z_A, z_pair_y⟩]
+    · intro y y_B
+      obtain ⟨x, ⟨x_A, x_pair_y⟩, unique⟩ := exists1 y y_B
+      exact ⟨x, x_A, x_pair_y⟩
+
+def IsMono {f A B : ZFSet}
+  [LTA : Preorder {x // x ∈ A}]
+  [LTB : Preorder {x // x ∈ B}]
+  (_ : IsFunc A B f) :=
+  ∀ x₁ x₂ y₁ y₂,
+    (x₁_A : x₁ ∈ A) →
+    (y₁_B :y₁ ∈ B) →
+    x₁.pair y₁ ∈ f →
+    (x₂_A : x₂ ∈ A) →
+    (y₂_B : y₂ ∈ B) →
+    x₂.pair y₂ ∈ f →
+    LTA.le ⟨x₁, x₁_A⟩ ⟨x₂, x₂_A⟩ →
+    LTB.le ⟨y₁, y₁_B⟩ ⟨y₂, y₂_B⟩
+
+def IsStrictMono {f A B : ZFSet}
+  [LTA : Preorder {x // x ∈ A}]
+  [LTB : Preorder {x // x ∈ B}]
+  (_ : IsFunc A B f) :=
+  ∀ x₁ x₂ y₁ y₂,
+    (x₁_A : x₁ ∈ A) →
+    (y₁_B :y₁ ∈ B) →
+    x₁.pair y₁ ∈ f →
+    (x₂_A : x₂ ∈ A) →
+    (y₂_B : y₂ ∈ B) →
+    x₂.pair y₂ ∈ f →
+    LTA.lt ⟨x₁, x₁_A⟩ ⟨x₂, x₂_A⟩ →
+    LTB.lt ⟨y₁, y₁_B⟩ ⟨y₂, y₂_B⟩
+
+def Id (A : ZFSet) : ZFSet :=
+  (A.prod A).sep fun x => ∃ y : ZFSet, y ∈ A ∧ x = y.pair y
+prefix:max "𝟙" => Id
+
+theorem pair_mem_Id_iff {A : ZFSet} {x y : ZFSet} (hx : x ∈ A) : x.pair y ∈ 𝟙A ↔ x = y := by
+  simp only [Id, mem_sep, mem_prod, pair_inj, exists_eq_right_right', and_assoc]
+  constructor
+  · rintro ⟨_, _, _, _, rfl⟩
+    rfl
+  · rintro rfl
+    simpa only [and_true, and_self]
+
+theorem mem_Id_iff {A : ZFSet} {z : ZFSet} : z ∈ 𝟙A ↔ ∃ x ∈ A, z = x.pair x := by
+  simp only [Id, mem_sep, mem_prod, and_iff_right_iff_imp, forall_exists_index, and_imp]
+  rintro x xA rfl
+  use x, xA, x, xA
+
+theorem pair_self_mem_Id {A : ZFSet} {x : ZFSet} (hx : x ∈ A) : x.pair x ∈ 𝟙A := by
+  rwa [pair_mem_Id_iff]
+
+@[zfun]
+theorem Id.IsFunc {A : ZFSet} : A.IsFunc A 𝟙A := by
+  unfold Id
+  and_intros
+  · intro z hz
+    rw [mem_sep] at hz
+    exact hz.1
+  · intro x xA
+    simp only [mem_sep, mem_prod, pair_inj, exists_eq_right_right']
+    exists x
+    beta_reduce
+    simp only [and_self, and_true, and_imp, forall_self_imp]
+    and_intros
+    · exact xA
+    · rintro _ _ _ rfl
+      rfl
+
+-- macro_rules | `(tactic| zfun) => `(tactic| apply Id.IsFunc; done)
+
+@[zpfun]
+theorem Id.IsPFunc {A : ZFSet} : (𝟙A).IsPFunc A A := is_func_is_pfunc IsFunc
+
+-- macro_rules | `(tactic| zpfun) => `(tactic| apply Id.IsPFunc; done)
+
+theorem Id.IsBijective {A : ZFSet} : (𝟙A).IsBijective Id.IsFunc := by
+  constructor
+  · intro x y z xA yA zA x_pair_y y_pair_z
+    rw [Id, mem_sep, pair_mem_prod] at x_pair_y y_pair_z
+    obtain ⟨x', x'_A, eq_x⟩ := x_pair_y.2
+    obtain ⟨y', y'_A, eq_y⟩ := y_pair_z.2
+    rw [pair_inj] at eq_x eq_y
+    obtain ⟨rfl, rfl⟩ := eq_x
+    obtain ⟨rfl, rfl⟩ := eq_y
+    rfl
+  · intro y yA
+    simp_rw [Id, mem_sep, pair_mem_prod, pair_inj, exists_eq_right_right',
+      existsAndEq, and_self, yA, and_true]
+
+@[simp]
+theorem range_Id {A : ZFSet} : (𝟙A).Range = A := by
+  ext1 z
+  simp only [mem_sep, and_iff_left_iff_imp]
+  intro hz
+  use z, ⟨hz, ?_⟩
+  · rw [pair_mem_Id_iff hz]
+  · use z, hz
+    rw [pair_mem_Id_iff hz]
+
+def IsPermutation (σ E : ZFSet) := ∃ (hσ : E.IsFunc E σ), σ.IsBijective
+
+def permutations (E : ZFSet) : ZFSet := (E.funs E).sep fun f => f.IsPermutation E
+
+theorem Id.IsPermutation {A : ZFSet} : IsPermutation 𝟙A A := by
+  exists Id.IsFunc
+  exact Id.IsBijective
+
+/--
+If `f : A → B` and `g : B → C` are functions, then `composition g f` is the function
+from `A` to `C` defined by `composition g f (x, z) = (x, y)` where `y` is such that
+`(x, y) ∈ f` and `(y, z) ∈ g`.
+-/
+def composition (g f : ZFSet) (A B C : ZFSet) : ZFSet :=
+  (A.prod C).sep fun xz =>
+    ∃ (x z : ZFSet), xz = x.pair z ∧ ∃ y ∈ B, x.pair y ∈ f ∧ y.pair z ∈ g
+
+theorem mem_composition (g f : ZFSet) {A B C : ZFSet} {z : ZFSet} :
+  z ∈ composition g f A B C ↔
+    ∃ (x w y : ZFSet), z = x.pair y ∧ x ∈ A ∧ y ∈ C ∧ w ∈ B ∧ x.pair w ∈ f ∧ w.pair y ∈ g := by
+  simp only [composition, mem_sep, mem_prod]
+  constructor
+  · rintro ⟨⟨a, ha, c, hc, rfl⟩, ⟨_, _, eq, _, memB, memf, memg⟩⟩
+    rw [pair_inj] at eq
+    obtain ⟨rfl, rfl⟩ := eq
+    simp only [pair_inj, existsAndEq, and_true, exists_and_left, exists_eq_left']
+    and_intros
+    · exact ha
+    · exact hc
+    · exact ⟨_, memB, memf, memg⟩
+  · rintro ⟨x, w, y, rfl, xA, yC, wB, xw_f, wy_g⟩
+    simp only [pair_inj, exists_eq_right_right', existsAndEq, and_true, exists_eq_left']
+    and_intros
+    · exact xA
+    · exact yC
+    · exact ⟨w, wB, xw_f, wy_g⟩
+
+theorem Id.composition_left {f A B : ZFSet} (hf : f ⊆ A.prod B) : composition 𝟙B f A B B = f := by
+  ext1 x
+  unfold Id composition
+  simp only [mem_sep, mem_prod, pair_inj, exists_eq_right_right', existsAndEq, and_self, and_true]
+  constructor
+  · rintro ⟨⟨a, aA, b, bB, rfl⟩, x, y, eq, yB, memf, -⟩
+    rw [pair_inj] at eq
+    obtain ⟨rfl, rfl⟩ := eq
+    exact memf
+  · intro xf
+    and_intros
+    · obtain ⟨a, aA, b, bB, rfl⟩ := mem_prod.mp <| hf xf
+      exists a, aA, b, bB
+    · obtain ⟨a, aA, b, bB, rfl⟩ := mem_prod.mp <| hf xf
+      exists a, b
+
+theorem Id.composition_right {f A B : ZFSet} (hf : f ⊆ A.prod B) : composition f 𝟙A A A B = f := by
+  ext1 x
+  unfold Id composition
+  simp only [mem_sep, mem_prod, pair_inj, exists_eq_right_right', existsAndEq, and_self, and_true]
+  constructor
+  · rintro ⟨⟨a, aA, b, bB, rfl⟩, x, y, eq, xB, xA, memf⟩
+    rw [pair_inj] at eq
+    obtain ⟨rfl, rfl⟩ := eq
+    exact memf
+  · intro xf
+    and_intros
+    · obtain ⟨a, aA, b, bB, rfl⟩ := mem_prod.mp <| hf xf
+      exists a, aA, b, bB
+    · obtain ⟨a, aA, b, bB, rfl⟩ := mem_prod.mp <| hf xf
+      exists a, b
+
+@[zpfun]
+theorem IsPFunc_of_composition_IsPFunc {f g : ZFSet} {A B C : ZFSet}
+  (hf : f.IsPFunc A B) (hg : g.IsPFunc B C) :
+    (composition g f A B C).IsPFunc A C := by
+  and_intros
+  · intro z hz
+    rw [composition, mem_sep] at hz
+    exact hz.1
+  · intro x y hxy z hz
+    rw [composition, mem_sep, pair_mem_prod] at hxy hz
+    obtain ⟨a, c, eq, b, bB, ab_f, bc_g⟩ := hz.2
+    obtain ⟨a', c', eq', b', bB', ab_f', bc_g'⟩ := hxy.2
+    rw [pair_inj] at eq eq'
+    obtain ⟨rfl, rfl⟩ := eq
+    obtain ⟨rfl, rfl⟩ := eq'
+    have := hf.2 _ _ ab_f _ ab_f'
+    subst this
+    symm
+    exact hg.2 _ _ bc_g _ bc_g'
+
+-- macro_rules | `(tactic| zpfun) =>
+--   `(tactic| apply IsPFunc_of_composition_IsPFunc <;> first | (assumption; done) | zpfun)
+
+@[zfun]
+theorem IsFunc_of_composition_IsFunc {g f : ZFSet} {A B C : ZFSet}
+  (hg : B.IsFunc C g) (hf : A.IsFunc B f) :
+    A.IsFunc C (composition g f A B C) := by
+  and_intros
+  · intro z hz
+    rw [composition, mem_sep] at hz
+    exact hz.1
+  · intro x xA
+    obtain ⟨y, xy_f, y_unq⟩ := hf.2 x xA
+    have yB : y ∈ B := And.right <| pair_mem_prod.mp <| hf.1 xy_f
+    obtain ⟨z, yz_g, z_unq⟩ := hg.2 y yB
+    have zC : z ∈ C := And.right <| pair_mem_prod.mp <| hg.1 yz_g
+    exists z
+    simp_rw [composition, mem_sep, pair_mem_prod]
+    and_intros
+    · exact xA
+    · exact zC
+    · exists x, z
+      and_intros
+      · rfl
+      · exists y
+    · intro z' hz'
+      obtain ⟨x', z', eq, y', y'_B, x'y'f, y'z'g⟩ := hz'.2
+      rw [pair_inj] at eq
+      obtain ⟨rfl, rfl⟩ := eq
+      apply z_unq
+      suffices y' = y by
+        rw [←this]
+        exact y'z'g
+      apply y_unq
+      exact x'y'f
+
+-- macro_rules | `(tactic| zfun) =>
+--   `(tactic| apply IsFunc_of_composition_IsFunc <;> first | (assumption; done) | zfun)
+
+abbrev fcomp (g f : ZFSet) {A B C : ZFSet}
+  (hg : B.IsFunc C g := by zfun) (hf : A.IsFunc B f := by zfun) :=
+    composition g f A B C
+infixl:90 " ∘ᶻ " => fcomp
+
+@[simp] theorem pair_mem_composition (g f : ZFSet) {A B C x y : ZFSet}
+  (hg : IsFunc B C g) (hf : IsFunc A B f) :
+    x.pair y ∈ (g ∘ᶻ f) ↔ ∃ w ∈ B, x.pair w ∈ f ∧ w.pair y ∈ g where
+  mp := by
+    intro hxy
+    simp only [mem_composition, pair_inj, ↓existsAndEq, and_true, exists_and_left,
+      exists_eq_left'] at hxy
+    obtain ⟨a, ha, b, hb, fxb, gby⟩ := hxy
+    use b, hb
+  mpr := by
+    intro ⟨w, hw, fxw, gwy⟩
+    simp only [mem_composition, pair_inj, ↓existsAndEq, and_true, exists_and_left, exists_eq_left']
+    and_intros
+    · exact hf.1 fxw |> pair_mem_prod.mp |>.1
+    · exact hg.1 gwy |> pair_mem_prod.mp |>.2
+    · use w
+
+theorem IsInjective.composition_of_injective {f g : ZFSet} {A B C : ZFSet}
+  {hf : A.IsFunc B f} {hg : B.IsFunc C g}
+  (finj : f.IsInjective) (ginj : g.IsInjective) :
+    (g ∘ᶻ f).IsInjective := by
+  intro x y z xA yA zC x_f y_f
+  rw [fcomp, composition, mem_sep, pair_mem_prod] at x_f y_f
+  obtain ⟨a, c, eq, b, bB, ab_f, bc_g⟩ := x_f.2
+  have cC : c ∈ C := And.right <| pair_mem_prod.mp <| hg.1 bc_g
+  obtain ⟨a', c', eq', b', bB', a'b_f, b'c_g⟩ := y_f.2
+  have cC' : c' ∈ C := And.right <| pair_mem_prod.mp <| hg.1 b'c_g
+  rw [pair_inj] at eq eq'
+  obtain ⟨rfl, rfl⟩ := eq
+  obtain ⟨rfl, rfl⟩ := eq'
+  obtain ⟨rfl⟩ := ginj _ _ _ bB bB' cC bc_g b'c_g
+  exact finj _ _ _ xA yA bB ab_f a'b_f
+
+theorem IsSurjective.composition_of_surjective {f g : ZFSet} {A B C : ZFSet}
+  {hf : A.IsFunc B f} {hg : B.IsFunc C g}
+  (fsurj : f.IsSurjective) (gsurj : g.IsSurjective) :
+    (g ∘ᶻ f).IsSurjective := by
+  intro z zC
+  simp only [composition, mem_sep, pair_mem_prod, pair_inj, existsAndEq, and_true, exists_eq_left']
+  obtain ⟨y, hy, yz_g⟩ := gsurj z zC
+  obtain ⟨x, xA, xy_f⟩ := fsurj y hy
+  exists x
+  and_intros
+  · exact xA
+  · exact xA
+  · exact zC
+  · exists y
+
+theorem IsBijective.composition_of_bijective {f g : ZFSet} {A B C : ZFSet}
+  {hf : A.IsFunc B f} {hg : B.IsFunc C g}
+  (fbij : f.IsBijective) (gbij : g.IsBijective) :
+    (g ∘ᶻ f).IsBijective :=
+  ⟨IsInjective.composition_of_injective fbij.1 gbij.1,
+    IsSurjective.composition_of_surjective fbij.2 gbij.2⟩
+
+theorem IsPermutation.composition_of_permutations {σ τ : ZFSet} {E : ZFSet}
+  (hσ : σ.IsPermutation E) (hτ : τ.IsPermutation E) :
+    (composition τ σ E E E).IsPermutation E := ⟨
+  IsFunc_of_composition_IsFunc hτ.1 hσ.1,
+  IsInjective.composition_of_injective hσ.2.1 hτ.2.1,
+  IsSurjective.composition_of_surjective hσ.2.2 hτ.2.2⟩
+
+@[simp]
+theorem composition_assoc {A B C D : ZFSet} {f : ZFSet} {g : ZFSet} {h : ZFSet} :
+    (h.composition (g.composition f A B C) A C D) =
+    ((h.composition g B C D).composition f A B D) := by
+  ext1 z
+  constructor <;> intro hz
+  · rw [mem_composition] at hz ⊢
+    obtain ⟨x, w, y, rfl, hx, hy, hw, hxw, hwy⟩ := hz
+    simp only [mem_composition, pair_inj, existsAndEq,
+      and_true, exists_and_left, exists_eq_left'] at hxw
+    obtain ⟨-, -, u, hu, hxu, huw⟩ := hxw
+    use x, u, y
+    refine ⟨rfl, hx, hy, hu, hxu, ?_⟩
+    rw [mem_composition]
+    use u, w, y
+  · rw [mem_composition] at hz ⊢
+    obtain ⟨x, u, y, rfl, hx, hy, hu, hxu, huy⟩ := hz
+    simp only [mem_composition, pair_inj, existsAndEq,
+      and_true, exists_and_left, exists_eq_left'] at huy
+    obtain ⟨-, -, w, hw, huw, hwy⟩ := huy
+    use x, w, y
+    refine ⟨rfl, hx, hy, hw, ?_, hwy⟩
+    rw [mem_composition]
+    use x, u, w
+
+@[simp]
+theorem fcomp_assoc {A B C D : ZFSet} {f : ZFSet} {g : ZFSet} {h : ZFSet}
+  (hf : IsFunc A B f) (hg : IsFunc B C g) (hh : IsFunc C D h) :
+    (h ∘ᶻ (g ∘ᶻ f)) = (h ∘ᶻ g ∘ᶻ f) := composition_assoc
+
+open Classical in
+noncomputable def fapply (f : ZFSet) {A B : ZFSet} (hf : f.IsPFunc A B := by zpfun) :
+  {x // x ∈ f.Dom} → {x // x ∈ B} := fun ⟨x, x_dom⟩ ↦
+  have : ∃ y ∈ B, pair x y ∈ f := by
+    unfold Dom at x_dom
+    rw [mem_sep] at x_dom
+    obtain ⟨xA, y, yB, xyf⟩ := x_dom
+    use y
+  ⟨choose this, choose_spec this |>.left⟩
+
+notation:max "@ᶻ" f:max => fapply f
+
+@[simp]
+theorem is_func_dom_eq {f A B : ZFSet} (hf : IsFunc A B f := by zfun) : f.Dom = A := by
+  ext1 x
+  constructor
+  · intro x_dom
+    rw [mem_sep] at x_dom
+    obtain ⟨xA⟩ := x_dom
+    exact xA
+  · intro mem_x_A
+    rw [mem_sep]
+    and_intros
+    · exact mem_x_A
+    · obtain ⟨y, hy, _⟩ := hf.2 x mem_x_A
+      use y
+      and_intros
+      · exact hf.1 hy |> pair_mem_prod.mp |>.2
+      · exact hy
+
+open Classical in
+theorem fapply_Id {A x : ZFSet} (hx : x ∈ A) :
+    @ᶻ𝟙A ⟨x, by rwa [is_func_dom_eq Id.IsFunc]⟩ = ⟨x, hx⟩ := by
+  rw [fapply]
+  generalize_proofs choose _
+  obtain ⟨_, mem_id⟩ := choose_spec choose
+  rw [pair_mem_Id_iff hx] at mem_id
+  congr
+  rw [←mem_id]
+
+theorem fapply_mem_range {f A B : ZFSet} (hf : f.IsPFunc A B) {x : ZFSet} (hx : x ∈ f.Dom) :
+    (@ᶻf ⟨x, hx⟩).val ∈ B := by
+  apply Subtype.property
+
+theorem fapply.def {f A B : ZFSet} (hf : f.IsPFunc A B) {x : ZFSet} (hx : x ∈ f.Dom) :
+  x.pair (@ᶻf ⟨x, hx⟩) ∈ f := by
+  dsimp [fapply]
+  generalize_proofs y_def
+  exact Classical.choose_spec y_def |>.2
+
+theorem IsInjective.apply_inj {f A B : ZFSet} (hf : IsFunc A B f) (inj : f.IsInjective) :
+    Function.Injective @ᶻf := by classical
+  rintro ⟨x, x_dom⟩ ⟨y, y_dom⟩ h
+  have x_A : x ∈ A := by rwa [is_func_dom_eq hf] at x_dom
+  have y_A : y ∈ A := by rwa [is_func_dom_eq hf] at y_dom
+  obtain ⟨pair_x_ε, unq_fx⟩ := Classical.choose_spec <| hf.right x x_A
+  obtain ⟨pair_y_ε, unq_fy⟩ := Classical.choose_spec <| hf.right y y_A
+  congr
+  unfold fapply at h
+  injection h with h
+  generalize_proofs hpf hpf' at h
+  have choose_eq {z} (z_dom : z ∈ f.Dom) :
+      Classical.choose (hf.right z (is_func_dom_eq hf ▸ z_dom)) =
+      Classical.choose (fapply._proof_1 f (is_func_is_pfunc hf) z z_dom) := by
+    congr
+    funext w
+    rw [propext_iff]
+    constructor
+    · rintro ⟨pair_z_w, unq_w⟩
+      obtain ⟨_,_,_,l,eq⟩ := mem_prod.mp <| hf.left pair_z_w
+      rcases pair_inj.mp eq with ⟨rfl, rfl⟩
+      exact ⟨l, pair_z_w⟩
+    · rintro ⟨_, pair_z_w⟩
+      obtain ⟨a,pair_z_a,unq_a⟩ := hf.right z (is_func_dom_eq hf ▸ z_dom)
+      exact ⟨pair_z_w, by intro w' pair_x_w'; rw [unq_a w' pair_x_w', unq_a w pair_z_w]⟩
+  apply inj x y (Classical.choose <| hf.right x x_A) x_A y_A
+  · exact choose_eq x_dom ▸ fapply_mem_range (is_func_is_pfunc hf) x_dom
+  · exact pair_x_ε
+  · rw [choose_eq x_dom, h, ← choose_eq y_dom]
+    exact pair_y_ε
+
+theorem IsPFunc.exists_unique_of_mem_dom {f A B : ZFSet}
+  (hf : f.IsPFunc A B) {x : ZFSet} (hx : x ∈ f.Dom) :
+    ∃! y, pair x y ∈ f := by
+  unfold Dom at hx
+  rw [mem_sep] at hx
+  obtain ⟨xA, y, yB, xy_f⟩ := hx
+  use y
+  and_intros
+  · exact xy_f
+  · intro y' xy'_f
+    symm
+    exact hf.2 _ _ xy_f _ xy'_f
+
+theorem fapply.of_pair {f A B : ZFSet} (hf : f.IsPFunc A B) {x y : ZFSet} (hxy : x.pair y ∈ f) :
+  @ᶻf ⟨x, mem_dom hf hxy⟩ = ⟨y, And.right <| pair_mem_prod.mp <| hf.1 hxy⟩ := by
+  dsimp [fapply]
+  generalize_proofs y_def choose_B yB
+  congr
+  have spec := Classical.choose_spec y_def |>.2
+  obtain ⟨w, xw, uniq⟩ := IsPFunc.exists_unique_of_mem_dom hf (mem_dom hf hxy)
+  exact uniq _ hxy ▸ uniq _ spec
+
+theorem IsPFunc.supset_of_range {f A B : ZFSet} (hf : f.IsPFunc A B) : f.Range ⊆ B := by
+  intro y y_B
+  rw [mem_sep] at y_B
+  exact y_B.1
+
+theorem IsPFunc.mem_range_of_mem {f A B : ZFSet}
+  (hf : f.IsPFunc A B) {x y : ZFSet} (hxy : x.pair y ∈ f) :
+    y ∈ f.Range := by
+  rw [mem_sep]
+  and_intros
+  · obtain ⟨_,_,_,_,eq⟩ := mem_prod.mp <| hf.1 hxy
+    rw [pair_inj] at eq
+    rcases eq with ⟨rfl, rfl⟩
+    assumption
+  · exists x
+    and_intros
+    · exact mem_dom hf hxy
+    · exact hxy
+
+theorem IsPFunc.nonempty_range_of_nonempty_dom {f A B x y : ZFSet}
+  (hf : f.IsPFunc A B) (hxy : x.pair y ∈ f) :
+    f.Range ≠ ∅ := by
+  have x_dom := mem_dom hf hxy
+  have y_dom := mem_range_of_mem hf hxy
+  rw [nonempty_exists_iff]
+  exists y
+
+theorem IsInjective.apply_inj_pfun {f A B : ZFSet}
+  (hf : IsPFunc f A B) (inj : f.IsInjective (is_func_of_pfunc f hf)) :
+    Function.Injective @ᶻf := by
+  rintro ⟨x, x_dom⟩ ⟨y, y_dom⟩ h
+  congr
+  unfold IsInjective at inj
+  apply inj x y (@ᶻf ⟨x, x_dom⟩) x_dom y_dom
+  · dsimp [fapply]
+    have : ∃ z ∈ B, pair x z ∈ f := by
+      unfold Dom at x_dom
+      rw [mem_sep] at x_dom
+      obtain ⟨xA, y, yB, xy_f⟩ := x_dom
+      use y
+    generalize_proofs
+    obtain ⟨memB, -⟩ := Classical.choose_spec this
+    exact memB
+  · exact fapply.def hf x_dom
+  · rw [h]
+    exact fapply.def hf y_dom
+
+theorem IsInjective.apply_surj {f A B : ZFSet} (hf : IsFunc A B f) (surj : f.IsSurjective) :
+    Function.Surjective @ᶻf := by
+  rintro ⟨y, yB⟩
+  obtain ⟨x, -, pair⟩ := surj y yB
+  have x_dom : x ∈ f.Dom := mem_dom (is_func_is_pfunc hf) pair
+  exists ⟨x, x_dom⟩
+  exact fapply.of_pair (is_func_is_pfunc hf) pair
+
+theorem IsInjective.apply_surj_pfun {f A B : ZFSet}
+  (hf : IsPFunc f A B) (surj : f.IsSurjective (is_func_of_pfunc f hf)) :
+    Function.Surjective @ᶻf := by
+  rintro ⟨y, yB⟩
+  obtain ⟨x, -, pair⟩ := surj y yB
+  have x_dom' : x ∈ f.Dom := mem_dom hf pair
+  exists ⟨x, x_dom'⟩
+  exact fapply.of_pair hf pair
+
+theorem prod_sep_is_pfunc_mem {A B C D : ZFSet} (subAC : A ⊆ C) (subBD : B ⊆ D) :
+    (A.prod B).powerset.sep (IsPFunc · A B) ∈ (C.prod D).powerset.powerset := by
+  rw [mem_powerset]
+  intro S hS
+  rw [mem_sep] at hS
+  rw [mem_powerset] at hS ⊢
+  intro x hx
+  obtain ⟨_,l,_,r,rfl⟩ := mem_prod.mp <| hS.left hx
+  rw [pair_mem_prod]
+  exact ⟨subAC l, subBD r⟩
+
+def lambda (dom : ZFSet) (ran : ZFSet) (exp : ZFSet → ZFSet) : ZFSet :=
+  (dom.prod ran).sep fun xy ↦ xy.π₂ = exp xy.π₁
+
+-- NOTE: deprecated syntax, use `λᶻ : dom → ran | x ↦ exp x` instead
+-- notation:60 "λᶻ" " : " dom:max " → " ran:max " := " exp:max => lambda dom ran exp
+
+open Lean Parser Term in
+section
+declare_syntax_cat funz_binder
+syntax (name := identZBinder) Term.ident : funz_binder
+syntax (name := tupleZBinder) "(" funz_binder ", " funz_binder ")" : funz_binder
+
+def funZBinder : Parser := categoryParser `funz_binder 0
+
+def funZType : Parser :=
+  ":" >> ppSpace >> termParser leadPrec >> ppSpace >>
+    unicodeSymbol "→" "->" >> ppSpace >> termParser leadPrec
+
+def funZAlts : Parser :=
+  "|" >> ppSpace >> funZBinder >> ppSpace >> unicodeSymbol "↦" "=>" >> ppSpace >> termParser
+
+def basicFunZ : Parser := leading_parser (withAnonymousAntiquot := false)
+  ppGroup (ppSpace >> funZType) >> funZAlts
+
+@[term_parser] def funZ := leading_parser:maxPrec
+  ppAllowUngrouped >> unicodeSymbol "λᶻ" "funᶻ" >> basicFunZ
+
+partial def interpZBinder (x_def : TSyntax `term) (e : TSyntax `term) :
+  TSyntax `funz_binder → MacroM (TSyntax `term)
+  | `(funz_binder| $x:ident) => `(term| letI $x := $x_def; $e)
+  | `(funz_binder| ($x, $y)) => do
+    let e₂ ← interpZBinder (← `(term| ZFSet.π₂ w)) e y
+    let e₁ ← interpZBinder (← `(term| ZFSet.π₁ w)) e₂ x
+    `(term| letI w := $x_def; $e₁)
+  | _ => Macro.throwUnsupported
+
+/--
+Interpret the syntax `λᶻ : dom → ran | x ↦ exp x` as `lambda dom ran (fun x ↦ exp x)`.
+
+*Thanks to Ghilain for this notation.*
+-/
+macro_rules
+| `(term| λᶻ : $dom → $ran | $x ↦ $e) => do
+  `(term| ZFSet.lambda $dom $ran fun a ↦ $(← interpZBinder (←`(term| a)) e x))
+end
+
+theorem lambda_spec {dom ran : ZFSet} {exp : ZFSet → ZFSet} {x : ZFSet} {y : ZFSet} :
+  x.pair y ∈ (λᶻ : dom → ran | z ↦ exp z) ↔ x ∈ dom ∧ y ∈ ran ∧ y = exp x := by
+  rw [lambda, mem_sep, pair_mem_prod, π₁_pair, π₂_pair, and_assoc]
+
+theorem mem_lambda {dom ran : ZFSet} {exp : ZFSet → ZFSet} {z : ZFSet} :
+    (z ∈ λᶻ : dom → ran | x ↦ exp x) ↔
+    ∃ x y : ZFSet, z = x.pair y ∧ x ∈ dom ∧ y ∈ ran ∧ y = exp x where
+  mp := by
+    intro hz
+    rw [lambda, mem_sep] at hz
+    obtain ⟨hz, eq⟩ := hz
+    rw [mem_prod] at hz
+    obtain ⟨x, x_dom, y, y_ran, rfl⟩ := hz
+    rw [π₁_pair, π₂_pair] at eq
+    subst y
+    exists x, exp x
+  mpr := by
+    rintro ⟨x, y, ⟨rfl, x_dom, y_ran, rfl⟩⟩
+    rw [lambda, mem_sep, mem_prod]
+    and_intros
+    · exact ⟨x, x_dom, exp x, y_ran, rfl⟩
+    · rw [π₁_pair, π₂_pair]
+
+theorem lambda_ext_iff {d r : ZFSet} {f₁ f₂ : ZFSet → ZFSet} (hf₁ : ∀ {x}, x ∈ d → f₁ x ∈ r) :
+    (λᶻ : d → r | x ↦ f₁ x) = (λᶻ : d → r | x ↦ f₂ x) ↔ ∀ z ∈ d, f₁ z = f₂ z where
+  mp := by
+    intro h z hz
+    rw [ZFSet.ext_iff] at h
+    specialize h (z.pair (f₁ z))
+    rw [lambda_spec, lambda_spec, eq_self, and_true] at h
+    exact h.mp ⟨hz, hf₁ hz⟩ |>.2.2
+  mpr := by
+    intro hext
+    ext1 z
+    constructor
+    · intro hz
+      rw [mem_lambda] at hz
+      obtain ⟨x, y, ⟨rfl, x_d, y_r, rfl⟩⟩ := hz
+      rw [lambda_spec]
+      exact ⟨x_d, y_r, hext x x_d⟩
+    · intro hz
+      rw [mem_lambda] at hz
+      obtain ⟨x, y, ⟨rfl, x_d, y_r, rfl⟩⟩ := hz
+      rw [lambda_spec]
+      exact ⟨x_d, y_r, hext x x_d |>.symm⟩
+
+theorem lambda_ext_iff' {d₁ d₂ r₁ r₂ : ZFSet} {f₁ f₂ : ZFSet → ZFSet}
+  (hf₁ : ∀ {x}, x ∈ d₁ → f₁ x ∈ r₁) (hf₂ : ∀ {x}, x ∈ d₂ → f₂ x ∈ r₂) :
+    (λᶻ : d₁ → r₁ | x ↦ f₁ x) = (λᶻ : d₂ → r₂ | x ↦ f₂ x) ↔ d₁ = d₂ ∧ ∀ z ∈ d₁, f₁ z = f₂ z where
+  mp h := by
+    rw [ZFSet.ext_iff] at h
+    and_intros
+    · ext1 z
+      constructor
+      · intro z_d₁
+        specialize h <| z.pair (f₁ z)
+        rw [lambda_spec, lambda_spec, eq_self, and_true] at h
+        exact h.mp ⟨z_d₁, hf₁ z_d₁⟩ |>.1
+      · intro z_d₂
+        specialize h <| z.pair (f₂ z)
+        rw [lambda_spec, lambda_spec, eq_self, and_true] at h
+        exact h.mpr ⟨z_d₂, hf₂ z_d₂⟩ |>.1
+    · intro z z_d₁
+      specialize h <| z.pair (f₁ z)
+      rw [lambda_spec, lambda_spec, eq_self, and_true] at h
+      exact h.mp ⟨z_d₁, hf₁ z_d₁⟩ |>.2.2
+  mpr := by
+    rintro ⟨rfl, hext⟩
+    ext1 z
+    unfold lambda
+    simp only [mem_sep, mem_prod]
+    constructor
+    · rintro ⟨⟨a, ha, b, hb, rfl⟩, eq⟩
+      rw [π₁_pair, π₂_pair] at eq
+      subst b
+      and_intros
+      · use a, ha, f₁ a
+        and_intros
+        · rw [hext a ha]
+          exact hf₂ ha
+        · rfl
+      · rw [π₁_pair, π₂_pair, hext a ha]
+    · rintro ⟨⟨a, ha, b, hb, rfl⟩, eq⟩
+      rw [π₁_pair, π₂_pair] at eq
+      subst b
+      and_intros
+      · use a, ha, f₂ a
+        and_intros
+        · rw [←hext a ha]
+          exact hf₁ ha
+        · rfl
+      · rw [π₁_pair, π₂_pair, ←hext a ha]
+
+open Classical in
+theorem lambda_eta {A B : ZFSet} {f : ZFSet} (hf : A.IsFunc B f) :
+  f = (λᶻ : A → B
+          | x ↦ if hx : x ∈ A then @ᶻf ⟨x, by rwa [is_func_dom_eq hf]⟩ else ∅)
+    := by
+  ext1 z
+  constructor <;> intro hz
+  · obtain ⟨x, hx, y, hy, rfl⟩ := hf.1 hz |> mem_prod.mp
+    rw [lambda_spec, dite_cond_eq_true (eq_true hx)]
+    refine ⟨hx, hy, ?_⟩
+    rw [fapply.of_pair (is_func_is_pfunc hf) hz]
+  · rw [mem_lambda] at hz
+    obtain ⟨x, y, rfl, xA, -, rfl⟩ := hz
+    rw [dite_cond_eq_true (eq_true xA)]
+    apply fapply.def
+
+theorem is_func_ext_iff {A B : ZFSet} {f g : ZFSet} (hf : IsFunc A B f) (hg : IsFunc A B g) :
+    f = g ↔ (∀ x,
+      (hx : x ∈ A) →
+      @ᶻf ⟨x, by rwa [is_func_dom_eq]⟩ = @ᶻg ⟨x, by rwa [is_func_dom_eq]⟩)
+where
+  mp := by
+    rintro rfl
+    exact fun _ _ ↦ rfl
+  mpr := by
+    intro h
+    rw [
+      lambda_eta hf,
+      lambda_eta hg,
+      lambda_ext_iff
+        (fun h ↦ by rw [dite_cond_eq_true (eq_true h)]; apply Subtype.property)]
+    intro z hz
+    simp_rw [dite_cond_eq_true (eq_true hz), ←Subtype.ext_iff]
+    exact h _ hz
+
+theorem lambda_subset {A B : ZFSet} {exp : ZFSet → ZFSet} : lambda A B exp ⊆ A.prod B := by
+  intro z hz
+  rw [lambda, mem_sep] at hz
+  exact hz.1
+
+theorem lambda_isFunc {A B : ZFSet} {f : ZFSet → ZFSet} (hf : ∀ {x}, x ∈ A → f x ∈ B) :
+    A.IsFunc B (lambda A B f) := by
+  and_intros
+  · exact lambda_subset
+  · intro x x_A
+    exists f x
+    and_intros
+    · beta_reduce
+      rw [lambda_spec]
+      exact ⟨x_A, hf x_A, rfl⟩
+    · beta_reduce
+      intro y hy
+      rw [lambda_spec] at hy
+      exact hy.2.2
+
+theorem mem_funs_of_lambda {A B : ZFSet} {f : ZFSet → ZFSet} (hf : ∀ {x}, x ∈ A → f x ∈ B) :
+  lambda A B f ∈ A.funs B := mem_funs.mpr <| lambda_isFunc hf
+
+theorem fapply_lambda {A B : ZFSet} {f : ZFSet → ZFSet}
+  (hf : ∀ {x}, x ∈ A → f x ∈ B) {a : ZFSet} (ha : a ∈ A) :
+    fapply (λᶻ : A → B | x ↦ f x) (is_func_is_pfunc <| lambda_isFunc hf)
+      ⟨a, by rwa [is_func_dom_eq (lambda_isFunc hf)]⟩ = f a := by
+  rw [fapply]
+  generalize_proofs choose_y y_mem_B
+  have y_def := Classical.choose_spec choose_y |>.2
+  rw [lambda_spec] at y_def
+  exact y_def.2.2
+
+/--
+The inverse of an injection is a function.
+-/
+@[zfun]
+theorem inv_is_func_of_injective {f A B : ZFSet} {f_is_func : A.IsFunc B f}
+  (hf : f.IsInjective f_is_func) :
+    (f.Range).IsFunc A f⁻¹ := by
+  and_intros
+  · intro y hy
+    rw [inv, mem_sep] at hy
+    obtain ⟨y_mem, pair_f⟩ := hy
+    rw [mem_prod] at y_mem
+    obtain ⟨b, hb, a, ha, rfl⟩ := y_mem
+    rw [π₁_pair, π₂_pair] at pair_f
+    dsimp at pair_f
+    rw [pair_mem_prod]
+    and_intros
+    · rw [mem_sep]
+      and_intros
+      · exact hb
+      · use a
+        and_intros
+        · rwa [is_func_dom_eq f_is_func]
+        · exact pair_f
+    · exact ha
+  · intro y hy
+    rw [mem_sep] at hy
+    obtain ⟨hy, x, hx, pair_f⟩ := hy
+    use x
+    have x_A : x ∈ A := by
+      rw [mem_sep] at hx
+      obtain ⟨xA, _, _, _⟩ := hx
+      exact xA
+    and_intros <;> beta_reduce
+    · unfold inv
+      rw [mem_sep, pair_mem_prod, π₁_pair, π₂_pair]
+      exact ⟨⟨hy, x_A⟩, pair_f⟩
+    · intro z hz
+      rw [inv, mem_sep, π₁_pair, π₂_pair, pair_mem_prod] at hz
+      symm
+      exact hf x z y x_A hz.1.2 hy pair_f hz.2
+
+-- macro_rules | `(tactic| zfun) => `(tactic| apply inv_is_func_of_injective; zfun)
+
+/--
+The inverse of a bijection is a function.
+-/
+@[zfun]
+theorem inv_is_func_of_bijective {f A B : ZFSet} {f_is_func : A.IsFunc B f}
+  (hf : f.IsBijective f_is_func) :
+    B.IsFunc A (f.inv ) := by
+  and_intros
+  · intro xy hxy
+    dsimp [inv] at hxy
+    rw [mem_sep] at hxy
+    obtain ⟨xy_prod, pair_f⟩ := hxy
+    rw [mem_prod] at xy_prod
+    obtain ⟨a, ha, b, hb, rfl⟩ := xy_prod
+    rw [pair_mem_prod]
+    exact ⟨ha, hb⟩
+  · intro z hz
+    rw [bijective_exists1_iff] at hf
+    obtain ⟨x, ⟨x_A, hx⟩, x_unq⟩ := hf z hz
+    simp_rw [mem_inv]
+    use x
+    and_intros <;> beta_reduce
+    · exact hx
+    · intro y hy
+      apply x_unq y
+      refine And.intro ?_ hy
+      exact f_is_func.1 hy |> pair_mem_prod.mp |>.1
+
+-- macro_rules | `(tactic| zfun) => `(tactic| apply inv_is_func_of_bijective; zfun)
+
+/--
+The inverse of a bijection is a bijection.
+-/
+theorem inv_bijective_of_bijective {f A B : ZFSet} {f_is_func : A.IsFunc B f}
+  (hf : f.IsBijective f_is_func) :
+    f⁻¹.IsBijective := by
+  and_intros
+  · intro x y z xB yB zA fxz fyz
+    rw [mem_inv] at fxz fyz
+    obtain ⟨_, _, unq⟩ := f_is_func.2 z zA
+    rw [unq x fxz, unq y fyz]
+  · intro x xA
+    obtain ⟨y, yA, _⟩ := f_is_func.2 x xA
+    use y
+    and_intros
+    · exact f_is_func.1 yA |> pair_mem_prod.mp |>.2
+    · rw [mem_inv]
+      exact yA
+
+theorem composition_self_inv_of_bijective {f A B : ZFSet} {f_is_func : A.IsFunc B f}
+  (hf : f.IsBijective) :
+    f⁻¹ ∘ᶻ f = 𝟙A := by
+  ext1 z
+  constructor
+  · intro hz
+    rw [mem_composition] at hz
+    obtain ⟨a, b, c, rfl, aA, cA, bB, ab_f, bc_finv⟩ := hz
+    rw [mem_inv] at bc_finv
+    rw [pair_mem_Id_iff aA]
+    exact hf.1 _ _ _ aA cA bB ab_f bc_finv
+  · intro hz
+    rw [mem_Id_iff] at hz
+    obtain ⟨a, aA, rfl⟩ := hz
+    obtain ⟨b, ab_f, -⟩ := f_is_func.2 a aA
+    simp only [mem_composition, pair_inj, existsAndEq, and_true, exists_and_left, exists_eq_left',
+      and_self_left]
+    apply And.intro aA
+    use b, f_is_func.1 ab_f |> pair_mem_prod.mp |>.2
+    rw [mem_inv, and_self]
+    exact ab_f
+
+theorem composition_inv_self_of_bijective {f A B : ZFSet} {f_is_func : A.IsFunc B f}
+  (hf : f.IsBijective) :
+    (f ∘ᶻ f⁻¹) = 𝟙B := by
+  set g := f⁻¹
+  have : B.IsFunc A g := inv_is_func_of_bijective hf
+  have ginv_eq : g⁻¹ = f := inv_involutive _
+  conv =>
+    enter [1,1]
+    rw [←ginv_eq]
+  exact composition_self_inv_of_bijective <| inv_bijective_of_bijective hf
+
+theorem inv_fcomp_iff {A B C : ZFSet} {f g : ZFSet} {hf : IsFunc A B f}
+  (fbij : f.IsBijective hf) {hg : IsFunc B C g} (gbij : g.IsBijective hg) :
+    (g ∘ᶻ f)⁻¹ = (f⁻¹ ∘ᶻ g⁻¹) := by
+  ext1 z
+  constructor <;> intro hz
+  · generalize_proofs g_f_rel at hz
+    obtain ⟨c, hc, a, ha, rfl⟩ := subset_prod_inv g_f_rel hz |> mem_prod.mp
+    rw [mem_inv, pair_mem_composition] at hz
+    obtain ⟨b, hb, fab, gbc⟩ := hz
+    rw [←mem_inv (is_rel_of_is_func ‹_›)] at fab gbc
+    rw [pair_mem_composition]
+    use b, hb, gbc, fab
+  · rw [mem_composition] at hz
+    obtain ⟨x, w, y, rfl, hx, hy, hw, gwx, fyw⟩ := hz
+    rw [mem_inv (is_rel_of_is_func ‹_›)] at gwx fyw
+    rw [mem_inv, pair_mem_composition]
+    use w, hw, fyw, gwx
+
+theorem fcomp_bij_fcomp_inv_right {A B C : ZFSet} {f g h : ZFSet} {hf : IsFunc A B f}
+  (hbij : f.IsBijective hf) (hg : IsFunc B C g) (hh : IsFunc A C h) :
+    (g ∘ᶻ f) = h ↔ g = (h ∘ᶻ f⁻¹) where
+  mp := by
+    intro eq
+    ext1 z
+    constructor <;> intro hz
+    · obtain ⟨x, hx, y, hy, rfl⟩ := hg.1 hz |> mem_prod.mp
+      obtain ⟨w, hw, fwx⟩ := hbij.2 x hx
+      rw [pair_mem_composition]
+      use w, hw
+      rw [mem_inv]
+      and_intros
+      · exact fwx
+      · rw [←eq, pair_mem_composition]
+        use x, hx, fwx, hz
+    · rw [mem_composition] at hz
+      obtain ⟨x, w, y, rfl, hx, hy, hw, fwx, hwy⟩ := hz
+      rw [←eq, pair_mem_composition] at hwy
+      obtain ⟨x', hx', fwx', gx'y⟩ := hwy
+      rw [mem_inv] at fwx
+      obtain rfl := hf.2 w hw |>.unique fwx fwx'
+      exact gx'y
+  mpr := by
+    intro eq
+    ext1 z
+    constructor <;> intro hz
+    · rw [mem_composition] at hz
+      obtain ⟨x, w, y, rfl, hx, hy, hw, fwx, gwy⟩ := hz
+      rw [eq, pair_mem_composition] at gwy
+      obtain ⟨w', hw', fww', hwy⟩ := gwy
+      rw [mem_inv] at fww'
+      obtain rfl := hbij.1 _ _ _ hx hw' hw fwx fww'
+      exact hwy
+    · obtain ⟨x, hx, y, hy, rfl⟩ := hh.1 hz |> mem_prod.mp
+      obtain ⟨w, hw, fxw⟩ := ZFSet.inv_bijective_of_bijective hbij |>.2 x hx
+      rw [mem_inv] at fxw
+      rw [pair_mem_composition]
+      use w, hw, fxw
+      rw [eq, pair_mem_composition]
+      use x, hx, (by rwa [mem_inv]), hz
+
+theorem fcomp_bij_fcomp_inv_left {A B C : ZFSet} {f g h : ZFSet} {hf : IsFunc B C f}
+  (hbij : f.IsBijective hf) (hg : IsFunc A B g) (hh : IsFunc A C h) :
+    (f ∘ᶻ g) = h ↔ g = (f⁻¹ ∘ᶻ h) where
+  mp := by
+    intro eq
+    ext1 z
+    constructor <;> intro hz
+    · obtain ⟨x, hx, y, hy, rfl⟩ := hg.1 hz |> mem_prod.mp
+      obtain ⟨w, fyw, w_unq⟩ := hf.2 y hy
+      have hw := hf.1 fyw |> pair_mem_prod.mp |>.2
+      rw [pair_mem_composition]
+      use w, hw
+      rw [mem_inv]
+      and_intros
+      · rw [←eq, pair_mem_composition]
+        use y, hy, hz, fyw
+      · exact fyw
+    · rw [mem_composition] at hz
+      obtain ⟨x, w, y, rfl, hx, hy, hw, gwx, fyw⟩ := hz
+      rw [mem_inv] at fyw
+      rw [←eq, pair_mem_composition] at gwx
+      obtain ⟨y', hy', gxy', fy'w⟩ := gwx
+      obtain rfl := hbij.1 _ _ _ hy hy' hw fyw fy'w
+      exact gxy'
+  mpr := by
+    intro eq
+    ext1 z
+    constructor <;> intro hz
+    · rw [mem_composition] at hz
+      obtain ⟨x, w, y, rfl, hx, hy, hw, gwx, fyw⟩ := hz
+      rw [eq, pair_mem_composition] at gwx
+      obtain ⟨y', hy', gy'y, fwy'⟩ := gwx
+      rw [mem_inv] at fwy'
+      obtain rfl := hf.2 w hw |>.unique fyw fwy'
+      exact gy'y
+    · obtain ⟨x, hx, y, hy, rfl⟩ := hh.1 hz |> mem_prod.mp
+      rw [pair_mem_composition]
+      obtain ⟨w, hw, fyw⟩ := hbij.2 y hy
+      use w, hw
+      and_intros
+      · rw [eq, pair_mem_composition]
+        use y, hy, hz
+        rwa [mem_inv]
+      · exact fyw
+
+@[simp] theorem fcomp_bij_right_cancel_iff {A B C : ZFSet} {f : ZFSet}
+  {hf : IsFunc A B f} (hbij : f.IsBijective hf) {g₁ g₂ : ZFSet}
+  (hg₁ : IsFunc B C g₁) (hg₂ : IsFunc B C g₂) :
+    g₁ ∘ᶻ f = g₂ ∘ᶻ f ↔ g₁ = g₂ := by
+  conv_lhs =>
+    rw [fcomp_bij_fcomp_inv_right hbij hg₁ (IsFunc_of_composition_IsFunc hg₂ hf)]
+    change g₁ = (g₂ ∘ᶻ f ∘ᶻ f⁻¹)
+    rw [←fcomp_assoc]
+    conv =>
+      enter [2]
+      conv =>
+        enter [2]
+        rw [composition_inv_self_of_bijective hbij]
+      rw [fcomp, Id.composition_right hg₂.1]
+
+@[simp] theorem fcomp_bij_left_cancel_iff {A B C : ZFSet} {f : ZFSet} {hf : IsFunc B C f}
+  (hbij : f.IsBijective hf) {g₁ g₂ : ZFSet} (hg₁ : IsFunc A B g₁) (hg₂ : IsFunc A B g₂) :
+    f ∘ᶻ g₁ = f ∘ᶻ g₂ ↔ g₁ = g₂ := by
+  conv_lhs =>
+    rw [fcomp_bij_fcomp_inv_left hbij hg₁ (IsFunc_of_composition_IsFunc hf hg₂)]
+    change g₁ = (f⁻¹ ∘ᶻ (f ∘ᶻ g₂))
+    rw [fcomp_assoc]
+    conv =>
+      enter [2]
+      conv =>
+        enter [1]
+        rw [composition_self_inv_of_bijective hbij]
+      rw [fcomp, Id.composition_left hg₂.1]
+
+/--
+The image of a set under a relation.
+-/
+def Image (R : ZFSet) {A B : ZFSet} (X : ZFSet) (hR : R ⊆ A.prod B := by zrel) : ZFSet :=
+  B.sep (fun y ↦ ∃ x ∈ X, x.pair y ∈ R)
+
+notation:60 R:max"[" X "]" => Image R X
+
+theorem mem_Image {R A B X y : ZFSet} (hR : R ⊆ A.prod B) :
+    y ∈ R[X] ↔ y ∈ B ∧ ∃ x ∈ X, x.pair y ∈ R where
+  mp := by
+    intro hy
+    rw [Image, mem_sep] at hy
+    exact ⟨hy.1, hy.2⟩
+  mpr := by
+    rintro ⟨yB, x, xX, xyR⟩
+    rw [Image, mem_sep]
+    exact ⟨yB, ⟨x, xX, xyR⟩⟩
+
+@[simp]
+theorem Image_empty {R A B : ZFSet} (hR : R ⊆ A.prod B) : R[∅] = ∅ := by
+  ext1 y
+  simp only [mem_Image, notMem_empty, false_and, exists_const, and_false]
+
+theorem Image_of_singleton_pair_mem_iff {A B : ZFSet} {f : ZFSet}
+  (hf : A.IsFunc B f) {a b : ZFSet} :
+    a.pair b ∈ f ↔ f[{a}] = {b} := by
+  constructor <;> intro h
+  · ext1 z
+    simp only [mem_Image, mem_singleton, exists_eq_left]
+    constructor
+    · rintro ⟨zB, hz⟩
+      apply hf.2 a (hf.1 h |> pair_mem_prod.mp |>.1) |>.unique
+      · exact hz
+      · exact h
+    · rintro rfl
+      exact ⟨hf.1 h |> pair_mem_prod.mp |>.2, h⟩
+  · rw [ZFSet.ext_iff] at h
+    specialize h b
+    rw [ZFSet.mem_singleton, eq_self, iff_true, mem_Image] at h
+    simp only [mem_singleton, exists_eq_left] at h
+    exact h.2
+
+theorem eq_singleton_of_bijective_inv_Image_of_singleton {A B : ZFSet} {f : ZFSet}
+  {hf : A.IsFunc B f} (hbij : f.IsBijective) {b : ZFSet} (hb : b ∈ B) :
+    ∃ a ∈ A, f⁻¹[{b}] = {a} := by
+  obtain ⟨a, aA, fab⟩ := hbij.2 b hb
+  use a, aA
+  rwa [←Image_of_singleton_pair_mem_iff (inv_is_func_of_bijective hbij), mem_inv]
+
+theorem Image_singleton_eq_fapply {A B : ZFSet} {f : ZFSet}
+  (hf : A.IsFunc B f) {a : ZFSet} (ha : a ∈ A) :
+    f[{a}] = { (@ᶻf ⟨a, by rwa [is_func_dom_eq hf]⟩).val } := by
+  rw [←Image_of_singleton_pair_mem_iff hf]
+  apply fapply.def
+
+theorem fapply_eq_Image_singleton {A B : ZFSet} {f : ZFSet}
+  (hf : A.IsFunc B f) {a : ZFSet} (ha : a ∈ A) :
+    @ᶻf ⟨a, by rwa [is_func_dom_eq hf]⟩ = ⋂₀ (f[{a}]) := by
+  rw [Image_singleton_eq_fapply hf ha, sInter_singleton]
+
+theorem fapply_composition {g f : ZFSet} {A B C : ZFSet}
+  (hg : B.IsFunc C g) (hf : A.IsFunc B f) {x : ZFSet} (xA : x ∈ A) :
+  @ᶻ(g ∘ᶻ f) ⟨x, by rwa [is_func_dom_eq]⟩ =
+    @ᶻg ⟨@ᶻf ⟨x, by rwa [is_func_dom_eq]⟩,
+      by rw [is_func_dom_eq]; apply fapply_mem_range⟩ := by
+  unfold fcomp
+  rw [Subtype.ext_iff]
+  rw [fapply_eq_Image_singleton (IsFunc_of_composition_IsFunc hg hf) xA,
+    fapply_eq_Image_singleton hg (fapply_mem_range _ _)]
+  congr 1
+  ext1 c
+  constructor
+  · intro hc
+    simp only [mem_Image, mem_singleton, mem_composition, pair_inj, existsAndEq, and_true,
+      exists_and_left, exists_eq_left', exists_eq_left] at hc
+    obtain ⟨cC, -, -, b, bB, xb_f, bc_g⟩ := hc
+    rw [fapply.of_pair (is_func_is_pfunc hf) xb_f, Image_singleton_eq_fapply hg bB, mem_singleton,
+      fapply.of_pair (is_func_is_pfunc hg) bc_g]
+  · intro hc
+    rw [mem_Image] at hc
+    obtain ⟨cC, b, hb, bc_g⟩ := hc
+    rw [mem_singleton] at hb
+    simp only [mem_Image, mem_singleton, mem_composition, pair_inj, existsAndEq, and_true,
+      exists_and_left, exists_eq_left', exists_eq_left]
+    and_intros
+    · exact cC
+    · exact xA
+    · exact cC
+    · use b
+      subst hb
+      and_intros
+      · apply fapply_mem_range
+      · apply fapply.def
+      · exact bc_g
+
+@[simp]
+theorem Image_of_composition_inv_self_of_bijective {f A B : ZFSet} {f_is_func : A.IsFunc B f}
+  (hf : f.IsBijective) {X : ZFSet} (hX : X ⊆ A) :
+    f⁻¹[f[X]] = X := by
+  ext1 x
+  constructor
+  · intro hx
+    rw [mem_Image] at hx
+    obtain ⟨xA, y, yfX, xy_finv⟩ := hx
+    rw [mem_inv] at xy_finv
+    rw [mem_Image] at yfX
+    obtain ⟨yB, z, zX, zy_f⟩ := yfX
+    obtain rfl := hf.1 x z y xA (f_is_func.1 zy_f |> pair_mem_prod.mp |>.1) yB xy_finv zy_f
+    exact zX
+  · intro hx
+    rw [mem_Image]
+    and_intros
+    · exact hX hx
+    · use @ᶻf ⟨x, by rw [is_func_dom_eq f_is_func]; exact hX hx⟩
+      and_intros
+      · rw [mem_Image]
+        and_intros
+        · apply fapply_mem_range
+        · use x, hx
+          apply fapply.def
+      · rw [mem_inv]
+        apply fapply.def
+
+@[simp]
+theorem Image_of_composition_self_inv_of_bijective {f A B : ZFSet} {f_is_func : A.IsFunc B f}
+  (hf : f.IsBijective f_is_func) {X : ZFSet} (hX : X ⊆ B) :
+    f[f⁻¹[X]] = X := by
+  have := Image_of_composition_inv_self_of_bijective (f := f⁻¹) (inv_bijective_of_bijective hf) hX
+  conv at this =>
+    enter [1,1]
+    rw [inv_involutive]
+  exact this
+
+theorem fapply_inv_of_bijective {A B : ZFSet} {f : ZFSet} {hf : IsFunc A B f}
+  (f_bij : f.IsBijective hf) {x y : ZFSet} (hx : x ∈ A) (hy : y ∈ B) :
+    @ᶻf ⟨x, by rwa [is_func_dom_eq]⟩ = y → @ᶻf⁻¹ ⟨y, by rwa [is_func_dom_eq]⟩ = x := by
+  intro rfl
+  conv_lhs =>
+    rw [←fapply_composition (inv_is_func_of_bijective f_bij) hf hx,
+      fapply_eq_Image_singleton
+        (IsFunc_of_composition_IsFunc (inv_is_func_of_bijective f_bij) hf) hx]
+    conv =>
+      enter [1,1]
+      rw [←fcomp.eq_def _ _ (inv_is_func_of_bijective f_bij) hf,
+        composition_self_inv_of_bijective f_bij]
+    rw [←fapply_eq_Image_singleton Id.IsFunc hx, fapply_Id hx]
+
+theorem fapply_inv_of_bijective_iff {A B : ZFSet} {f : ZFSet} {hf : IsFunc A B f}
+  (f_bij : f.IsBijective hf) {x y : ZFSet} (hx : x ∈ A) (hy : y ∈ B) :
+    @ᶻf ⟨x, by rwa [is_func_dom_eq]⟩ = y ↔ @ᶻf⁻¹ ⟨y, by rwa [is_func_dom_eq]⟩ = x
+  where
+    mp := fapply_inv_of_bijective f_bij hx hy
+    mpr := by
+      intro h
+      have := fapply_inv_of_bijective (inv_bijective_of_bijective f_bij) hy hx h
+      conv_lhs at this =>
+        rw [fapply_eq_Image_singleton
+          (inv_is_func_of_bijective (inv_bijective_of_bijective f_bij)) hx]
+        conv =>
+          enter [1,1]
+          rw [inv_involutive]
+        rw [←fapply_eq_Image_singleton hf hx]
+      exact this
+
+end Functions
+
+section Finite
+/--
+A set is finite if it is equinumerous to a (ZF) natural number, i.e.
+if there is a bijection between the set and a natural number.
+-/
+def IsFinite (x : ZFSet) := ∃ (n f : ZFSet) (_ : n ∈ Nat)
+  (hf : f ∈ x.funs n), f.IsInjective (mem_funs.mp hf)
+
+abbrev ZFFinSet := {x : ZFSet // x.IsFinite}
+
+noncomputable def Max (S : ZFSet) [linord : LinearOrder {x // x ∈ S}] : ZFSet :=
+  ε (S.sep fun x ↦ (_ : x ∈ S) → ∀ y, (_ : y ∈ S) → linord.le ⟨y, ‹_›⟩ ⟨x, ‹_›⟩)
+noncomputable def Min (S : ZFSet) [linord : LinearOrder {x // x ∈ S}] : ZFSet :=
+  ε (S.sep fun x ↦ (_ : x ∈ S) → ∀ y, (_ : y ∈ S) → linord.le ⟨x, ‹_›⟩ ⟨y, ‹_›⟩)
+
+def LinearOrder.ofSubset {S T : ZFSet} (S_T : S ⊆ T) [linordT : LinearOrder {x // x ∈ T}] :
+    LinearOrder {x // x ∈ S} :=
+  LinearOrder.lift'
+    (fun ⟨x, hx⟩ => (⟨x, S_T hx⟩:{x // x ∈ T})) (by rintro ⟨x, hx⟩ ⟨y, hy⟩ _; injections; congr)
+
+example {x : ZFSet} {hx : x ∈ Nat} :
+  @ZFSet.Max ({x} : ZFSet)
+    (@LinearOrder.ofSubset ({x} : ZFSet) Nat
+      (by intro; rw [mem_singleton]; rintro rfl; exact hx) ZFNat.instLinearOrder) = x := by
+  unfold Max
+  simp_rw [mem_singleton, mem_sep, mem_singleton]
+  have :
+    ∃ z, z = x ∧ ∀ (x_1 : z = x) (y : ZFSet) (x_2 : y = x),
+      (⟨y, by rwa [x_2]⟩ : ZFNat) ≤ ⟨z, by rwa [x_1]⟩ := by
+    exists x
+    and_intros
+    · rfl
+    · rintro _ y rfl
+      apply le_refl
+  exact Classical.epsilon_spec this |>.left
+
+/- NOTE:
+The following is now unprovable: `∃ x, ZFSet.Max Nat = x`
+-/
+
+/-
+-- Is this even true?
+example {x : ZFSet} : x.IsFinite ↔ Finite (x.toSet) := by
+-/
+
+theorem Min_exists {S : ZFFinSet} [linord : LinearOrder {x // x ∈ S.val}] (nempS : S.val.Nonempty) :
+  ∃ (x : {x // x ∈ S.val}), ∀ y, (y_S : y ∈ S.val) → linord.le x ⟨y, ‹_›⟩ := by
+  -- obtain ⟨n, f, n_Nat, hf, inj⟩ := IsFinite.exist_bij S.property
+  by_contra! contr
+  admit
+
+theorem Min_mem (S : ZFFinSet) [linord : LinearOrder {x // x ∈ S.val}] (nempS : S.val.Nonempty) :
+    S.val.Min ∈ S.val := by
+  admit
+
+theorem Min_spec {S : ZFFinSet} [linord : LinearOrder {x // x ∈ S.val}] (nempS : S.val.Nonempty) :
+  ∀ (y : {x // x ∈ S.val}), linord.le ⟨S.val.Min, Min_mem S nempS⟩ y := by
+  obtain ⟨n, f, n_Nat, hf, inj⟩ := S.property
+  by_contra! contr
+  admit
+
+theorem Max_exists {S : ZFFinSet} [linord : LinearOrder {x // x ∈ S.val}] (nempS : S.val.Nonempty) :
+  ∃ (x : {x // x ∈ S.val}), ∀ y, y ≤ x := by
+  obtain ⟨n, f, n_Nat, hf, inj⟩ := S.property
+  by_contra! contr
+  admit
+
+theorem Max_mem (S : ZFFinSet) [linord : LinearOrder {x // x ∈ S.val}] (nempS : S.val.Nonempty) :
+    S.val.Max ∈ S.val := by
+  admit
+
+theorem Max_spec {S : ZFFinSet} [linord : LinearOrder {x // x ∈ S.val}] (nempS : S.val.Nonempty) :
+  ∀ (y : {x // x ∈ S.val}), linord.le ⟨S.val.Max, Max_mem S nempS⟩ y := by
+  obtain ⟨n, f, n_Nat, hf, inj⟩ := S.property
+  by_contra! contr
+  admit
+
+end Finite
+
+section Auxiliary
+
+@[simp]
+noncomputable def get (x : ZFSet) (n : ℕ) (i : Fin n) : ZFSet :=
+  match n, i with
+  | 1, i => x
+  | n+2, i => if h : i = Fin.last (n+1) then x.π₂ else get x.π₁ (n+1) (i.castPred h)
+
+open Classical in
+def hasArity (x : ZFSet) (n : ℕ) : Prop :=
+  match n with
+  | 0 => False
+  | 1 => True
+  | n+1 =>
+    if ∃ a b, x = ZFSet.pair a b then hasArity x.π₁ n
+    else False
+
+theorem isTuple_pair {a b : ZFSet} : hasArity (ZFSet.pair a b) 2 := by
+  rw [hasArity]
+  · split_ifs with cond
+    · trivial
+    · push_neg at cond
+      nomatch cond a b
+  · rintro ⟨⟩
+
+theorem sep_mem_powerset {D T : ZFSet} {P : ZFSet → Prop} :
+    D ∈ T.powerset → D.sep P ∈ T.powerset := by
+  intro hD
+  rw [mem_powerset, subset_def] at hD ⊢
+  exact fun _ hz => hD (ZFSet.mem_sep.mp hz).1
+
+theorem subset_of_𝔹_sInter (B : ZFSet) : B ⊆ ZFSet.𝔹 → (⋂₀ B : ZFSet) ∈ ZFSet.𝔹 := by
+  intro h
+  simp_rw [← ZFSet.mem_powerset, ZFSet.ZFBool.powerset_𝔹_def,
+    ZFSet.mem_insert_iff, ZFSet.mem_singleton] at h
+  rcases h with rfl | rfl | rfl | rfl
+  · rw [ZFSet.sInter_empty]
+    exact ZFSet.ZFBool.zffalse_mem_𝔹
+  · rw [ZFSet.sInter_singleton]
+    exact ZFSet.ZFBool.zffalse_mem_𝔹
+  · rw [ZFSet.sInter_singleton]
+    exact ZFSet.ZFBool.zftrue_mem_𝔹
+  · rw [ZFSet.sInter_pair, ZFSet.ZFBool.mem_𝔹_iff]
+    left
+    ext1 x
+    constructor
+    · intro hx
+      rcases ZFSet.mem_inter.mp hx
+      assumption
+    · intro hx
+      unfold ZFSet.zffalse at hx
+      nomatch (ZFSet.notMem_empty x) hx
+
+theorem subset_of_𝔹_sUnion (B : ZFSet) : B ⊆ ZFSet.𝔹 → (⋃₀ B : ZFSet) ∈ ZFSet.𝔹 := by
+  intro h
+  simp_rw [← ZFSet.mem_powerset, ZFSet.ZFBool.powerset_𝔹_def,
+    ZFSet.mem_insert_iff, ZFSet.mem_singleton] at h
+  rcases h with rfl | rfl | rfl | rfl
+  · rw [ZFSet.sUnion_empty]
+    exact ZFSet.ZFBool.zffalse_mem_𝔹
+  · rw [ZFSet.sUnion_singleton]
+    exact ZFSet.ZFBool.zffalse_mem_𝔹
+  · rw [ZFSet.sUnion_singleton]
+    exact ZFSet.ZFBool.zftrue_mem_𝔹
+  · rw [ZFSet.sUnion_pair, ZFSet.ZFBool.mem_𝔹_iff]
+    right
+    ext1 x
+    constructor
+    · intro hx
+      rcases ZFSet.mem_union.mp hx with hx | hx
+      · nomatch (ZFSet.notMem_empty x) hx
+      · exact hx
+    · intro hx
+      exact mem_union.mpr <| Or.inr hx
+
+theorem sInter_sep_subset_of_𝔹_mem_𝔹 {D : ZFSet} {P : ZFSet → Prop} :
+    D ⊆ ZFSet.𝔹 → (⋂₀ (D.sep P) : ZFSet) ∈ ZFSet.𝔹 := by
+  intro h
+  apply ZFSet.subset_of_𝔹_sInter (ZFSet.sep P D)
+  intros _ hx
+  rw [ZFSet.mem_sep] at hx
+  exact h hx.1
+
+theorem sUnion_sep_subset_of_𝔹_mem_𝔹 {D : ZFSet} {P : ZFSet → Prop} :
+    D ⊆ ZFSet.𝔹 → (⋃₀ (D.sep P) : ZFSet) ∈ ZFSet.𝔹 := by
+  intro h
+  apply ZFSet.subset_of_𝔹_sUnion (ZFSet.sep P D)
+  intros _ hx
+  rw [ZFSet.mem_sep] at hx
+  exact h hx.1
+
+theorem IsFunc.sep_on_eq {A B : ZFSet} {f : ZFSet → ZFSet} (hf : ∀ x ∈ A, f x ∈ B) :
+    IsFunc A B <| (A.prod B).sep (fun z ↦ ∃ x y : ZFSet, z = x.pair y ∧ y = f z.π₁) := by
+  unfold IsFunc
+  and_intros
+  · exact sep_subset_self
+  · intro x hx
+    exists f x
+    and_intros
+    · beta_reduce
+      rw [mem_sep, pair_mem_prod]
+      and_intros
+      · exact hx
+      · exact hf x hx
+      · exists x, (f x)
+        and_intros
+        · rfl
+        · rw [π₁_pair]
+    · intro w hw
+      rw [mem_sep, pair_mem_prod] at hw
+      obtain ⟨⟨hx, hw⟩, z, _, eq, rfl⟩ := hw
+      rw [π₁_pair] at eq
+      obtain ⟨rfl, rfl⟩ := pair_inj.mp eq
+      rfl
+
+theorem IsFunc.is_func_on_range {f A B : ZFSet} (hf : A.IsFunc B f) :
+  A.IsFunc (f.Range) f := by
+    conv =>
+      arg 1
+      rw [←is_func_dom_eq hf]
+    exact is_func_dom_range f (is_func_is_pfunc hf)
+
+theorem IsPFunc.empty_dom {f A B : ZFSet} (hf : IsPFunc f A B) (dom_emp : f.Dom = ∅) : f = ∅ := by
+  ext1 z
+  constructor
+  · intro hz
+    obtain ⟨x, xA, y, yB, rfl⟩ := mem_prod.mp <| hf.1 hz
+    nomatch notMem_empty _ <| dom_emp ▸ mem_dom hf hz
+  · intro hz
+    nomatch notMem_empty _ <| hz
+
+theorem IsPFunc.empty_range_of_empty_dom {f A B : ZFSet}
+  (hf : IsPFunc f A B) (dom_emp : f.Dom = ∅) : f.Range = ∅ := by
+    unfold Range
+    conv =>
+      arg 1
+      rw [dom_emp, empty_dom hf dom_emp]
+    simp only [notMem_empty, and_self, exists_const, sep_empty_iff,
+      not_false_eq_true, implies_true, or_true]
+
+theorem IsPFunc.exists_dom_of_mem_range {f A B : ZFSet}
+  (hf : IsPFunc f A B) {y : ZFSet} (hy : y ∈ f.Range) :
+    ∃ x ∈ A, pair x y ∈ f := by
+  unfold Range at hy
+  rw [mem_sep] at hy
+  obtain ⟨y_B, x, x_dom, pair⟩ := hy
+  exists x
+  and_intros
+  · unfold Dom at x_dom
+    rw [mem_sep] at x_dom
+    exact x_dom.1
+  · exact pair
+
+theorem IsFunc.surj_on_range {f A B : ZFSet} (hf : IsFunc A B f) :
+    IsSurjective (f := f) (A := A) (B := f.Range) (is_func_on_range hf) := by
+  intro y hy
+  exact IsPFunc.exists_dom_of_mem_range (is_func_is_pfunc hf) hy
+
+theorem bijective_of_injective {f A B : ZFSet} (hf : IsFunc A B f) (inj : f.IsInjective hf) :
+    f.IsBijective (A := A) (B := Range f) (IsFunc.is_func_on_range hf) := by
+  constructor
+  · intro x y z xA yA zRange xz yz
+    apply inj x y z xA yA _ xz yz
+    rw [mem_sep] at zRange
+    exact zRange.1
+  · intro y hy
+    exact IsPFunc.exists_dom_of_mem_range (is_func_is_pfunc hf) hy
+
+theorem IsFunc.range_eq_of_surjective {f A B : ZFSet} (hf : IsFunc A B f)
+  (surj : f.IsSurjective hf) :
+    f.Range = B := by
+  ext1 y
+  constructor
+  · intro hy
+    exact (mem_sep.mp hy).1
+  · intro hy
+    rw [mem_sep]
+    and_intros
+    · exact hy
+    · obtain ⟨x, x_dom, xy⟩ := surj y hy
+      exists x
+      and_intros
+      · exact ZFSet.mem_dom (is_func_is_pfunc hf) xy
+      · exact xy
+
+attribute [-instance] SetLike.instPartialOrder
+
+instance instPreorder_mem_Nat {n : ZFSet} (hn : n ∈ Nat) : Preorder {x // x ∈ n} where
+  le := fun ⟨a, ha⟩ ⟨b, hb⟩ ↦
+    (⟨a, ZFNat.mem_Nat_of_mem_mem_Nat hn ha⟩ : ZFNat) ≤
+    (⟨b, ZFNat.mem_Nat_of_mem_mem_Nat hn hb⟩ : ZFNat)
+  le_trans _ _ _ := ZFNat.le_trans
+  le_refl _ := ZFNat.instPreorder.le_refl _
+  lt_iff_le_not_ge := fun _ _ => Eq.to_iff rfl
+
+theorem IsFinite.empty : (∅:ZFSet).IsFinite := by
+  unfold IsFinite IsInjective
+  simp only [notMem_empty, IsEmpty.forall_iff, implies_true, mem_funs, exists_prop, and_true,
+    exists_and_left, IsFunc, prod_empty_left]
+  exact ⟨∅, ZFNat.zero_in_Nat, ∅, fun _ => id⟩
+
+theorem IsFinite.subset {A B : ZFSet} (finB : B.IsFinite) (subAB : A ⊆ B) :
+  A.IsFinite := by
+  obtain ⟨n, f, hn, hf, inj⟩ := finB
+  generalize_proofs f_func at inj
+  exists n, A.prod n |>.sep fun z => ∃ x y : ZFSet, z ∈ f ∧ z = x.pair y, hn, ?_
+  · rw [mem_funs] at hf ⊢
+    and_intros
+    · intro z hz
+      rw [mem_sep] at hz
+      exact hz.1
+    · intro x xA
+      simp only [exists_and_left, mem_sep, mem_prod, pair_inj,
+        exists_eq_right_right', exists_eq', and_true]
+      obtain ⟨z, hz, z_unq⟩ := hf.2 x (subAB xA)
+      exists z
+      and_intros
+      · exact xA
+      · exact And.right <| pair_mem_prod.mp <| hf.1 hz
+      · exact hz
+      · intro y hy
+        apply z_unq
+        exact hy.2
+  · generalize_proofs f'_A_n
+    intro x y z xA yA zn eq
+    simp_rw [mem_sep, pair_mem_prod, pair_inj] at eq ⊢
+    intro ⟨_, _, _, yz, rfl, rfl⟩
+    obtain ⟨_, _, xz, rfl, rfl⟩ := eq.2
+    exact inj x y z (subAB xA) (subAB yA) zn xz yz
+
+theorem IsFinite.insert {A : ZFSet} (finA : A.IsFinite) (x : ZFSet) :
+  (insert x A).IsFinite := by
+  by_cases hx : x ∈ A
+  · have : Insert.insert x A = A := by
+      ext1 w
+      rw [mem_insert_iff]
+      constructor
+      · rintro (rfl | h) <;> assumption
+      · intro; right; assumption
+    rwa [this]
+  · obtain ⟨n, f, hn, hf, inj⟩ := finA
+    let sucn := ZFNat.succ (⟨n, hn⟩:ZFNat)
+    exists sucn, f ∪ {x.pair n}, Subtype.property _, ?_
+    · rw [mem_funs]
+      and_intros
+      · intro z hz
+        rw [mem_union, mem_singleton] at hz
+        rcases hz with hz | rfl
+        · obtain ⟨a, ha, b, hb, rfl⟩ := mem_prod.mp <| mem_funs.mp hf |>.1 hz
+          simp_rw [mem_prod, mem_insert_iff]
+          exists a
+          and_intros
+          · right; exact ha
+          · exists b
+            and_intros
+            · unfold sucn ZFNat.succ
+              rw [mem_insert_iff]
+              right
+              exact hb
+            · rfl
+        · rw [pair_mem_prod]
+          and_intros
+          · exact mem_insert x A
+          · unfold sucn ZFNat.succ
+            rw [mem_insert_iff]
+            left
+            rfl
+      · intro z hz
+        rw [mem_insert_iff] at hz
+        rcases hz with rfl | hz
+        · exists n
+          beta_reduce
+          and_intros
+          · rw [mem_union, mem_singleton]
+            right
+            rfl
+          · intro z' hz'
+            rw [mem_union, mem_singleton] at hz'
+            rcases hz' with hz' | hz'
+            · nomatch hx <| And.left <| pair_mem_prod.mp <| mem_funs.mp hf |>.1 hz'
+            · rw [pair_inj] at hz'
+              exact hz'.2
+        · obtain ⟨w, hw, w_unq⟩ := mem_funs.mp hf |>.2 z hz
+          exists w
+          beta_reduce
+          and_intros
+          · rw [mem_union]
+            left
+            exact hw
+          · intro w' hw'
+            rw [mem_union, mem_singleton, pair_inj] at hw'
+            rcases hw' with hw' | ⟨rfl, rfl⟩
+            · exact w_unq w' hw'
+            · contradiction
+    · intro w y z wA yA zn wz yz
+      rw [mem_insert_iff] at wA yA
+      unfold sucn ZFNat.succ at zn
+      rw [mem_insert_iff] at zn
+      simp_rw [mem_union, mem_singleton, pair_inj] at zn wz yz
+      rcases wz with wz | ⟨rfl, rfl⟩ <;>
+      rcases yz with yz | ⟨rfl, ⟨⟩⟩
+      · exact inj w y z
+          (And.left <| pair_mem_prod.mp <| mem_funs.mp hf |>.1 wz)
+          (And.left <| pair_mem_prod.mp <| mem_funs.mp hf |>.1 yz)
+          (And.right <| pair_mem_prod.mp <| mem_funs.mp hf |>.1 yz) wz yz
+      · nomatch mem_irrefl _ (And.right <| pair_mem_prod.mp <| mem_funs.mp hf |>.1 wz)
+      · nomatch mem_irrefl _ (And.right <| pair_mem_prod.mp <| mem_funs.mp hf |>.1 yz)
+      · rfl
+
+theorem IsFinite.disjoint_union {A B : ZFSet}
+  (finA : A.IsFinite) (finB : B.IsFinite) (disjoint : A ∩ B = ∅) :
+    (A ∪ B).IsFinite := by
+  obtain ⟨n₁, fA, hn₁, hfA, injA⟩ := finA
+  by_cases A_emp : A = ∅
+  · subst A
+    rwa [empty_union]
+  · have n₁_ne_zero : n₁ ≠ ∅ := by
+      rintro rfl
+      obtain ⟨a, ha⟩ := nonempty_exists_iff.mp A_emp
+      obtain ⟨b, hb, -⟩ := mem_funs.mp hfA |>.2 a ha
+      nomatch notMem_empty _ <| And.right <| pair_mem_prod.mp <| mem_funs.mp hfA |>.1 hb
+    obtain ⟨n₂, fB, hn₂, hfB, injB⟩ := finB
+    let f' :=
+      fA ∪ (B.prod (⟨n₁, hn₁⟩ + ⟨n₂, hn₂⟩ : ZFNat)).sep fun z ↦
+        ∃ (x y : ZFSet) (hy : y ∈ Nat), z = x.pair (⟨y, hy⟩ + ⟨n₁, hn₁⟩ : ZFNat) ∧ x.pair y ∈ fB
+    exists ((⟨n₁, hn₁⟩ : ZFNat) + (⟨n₂, hn₂⟩ : ZFNat)), f', ?_, ?_
+    · apply Subtype.property
+    · rw [mem_funs]
+      and_intros
+      · intro z hz
+        rcases mem_union.mp hz with hz | hz
+        · obtain ⟨a, ha, b, hb, rfl⟩ := mem_prod.mp <| mem_funs.mp hfA |>.1 hz
+          rw [pair_mem_prod, mem_union]
+          and_intros
+          · left; exact ha
+          · have b_mem_Nat : b ∈ Nat := ZFNat.mem_Nat_of_mem_mem_Nat hn₁ hb
+            change (⟨b, b_mem_Nat⟩ : ZFNat) < ⟨n₁, hn₁⟩ at hb
+            change (⟨b, b_mem_Nat⟩ : ZFNat) < ⟨n₁, hn₁⟩ + ⟨n₂, hn₂⟩
+            rw [←@ZFNat.add_zero ⟨b, b_mem_Nat⟩]
+            exact ZFNat.add_lt_add_of_lt_of_le hb ZFNat.zero_le
+        · rw [mem_sep, mem_prod] at hz
+          obtain ⟨⟨z₁,hz₁,z₂,hz₂, rfl⟩, _, b, hb, eq, z₁b⟩ := hz
+          obtain ⟨rfl, rfl⟩ := pair_inj.mp eq
+          rw [pair_mem_prod, mem_union]
+          and_intros
+          · right; exact hz₁
+          · exact hz₂
+      · intro z hz
+        rw [mem_union] at hz
+        rcases hz with hz | hz
+        · obtain ⟨a, z_a_fA, a_unq⟩ := mem_funs.mp hfA |>.2 z hz
+          exists a
+          beta_reduce
+          and_intros
+          · unfold f'
+            rw [mem_union]
+            left
+            exact z_a_fA
+          · intro y hy
+            rw [mem_union] at hy
+            rcases hy with hy | hy
+            · exact a_unq y hy
+            · simp_rw [mem_sep, pair_mem_prod, pair_inj] at hy
+              obtain ⟨⟨hz, hy⟩, _, b, hb, eq, z_b⟩ := hy
+              have zB := And.left <| pair_mem_prod.mp <| mem_funs.mp hfB |>.1 z_b
+              have contr := ZFSet.ext_iff.mp disjoint z
+              simp_rw [mem_inter, notMem_empty, iff_false] at contr
+              nomatch contr ⟨‹z ∈ A›, hz⟩
+        · obtain ⟨a, z_a_fB, a_unq⟩ := mem_funs.mp hfB |>.2 z hz
+          have a_Nat : a ∈ Nat :=
+            ZFNat.mem_Nat_of_mem_mem_Nat hn₂ <|
+              And.right <| pair_mem_prod.mp <| mem_funs.mp hfB |>.1 z_a_fB
+          exists (⟨a, a_Nat⟩ + ⟨n₁, hn₁⟩ : ZFNat)
+          beta_reduce
+          and_intros
+          · unfold f'
+            rw [mem_union, mem_sep, pair_mem_prod]
+            right
+            and_intros
+            · exact hz
+            · change (⟨a, a_Nat⟩ + ⟨n₁, hn₁⟩ : ZFNat) < ⟨n₁, hn₁⟩ + ⟨n₂, hn₂⟩
+              rw [add_comm, ZFNat.add_lt_add_iff_left]
+              exact And.right <| pair_mem_prod.mp <| mem_funs.mp hfB |>.1 z_a_fB
+            · exists z, a, a_Nat
+          · intro y hy
+            rw [mem_union] at hy
+            rcases hy with hy | hy
+            · have zA := And.left <| pair_mem_prod.mp <| mem_funs.mp hfA |>.1 hy
+              have contr := ZFSet.ext_iff.mp disjoint z
+              simp_rw [mem_inter, notMem_empty, iff_false] at contr
+              nomatch contr ⟨zA, hz⟩
+            · simp only [exists_and_right, mem_sep, mem_prod, pair_inj,
+                exists_eq_right_right', exists_and_left] at hy
+              obtain ⟨⟨zB, z_lt_n₂⟩, _, w, ⟨rfl, w_Nat, rfl⟩, zw⟩ := hy
+              obtain ⟨⟩ := a_unq w zw
+              rfl
+    · intro x y z xA yA hz xz yz
+      have contr := ZFSet.ext_iff.mp disjoint
+      simp_rw [mem_inter, notMem_empty, iff_false] at contr
+      rw [mem_union] at xA yA
+      rcases xA with xA | xB <;>
+      rcases yA with yA | yB <;>
+      unfold f' at xz yz <;>
+      rw [mem_union] at xz yz <;>
+      rcases xz with xz | xz <;>
+      rcases yz with yz | yz
+      · obtain ⟨⟩ := pair_mem_prod.mp <| mem_funs.mp hfA |>.1 xz
+        obtain ⟨⟩ := pair_mem_prod.mp <| mem_funs.mp hfA |>.1 yz
+        apply injA <;> assumption
+      · simp_rw [mem_sep, pair_mem_prod, pair_inj, exists_and_right, exists_and_left] at yz
+        obtain ⟨_, w, ⟨rfl, ⟨w_Nat, rfl⟩⟩, yw⟩ := yz.2
+        nomatch contr y ⟨yA, And.left <| pair_mem_prod.mp <| mem_funs.mp hfB |>.1 yw⟩
+      · simp_rw [mem_sep, pair_mem_prod, pair_inj, exists_and_right, exists_and_left] at xz
+        obtain ⟨_, w, ⟨rfl, ⟨w_Nat, rfl⟩⟩, xw⟩ := xz.2
+        nomatch contr x ⟨xA, And.left <| pair_mem_prod.mp <| mem_funs.mp hfB |>.1 xw⟩
+      · simp only [exists_and_right, mem_sep, mem_prod, pair_inj,
+          exists_eq_right_right', exists_and_left] at xz
+        nomatch contr x ⟨xA, xz.1.1⟩
+      · obtain ⟨⟩ := pair_mem_prod.mp <| mem_funs.mp hfA |>.1 xz
+        obtain ⟨⟩ := pair_mem_prod.mp <| mem_funs.mp hfA |>.1 yz
+        apply injA <;> assumption
+      · simp only [exists_and_right, mem_sep, mem_prod, pair_inj,
+          exists_eq_right_right', exists_and_left] at yz
+        obtain ⟨⟨-, w_lt_n₂⟩, ⟨_, v, ⟨rfl, v_Nat, rfl⟩, yv⟩⟩ := yz
+        have v_add_n₁_lt_n₁ := And.right <| pair_mem_prod.mp <| mem_funs.mp hfA |>.1 xz
+        change (⟨v, v_Nat⟩ + ⟨n₁, hn₁⟩ : ZFNat) < ⟨n₁, hn₁⟩ at v_add_n₁_lt_n₁
+        conv at v_add_n₁_lt_n₁ =>
+          rhs
+          rw [←@ZFNat.zero_add ⟨n₁, hn₁⟩]
+        rw [ZFNat.add_lt_add_iff_right] at v_add_n₁_lt_n₁
+        nomatch ZFNat.not_lt_zero v_add_n₁_lt_n₁
+      · nomatch contr y ⟨And.left <| pair_mem_prod.mp <| mem_funs.mp hfA |>.1 yz, yB⟩
+      · simp only [exists_and_right, mem_sep, mem_prod, pair_inj,
+          exists_eq_right_right', exists_and_left] at xz
+        nomatch contr x ⟨xA, xz.1.1⟩
+      · obtain ⟨⟩ := pair_mem_prod.mp <| mem_funs.mp hfA |>.1 xz
+        obtain ⟨⟩ := pair_mem_prod.mp <| mem_funs.mp hfA |>.1 yz
+        apply injA <;> assumption
+      · obtain ⟨zA, -⟩ := pair_mem_prod.mp <| mem_funs.mp hfA |>.1 xz
+        nomatch contr x ⟨And.left <| pair_mem_prod.mp <| mem_funs.mp hfA |>.1 xz, xB⟩
+      · simp only [exists_and_right, mem_sep, mem_prod, pair_inj,
+          exists_eq_right_right', exists_and_left] at xz
+        obtain ⟨⟨-, w_lt_n₂⟩, ⟨_, v, ⟨rfl, v_Nat, rfl⟩, yv⟩⟩ := xz
+        have v_add_n₁_lt_n₁ := And.right <| pair_mem_prod.mp <| mem_funs.mp hfA |>.1 yz
+        change (⟨v, v_Nat⟩ + ⟨n₁, hn₁⟩ : ZFNat) < ⟨n₁, hn₁⟩ at v_add_n₁_lt_n₁
+        conv at v_add_n₁_lt_n₁ =>
+          rhs
+          rw [←@ZFNat.zero_add ⟨n₁, hn₁⟩]
+        rw [ZFNat.add_lt_add_iff_right] at v_add_n₁_lt_n₁
+        nomatch ZFNat.not_lt_zero v_add_n₁_lt_n₁
+      · simp only [exists_and_right, mem_sep, mem_prod, pair_inj,
+          exists_eq_right_right', exists_and_left] at yz
+        nomatch contr y ⟨yA, yz.1.1⟩
+      · obtain ⟨⟩ := pair_mem_prod.mp <| mem_funs.mp hfA |>.1 xz
+        obtain ⟨⟩ := pair_mem_prod.mp <| mem_funs.mp hfA |>.1 yz
+        apply injA <;> assumption
+      · obtain ⟨xA, -⟩ := pair_mem_prod.mp <| mem_funs.mp hfA |>.1 xz
+        nomatch contr x ⟨xA, xB⟩
+      · obtain ⟨yA, -⟩ := pair_mem_prod.mp <| mem_funs.mp hfA |>.1 yz
+        nomatch contr y ⟨yA, yB⟩
+      · simp only [exists_and_right, mem_sep, mem_prod, pair_inj,
+          exists_eq_right_right', exists_and_left] at xz yz
+        obtain ⟨⟨-, w_lt_n₂⟩, ⟨_, w, ⟨rfl, w_Nat, rfl⟩, xw⟩⟩ := xz
+        obtain ⟨⟨_, w_lt_n₁⟩, ⟨_, v, ⟨rfl, v_Nat, eq⟩, yv⟩⟩ := yz
+        rw [←Subtype.ext_iff, ZFNat.add_right_cancel] at eq
+        injection eq
+        subst w
+        exact injB x y v xB yB (And.right <| pair_mem_prod.mp <| mem_funs.mp hfB |>.1 xw) xw yv
+
+theorem IsFinite.union {A B : ZFSet} (finA : A.IsFinite) (finB : B.IsFinite) :
+  (A ∪ B).IsFinite := by
+  have : A ∪ B = (A \ B) ∪ B := by
+    ext1 z
+    simp_rw [mem_union, mem_diff]
+    constructor
+    · rintro (hA | hB)
+      · by_cases hB : z ∈ B
+        · right; exact hB
+        · left; exact ⟨hA, hB⟩
+      · right; exact hB
+    · rintro (⟨hA, -⟩ | hB)
+      · left; exact hA
+      · right; exact hB
+  rw [this]
+  have : (A \ B) ∩ B = ∅ := by
+    ext1 z
+    rw [mem_inter, mem_diff, and_assoc]
+    simp only [not_and_self, and_false, notMem_empty]
+  apply IsFinite.disjoint_union (IsFinite.subset finA ?_) finB this
+  intro z hz
+  rw [mem_diff] at hz
+  exact hz.1
+
+theorem IsFinite.inter {A B : ZFSet} (fin : A.IsFinite ∨ B.IsFinite) :
+  (A ∩ B).IsFinite := by
+  wlog fin : A.IsFinite
+  · replace fin := Or.resolve_left ‹_ ∨ _› fin
+    rw [inter_comm]
+    exact this (Or.inl fin) fin
+  · apply IsFinite.subset fin
+    · intro z hz
+      rw [mem_inter] at hz
+      exact hz.1
+
+theorem IsFinite.diff {A B : ZFSet} (finA : A.IsFinite) :
+  (A \ B).IsFinite := by
+  apply IsFinite.subset finA
+  intro z hz
+  rw [mem_diff] at hz
+  exact hz.1
+
+@[induction_eliminator]
+def ZFFinSet.inductionOn {P : ZFFinSet → Prop}
+  (empty : P ⟨∅, IsFinite.empty⟩)
+  (insert : ∀ (S : ZFFinSet) (x : ZFSet), P S → x ∉ S.val → P ⟨insert x S, S.property.insert x⟩) :
+  ∀ (S : ZFFinSet), P S := by
+  intro ⟨S, finS⟩
+  obtain ⟨n , fS , hn, hfS, fS_inj⟩ := finS
+  generalize_proofs finS
+  generalize_proofs fS_is_func at fS_inj
+  revert S fS
+  apply ZFNat.ind n hn
+  · intro S fS h _ _ _
+    rw [mem_funs, IsFunc, prod_empty_right] at h
+    obtain ⟨⟩ := subset_of_empty h.1
+    have : S = ∅ := by
+      simp only [subset_refl, notMem_empty, existsUnique_false, imp_false, true_and] at h
+      exact (eq_empty S).mpr h
+    subst S
+    exact empty
+  · intro n hn IH S fS _ S_fin fS_fun fS_inj
+    by_cases n_range : n ∈ fS.Range
+    · rw [Range, mem_sep, mem_insert_iff, eq_self, true_or, true_and,] at n_range
+      obtain ⟨a, a_dom, an⟩ := n_range
+      let S' := S \ {a}
+      let fS' := fS \ {a.pair n}
+      have S'_fin : S'.IsFinite := IsFinite.diff S_fin
+      have S'_is_func : S'.IsFunc n fS' := by
+        and_intros
+        · intro z hz
+          unfold fS' at hz
+          rw [mem_diff, mem_singleton] at hz
+          obtain ⟨x, xS, y, yS, rfl⟩ := mem_prod.mp <| fS_fun.1 hz.1
+          rw [pair_inj] at hz
+          rw [pair_mem_prod]
+          rw [mem_insert_iff] at yS
+          rcases yS with rfl | yS
+          · obtain ⟨⟩ :=
+              fS_inj a x y (And.left <| pair_mem_prod.mp <| fS_fun.1 an) xS (mem_insert y y) an hz.1
+            nomatch hz.2 (pair_inj.mp rfl)
+          · and_intros
+            · unfold S'
+              rw [mem_diff, mem_singleton]
+              and_intros
+              · exact xS
+              · rintro rfl
+                rw [not_and, eq_self, true_implies] at hz
+                obtain ⟨fS_x, hfS_x, fS_x_unq⟩ := fS_fun.2 x xS
+                obtain ⟨⟩ := fS_x_unq y hz.1
+                obtain ⟨⟩ := fS_x_unq n an
+                nomatch mem_irrefl _ yS
+            · exact yS
+        · intro z zS
+          rw [mem_diff, mem_singleton] at zS
+          obtain ⟨w, hw, w_unq⟩ := fS_fun.2 z zS.1
+          exists w
+          and_intros
+          · unfold fS'
+            beta_reduce
+            rw [mem_diff, mem_singleton, pair_inj]
+            and_intros
+            · exact hw
+            · rw [not_and_or]
+              left
+              exact zS.2
+          · intro w' hw'
+            unfold fS' at hw'
+            rw [mem_diff, mem_singleton, pair_inj] at hw'
+            exact w_unq w' hw'.left
+      have : fS'.IsInjective := by
+        intro x y z xS' yS' zn xy yz
+        apply fS_inj x y z
+        · exact mem_diff.mp xS' |>.1
+        · exact mem_diff.mp yS' |>.1
+        · exact mem_insert_of_mem n zn
+        all_goals
+          unfold fS' at xy
+          rw [mem_diff, mem_singleton] at xy yz
+        · exact xy.1
+        · exact yz.1
+      specialize IH S' fS' (mem_funs.mpr S'_is_func) S'_fin S'_is_func this
+      have : S = Insert.insert a S' := by classical
+        unfold S'
+        ext1 z
+        simp_rw [mem_insert_iff, mem_diff, mem_singleton, or_and_left, Classical.em, and_true]
+        constructor
+        · exact Or.inr
+        · rintro (rfl | hz)
+          · exact And.left <| pair_mem_prod.mp <| fS_fun |>.1 an
+          · exact hz
+      specialize insert _ a IH (by
+        unfold S'
+        rw [mem_diff, mem_singleton, not_and_or, not_not]
+        right; rfl)
+      conv at insert =>
+        enter [1,1]
+        rw [←this]
+      exact insert
+    · have : S.IsFunc n fS := by
+        and_intros
+        · intro z hz
+          obtain ⟨a, aS, b, bS, rfl⟩ := mem_prod.mp <| fS_fun.1 hz
+          rw [mem_insert_iff] at bS
+          rw [pair_mem_prod]
+          apply And.intro aS
+          rcases bS with rfl | bS
+          · unfold Range at n_range
+            simp_rw [mem_sep, mem_insert_iff, true_or, true_and, not_exists, not_and] at n_range
+            nomatch n_range a ⟨aS, b, Or.inl rfl, hz⟩ hz
+          · exact bS
+        · exact fS_fun.2
+      apply IH S fS (mem_funs.mpr this) S_fin this
+      intro x y z xS yS zn xy yz
+      apply fS_inj x y z xS yS
+      · rw [mem_insert_iff]
+        right
+        exact zn
+      · exact xy
+      · exact yz
+
+theorem IsFinite.singleton {x : ZFSet} : ({x} : ZFSet).IsFinite := by
+  exists (1:ZFNat), {x.pair (0:ZFNat)}, ?_, ?_
+  · exact SetLike.coe_mem 1
+  · rw [mem_funs]
+    and_intros
+    · intro z hz
+      rw [mem_singleton] at hz
+      obtain ⟨⟩ := hz
+      rw [pair_mem_prod, mem_singleton, eq_self, true_and]
+      exact singleton_subset_mem_iff.mp fun _ => id
+    · intro z
+      simp only [mem_singleton, pair_inj]
+      rintro rfl
+      simp only [true_and, existsUnique_eq]
+  · intro x y z
+    simp only [mem_singleton, pair_inj, and_imp]
+    intros
+    subst_eqs
+    rfl
+
+theorem IsFinite.prod_singleton {A x : ZFSet} (finA : A.IsFinite) :
+  (A.prod {x}).IsFinite := by
+  induction hA : (⟨A, finA⟩ : ZFFinSet) using ZFFinSet.inductionOn generalizing A finA x with
+  | empty =>
+    injections
+    subst_vars
+    rwa [prod_empty_left]
+  | insert E e ih he =>
+    injections
+    subst_vars
+    rw [insert_prod]
+    apply IsFinite.union
+    · apply ih
+      rfl
+    · have : ({e} : ZFSet).prod {x} = {e.pair x} := by
+        ext1 z
+        simp only [mem_prod, mem_singleton, exists_eq_left]
+      rw [this]
+      apply IsFinite.singleton
+
+theorem IsFinite.singleton_prod {A x : ZFSet} (finA : A.IsFinite) :
+  (({x} : ZFSet).prod A).IsFinite := by
+  induction hA : (⟨A, finA⟩ : ZFFinSet) using ZFFinSet.inductionOn generalizing A finA x with
+  | empty =>
+    injections
+    subst_vars
+    rwa [prod_empty_right]
+  | insert E e ih he =>
+    injections
+    subst_vars
+    rw [prod_insert]
+    apply IsFinite.union
+    · apply ih
+      rfl
+    · have : ({x} : ZFSet).prod {e} = {x.pair e} := by
+        ext1 z
+        simp only [mem_prod, mem_singleton, exists_eq_left]
+      rw [this]
+      apply IsFinite.singleton
+
+theorem IsFinite.prod {A B : ZFSet} (finA : A.IsFinite) (finB : B.IsFinite) :
+  (A.prod B).IsFinite := by
+  induction hA : (⟨A, finA⟩ : ZFFinSet) using ZFFinSet.inductionOn generalizing A finA with
+  | empty =>
+    injections
+    subst_vars
+    rwa [prod_empty_left]
+  | insert S x ih x_not_mem_S =>
+    injections
+    subst_vars
+    rw [insert_prod]
+    apply IsFinite.union
+    · apply ih
+      rfl
+    · exact singleton_prod finB
+
+theorem IsFinite.sep {A : ZFSet} (finA : A.IsFinite) (P : ZFSet → Prop) : (A.sep P).IsFinite :=
+  subset finA sep_subset_self
+
+theorem ZFNat.every_nat_isfinite (n : ZFNat) : n.val.IsFinite :=
+  ⟨n, 𝟙n, n.property, mem_funs.mpr <| Id.IsFunc, Id.IsBijective.1⟩
+
+theorem IsFinite.exists_bij {A : ZFSet} (finA : A.IsFinite) :
+  ∃ (n : ZFSet) (f : ZFSet) (_ : n ∈ Nat) (hf : f ∈ A.funs n), f.IsBijective (mem_funs.mp hf) := by
+  induction hA : (⟨A, finA⟩ : ZFFinSet) using ZFFinSet.inductionOn generalizing A finA with
+  | empty =>
+    injections
+    subst_vars
+    exists (0 : ZFNat), ∅, ?_, ?_
+    · exact SetLike.coe_mem 0
+    · simp_rw [mem_funs, IsFunc, prod_empty_left, subset_refl, notMem_empty,
+        existsUnique_false, imp_self, implies_true, and_self]
+    · and_intros
+      · intro _ _ _ h
+        nomatch notMem_empty _ h
+      · intro _ h
+        nomatch notMem_empty _ h
+  | insert S x ih x_not_mem_S =>
+    injections
+    subst_vars
+    obtain ⟨n, f, hn, hf, bij⟩ :=
+      ih (IsFinite.subset (A := S) finA (fun _ ↦ mem_insert_of_mem x)) rfl
+    exists (ZFNat.succ ⟨n, hn⟩), f ∪ {x.pair n}, ?_, ?_
+    · exact SetLike.coe_mem (ZFNat.succ ⟨n, hn⟩)
+    · rw [mem_funs]
+      and_intros
+      · intro z hz
+        rw [mem_union, mem_singleton] at hz
+        rcases hz with hz | rfl
+        · obtain ⟨a, aS, b, bS, rfl⟩ := mem_prod.mp <| (mem_funs.mp hf).1 hz
+          simp only [mem_prod, mem_insert_iff, pair_inj, exists_eq_right_right']
+          obtain ⟨aS, bn⟩ := pair_mem_prod.mp <| (mem_funs.mp hf).1 hz
+          and_intros
+          · right
+            exact aS
+          · change ⟨b, ZFNat.mem_Nat_of_mem_mem_Nat hn bS⟩ < ZFNat.succ ⟨n, hn⟩
+            trans ⟨n, hn⟩
+            · exact bn
+            · exact ZFNat.lt_succ
+        · rw [pair_mem_prod, mem_insert_iff]
+          and_intros
+          · left
+            rfl
+          · exact ZFNat.lt_succ
+      · simp only [mem_insert_iff, mem_union, mem_singleton, pair_inj, forall_eq_or_imp, true_and]
+        and_intros
+        · exists n
+          and_intros
+          · right; rfl
+          · intro w hw
+            rcases hw with hw | rfl
+            · nomatch x_not_mem_S (And.left <| pair_mem_prod.mp <| (mem_funs.mp hf).1 hw)
+            · rfl
+        · intro a aS
+          obtain ⟨w, wS, w_unq⟩ := (mem_funs.mp hf).2 a aS
+          exists w
+          and_intros
+          · left; exact wS
+          · intro w' hw'
+            rcases hw' with hw' | ⟨rfl, rfl⟩
+            · obtain ⟨⟩ := w_unq w' hw'
+              rfl
+            · contradiction
+    · rw [bijective_exists1_iff] at bij ⊢
+      intro y hy
+      have y_Nat := ZFNat.mem_Nat_of_mem_mem_Nat (SetLike.coe_mem (ZFNat.succ ⟨n, hn⟩)) hy
+      change (⟨y, y_Nat⟩ : ZFNat) < ZFNat.succ ⟨n, hn⟩ at hy
+      rw [← ZFNat.lt_le_iff] at hy
+      rcases hy with hy | hy
+      · obtain ⟨x, ⟨xS, xy⟩, x_unq⟩ := bij y hy
+        exists x
+        and_intros
+        · rw [mem_insert_iff]
+          right; exact xS
+        · rw [mem_union, mem_singleton]
+          left; exact xy
+        · intro x' hx'
+          rw [mem_insert_iff, mem_union, mem_singleton, pair_inj] at hx'
+          rcases hx' with ⟨rfl|_, _|⟨_,rfl⟩⟩
+          · nomatch x_not_mem_S <| And.left <| pair_mem_prod.mp <| (mem_funs.mp hf).1 ‹_ ∈ f›
+          · nomatch mem_irrefl _ <| And.right <| pair_mem_prod.mp <| (mem_funs.mp hf).1 ‹_ ∈ f›
+          · obtain ⟨⟩ := x_unq x' ⟨‹_›, ‹_›⟩
+            rfl
+          · subst_vars
+            contradiction
+      · injection hy
+        subst y
+        exists x
+        and_intros
+        · rw [mem_insert_iff]
+          left; rfl
+        · rw [mem_union, mem_singleton]
+          right; rfl
+        · intro y hy
+          simp only [mem_insert_iff, mem_union, mem_singleton, pair_inj, and_true] at hy
+          rcases hy with ⟨rfl|_, _|_⟩
+          · rfl
+          · rfl
+          · nomatch mem_irrefl _ <| And.right <| pair_mem_prod.mp <| (mem_funs.mp hf).1 ‹_ ∈ f›
+          · assumption
+
+open Classical in
+noncomputable def Card : ZFFinSet → ZFNat := fun ⟨S, Sfin⟩ =>
+  if S = ∅ then 0 else
+  have ex_bij := (IsFinite.exists_bij Sfin)
+  ⟨choose ex_bij, choose <| choose_spec <| choose_spec ex_bij⟩
+
+@[simp]
+theorem Card.empty_iff {S : ZFFinSet} : Card S = 0 ↔ S = ⟨∅, IsFinite.empty⟩ := by
+  constructor
+  · intro h
+    rw [Card] at h
+    split_ifs at h with Semp
+    · exact Subtype.ext Semp
+    · replace Semp : S.val ≠ ∅ := Semp
+      obtain ⟨s, hs⟩ := (@nonempty_exists_iff S).mp Semp
+      extract_lets ex_bij at h
+      let n := Classical.choose ex_bij
+      obtain ⟨f, hn, hf, bij⟩ := Classical.choose_spec ex_bij
+      refold_let n at *
+      have : n = ∅ := by
+        rwa [ZFNat.nat_zero_eq, ←Subtype.val_inj] at h
+      rw [this, mem_funs, IsFunc] at hf
+      obtain ⟨w, hw, w_unq⟩ := hf.2 s hs
+      nomatch notMem_empty _ <| And.right <| pair_mem_prod.mp <| hf.1 hw
+  · rintro ⟨⟩
+    rw [Card, eq_self, if_true]
+
+@[simp]
+theorem Card.empty : Card ⟨∅, IsFinite.empty⟩ = 0 := empty_iff.mpr rfl
+
+@[simp]
+theorem Card.singleton (x : ZFSet) : Card ⟨{x}, IsFinite.singleton⟩ = 1 := by
+  rw [Card]
+  split_ifs with h
+  · simp_rw [eq_empty, mem_singleton] at h
+    nomatch h x
+  · extract_lets ex_bij
+    let n := Classical.choose ex_bij
+    generalize_proofs _ hn
+    obtain ⟨f, hn, hf, bij⟩ := Classical.choose_spec ex_bij
+    refold_let n at *
+    have : (⟨n, hn⟩ : ZFNat) = 1 := by
+      simp_rw [mem_funs, IsFunc, mem_singleton, forall_eq] at hf
+      obtain ⟨k, hk, k_unq⟩ := hf.2
+      have := And.right <| pair_mem_prod.mp <| hf.1 hk
+      induction ind_n : (⟨n, hn⟩ : ZFNat) using ZFNat.induction generalizing n hn with
+      | zero =>
+        injection ind_n with eq
+        rw [eq] at this
+        nomatch notMem_empty _ this
+      | succ m IH =>
+        injection ind_n with eq
+        rw [eq, mem_insert_iff] at this
+        rcases this with rfl | this
+        · rw [←@ZFNat.zero_add 1, ←ZFNat.add_one_eq_succ,
+            ZFNat.add_right_cancel, ZFNat.nat_zero_eq, Subtype.ext_iff]
+          dsimp
+          symm
+          apply k_unq
+          obtain ⟨x', hx'⟩ := bij.2 ∅ <| eq ▸ ZFNat.zero_lt_succ
+          obtain ⟨⟩ := mem_singleton.mp hx'.1
+          exact hx'.2
+        · obtain ⟨w, hw, xm⟩ := bij.2 m (eq ▸ mem_insert m m)
+          obtain ⟨⟩ := mem_singleton.mp hw
+          rw [k_unq m xm] at this
+          nomatch mem_irrefl _ this
+    exact this
+
+theorem Card.insert {S : ZFFinSet} {x : ZFSet} (hx : x ∉ S.val) :
+  Card ⟨insert x S.val, S.property.insert x⟩ = Card S + 1 := by
+  induction S with
+  | empty =>
+      rw [Card.empty, zero_add]
+      simp only [insert_empty_eq, singleton]
+  | insert S s IH hs =>
+    admit
+
+def Card.inductionOn {P : ZFFinSet → Prop}
+  (zero : P ⟨∅, IsFinite.empty⟩)
+  (succ : ∀ n : ZFNat,
+    (∀ (S : ZFFinSet), n = Card S → P S) → ∀ (S' : ZFFinSet), Card S' = n + 1 → P S') :
+    ∀ (S : ZFFinSet), P S := by
+  intro ⟨S, hS⟩
+  admit
+
+theorem IsFinite.powerset {A : ZFSet} (finA : A.IsFinite) : A.powerset.IsFinite := by
+  induction hA : (⟨A, finA⟩ : ZFFinSet) using Card.inductionOn generalizing A finA with
+  | zero =>
+    injections
+    subst_vars
+    rw [ZFBool.powerset_false]
+    exact singleton
+  | succ n IH S cardS =>
+    rw [Subtype.ext_iff] at hA
+    dsimp at hA
+    subst A
+    by_cases hS : S.val = ∅
+    · rw [hS, ZFBool.powerset_false]
+      exact singleton
+    · obtain ⟨s, hs⟩ := (@nonempty_exists_iff S).mp hS
+      specialize IH ⟨S \ ({s} : ZFSet), IsFinite.diff finA⟩
+      have : S.val = Insert.insert s (S.val \ ({s} : ZFSet)) := by
+        ext
+        simp only [mem_insert_iff, mem_diff, mem_singleton, or_and_left,
+          Classical.em, and_true, iff_or_self]
+        rintro rfl
+        assumption
+      change Card ⟨S.val, S.property⟩ = n + 1 at cardS
+      have : S = ⟨
+        Insert.insert s (S.val \ ({s} : ZFSet)),
+        IsFinite.subset finA <| subset_of_subset_of_eq (fun _ => id) this.symm⟩ :=
+        Subtype.ext this
+      rw [this] at cardS
+      dsimp at cardS
+      have := Card.insert (S := ⟨S.val \ ({s} : ZFSet), IsFinite.diff finA⟩) (x := s) (by
+        rw [mem_diff, mem_singleton, not_and_or, not_not]
+        right; rfl)
+      rw [this, ZFNat.add_right_cancel] at cardS
+      clear this
+      specialize IH cardS.symm (IsFinite.diff finA)
+      · exact ({s} : ZFSet)
+      · admit
+
+theorem IsFinite.finite_funs (S T : ZFSet) (finS : S.IsFinite) (finT : T.IsFinite) :
+    (S.funs T).IsFinite :=
+  sep (powerset (prod finS finT)) (S.IsFunc T)
+
+theorem IsFinite.exists_bij_mono_iff {S : ZFSet} [inst : Preorder {x // x ∈ S}] :
+    S.IsFinite ↔
+    ∃ (n : ZFSet) (f : ZFSet) (_ : n ∈ Nat) (hf : f ∈ S.funs n),
+      f.IsBijective (mem_funs.mp hf) ∧
+      @IsStrictMono f S n inst (instPreorder_mem_Nat ‹_ ∈ Nat›) (mem_funs.mp hf) := by
+  constructor
+  · intro Sfin
+    obtain ⟨n, f, hn, hf, bij⟩ := Sfin.exists_bij
+    exists n
+    admit
+  · rintro ⟨n, f, hn, hf, bij, -⟩
+    exists n, f, hn, hf
+    exact bij.1
+
+
+open Classical in
+theorem Min_mem_of_non_empty_finite {S : ZFSet} [inst : LinearOrder {x // x ∈ S}]
+  (S_nemp : S.Nonempty) (S_fin : S.IsFinite) :
+  ZFSet.Min S ∈ S := by
+  unfold ZFSet.Min
+  beta_reduce
+  simp only [mem_sep]
+  apply epsilon_spec ?_
+    (p := fun z ↦
+      z ∈ S ∧ ∀ (x : z ∈ S) (y : ZFSet.{u_1}) (x_1 : y ∈ S), inst.le ⟨z, x⟩ ⟨y, x_1⟩) |>.1
+  beta_reduce
+  obtain ⟨n, f, hn, hf, bij, mono⟩ :=
+    IsFinite.exists_bij_mono_iff (inst := inst.toPreorder).mp S_fin
+  have : n ≠ (0 : ZFNat).1 := by
+    suffices (⟨n, hn⟩ : ZFNat) ≠ (0 : ZFNat) by
+      rintro rfl
+      exact this rfl
+    induction h : (⟨n, hn⟩ : ZFNat) using ZFNat.induction with
+    | zero =>
+      injections
+      subst n
+      rw [mem_funs, IsFunc, prod_empty_right] at hf
+      have : f = ∅ := by
+        ext1
+        constructor
+        · exact (hf.1 ·)
+        · exact (False.elim <| notMem_empty _ ·)
+      exfalso
+      obtain ⟨x, hx⟩ := (nonempty_def _).mp S_nemp
+      obtain ⟨y, hy, -⟩ := hf.2 x hx
+      have := IsPFunc.mem_range_of_mem (is_func_is_pfunc (mem_funs.mp ‹f ∈ _›)) hy
+      rw [IsFunc.range_eq_of_surjective (mem_funs.mp ‹f ∈ _›) bij.2] at this
+      nomatch notMem_empty _ this
+    | succ n _ => exact ZFNat.succ_ne_zero n
+  rw [mem_funs] at hf
+  have : (0 : ZFNat).1 ∈ f.Range := by
+    rw [IsFunc.range_eq_of_surjective hf bij.2]
+    suffices (0:ZFNat) < ⟨n, hn⟩ from this
+    cases h : (⟨n, hn⟩:ZFNat) using ZFNat.cases with
+    | zero =>
+      injection h
+      contradiction
+    | succ => exact ZFNat.zero_lt_succ
+  rw [mem_sep] at this
+  obtain ⟨x₀, x₀_dom, x₀_def⟩ := this.2
+  have x₀_S : x₀ ∈ S := by
+    rw [mem_sep] at x₀_dom
+    exact x₀_dom.1
+
+  by_contra! contr
+  specialize contr x₀ x₀_S
+  obtain ⟨_, x₁, x₁_S, x₁_lt_x₀⟩ := contr
+  obtain ⟨y₁, y₁_def, -⟩ := hf.2 x₁ x₁_S
+  have := IsPFunc.mem_range_of_mem (is_func_is_pfunc hf) y₁_def
+  rw [IsFunc.range_eq_of_surjective hf bij.2] at this
+
+  unfold IsStrictMono at mono
+  have : (⟨y₁, ZFNat.mem_Nat_of_mem_mem_Nat hn this⟩ : ZFNat) < 0 := by
+    specialize mono x₁ x₀ y₁ (0:ZFNat) x₁_S this y₁_def x₀_S _ x₀_def _
+    · suffices 0 < (⟨n, hn⟩ : ZFNat) from this
+      cases h : (⟨n, hn⟩:ZFNat) using ZFNat.cases with
+      | zero =>
+        injection h
+        contradiction
+      | succ n => exact ZFNat.zero_lt_succ
+    · exact x₁_lt_x₀
+    · nomatch ZFNat.not_lt_zero <| not_le.mp mono.2
+  exact ZFNat.not_lt_zero this
+
+theorem image_of_lambda_subset_range {A B φ : ZFSet} {hφ : A.IsFunc B φ} {S : ZFSet} :
+  φ[S] ⊆ B := by
+  intro y hy
+  rw [mem_Image] at hy
+  obtain ⟨hy, x, hx, φxy⟩ := hy
+  exact hφ.1 φxy |> pair_mem_prod.mp |>.2
+
+open Classical in
+noncomputable def fprod {A B A' B' : ZFSet} (f g : ZFSet)
+  (hf : A.IsFunc A' f := by zfun) (hg : B.IsFunc B' g := by zfun) : ZFSet :=
+  λᶻ : A.prod B → A'.prod B'
+     |    z     ↦ if hz : z ∈ A.prod B then
+                   let a := z.π₁
+                   let b := z.π₂
+                   let fa : ZFSet := @ᶻf ⟨a, by
+                     rw [is_func_dom_eq hf]
+                     rw [pair_eta hz, pair_mem_prod] at hz
+                     exact hz.1⟩
+                   let gb : ZFSet := @ᶻg ⟨b, by
+                     rw [is_func_dom_eq hg]
+                     rw [pair_eta hz, pair_mem_prod] at hz
+                     exact hz.2⟩
+                   fa.pair gb
+                  else ∅
+@[zfun]
+theorem fprod_is_func {A B A' B' φ ψ : ZFSet} (hφ : A.IsFunc A' φ) (hψ : B.IsFunc B' ψ) :
+  (A.prod B).IsFunc (A'.prod B') (fprod φ ψ) := by
+  and_intros
+  · intro z hz
+    simp only [fprod, mem_prod, mem_lambda, existsAndEq, and_true] at hz
+    obtain ⟨a', b', a, b, rfl, ⟨aA, bB⟩, ⟨a'A', b'B'⟩, eq⟩ := hz
+    rw [dite_cond_eq_true (eq_true (by rw [pair_mem_prod]; exact ⟨aA, bB⟩)), pair_inj] at eq
+    obtain ⟨rfl, rfl⟩ := eq
+    let φa : ZFSet := @ᶻφ ⟨a, by rwa [is_func_dom_eq hφ]⟩
+    let ψb : ZFSet := @ᶻψ ⟨b, by rwa [is_func_dom_eq hψ]⟩
+
+    simp only [mem_prod, pair_inj, exists_eq_right_right', π₁_pair, π₂_pair]
+    and_intros
+    · exact aA
+    · exact bB
+    · apply fapply_mem_range
+    · apply fapply_mem_range
+  · intro z hz
+    rw [mem_prod] at hz
+    obtain ⟨a, ha, b, hb, rfl⟩ := hz
+    let φa : ZFSet := @ᶻφ ⟨a, by rwa [is_func_dom_eq hφ]⟩
+    let ψb : ZFSet := @ᶻψ ⟨b, by rwa [is_func_dom_eq hψ]⟩
+    use φa.pair ψb
+    and_intros <;> beta_reduce
+    · simp_rw [fprod, lambda_spec, pair_mem_prod]
+      rw [dite_cond_eq_true (eq_true (by rw [pair_mem_prod]; exact ⟨ha, hb⟩)), pair_inj]
+      and_intros
+      · exact ha
+      · exact hb
+      · apply fapply_mem_range
+      · apply fapply_mem_range
+      · simp only [π₁_pair]
+        rfl
+      · simp only [π₂_pair]
+        rfl
+    · intro y hy
+      simp_rw [fprod, lambda_spec, pair_mem_prod, π₁_pair, π₂_pair] at hy
+      rw [dite_cond_eq_true (eq_true (by rw [pair_mem_prod]; exact ⟨ha, hb⟩))] at hy
+      exact hy.2.2
+
+-- macro_rules | `(tactic| zfun) => `(tactic| apply fprod_is_func <;> zfun)
+
+theorem fprod_bijective_of_bijective {A B A' B' φ ψ : ZFSet}
+  {hφ : A.IsFunc A' φ} {hψ : B.IsFunc B' ψ}
+  (φ_bij : φ.IsBijective) (ψ_bij : ψ.IsBijective) :
+    (fprod φ ψ).IsBijective := by
+  and_intros
+  · intro x y z hx hy hz xy yz
+    simp only [fprod, mem_prod, mem_lambda, pair_inj, existsAndEq, and_true,
+      exists_eq_left'] at xy yz
+    obtain ⟨⟨a, ha, b, hb, rfl⟩, -, rfl⟩ := xy
+    obtain ⟨⟨c, hc, d, hd, rfl⟩, -, eq⟩ := yz
+    rw [dite_cond_eq_true (eq_true (by rw [pair_mem_prod]; exact ⟨ha, hb⟩)),
+        dite_cond_eq_true (eq_true (by rw [pair_mem_prod]; exact ⟨hc, hd⟩)), pair_inj] at eq
+    simp only [π₁_pair, SetLike.coe_eq_coe, π₂_pair] at eq
+    obtain ⟨φa_eq_φc, ψb_eq_ψd⟩ := eq
+    rw [pair_inj]
+    and_intros
+    · obtain ⟨⟩ := IsInjective.apply_inj hφ φ_bij.1 φa_eq_φc
+      rfl
+    · obtain ⟨⟩ := IsInjective.apply_inj hψ ψ_bij.1 ψb_eq_ψd
+      rfl
+  · intro y hy
+    rw [mem_prod] at hy
+    obtain ⟨a', ha', b', hb', rfl⟩ := hy
+    let φ_inv_a' : ZFSet := fapply φ⁻¹ (is_func_is_pfunc <| inv_is_func_of_bijective φ_bij)
+      ⟨a', by rwa [is_func_dom_eq (inv_is_func_of_bijective φ_bij)]⟩
+    let ψ_inv_b' : ZFSet := fapply ψ⁻¹ (is_func_is_pfunc <| inv_is_func_of_bijective ψ_bij)
+      ⟨b', by rwa [is_func_dom_eq (inv_is_func_of_bijective ψ_bij)]⟩
+    use φ_inv_a'.pair ψ_inv_b'
+    and_intros
+    · rw [pair_mem_prod]
+      and_intros
+      · apply fapply_mem_range
+      · apply fapply_mem_range
+    · simp only [fprod, mem_prod, lambda_spec, pair_inj, exists_eq_right_right', π₁_pair, π₂_pair]
+      and_intros
+      · apply fapply_mem_range
+      · apply fapply_mem_range
+      · exact ha'
+      · exact hb'
+      · rw [dite_cond_eq_true
+          (eq_true (by rw [pair_mem_prod]; and_intros <;> apply fapply_mem_range)),
+          pair_inj]
+        and_intros
+        · rw [←fapply_composition hφ (inv_is_func_of_bijective φ_bij) ha',
+            fapply_eq_Image_singleton
+              (IsFunc_of_composition_IsFunc hφ (inv_is_func_of_bijective φ_bij)) ha']
+          conv =>
+            enter [2, 1, 1]
+            change φ ∘ᶻ φ⁻¹
+            rw [composition_inv_self_of_bijective φ_bij]
+          rw [←fapply_eq_Image_singleton Id.IsFunc ha', fapply_Id ha']
+        · rw [←fapply_composition hψ (inv_is_func_of_bijective ψ_bij) hb',
+            fapply_eq_Image_singleton
+              (IsFunc_of_composition_IsFunc hψ (inv_is_func_of_bijective ψ_bij)) hb']
+          conv =>
+            enter [2, 1, 1]
+            change ψ ∘ᶻ ψ⁻¹
+            rw [composition_inv_self_of_bijective ψ_bij]
+          rw [←fapply_eq_Image_singleton Id.IsFunc hb', fapply_Id hb']
+
+theorem mem_fprod {A B C D f g x : ZFSet} {hf : A.IsFunc C f} {hg : B.IsFunc D g} :
+  x ∈ fprod f g ↔ ∃ (a b : ZFSet) (ha : a ∈ A) (hb : b ∈ B),
+    let fa : ZFSet := @ᶻf ⟨a, by rwa [is_func_dom_eq hf]⟩
+    let gb : ZFSet := @ᶻg ⟨b, by rwa [is_func_dom_eq hg]⟩
+    x = (a.pair b).pair (fa.pair gb) where
+  mp := by
+    intro hx
+    rw [fprod, mem_lambda] at hx
+    obtain ⟨ab, cd, rfl, hab, hcd, rfl⟩ := hx
+    rw [dite_cond_eq_true (eq_true hab)] at hcd
+    rw [mem_prod] at hab
+    obtain ⟨a, ha, b, hb, rfl⟩ := hab
+    rw [pair_mem_prod] at hab
+    simp only [mem_prod, pair_inj, exists_eq_right_right', π₁_pair, π₂_pair,
+      exists_and_left, existsAndEq, and_true, exists_eq_left']
+    rw [dite_cond_eq_true (eq_true ‹_›)]
+    simp only [exists_prop, and_true, ha, hb]
+  mpr := by
+    rintro ⟨a, b, ha, hb, rfl⟩
+    simp only [fprod, mem_prod, mem_lambda, pair_inj, existsAndEq, and_true,
+      exists_eq_right_right', SetLike.coe_mem, true_and, exists_eq_right', exists_eq_left', π₁_pair,
+      π₂_pair, left_eq_dite_iff, not_and]
+    and_intros
+    · exact ha
+    · exact hb
+    · intro c
+      nomatch c ha hb
+
+theorem pair_mem_fprod {A B C D f g x y : ZFSet} {hf : A.IsFunc C f} {hg : B.IsFunc D g} :
+  x.pair y ∈ fprod f g ↔ ∃ (a b : ZFSet) (ha : a ∈ A) (hb : b ∈ B),
+    let fa : ZFSet := @ᶻf ⟨a, by rwa [is_func_dom_eq hf]⟩
+    let gb : ZFSet := @ᶻg ⟨b, by rwa [is_func_dom_eq hg]⟩
+    x = a.pair b ∧ y = fa.pair gb := by
+  rw [mem_fprod]
+  simp only [pair_inj, exists_and_left]
+
+@[simp]
+theorem fapply_fprod {A B C D f g a b : ZFSet} (hf : A.IsFunc C f) (hg : B.IsFunc D g)
+  (ha : a ∈ A) (hb : b ∈ B) :
+    @ᶻ(fprod f g)
+      ⟨a.pair b, by rw [is_func_dom_eq (fprod_is_func hf hg), pair_mem_prod]; exact ⟨ha, hb⟩⟩ =
+    let fa : ZFSet := @ᶻf ⟨a, by rwa [is_func_dom_eq hf]⟩
+    let gb : ZFSet := @ᶻg ⟨b, by rwa [is_func_dom_eq hg]⟩
+    fa.pair gb := by
+  conv =>
+    enter [1]
+    rw [fapply_eq_Image_singleton (fprod_is_func hf hg) (by rw [pair_mem_prod]; exact ⟨ha, hb⟩)]
+    dsimp [fprod]
+    rw [
+      ←fapply_eq_Image_singleton
+        (lambda_isFunc
+          (fun h ↦ by
+            rw [dite_cond_eq_true (eq_true h), pair_mem_prod]
+            and_intros <;> apply fapply_mem_range))
+        (by rw [pair_mem_prod]; exact ⟨ha, hb⟩),
+      fapply_lambda (fun h ↦ by
+        rw [dite_cond_eq_true (eq_true h), pair_mem_prod]
+        and_intros <;> apply fapply_mem_range)
+        (by rw [pair_mem_prod]; exact ⟨ha, hb⟩),
+      dite_cond_eq_true (eq_true (by rw [pair_mem_prod]; exact ⟨ha, hb⟩))]
+    simp only [π₁_pair, π₂_pair]
+
+open ZFSet Classical in
+theorem composition_fprod_Image_bijective {A B A' B' φ ψ : ZFSet}
+  {hφ : A.IsFunc A' φ} {hψ : B.IsFunc B' ψ}
+  (φ_bij : φ.IsBijective) (ψ_bij : ψ.IsBijective) :
+    let φ_ψ : ZFSet := fprod φ ψ
+    have φ_ψ_bij : φ_ψ.IsBijective := fprod_bijective_of_bijective φ_bij ψ_bij
+
+    let Φ : ZFSet := λᶻ : (A.prod B).powerset → (A'.prod B').powerset
+                        |                   S ↦ φ_ψ[S]
+    ∃ (hΦ : (A.prod B).powerset.IsFunc (A'.prod B').powerset Φ), IsBijective Φ hΦ := by
+  extract_lets φ_ψ hφ_ψ φ_ψ_bij
+  use ?_
+  · and_intros
+    · intro x y z hx hy hz x_z y_z
+      rw [mem_lambda] at x_z y_z
+      simp only [pair_inj, mem_powerset, existsAndEq, and_true, exists_eq_left'] at x_z y_z
+      obtain ⟨_, _, rfl⟩ := x_z
+      obtain ⟨_, _, eq⟩ := y_z
+      rw [ZFSet.ext_iff] at eq
+      simp only [mem_Image, mem_prod, and_congr_right_iff, forall_exists_index, and_imp] at eq
+      ext1 z
+      constructor <;> intro hz
+      · obtain ⟨a, ha, b, hb, rfl⟩ := ‹x ⊆ A.prod B› hz |> mem_prod.mp
+        letI φa : ZFSet := @ᶻφ ⟨a, by rwa [is_func_dom_eq hφ]⟩
+        letI ψb : ZFSet := @ᶻψ ⟨b, by rwa [is_func_dom_eq hψ]⟩
+        specialize eq (φa.pair ψb) φa (fapply_mem_range _ _) ψb (fapply_mem_range _ _) rfl
+        have := eq.mp ⟨a.pair b, hz, ?_⟩
+        · obtain ⟨p, hp, p_def⟩ := this
+          simp_rw [φ_ψ, pair_mem_fprod, pair_inj] at p_def
+          obtain ⟨a', b', ha', hb', rfl, φa_φa', ψb_ψb'⟩ := p_def
+          rw [←Subtype.ext_iff] at φa_φa' ψb_ψb'
+          obtain ⟨⟩ := IsInjective.apply_inj hφ φ_bij.1 φa_φa'
+          obtain ⟨⟩ := IsInjective.apply_inj hψ ψ_bij.1 ψb_ψb'
+          exact hp
+        · simp_rw [φ_ψ, pair_mem_fprod, pair_inj]
+          simp only [exists_and_left, exists_and_right, existsAndEq, and_true, exists_eq_left']
+          and_intros
+          · use ha
+          · use hb
+      · obtain ⟨a, ha, b, hb, rfl⟩ := ‹y ⊆ A.prod B› hz |> mem_prod.mp
+        letI φa : ZFSet := @ᶻφ ⟨a, by rwa [is_func_dom_eq hφ]⟩
+        letI ψb : ZFSet := @ᶻψ ⟨b, by rwa [is_func_dom_eq hψ]⟩
+        specialize eq (φa.pair ψb) φa (fapply_mem_range _ _) ψb (fapply_mem_range _ _) rfl
+        have := eq.mpr ⟨a.pair b, hz, ?_⟩
+        · obtain ⟨p, hp, p_def⟩ := this
+          simp_rw [φ_ψ, pair_mem_fprod, pair_inj] at p_def
+          obtain ⟨a', b', ha', hb', rfl, φa_φa', ψb_ψb'⟩ := p_def
+          rw [←Subtype.ext_iff] at φa_φa' ψb_ψb'
+          obtain ⟨⟩ := IsInjective.apply_inj hφ φ_bij.1 φa_φa'
+          obtain ⟨⟩ := IsInjective.apply_inj hψ ψ_bij.1 ψb_ψb'
+          exact hp
+        · simp_rw [φ_ψ, pair_mem_fprod, pair_inj]
+          simp only [exists_and_left, exists_and_right, existsAndEq, and_true, exists_eq_left']
+          and_intros
+          · use ha
+          · use hb
+    · intro Y hY
+      rw [mem_powerset] at hY
+      use φ_ψ⁻¹[Y]
+      rw [mem_lambda]
+      simp only [mem_powerset, pair_inj, existsAndEq, and_true, exists_eq_left', and_self_left]
+      and_intros
+      · intro z hz
+        rw [mem_Image] at hz
+        obtain ⟨hz, y, hy, yz⟩ := hz
+        rw [mem_inv, pair_mem_fprod] at yz
+        obtain ⟨a, b, ha, hb, rfl, rfl⟩ := yz
+        exact hz
+      · exact hY
+      · rw [Image_of_composition_self_inv_of_bijective hφ_ψ hY]
+  · apply lambda_isFunc
+    intro S hS
+    rw [mem_powerset] at hS ⊢
+    intro z hz
+    rw [mem_Image] at hz
+    exact hz.1
+
+theorem fprod_injective_of_injective {A B A' B' φ ψ : ZFSet}
+  {hφ : A.IsFunc A' φ} {hψ : B.IsFunc B' ψ}
+  (φ_inj : φ.IsInjective) (ψ_inj : ψ.IsInjective) :
+    (fprod φ ψ).IsInjective := by
+  intro x y z hx hy hz xy yz
+  simp only [fprod, mem_prod, mem_lambda, pair_inj, existsAndEq, and_true,
+    exists_eq_left'] at xy yz
+  obtain ⟨⟨a, ha, b, hb, rfl⟩, -, rfl⟩ := xy
+  obtain ⟨⟨c, hc, d, hd, rfl⟩, -, eq⟩ := yz
+  rw [dite_cond_eq_true (eq_true (by rw [pair_mem_prod]; exact ⟨ha, hb⟩)),
+      dite_cond_eq_true (eq_true (by rw [pair_mem_prod]; exact ⟨hc, hd⟩)), pair_inj] at eq
+  simp only [π₁_pair, SetLike.coe_eq_coe, π₂_pair] at eq
+  obtain ⟨φa_eq_φc, ψb_eq_ψd⟩ := eq
+  rw [pair_inj]
+  and_intros
+  · obtain ⟨⟩ := IsInjective.apply_inj hφ φ_inj φa_eq_φc
+    rfl
+  · obtain ⟨⟩ := IsInjective.apply_inj hψ ψ_inj ψb_eq_ψd
+    rfl
+
+end Auxiliary
+
+end ZFSet

--- a/LeanPool/ZFLean/Integers.lean
+++ b/LeanPool/ZFLean/Integers.lean
@@ -1,0 +1,1541 @@
+/-
+Copyright (c) 2026 Vincent Trélat. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vincent Trélat
+-/
+
+import LeanPool.ZFLean.Naturals
+import Mathlib.Algebra.Order.Ring.Defs
+import Mathlib.Algebra.Order.Group.Defs
+import Mathlib.SetTheory.Cardinal.SchroederBernstein
+
+/-! # ZFC Integers
+
+This file provides a construction of the integers in ZFC based on the construction of natural
+numbers. It follows the usual construction of integers as equivalence classes of pairs of natural
+numbers.
+
+The theory also comes with usual theorems and arithmetic operations on integers and wraps everything
+in a commutative ring structure.
+
+Finally, we show that that the `ZFInt` type is isomorphic to the type of elements contained in
+`ZFSet.Int` type using the Schröder-Bernstein theorem.
+-/
+
+namespace ZFSet
+
+section Integers
+
+protected abbrev zrel (a b : ZFNat × ZFNat) : Prop := a.1 + b.2 = a.2 + b.1
+
+protected def zrel_eq : Equivalence ZFSet.zrel where
+  refl := fun _ => add_comm _ _
+  symm := by
+    unfold ZFSet.zrel
+    intro x y h
+    rw [add_comm, add_comm y.2]
+    symm
+    assumption
+  trans := by
+    unfold ZFSet.zrel
+    intro x y z hxy hyz
+    have : x.1 + y.2 + y.1 + z.2 = x.2 + y.1 + y.2 + z.1 := by
+      rw [hxy, ← ZFNat.add_assoc, hyz, ZFNat.add_assoc _ _ _]
+    rw [add_assoc x.1, add_comm _ (y.2 + y.1), add_assoc, add_assoc x.2, add_comm _ (y.1 + y.2),
+      add_comm y.1, ← add_assoc (y.2 + y.1)] at this
+    apply add_left_cancel (a := y.2 + y.1)
+    simpa only [add_assoc]
+
+protected instance instSetoidZFNatZFNat : Setoid (ZFNat × ZFNat) where
+  r := ZFSet.zrel
+  iseqv := ZFSet.zrel_eq
+
+abbrev ZFInt := Quotient ZFSet.instSetoidZFNatZFNat
+
+namespace ZFInt
+
+def mk : ZFNat × ZFNat → ZFInt := Quotient.mk''
+
+@[simp]
+theorem mk_eq (x : ZFNat × ZFNat) : @Eq ZFInt ⟦x⟧ (mk x) := rfl
+
+@[simp]
+theorem mk_out : ∀ x : ZFInt, mk x.out = x := Quotient.out_eq
+
+theorem eq {x y : ZFNat × ZFNat} : mk x = mk y ↔ ZFSet.zrel x y := Quotient.eq
+
+theorem sound {x y : ZFNat × ZFNat} (h : ZFSet.zrel x y) : mk x = mk y := Quotient.sound h
+
+theorem exact {x y : ZFNat × ZFNat} : mk x = mk y → ZFSet.zrel x y := Quotient.exact
+
+abbrev zero : ZFInt := mk (0, 0)
+abbrev one : ZFInt := mk (1, 0) -- (0,1) works too
+
+protected instance : Zero ZFInt := ⟨zero⟩
+protected instance : One ZFInt := ⟨one⟩
+
+theorem zero_eq : (0 : ZFInt) = mk (0, 0) := rfl
+theorem one_eq : (1 : ZFInt) = mk (1, 0) := rfl
+
+theorem one_ne_zero : (1 : ZFInt) ≠ 0 := by
+  rw [zero_eq, one_eq]
+  rintro h
+  rw [ZFInt.eq, ZFSet.zrel] at h
+  simp at h
+  unfold_projs at h
+  injection h with h
+  rw [ZFSet.ext_iff] at h
+  simp only [mem_insert_iff, or_iff_right_iff_imp, forall_eq] at h
+  nomatch h
+
+theorem mk_eq_zero_iff {n m} : ZFInt.mk (n,m) = 0 ↔ n = m := by
+  constructor
+  · intro h
+    rw [ZFInt.zero_eq, ZFInt.eq, ZFSet.zrel] at h
+    exact ZFNat.add_right_cancel.mp h
+  · rintro rfl
+    exact ZFInt.sound rfl
+
+open ZFNat in
+noncomputable abbrev add (n m : ZFInt) : ZFInt :=
+  Quotient.liftOn₂ n m (fun ⟨a, b⟩ ⟨c, d⟩ => mk (a + c, b + d)) fun x y x' y' hx hy => sound (by
+    have h1 : x.1 + x'.2 = x.2 + x'.1 := hx
+    have h2 : y.1 + y'.2 = y.2 + y'.1 := hy
+    simp only [ZFSet.zrel]
+    have : x.1 + x'.2 + y.1 + y'.2 = x.2 + x'.1 + y.2 + y'.1 := by
+      rw [h1, ← add_assoc, h2, add_assoc]
+    conv_lhs => rw [add_assoc, ← add_assoc, ← add_assoc, ZFNat.add_comm y.1, add_assoc, add_assoc,
+      ← add_assoc, ZFNat.add_comm y'.2, add_assoc, this]
+    conv_rhs => rw [add_assoc]; lhs; rw [← add_assoc]; rhs; rw [add_comm]
+    rw [add_assoc])
+
+protected noncomputable instance : Add ZFInt := ⟨ZFInt.add⟩
+theorem add_eq (n m : ZFNat × ZFNat) : mk n + mk m = mk (n.1 + m.1, n.2 + m.2) := rfl
+
+theorem add_assoc (n m k : ZFInt) : n + (m + k) = n + m + k := by
+  induction n using Quotient.ind
+  induction m using Quotient.ind
+  induction k using Quotient.ind
+  simp_rw [mk_eq, ZFInt.add_eq, ZFNat.add_assoc]
+
+theorem add_comm (n m : ZFInt) : n + m = m + n := by
+  induction n using Quotient.ind
+  induction m using Quotient.ind
+  simp_rw [mk_eq, ZFInt.add_eq, ZFNat.add_comm]
+
+lemma add_left_comm (n m k : ZFInt) : n + (m + k) = m + (n + k) := by
+  rw [add_assoc, add_assoc, add_comm n]
+
+lemma add_right_comm (n m k : ZFInt) : (n + m) + k = (n + k) + m := by
+  rw [← add_assoc, add_comm m, add_assoc]
+
+@[simp]
+theorem add_zero {x : ZFInt} : x + 0 = x := by
+  induction x using Quotient.ind
+  simp_rw [mk_eq, zero_eq, ZFInt.add_eq, ZFNat.add_zero]
+
+@[simp]
+theorem zero_add {x : ZFInt} : 0 + x = x := by
+  rw [add_comm, add_zero]
+
+protected abbrev neg (n : ZFInt) : ZFInt :=
+  Quotient.liftOn n (fun x => mk (x.2, x.1)) fun x y h => sound (ZFSet.zrel_eq.symm (by
+    simp only [ZFSet.zrel]
+    rw [ZFNat.add_comm, ZFNat.add_comm y.1, ← ZFSet.zrel]
+    assumption))
+protected instance : Neg ZFInt := ⟨ZFInt.neg⟩
+theorem neg_eq (n : ZFNat × ZFNat) : -mk n = mk (n.2, n.1) := rfl
+
+@[simp]
+theorem neg_neg (n : ZFInt) : -(-n) = n := by
+  induction n using Quotient.ind
+  rw [mk_eq, neg_eq, neg_eq]
+
+@[simp]
+theorem neg_zero : -(0 : ZFInt) = 0 := by
+  rw [zero_eq, neg_eq]
+
+theorem neg_inj {a b : ZFInt} : -a = -b ↔ a = b :=
+  ⟨fun h => by rw [← neg_neg a, ← neg_neg b, h], congrArg _⟩
+
+@[simp]
+theorem neg_eq_zero {a : ZFInt} : -a = 0 ↔ a = 0 := ZFInt.neg_inj (b := 0)
+
+theorem neg_ne_zero {a : ZFInt} : -a ≠ 0 ↔ a ≠ 0 := not_congr neg_eq_zero
+
+theorem add_left_neg {a : ZFInt} : -a + a = 0 := by
+  induction a using Quotient.ind
+  apply sound
+  rw [ZFNat.add_comm]
+
+theorem add_right_neg (a : ZFInt) : a + -a = 0 := by
+  rw [add_comm]
+  exact add_left_neg
+
+theorem neg_eq_of_add_eq_zero {a b : ZFInt} (h : a + b = 0) : -a = b := by
+  rw [← @add_zero (-a), ← h, add_assoc, add_left_neg, zero_add]
+
+theorem eq_neg_of_eq_neg {a b : ZFInt} (h : a = -b) : b = -a := by
+  rw [h, neg_neg]
+
+theorem eq_neg_comm {a b : ZFInt} : a = -b ↔ b = -a := ⟨eq_neg_of_eq_neg, eq_neg_of_eq_neg⟩
+
+theorem neg_eq_comm {a b : ZFInt} : -a = b ↔ -b = a := by
+  rw [eq_comm, eq_neg_comm, eq_comm]
+
+theorem neg_add_cancel_left (a b : ZFInt) : -a + (a + b) = b := by
+  rw [add_assoc, add_left_neg, zero_add]
+
+theorem add_neg_cancel_left (a b : ZFInt) : a + (-a + b) = b := by
+  rw [add_assoc, add_right_neg, zero_add]
+
+theorem add_neg_cancel_right (a b : ZFInt) : a + b + -b = a := by
+  rw [← add_assoc, add_right_neg, add_zero]
+
+theorem neg_add_cancel_right (a b : ZFInt) : a + -b + b = a := by
+  rw [← add_assoc, add_left_neg, add_zero]
+
+theorem add_left_cancel {a b c : ZFInt} (h : a + b = a + c) : b = c := by
+  have h₁ : -a + (a + b) = -a + (a + c) := by rw [h]
+  simp [add_assoc, add_left_neg, zero_add] at h₁
+  exact h₁
+
+@[simp]
+theorem neg_add {a b : ZFInt} : -(a + b) = -a + -b := by
+  apply add_left_cancel (a := a + b)
+  rw [add_right_neg, add_comm a, add_assoc, ← add_assoc b, add_right_neg, add_zero, add_right_neg]
+
+noncomputable abbrev sub (n m : ZFInt) : ZFInt := n + -m
+protected noncomputable instance : Sub ZFInt := ⟨ZFInt.sub⟩
+theorem sub_eq (n m : ZFNat × ZFNat) : mk n - mk m = mk (n.1 + m.2, n.2 + m.1) := rfl
+
+theorem sub_eq_add_neg {a b : ZFInt} : a - b = a + -b := rfl
+
+theorem add_neg_one (i : ZFInt) : i + -1 = i - 1 := rfl
+
+@[simp]
+theorem sub_self (a : ZFInt) : a - a = 0 := by rw [sub_eq_add_neg, add_right_neg]
+
+@[simp]
+theorem sub_zero (a : ZFInt) : a - 0 = a := by simp [sub_eq_add_neg]
+
+@[simp]
+theorem zero_sub (a : ZFInt) : 0 - a = -a := by simp [sub_eq_add_neg]
+
+theorem sub_eq_zero_of_eq {a b : ZFInt} (h : a = b) : a - b = 0 := by rw [h, sub_self]
+
+theorem eq_of_sub_eq_zero {a b : ZFInt} (h : a - b = 0) : a = b := by
+  have : 0 + b = b := by rw [zero_add]
+  have : a - b + b = b := by rwa [h]
+  rwa [sub_eq_add_neg, neg_add_cancel_right] at this
+
+theorem sub_eq_zero {a b : ZFInt} : a - b = 0 ↔ a = b := ⟨eq_of_sub_eq_zero, sub_eq_zero_of_eq⟩
+
+theorem sub_sub (a b c : ZFInt) : a - b - c = a - (b + c) := by
+  simp [sub_eq_add_neg, add_assoc]
+
+theorem neg_sub (a b : ZFInt) : -(a - b) = b - a := by
+  simp [sub_eq_add_neg, add_comm]
+
+theorem sub_sub_self (a b : ZFInt) : a - (a - b) = b := by
+  simp [sub_eq_add_neg, add_assoc, add_right_neg]
+
+@[simp]
+theorem sub_neg (a b : ZFInt) : a - -b = a + b := by simp [sub_eq_add_neg]
+
+@[simp]
+theorem sub_add_cancel (a b : ZFInt) : a - b + b = a := neg_add_cancel_right a b
+
+@[simp]
+theorem add_sub_cancel (a b : ZFInt) : a + b - b = a := add_neg_cancel_right a b
+
+theorem add_sub_assoc (a b c : ZFInt) : a + b - c = a + (b - c) := by
+  rw [sub_eq_add_neg, ← add_assoc, ← sub_eq_add_neg]
+
+theorem sub_left_cancel (a b c : ZFInt) : a - c = b - c → a = b := by
+  intro h
+  rwa [← sub_eq_zero, sub_sub, sub_eq_zero, ← add_sub_assoc, add_comm, add_sub_cancel] at h
+
+theorem sub_right_cancel (a b c : ZFInt) : c - a = c - b → a = b := by
+  rw [← neg_sub a, ← neg_sub b, neg_inj]
+  apply sub_left_cancel
+
+theorem add_eq_sub_iff {a b c : ZFInt} : a + b = c ↔ a = c - b where
+  mp := fun h => by rw [← h, add_sub_cancel]
+  mpr := fun h => by rw [h, sub_add_cancel]
+
+private noncomputable abbrev nsmul : ℕ → ZFInt → ZFInt
+  | 0, _ => 0
+  | n+1, m => m + nsmul n m
+
+private noncomputable abbrev zsmul (n : ℤ) (x : ZFInt) : ZFInt :=
+  match n with
+  | .ofNat n => nsmul n x
+  | .negSucc n => -nsmul (n+1) x
+
+private theorem mul_wf {a b c d s t u v : ZFNat}
+  (h₁ : ZFSet.zrel (a, b) (s, t)) (h₂ : ZFSet.zrel (c, d) (u, v)) :
+  ZFSet.zrel (a * c + b * d, a * d + b * c) (s * u + t * v, s * v + t * u) := by
+  dsimp [ZFSet.zrel] at *
+
+  suffices h₃ : t * c + a * c + b * d + s * v + t * u = a * d + b * c + s * u + t * v + t * c by
+    simp_rw [ZFNat.add_comm _ (t*c), ← ZFNat.add_assoc (t*c)] at h₃
+    apply ZFNat.add_left_cancel.mp at h₃
+    simp_rw [ZFNat.add_assoc, h₃]
+
+  conv in t*c + a*c => rw [← right_distrib, ZFNat.add_comm, h₁, right_distrib]
+  conv in _ + t*v + t*c => rw [← ZFNat.add_assoc, ← left_distrib, ZFNat.add_comm v c, h₂,
+    left_distrib, ZFNat.add_assoc]
+
+  apply ZFNat.add_right_cancel.mpr
+
+  conv_rhs =>
+    rw [ZFNat.add_comm, ZFNat.add_assoc, ZFNat.add_assoc, ← right_distrib, ZFNat.add_comm t a, h₁,
+      right_distrib]
+    rw [ZFNat.add_comm (b * d + s * d), ZFNat.add_assoc, ← ZFNat.add_assoc,  ← left_distrib s, ← h₂,
+      left_distrib]
+
+  ac_rfl
+
+noncomputable abbrev mul (n m : ZFInt) : ZFInt :=
+  Quotient.liftOn₂ n m
+    (fun ⟨a, b⟩ ⟨c, d⟩ => mk (a * c + b * d, a * d + b * c)) fun _ _ _ _ => (sound <| mul_wf · ·)
+
+noncomputable instance : Mul ZFInt := ⟨ZFInt.mul⟩
+theorem mul_eq (n m : ZFNat × ZFNat) :
+  mk n * mk m = mk (n.1 * m.1 + n.2 * m.2, n.1 * m.2 + n.2 * m.1) := rfl
+
+theorem mul_comm (n m : ZFInt) : n * m = m * n := by
+  induction n using Quotient.ind
+  induction m using Quotient.ind
+  apply sound
+  rw [ZFSet.zrel]
+  ac_rfl
+
+theorem left_distrib (a b c : ZFInt) : a * (b + c) = a * b + a * c := by
+  induction a using Quotient.ind
+  induction b using Quotient.ind
+  induction c using Quotient.ind
+  rename_i a b c
+  let ⟨a₁, a₂⟩ := a
+  let ⟨b₁, b₂⟩ := b
+  let ⟨c₁, c₂⟩ := c
+  apply sound
+  simp_rw [ZFNat.left_distrib, ZFSet.zrel]
+  ac_rfl
+
+theorem right_distrib (a b c : ZFInt) : (a + b) * c = a * c + b * c := by
+  rw [mul_comm, left_distrib, mul_comm, mul_comm b c]
+
+@[simp]
+theorem zero_mul (a : ZFInt) : 0 * a = 0 := by
+  induction a using Quotient.ind
+  apply sound
+  simp_rw [ZFNat.zero_mul]
+
+@[simp]
+theorem mul_zero (a : ZFInt) : a * 0 = 0 := by
+  rw [mul_comm, zero_mul]
+
+theorem mul_assoc (a b c : ZFInt) : a * b * c = a * (b * c) := by
+  induction a using Quotient.ind
+  induction b using Quotient.ind
+  induction c using Quotient.ind
+  apply sound
+  simp_rw [ZFSet.zrel, ZFNat.left_distrib, ZFNat.right_distrib]
+  ac_rfl
+
+@[simp]
+theorem one_mul (a : ZFInt) : 1 * a = a := by
+  induction a using Quotient.ind
+  apply sound
+  simp_rw [ZFNat.one_mul, ZFNat.zero_mul, ZFNat.add_zero]
+  apply ZFSet.zrel_eq.refl
+
+@[simp]
+theorem mul_one (a : ZFInt) : a * 1 = a := by
+  rw [mul_comm, one_mul]
+
+noncomputable instance : CommRing ZFInt where
+  zero := 0
+  one := 1
+  add := add
+  add_assoc _ _ _ := by rw [add_assoc]
+  zero_add _ := zero_add
+  add_zero _ := add_zero
+  nsmul := ZFSet.ZFInt.nsmul
+  nsmul_zero _ := rfl
+  nsmul_succ _ _ := add_comm _ _
+  add_comm := add_comm
+  left_distrib := left_distrib
+  right_distrib := right_distrib
+  zero_mul := zero_mul
+  mul_zero := mul_zero
+  mul_comm := mul_comm
+  mul_assoc := mul_assoc
+  one_mul := one_mul
+  mul_one := mul_one
+  zsmul := ZFSet.ZFInt.zsmul
+  zsmul_zero' _ := rfl
+  zsmul_succ' _ _ := add_comm _ _
+  zsmul_neg' _ _ := rfl
+  neg_add_cancel _ := add_left_neg
+
+section Inequalities
+
+instance int_lt : LT ZFInt where
+  lt x y := Quotient.liftOn₂ x y
+    (fun ⟨a, b⟩ ⟨c, d⟩ => a + d < b + c) fun ⟨a, b⟩ ⟨c, d⟩ ⟨s, t⟩ ⟨u, v⟩ h₁ h₂ => by
+      replace h₁ : a + t = b + s := h₁
+      replace h₂ : c + v = d + u := h₂
+      simp only [eq_iff_iff]
+      apply Iff.intro
+      · intro lt
+        rw [← ZFNat.add_lt_add_iff_right (k := t)] at lt
+        conv_lhs at lt => rw [← ZFNat.add_assoc, ZFNat.add_comm, ← ZFNat.add_assoc,
+          ZFNat.add_comm t, h₁, ZFNat.add_comm b, ZFNat.add_assoc]
+        conv_rhs at lt => rw [← ZFNat.add_assoc, ZFNat.add_comm]
+        rw [ZFNat.add_lt_add_iff_right, ← ZFNat.add_lt_add_iff_right (k := u)] at lt
+        conv_lhs at lt => rw [← ZFNat.add_assoc, ZFNat.add_comm, ← ZFNat.add_assoc,
+          ZFNat.add_comm u, ← h₂, ZFNat.add_assoc, ZFNat.add_comm, ZFNat.add_assoc]
+        conv_rhs at lt => rw [ZFNat.add_comm, ZFNat.add_comm c, ZFNat.add_assoc]
+        rwa [ZFNat.add_lt_add_iff_right, ZFNat.add_comm, ZFNat.add_comm u] at lt
+      · intro lt
+        rw [← ZFNat.add_lt_add_iff_right (k := b)] at lt
+        conv_lhs at lt => rw [← ZFNat.add_assoc, ZFNat.add_comm, ← ZFNat.add_assoc, ← h₁,
+          ZFNat.add_assoc]
+        conv_rhs at lt => rw [← ZFNat.add_assoc, ZFNat.add_comm]
+        rw [ZFNat.add_lt_add_iff_right, ← ZFNat.add_lt_add_iff_right (k := c)] at lt
+        conv_lhs at lt => rw [ZFNat.add_comm, ZFNat.add_assoc, h₂, ZFNat.add_comm, ZFNat.add_assoc]
+        conv_rhs at lt => rw [ZFNat.add_comm, ZFNat.add_comm u, ZFNat.add_assoc]
+        rwa [ZFNat.add_lt_add_iff_right, ZFNat.add_comm c] at lt
+
+instance int_le : LE ZFInt where
+  le x y := x < y ∨ x = y
+
+theorem lt_succ {n : ZFInt} : n < n + 1 := by
+  induction n using Quotient.ind with
+  | _ n =>
+    obtain ⟨n, m⟩ := n
+    rw [ZFInt.mk_eq, ZFInt.one_eq, ZFInt.add_eq]
+    dsimp
+    rw [ZFNat.add_zero]
+    change n+m < m+(n+1)
+    rw [ZFNat.add_comm, ZFNat.add_lt_add_iff_left, ZFNat.add_one_eq_succ]
+    exact ZFNat.lt_succ
+
+theorem lt_trans {a b c : ZFInt} : a < b → b < c → a < c := by
+  induction a using Quotient.ind
+  induction b using Quotient.ind
+  induction c using Quotient.ind
+  rename_i a b c
+  let ⟨a₁, a₂⟩ := a
+  let ⟨b₁, b₂⟩ := b
+  let ⟨c₁, c₂⟩ := c
+  intros h₁ h₂
+  let this := ZFNat.add_lt_trans h₁ h₂
+  conv at this =>
+    conv => lhs; rw [← ZFNat.add_assoc, ZFNat.add_comm b₂, ZFNat.add_comm b₁, ZFNat.add_assoc,
+      ZFNat.add_assoc]
+    conv => rhs; rw [← ZFNat.add_assoc, ZFNat.add_comm b₁, ZFNat.add_comm b₂, ← ZFNat.add_assoc,
+      ZFNat.add_comm b₂, ZFNat.add_assoc, ZFNat.add_assoc]
+    rw [ZFNat.add_lt_add_iff_right (k := b₂), ZFNat.add_lt_add_iff_right (k := b₁)]
+  assumption
+
+theorem lt_irrefl {a : ZFInt} : ¬ a < a := by
+  induction a using Quotient.ind with
+  | _ a =>
+    let ⟨a₁, a₂⟩ := a
+    intro h
+    replace h : a₁ + a₂ < a₂ + a₁ := h
+    rw [ZFNat.add_comm] at h
+    nomatch ZFNat.lt_irrefl h
+
+theorem lt_zero_iff {n m : ZFNat} : m < n ↔ 0 < ZFInt.mk (n,m) := by
+  constructor
+  · intro h
+    induction n using ZFNat.induction generalizing m with
+    | zero =>
+      rw [ZFInt.zero_eq]
+      change 0 + m < 0 + 0
+      exact ZFNat.add_lt_add_left h 0
+    | succ n ih =>
+      rw [ZFInt.zero_eq]
+      change 0 + m < 0 + n.succ
+      exact ZFNat.add_lt_add_left h 0
+  · intro h
+    rw [ZFInt.zero_eq] at h
+    change 0 + m < 0 + n at h
+    exact ZFNat.add_lt_add_iff_left.mp h
+
+theorem neg_one_lt_zero : (-1 : ZFInt) < 0 := add_left_neg ▸ lt_succ (n := (-1))
+theorem zero_lt_one : (0 : ZFInt) < 1 := ZFInt.zero_add (x:=1) ▸ lt_succ
+
+theorem le_trans {a b c : ZFInt} : a ≤ b → b ≤ c → a ≤ c := by
+  intro h₁ h₂
+  rcases h₁ with h₁ | rfl
+  · rcases h₂ with h₂ | rfl
+    · left
+      exact lt_trans h₁ h₂
+    · left; assumption
+  · assumption
+
+theorem le_antisymm {a b : ZFInt} : a ≤ b → b ≤ a → a = b := by
+  intro h₁ h₂
+  rcases h₁ with h₁ | rfl
+  · rcases h₂ with h₂ | rfl
+    · nomatch lt_irrefl <| lt_trans h₁ h₂
+    · rfl
+  · rfl
+
+theorem le_total {a b : ZFInt} : a ≤ b ∨ b ≤ a := by
+  induction a using Quotient.ind
+  induction b using Quotient.ind
+  rename_i a b
+  let ⟨a₁, a₂⟩ := a
+  let ⟨b₁, b₂⟩ := b
+  rcases @ZFNat.le_total (a₁ + b₂) (a₂ + b₁) with (_ | _) | (h | h)
+  · left; left; assumption
+  · left; right; apply sound; assumption
+  · right; left; rw [ZFNat.add_comm a₂, ZFNat.add_comm a₁] at h; assumption
+  · right; right; apply sound; rw [ZFNat.add_comm a₂, ZFNat.add_comm a₁] at h; assumption
+
+theorem lt_iff_le_not_ge {x y : ZFInt} : x < y ↔ x ≤ y ∧ ¬y ≤ x := by
+  apply Iff.intro
+  · intro
+    apply And.intro
+    · left
+      assumption
+    · rintro (_ | rfl)
+      · nomatch lt_irrefl (lt_trans ‹_› ‹_›)
+      · nomatch lt_irrefl ‹_›
+  · rintro ⟨h | rfl, h'⟩
+    · assumption
+    · simp only [int_le, or_true] at h'
+      contradiction
+
+theorem lt_neg_iff {a b : ZFInt} : a < b ↔ -b < -a := by
+  constructor <;>
+  (
+    intro le
+    induction a using Quotient.ind
+    induction b using Quotient.ind
+    rename_i a b
+    let ⟨a₁, a₂⟩ := a
+    let ⟨b₁, b₂⟩ := b
+    rw [ZFInt.mk_eq, ZFInt.mk_eq] at le ⊢
+  )
+  · change a₁ + b₂ < a₂ + b₁ at le
+    change b₂ + a₁ < b₁ + a₂
+    rwa [ZFNat.add_comm b₂, ZFNat.add_comm b₁]
+  · change b₂ + a₁ < b₁ + a₂ at le
+    change a₁ + b₂ < a₂ + b₁
+    rwa [ZFNat.add_comm a₂, ZFNat.add_comm a₁]
+
+theorem le_neg_iff {a b : ZFInt} : a ≤ b ↔ -b ≤ -a := by
+  constructor <;>
+  (
+    intro le
+    induction a using Quotient.ind
+    induction b using Quotient.ind
+    rename_i a b
+    let ⟨a₁, a₂⟩ := a
+    let ⟨b₁, b₂⟩ := b
+    rw [ZFInt.mk_eq, ZFInt.mk_eq] at le ⊢
+  )
+  · rcases le with le | le
+    · left
+      exact lt_neg_iff.mp le
+    · rw [eq, ZFSet.zrel] at le
+      right
+      rwa [neg_eq, neg_eq, eq, ZFSet.zrel, ZFNat.add_comm b₂, ZFNat.add_comm b₁]
+  · rcases le with le | le
+    · left
+      exact lt_neg_iff.mpr le
+    · rw [neg_eq, neg_eq, eq, ZFSet.zrel] at le
+      right
+      rwa [eq, ZFSet.zrel, ZFNat.add_comm a₁, ZFNat.add_comm a₂]
+
+noncomputable instance : LinearOrder ZFInt where
+  le := int_le.le
+  le_refl x := Or.inr rfl
+  le_trans _ _ _ := le_trans
+  le_antisymm _ _ := le_antisymm
+  le_total _ _ := le_total
+  toDecidableLE := fun _ _ => Classical.propDecidable ((· ≤ ·) _ _)
+  lt_iff_le_not_ge _ _ := lt_iff_le_not_ge
+
+noncomputable instance : AddCommGroup ZFInt where
+  add := add
+  add_assoc := (add_assoc · · · |>.symm)
+  zero := zero
+  zero_add := @zero_add
+  add_zero := @add_zero
+  nsmul := nsmul
+  nsmul_succ x y := add_comm y (nsmul x y)
+  neg := ZFInt.neg
+  zsmul := zsmul
+  zsmul_succ' x y := add_comm y (nsmul x y)
+  neg_add_cancel := @add_left_neg
+  add_comm := @add_comm
+
+instance : PartialOrder ZFInt where
+  le := int_le.le
+  le_refl := le_refl
+  le_trans := @le_trans
+  lt_iff_le_not_ge := @lt_iff_le_not_ge
+  le_antisymm := @le_antisymm
+
+instance : IsOrderedAddMonoid ZFInt where
+  add_le_add_left x y h z := by
+    induction x using Quotient.ind
+    induction y using Quotient.ind
+    induction z using Quotient.ind
+    rename_i x y z
+    let ⟨x₁, x₂⟩ := x
+    let ⟨y₁, y₂⟩ := y
+    let ⟨z₁, z₂⟩ := z
+    simp_rw [mk_eq] at h ⊢
+    rcases h with h | h
+    · change x₁ + y₂ < x₂ + y₁ at h
+      simp_rw [add_eq]
+      left
+      change (x₁ + z₁) + (y₂ + z₂) < (x₂ + z₂) + (y₁ + z₁)
+      ac_change (x₁ + y₂) + (z₁ + z₂) <  (x₂ + y₁) + (z₁ + z₂)
+      rwa [ZFNat.add_lt_add_iff_right]
+    · rw [eq, ZFSet.zrel] at h
+      dsimp at h
+      right
+      rw [add_eq, add_eq, eq, ZFSet.zrel]
+      dsimp
+      ac_change (x₁ + y₂) + (z₁ + z₂) =  (x₂ + y₁) + (z₁ + z₂)
+      rw [h]
+
+end Inequalities
+
+section Induction
+
+lemma ind {P : ZFNat → ZFNat → Prop} (n m : ZFNat) (zero : P 0 0)
+  (succ_l : ∀ n m, P n m → P (n + 1) m) (succ_r : ∀ n m, P n m → P n (m + 1)) : P n m := by
+  induction n using ZFNat.induction with
+  | zero =>
+    induction m using ZFNat.induction with
+    | zero => exact zero
+    | succ m ih =>
+      rw [←ZFNat.add_one_eq_succ]
+      exact succ_r 0 m ih
+  | succ n ih =>
+    rw [←ZFNat.add_one_eq_succ]
+    exact succ_l n m ih
+
+lemma induction_pos {P : ZFInt → Prop} (n : ZFInt) (n_pos : 0 ≤ n)
+  (zero : P 0) (succ : ∀ k, P k → P (k + 1)) : P n := by
+  induction n using Quotient.ind
+  rename_i n
+  obtain ⟨n, m⟩ := n
+  rcases ZFNat.instIsStrictTotalOrderLt.trichotomous n m with h | rfl | h
+  · exfalso
+    rw [ZFInt.lt_zero_iff] at h
+    rcases n_pos with n_pos | eq
+    · rw [ZFInt.zero_eq] at h n_pos
+      change 0 + n < 0 + m at h
+      change 0 + m < 0 + n at n_pos
+      rw [ZFNat.zero_add, ZFNat.zero_add] at h n_pos
+      nomatch ZFNat.lt_irrefl <| ZFNat.lt_trans h n_pos
+    · rw [ZFInt.mk_eq] at eq
+      rcases ZFInt.mk_eq_zero_iff.mp eq.symm with rfl
+      rw [eq] at h
+      change n + n < n + n at h
+      nomatch ZFNat.lt_irrefl h
+  · rcases n_pos with n_pos | eq
+    · rw [ZFInt.zero_eq] at n_pos
+      change 0 + n < 0 + n at n_pos
+      nomatch ZFNat.lt_irrefl n_pos
+    · rwa [←eq]
+  · let k := n - m
+    have : n = k + m := by
+      apply ZFNat.eq_add_of_sub_eq _ rfl
+      left
+      exact h
+    rw [this]
+    induction k using ZFNat.induction with
+    | zero =>
+      rw [ZFInt.zero_eq] at zero
+      rwa [ZFNat.zero_add, ZFInt.mk_eq, ZFInt.eq (x := (m,m)) (y := (0,0)) |>.mpr rfl]
+    | succ k ih =>
+      rw [ZFNat.add_comm] at ih
+      rw [←ZFNat.add_one_eq_succ, ZFNat.add_comm, ZFNat.add_assoc]
+      specialize succ <| ZFInt.mk (m+k,m)
+      rw [ZFInt.one_eq, ZFInt.add_eq] at succ
+      dsimp at succ
+      rw [ZFNat.add_zero, ←ZFInt.mk_eq] at succ
+      exact succ ih
+
+lemma induction_neg {P : ZFInt → Prop} (n : ZFInt) (n_neg : n ≤ 0)
+  (zero : P 0) (succ : ∀ k, P k → P (k - 1)) : P n := by
+  have  : 0 ≤ -n := by rwa [← ZFInt.neg_zero, ZFInt.le_neg_iff, neg_neg n, neg_neg 0]
+  letI P' n := P (-n)
+  suffices P' (-n) by
+    unfold P' at this
+    rwa [ZFInt.neg_neg] at this
+  have succ' : ∀ k, P' k → P' (k + 1) := by
+    intro k hk
+    unfold P' at hk ⊢
+    rw [ZFInt.neg_add]
+    exact succ _ hk
+  exact induction_pos (P := P') (-n) this zero succ'
+
+@[induction_eliminator]
+theorem induction {P : ZFInt → Prop} (n : ZFInt)
+  (zero : P 0) (pos : ∀ k, P k → P (k + 1)) (neg : ∀ k, P k → P (k - 1)) : P n := by
+  rcases instIsStrictTotalOrderLt.trichotomous n 0 with h | rfl | h
+  · exact induction_neg n (Or.inl h) zero neg
+  · exact zero
+  · exact induction_pos n (Or.inl h) zero pos
+
+@[cases_eliminator]
+theorem sign_cases {P : ZFInt → Prop} (n : ZFInt)
+  (zero : P 0) (neg : n < 0 → P n) (pos : 0 < n → P n) : P n := by
+  induction n with
+  | zero => exact zero
+  | pos k ih =>
+    rcases lt_trichotomy (k+1) 0 with h | h | h
+    · exact neg h
+    · rwa [h]
+    · exact pos h
+  | neg k ih =>
+    rcases lt_trichotomy (k-1) 0 with h | h | h
+    · exact neg h
+    · rwa [h]
+    · exact pos h
+
+@[cases_eliminator]
+theorem cases {P : ZFInt → Prop} (n : ZFInt) (pos : 0 ≤ n → P n) (neg : n < 0 → P n) : P n := by
+  induction n with
+  | zero => exact pos (Or.inr rfl)
+  | pos n ih =>
+    generalize h : n + 1 = m at *
+    cases m using sign_cases with
+    | zero => exact pos (Or.inr rfl)
+    | neg h => exact neg h
+    | pos h => exact pos (Or.inl h)
+  | neg n ih =>
+    generalize h : n - 1 = m at *
+    cases m using sign_cases with
+    | zero => exact pos (Or.inr rfl)
+    | neg h => exact neg h
+    | pos h => exact pos (Or.inl h)
+
+end Induction
+
+theorem add_eq_add_sub_eq_sub {a b c d : ZFNat} : a + b = c + d → a - c = d - b := by
+  intro h
+  have : a = c + d - b := ZFNat.sub_eq_of_eq_add h.symm |>.symm
+  subst this
+  rw [←ZFNat.sub_add_distrib, ZFNat.add_comm b c, ZFNat.add_sub_add_left c d b]
+
+theorem le_of_lt_succ (n m : ZFInt) : n < m + 1 → n ≤ m := by
+  intro h
+  induction n using Quotient.ind
+  induction m using Quotient.ind
+  rename_i n m
+  obtain ⟨a, b⟩ := n
+  obtain ⟨c, d⟩ := m
+  simp_rw [mk_eq] at h ⊢
+  rw [one_eq, add_eq, ZFNat.add_zero] at h
+  change a + d < b + (c + 1) at h
+  suffices a + d ≤ b + c by
+    rcases this with h | h
+    · left; exact h
+    · right; exact sound h
+  rwa [ZFNat.add_assoc, ZFNat.add_one_eq_succ, ←ZFNat.lt_le_iff] at h
+
+theorem lt_succ_of_le (n m : ZFInt) : n ≤ m → n < m + 1 := by
+  rintro (h | rfl)
+  · trans n+1
+    · exact lt_succ
+    · exact (add_lt_add_iff_right 1).mpr h
+  · exact lt_succ
+
+theorem lt_succ_of_le_iff (n m : ZFInt) : n ≤ m ↔ n < m + 1 where
+  mp := lt_succ_of_le n m
+  mpr := le_of_lt_succ n m
+
+theorem int_le.dest {n m : ZFInt} : n ≤ m → ∃ k, 0 ≤ k ∧ n + k = m := by
+  intro h
+  exists m - n
+  and_intros
+  · exact sub_nonneg_of_le h
+  · exact _root_.add_sub_cancel n m
+
+theorem mul_pos_pos_pos (a b : ZFInt) (ha : 0 < a) (hb : 0 < b) : 0 < a * b := by
+  induction a using Quotient.ind
+  induction b using Quotient.ind
+  rename_i a b
+  obtain ⟨c, d⟩ := b
+  obtain ⟨a, b⟩ := a
+  simp_rw [mk_eq, zero_eq] at ha hb ⊢
+  rw [mul_eq]
+  change 0 + d < 0 + c at hb
+  change 0 + b < 0 + a at ha
+  change 0 + (a * d + b * c) < 0 + (a * c + b * d)
+  simp_rw [ZFNat.zero_add] at ha hb ⊢
+  rw [ZFNat.sub_add_cancel (Or.inl hb) |>.symm, ZFNat.left_distrib, ZFNat.left_distrib,
+    ZFNat.add_comm _ (b*d), ZFNat.add_assoc, ←ZFNat.right_distrib, ←ZFNat.add_assoc,
+    ←ZFNat.right_distrib, ZFNat.add_comm, ZFNat.add_lt_add_iff_right, ZFNat.mul_comm b,
+    ZFNat.mul_comm a]
+  apply ZFNat.mul_lt_mono
+  · exact ZFNat.pos_of_ne_zero (ZFNat.sub_ne_zero_of_lt hb).symm
+  · exact ha
+
+theorem neg_one_mul (a : ZFInt) : (-1 : ZFInt) * a = -a := by
+  induction a using Quotient.ind
+  rename_i a
+  obtain ⟨a, b⟩ := a
+  rw [mk_eq, one_eq, neg_eq, mul_eq, neg_eq]
+  dsimp
+  rw [ZFNat.zero_mul, ZFNat.zero_mul, ZFNat.one_mul, ZFNat.one_mul, ZFNat.zero_add, ZFNat.zero_add]
+
+theorem neg_one_mul_neg_one : (-1 : ZFInt) * (-1) = 1 := by
+  rw [one_eq, neg_eq, mul_eq, ZFNat.mul_zero, ZFNat.zero_mul, ZFNat.zero_add, ZFNat.zero_add,
+    ZFNat.one_mul, ZFNat.one_mul]
+
+theorem mul_neg_neg (a b : ZFInt) : a * b = -a * -b := by
+  rw [←one_mul (a*b), ←neg_one_mul_neg_one, ←mul_assoc, mul_comm, mul_assoc, mul_comm, mul_assoc,
+    mul_comm (-1), mul_assoc, mul_comm b, neg_one_mul, neg_one_mul]
+
+theorem neg_mul_distrib (a b : ZFInt) : -(a * b) = -a * b := neg_mul_eq_neg_mul a b
+
+theorem mul_neg_neg_pos (a b : ZFInt) (ha : a < 0) (hb : b < 0) : 0 < a * b := by
+  rw [mul_neg_neg]
+  exact mul_pos_pos_pos _ _ (Left.neg_pos_iff.mpr ha) (Left.neg_pos_iff.mpr hb)
+
+theorem neg_flip_lt (a : ZFInt) : a < 0 ↔ 0 < -a := Iff.symm Left.neg_pos_iff
+theorem neg_flip_le (a : ZFInt) : a ≤ 0 ↔ 0 ≤ -a := Iff.symm neg_nonneg
+
+theorem mul_neg_pos_neg (a b : ZFInt) (ha : a < 0) (hb : 0 < b) : a * b < 0 := by
+  rw [neg_flip_lt, neg_mul_eq_neg_mul]
+  exact mul_pos_pos_pos _ _ ((neg_flip_lt a).mp ha) hb
+
+theorem mul_pos_neg_neg (a b : ZFInt) (ha : 0 < a) (hb : b < 0) : a * b < 0 := by
+  rw [mul_comm, neg_flip_lt, neg_mul_eq_neg_mul]
+  exact mul_pos_pos_pos _ _ ((neg_flip_lt b).mp hb) ha
+
+theorem mul_nonneg_nonneg_nonneg (a b : ZFInt) (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a * b := by
+  rcases ha with ha | rfl <;> rcases hb with hb | rfl
+  · left
+    exact mul_pos_pos_pos a b ha hb
+  · right
+    rw [mul_zero]
+  · right
+    rw [zero_mul]
+  · right
+    rw [zero_mul]
+
+theorem mul_nonpos_nonneg_nonpos (a b : ZFInt) (ha : a ≤ 0) (hb : 0 ≤ b) : a * b ≤ 0 := by
+  rw [neg_flip_le, neg_mul_eq_neg_mul]
+  exact mul_nonneg_nonneg_nonneg _ _ (neg_nonneg.mpr ha) hb
+
+theorem mul_nonneg_nonpos_nonpos (a b : ZFInt) (ha : 0 ≤ a) (hb : b ≤ 0) : a * b ≤ 0 := by
+  rw [mul_comm, neg_flip_le, neg_mul_eq_neg_mul]
+  exact mul_nonneg_nonneg_nonneg _ _ (neg_nonneg.mpr hb) ha
+
+theorem mul_nonpos_nonpos_nonneg (a b : ZFInt) (ha : a ≤ 0) (hb : b ≤ 0) : 0 ≤ a * b := by
+  rw [mul_neg_neg]
+  exact mul_nonneg_nonneg_nonneg _ _ (neg_nonneg.mpr ha) (neg_nonneg.mpr hb)
+
+theorem mul_le_mul_left {n m : ZFInt} (k : ZFInt) (h : n ≤ m) (h' : 0 ≤ k) : k * n ≤ k * m := by
+  obtain ⟨l, pos, hl⟩ := int_le.dest h
+  have : k * n + k * l = k * m := by rw [←hl, left_distrib]
+  rw [←this]
+  apply le_add_of_nonneg_right
+  exact mul_nonneg_nonneg_nonneg k l h' pos
+
+theorem mul_lt_mul_of_pos_left {n m k : ZFInt} (h : n < m) (hk : k > 0) : k * n < k * m := by
+  apply lt_of_lt_of_le (b := k*n+k)
+  · exact lt_add_of_pos_right _ hk
+  · conv =>
+      enter [1,2]
+      rw [←mul_one k]
+    rw [←left_distrib]
+    apply mul_le_mul_left k
+    · exact (lt_succ_of_le_iff (n + 1) m).mpr <| (add_lt_add_iff_right 1).mpr h
+    · exact le_of_lt hk
+
+theorem pos_of_mul_pos {a b : ZFInt} (h : 0 < a * b) (ha : 0 < a) : 0 < b := by
+  classical
+  by_contra hb
+  rw [not_lt_iff_eq_or_lt] at hb
+  rcases hb with rfl | hb
+  · rw [mul_zero] at h
+    exact lt_irrefl h
+  · rcases instIsStrictTotalOrderLt.trichotomous a b with h' | rfl | h'
+    · nomatch lt_irrefl <| lt_trans (lt_trans ha h') hb
+    · nomatch lt_irrefl <| lt_trans ha hb
+    · nomatch lt_irrefl <| lt_trans h <| mul_pos_neg_neg a b ha hb
+
+theorem mul_lt_mul_of_pos_right {n m k : ZFInt} (h : n < m) (hk : k > 0) : n * k < m * k := by
+  rw [mul_comm n, mul_comm m]
+  exact mul_lt_mul_of_pos_left h hk
+
+theorem mul_pos_iff {a b : ZFInt} : 0 < a * b ↔ (0 < a ∧ 0 < b) ∨ (a < 0 ∧ b < 0) := by
+  constructor
+  · intro h
+    cases a with
+    | pos pos =>
+      rcases pos with pos | rfl
+      · left
+        and_intros
+        · exact pos
+        · exact pos_of_mul_pos h pos
+      · rw [zero_mul] at h
+        nomatch lt_irrefl h
+    | neg neg =>
+      right
+      and_intros
+      · exact neg
+      · rw [mul_neg_neg] at h
+        rw [neg_flip_lt] at neg
+        have := pos_of_mul_pos h neg
+        rwa [←neg_flip_lt] at this
+  · rintro (⟨l, r⟩ | ⟨l, r⟩)
+    · exact mul_pos_pos_pos a b l r
+    · exact mul_neg_neg_pos a b l r
+
+theorem eq_le_iff {a b : ZFInt} : a = b ↔ a ≤ b ∧ b ≤ a := by
+  constructor
+  · rintro rfl
+    exact ⟨le_refl _, le_refl _⟩
+  · rintro ⟨h₁, h₂⟩
+    rcases h₁ with h₁ | rfl <;> rcases h₂ with h₂ | h₂
+    · nomatch lt_irrefl <| lt_trans h₁ h₂
+    · exact h₂.symm
+    · rfl
+    · rfl
+
+theorem mul_eq_zero_iff {a b : ZFInt} : a * b = 0 ↔ a = 0 ∨ b = 0 := by
+  constructor
+  · intro h
+    induction a using Quotient.ind
+    induction b using Quotient.ind
+    rename_i a b
+    simp_rw [mk_eq, mul_eq, zero_eq, eq, ZFSet.zrel, ZFNat.add_zero] at h ⊢
+    rcases ZFNat.instIsStrictTotalOrderLt.trichotomous b.1 b.2 with h' | eq | h'
+    · have := ZFNat.add_eq_add_sub_eq_sub h.symm
+      rw [←ZFNat.left_distrib_mul_sub, ←ZFNat.left_distrib_mul_sub] at this
+      have b₁b₂_ne_0 : b.2 - b.1 ≠ 0 := by
+        intro contr
+        rw [ZFNat.sub_eq_zero_imp_le] at contr
+        rcases contr with contr | eq
+        · nomatch ZFNat.lt_irrefl <| ZFNat.lt_trans contr h'
+        · rw [eq] at h'
+          nomatch ZFNat.lt_irrefl h'
+      left
+      exact ZFNat.mul_right_cancel_iff b₁b₂_ne_0 |>.mp this
+    · right; assumption
+    · have := ZFNat.add_eq_add_sub_eq_sub h
+      rw [←ZFNat.left_distrib_mul_sub, ←ZFNat.left_distrib_mul_sub] at this
+      have b₁b₂_ne_0 : b.1 - b.2 ≠ 0 := by
+        intro contr
+        rw [ZFNat.sub_eq_zero_imp_le] at contr
+        rcases contr with contr | eq
+        · nomatch ZFNat.lt_irrefl <| ZFNat.lt_trans contr h'
+        · rw [eq] at h'
+          nomatch ZFNat.lt_irrefl h'
+      left
+      exact ZFNat.mul_right_cancel_iff b₁b₂_ne_0 |>.mp this
+  · rintro (h | h)
+    · rw [h, zero_mul]
+    · rw [h, mul_zero]
+
+theorem mul_eq_zero_of_ne_zero {a b : ZFInt} : a * b = 0 → a ≠ 0 → b = 0 := by
+  intro h h'
+  rw [mul_eq_zero_iff] at h
+  exact Or.resolve_left h h'
+
+theorem mul_left_cancel_iff {a b n : ZFInt} (h : n ≠ 0) : n * a = n * b ↔ a = b := by
+  constructor
+  · intro eq
+    have : n*a - n*b = 0 := sub_eq_zero_of_eq eq
+    rw [ZFInt.sub_eq_add_neg, mul_comm n b, neg_mul_distrib, mul_comm _ n, ←left_distrib,
+      mul_eq_zero_iff] at this
+    rcases this with rfl | this
+    · nomatch h
+    · exact eq_of_sub_eq_zero this
+  · exact fun h => h ▸ rfl
+
+theorem mul_right_cancel_iff {a b n : ZFInt} (h : n ≠ 0) : a * n = b * n ↔ a = b := by
+  rw [mul_comm a n, mul_comm b n]
+  exact mul_left_cancel_iff h
+
+noncomputable instance : CommRing ZFInt where
+  add := add
+  add_assoc := (add_assoc · · · |>.symm)
+  add_comm := add_comm
+  zero_add _ := zero_add
+  add_zero _ := add_zero
+  nsmul := nsmul
+  nsmul_succ x y := add_comm y (nsmul x y)
+  left_distrib := left_distrib
+  right_distrib := right_distrib
+  zsmul := zsmul
+  zsmul_succ' x y := add_comm y (nsmul x y)
+  neg_add_cancel := @add_left_neg
+
+instance : PartialOrder ZFInt where
+  le := int_le.le
+  le_refl := le_refl
+  le_trans := @le_trans
+  le_antisymm := @le_antisymm
+  lt_iff_le_not_ge := @lt_iff_le_not_ge
+
+instance : IsOrderedRing ZFInt where
+  add_le_add_left _ _ h z := add_le_add_left h z
+  zero_le_one := Or.inl zero_lt_one
+  mul_le_mul_of_nonneg_left a b := fun _ _ ↦ (mul_le_mul_left a · b)
+  mul_le_mul_of_nonneg_right a h b c h' := by
+    rw [mul_comm b, mul_comm c]
+    exact mul_le_mul_left a h' h
+
+instance : PosMulStrictMono ZFInt where
+  mul_lt_mul_of_pos_left _ h _ _ h' := mul_lt_mul_of_pos_left h' h
+instance : MulPosStrictMono ZFInt where
+  mul_lt_mul_of_pos_right _ h _ _ h' := mul_lt_mul_of_pos_right h' h
+
+end ZFInt
+
+noncomputable abbrev Int := Nat.prod {∅} ∪ ZFSet.prod {∅} Nat
+
+def ZFInt.ofZFNat (n : ZFNat) : ZFInt := ZFInt.mk ⟨n, 0⟩
+
+noncomputable def ofInt : ℤ → ZFSet
+  | .ofNat n => ZFSet.pair ∅ (n : ZFNat)
+  | .negSucc n => ZFSet.pair (n+1 : ZFNat) ∅
+
+noncomputable def toZFInt : ℤ → ZFInt
+  | .ofNat n => ZFInt.mk (0, ↑n)
+  | .negSucc n => ZFInt.mk (↑n+1, 0)
+
+example : ofInt 0 = {{∅}} := by
+  dsimp [ofInt, pair]
+  ext x
+  simp
+  intro
+  subst x
+  ext x
+  simp
+  exact id
+
+section -- could be another definition
+private def ofInt' : (n : ℤ) → PSet
+  | .ofNat 0 => {{∅}}
+  | .ofNat (n+1) => {{∅}, {∅, .ofNat n}} -- (0, n)
+  | .negSucc n => {{.ofNat (n+1)}, {∅, .ofNat (n+1)}} -- (n, 0)
+
+def PInt' : PSet := ⟨ULift ℤ, fun n => ofInt' n.down⟩
+def Int' : ZFSet := ZFSet.mk PInt'
+end
+
+theorem ZFNat.mem_lift_lift_Nat (n : ℕ) : ↑(↑n : ZFNat) ∈ Nat := by
+  induction n with
+  | zero => simp only [Nat.cast_zero, ZFNat.nat_zero_eq, ZFNat.zero_in_Nat]
+  | succ n ih =>
+    simp only [Nat.cast_succ, ZFNat.add_one_eq_succ, ZFNat.succ]
+    exact ZFNat.succ_mem_Nat' ih
+
+theorem mem_ofInt_Int (n : ℤ) : ofInt n ∈ Int := by
+  induction n using Int.recOn with
+  | ofNat n =>
+    rw [Int, mem_union, ofInt]
+    right
+    rw [pair_mem_prod]
+    exact ⟨singleton_subset_mem_iff.mp fun _ => id, ZFNat.mem_lift_lift_Nat n⟩
+  | negSucc n =>
+    rw [Int, mem_union, ofInt]
+    left
+    rw [pair_mem_prod]
+    exact ⟨ZFNat.mem_lift_lift_Nat (n+1), singleton_subset_mem_iff.mp fun _ => id⟩
+
+theorem sub_ofInt_singleton_Int (n : ℤ) : {ofInt n} ⊆ Int := by
+  intro
+  rw [mem_singleton]
+  rintro rfl
+  exact mem_ofInt_Int n
+
+lemma Int.nonempty : ZFSet.Int ≠ ∅ := by
+  intro h
+  rw [ZFSet.ext_iff] at h
+  simp only [notMem_empty, iff_false] at h
+  nomatch h (ZFSet.ofInt 0) (ZFSet.mem_ofInt_Int 0)
+
+def π₁ (x : ZFSet) : ZFSet := ⋃₀ (⋂₀ x)
+
+open Classical in -- couldn't find another way
+noncomputable def π₂ (x : ZFSet) : ZFSet :=
+  let δ : ZFSet := (⋃₀ x \ ⋂₀ x)
+  if δ = ∅ then π₁ x else ⋃₀ δ
+
+@[simp] theorem π₁_pair (x y : ZFSet) : π₁ (x.pair y) = x := by
+  unfold π₁ pair
+  ext
+  rw [sInter_pair, mem_sUnion]
+  constructor
+  · rintro ⟨w, l, r⟩
+    rw [mem_inter, mem_singleton, mem_pair] at l
+    rw [l.1] at r
+    assumption
+  · intro h
+    exists x
+    rw [mem_inter, mem_singleton, mem_pair]
+    exact ⟨⟨rfl, .inl rfl⟩, h⟩
+
+@[simp] theorem pair_inter {x y : ZFSet} : {x} ∩ {x, y} = ({x} : ZFSet) := by
+    ext
+    rw [mem_inter, mem_singleton, mem_pair]
+    constructor
+    · rintro ⟨rfl, _ | rfl⟩ <;> rfl
+    · rintro rfl
+      exact ⟨rfl, .inl rfl⟩
+
+@[simp] theorem pair_union {x y : ZFSet} : {x} ∪ {x, y} = ({x, y} : ZFSet) := by
+    ext
+    rw [mem_union, mem_singleton, mem_pair]
+    exact or_self_left
+
+@[simp] theorem pair_minus {x y : ZFSet} : x ≠ y → {x, y} \ {x} = ({y} : ZFSet) := by
+  intro x_ne_y
+  ext z
+  rw [mem_diff, mem_pair, mem_singleton, mem_singleton]
+  constructor
+  · rintro ⟨rfl | rfl, r⟩
+    · contradiction
+    · rfl
+  · rintro rfl
+    exact ⟨.inr rfl, x_ne_y ∘ Eq.symm⟩
+
+@[simp] theorem π₂_pair (x y : ZFSet) : π₂ (x.pair y) = y := by
+  unfold π₂
+  dsimp
+  split_ifs with h
+  · rw [π₁_pair]
+    unfold pair at h
+    rw [sUnion_pair, pair_union, sInter_pair, pair_inter] at h
+    rw [ZFSet.ext_iff] at h
+    specialize h y
+    simpa only [mem_diff, mem_insert_iff, mem_singleton, eq_self,
+      or_true, true_and, notMem_empty, iff_false, not_not, eq_comm] using h
+  · unfold pair at *
+    rw [sUnion_pair, pair_union, sInter_pair, pair_inter] at h ⊢
+    rw [pair_minus]
+    · exact sUnion_singleton
+    · intro h'
+      rw [h'] at h
+      simp [ZFSet.ext_iff] at h
+
+theorem pair_eta {z A B : ZFSet} (h : z ∈ A.prod B) : z = z.π₁.pair z.π₂ := by
+  rw [mem_prod] at h
+  obtain ⟨a, ha, b, hb, rfl⟩ := h
+  rw [π₁_pair, π₂_pair]
+
+theorem mem_Int_proj {x : ZFSet} (h : x ∈ Int) :
+  ∃ n ∈ Nat, (x.π₁ = ∅ ∧ x.π₂ = n) ∨ (x.π₁ = n ∧ x.π₂ = ∅) := by
+  simp_rw [mem_union, mem_prod] at h
+  rcases h with ⟨a, ha, b, hb, x_eq⟩ | ⟨b, hb, a, ha, x_eq⟩
+    <;> (simp at hb; subst x_eq; rw [π₁_pair, π₂_pair]; exists a)
+  · exact ⟨ha, .inr ⟨rfl, hb⟩⟩
+  · exact ⟨ha, .inl ⟨hb, rfl⟩⟩
+
+theorem mem_Int_proj' {x : ZFSet} :
+  x ∈ Int → (x.π₁ = ∅ ∧ x.π₂ ∈ Nat) ∨ (x.π₁ ∈ Nat ∧ x.π₂ = ∅) := by
+  intro h
+  rcases mem_Int_proj h with ⟨n, hn, ⟨l, r⟩ | ⟨l, r⟩⟩
+  · left
+    exact ⟨l, r ▸ hn⟩
+  · right
+    exact ⟨l ▸ hn, r⟩
+
+open Classical in
+private noncomputable def ZFInt.outof : {x // x ∈ Int} → ZFInt := fun ⟨n, hn⟩ =>
+  have := mem_Int_proj' hn
+  if case : n.π₁ = ∅ ∧ n.π₂ ∈ Nat then
+    ZFInt.mk ⟨0, n.π₂, case.right⟩
+  else
+    ZFInt.mk ⟨⟨n.π₁, Or.resolve_left this case |>.left⟩, 0⟩
+
+theorem ZFInt.outof_inj (x y : {x // x ∈ Int}) : outof x = outof y → x = y := by
+  let ⟨x, hx⟩ := x
+  let ⟨y, hy⟩ := y
+  simp [outof]
+  intro outof_eq
+  split_ifs at outof_eq with h₁ h₂ h₂
+    <;> (
+      first
+      | obtain ⟨l₁, r₁⟩ := h₁
+      | obtain ⟨l₁, r₁⟩ := Or.resolve_left (mem_Int_proj' hx) h₁
+      first
+      | obtain ⟨l₂, r₂⟩ := h₂
+      | obtain ⟨l₂, r₂⟩ := Or.resolve_left (mem_Int_proj' hy) h₂
+    )
+  · apply exact at outof_eq
+    simp [ZFSet.zrel] at outof_eq
+    simp_rw [mem_union, mem_prod] at hx hy
+    rcases hx, hy with ⟨⟨_, _, _, _, rfl⟩|⟨_, _, _, _, rfl⟩,⟨_, _, _, _, rfl⟩|⟨_, _, _, _, rfl⟩⟩
+      <;> (simp [π₁_pair, π₂_pair] at l₁ r₁ l₂ r₂ outof_eq; subst_eqs; congr)
+  · apply exact at outof_eq
+    simp [ZFSet.zrel] at outof_eq
+    obtain ⟨l₃, r₃⟩ := ZFNat.eq_zero_of_add_eq_zero outof_eq.symm
+    injection l₃ with l₃
+    injection r₃ with r₃
+    simp_rw [mem_union, mem_prod] at hx hy
+    rcases hx, hy with ⟨⟨_, _, _, _, rfl⟩|⟨_, _, _, _, rfl⟩,⟨_, _, _, _, rfl⟩|⟨_, _, _, _, rfl⟩⟩
+      <;> (simp [π₁_pair, π₂_pair] at l₁ r₁ l₂ r₂ l₃ r₃ outof_eq; subst_eqs; congr)
+  · apply exact at outof_eq
+    simp [ZFSet.zrel] at outof_eq
+    obtain ⟨l₃, r₃⟩ := ZFNat.eq_zero_of_add_eq_zero outof_eq
+    injection l₃ with l₃
+    injection r₃ with r₃
+    simp_rw [mem_union, mem_prod] at hx hy
+    rcases hx, hy with ⟨⟨_, _, _, _, rfl⟩|⟨_, _, _, _, rfl⟩,⟨_, _, _, _, rfl⟩|⟨_, _, _, _, rfl⟩⟩
+      <;> (simp [π₁_pair, π₂_pair] at l₁ r₁ l₂ r₂ l₃ r₃ outof_eq; subst_eqs; congr)
+  · apply exact at outof_eq
+    simp [ZFSet.zrel] at outof_eq
+    simp_rw [mem_union, mem_prod] at hx hy
+    rcases hx, hy with ⟨⟨_, _, _, _, rfl⟩|⟨_, _, _, _, rfl⟩,⟨_, _, _, _, rfl⟩|⟨_, _, _, _, rfl⟩⟩
+      <;> (simp [π₁_pair, π₂_pair] at l₁ r₁ l₂ r₂ outof_eq; subst_eqs; congr)
+
+theorem ZFNat.mem_Nat_sub_one {n : ZFNat} : (n - 1).1 ∈ Nat := by
+  induction n with
+  | zero => rw [ZFNat.zero_sub]; exact ZFNat.zero_in_Nat
+  | succ n _ =>
+    rw [ZFNat.sub_one_eq_pred, ZFNat.add_one_eq_succ, ZFNat.pred_succ]
+    rcases n; simpa
+
+theorem ZFNat.mem_Nat_sub {n m : ZFNat} : (n - m).1 ∈ Nat := by
+  induction m with
+  | zero => rcases n; simpa
+  | succ m _ =>
+    rw [ZFNat.sub_add_distrib]
+    exact ZFNat.mem_Nat_sub_one
+
+theorem mem_Int_empty_not_mem {x : ZFSet} {h : x ∈ Int} : ∅ ∉ x := by
+  intro contr
+  simp_rw [mem_union, mem_prod] at h
+  rcases h with ⟨a, _, b, _, h⟩ | ⟨a, _, b, _, h⟩
+  all_goals
+    unfold pair at h
+    subst h
+    rw [mem_insert_iff, mem_singleton] at contr
+    rcases contr with contr | contr
+    all_goals
+      simp only [ZFSet.ext_iff, notMem_empty, false_iff] at contr
+      specialize contr a
+      simp at contr
+
+/-! ## Well-definedness of `ZFInt` with respect to `ZFSet.Int` -/
+noncomputable section ZFIntEquivInt
+
+open Classical in
+
+/--
+This function maps `ZFInt` to `Int` by taking the first projection of the pair.
+-/
+def ZFInt.into (x : ZFInt) : {x // x ∈ Int} :=
+  let ⟨a,b⟩ := x.out
+  if a < b then
+    let n := ZFSet.pair ∅ (b-a).1
+    have : n ∈ Int := by
+      rw [mem_union]
+      right
+      rw [mem_prod]
+      exact ⟨∅, mem_singleton.mpr rfl, (b-a).1, ZFNat.mem_Nat_sub, rfl⟩
+    ⟨n, this⟩
+  else
+    let n := ZFSet.pair (a-b).1 ∅
+    have : n ∈ Int := by
+      rw [mem_union]
+      left
+      rw [mem_prod]
+      exact ⟨(a-b).1, ZFNat.mem_Nat_sub, ∅, mem_singleton.mpr rfl, rfl⟩
+    ⟨n, this⟩
+
+theorem ZFInt.into_inj_aux (x y : ZFInt) : into x = into y → x.out ≈ y.out := by
+  dsimp [into]
+  obtain ⟨a, b⟩ := Quotient.out x
+  obtain ⟨c, d⟩ := Quotient.out y
+  split_ifs with h₁ h₂ h₂ <;> (intro eq; simp at *)
+  · have := ZFNat.eq_add_of_sub_eq (hle := .inl h₁) (h := eq)
+    rw [ZFNat.add_comm, ← ZFNat.add_sub_assoc (.inl h₂)] at this
+    apply ZFNat.eq_add_of_sub_eq (h := this.symm)
+    rw [ZFNat.add_comm]
+    exact ZFNat.le_trans (.inl h₂) (ZFNat.le_add_right d a)
+  · obtain ⟨eq₁, eq₂⟩ := eq
+    replace eq₁ : 0 = c - d := Subtype.eq eq₁
+    replace eq₂ : b - a = 0 := Subtype.eq eq₂
+    have := ZFNat.le_antisymm (ZFNat.sub_eq_zero_imp_le.mp (eq₁.symm)) h₂
+    subst this
+    rw [eq₁] at eq₂
+    apply ZFNat.eq_add_of_sub_eq (.inl h₁) at eq₂
+    rw [ZFNat.add_comm, ← ZFNat.add_sub_assoc h₂] at eq₂
+    symm at eq₂
+    apply ZFNat.eq_add_of_sub_eq (h := eq₂)
+    exact ZFNat.le_add_left c a
+  · obtain ⟨eq₁, eq₂⟩ := eq
+    replace eq₁ : a - b = 0 := Subtype.eq eq₁
+    replace eq₂ : 0 = d - c := Subtype.eq eq₂
+    have := ZFNat.le_antisymm (ZFNat.sub_eq_zero_imp_le.mp eq₁) h₁
+    subst this
+    rw [eq₂] at eq₁
+    apply ZFNat.eq_add_of_sub_eq h₁ at eq₁
+    rw [ZFNat.add_comm, ← ZFNat.add_sub_assoc (.inl h₂)] at eq₁
+    symm at eq₁
+    apply ZFNat.eq_add_of_sub_eq (h := eq₁)
+    left
+    rw [← @ZFNat.zero_add c]
+    apply ZFNat.add_lt_add_of_le_of_lt
+    · exact ZFNat.zero_le
+    · assumption
+  · have := ZFNat.eq_add_of_sub_eq (hle := h₁) (h := eq)
+    rw [ZFNat.add_comm, ← ZFNat.add_sub_assoc h₂] at this
+    apply Eq.symm ∘ ZFNat.eq_add_of_sub_eq (h := this.symm)
+    exact ZFNat.le_trans h₂ (ZFNat.le_add_left c b)
+
+theorem ZFInt.into_inj (x y : ZFInt) : into x = into y → x = y := by
+  intro h
+  apply ZFInt.into_inj_aux at h
+  exact Quotient.out_equiv_out.mp h
+
+theorem ZFInt.into.injective : Function.Injective into := into_inj
+theorem ZFInt.outof.injective : Function.Injective outof := outof_inj
+
+def ZFInt.EmbeddingZFIntInt : ZFInt ↪ {x // x ∈ Int} where
+  toFun := into
+  inj' := into.injective
+def ZFInt.EmbeddingIntZFInt : {x // x ∈ Int} ↪ ZFInt where
+  toFun := outof
+  inj' := outof.injective
+
+instance : LT {x // x ∈ Int} where
+  -- lt := fun ⟨x, hx⟩ ⟨y, hy⟩ =>
+  --   let x₁ : ZFNat := ⟨x.π₁, by
+  --     unfold Int at hx
+  --     simp_rw [mem_union, mem_prod, mem_singleton, exists_eq_left] at hx
+  --     rcases hx with ⟨a, ha, rfl⟩ | ⟨b, hb, rfl⟩
+  --     · rwa [π₁_pair]
+  --     · rw [π₁_pair]
+  --       exact ZFNat.zero_in_Nat⟩
+  --   let x₂ : ZFNat := ⟨x.π₂, by
+  --     unfold Int at hx
+  --     simp_rw [mem_union, mem_prod, mem_singleton, exists_eq_left] at hx
+  --     rcases hx with ⟨a, ha, rfl⟩ | ⟨b, hb, rfl⟩
+  --     · rw [π₂_pair]
+  --       exact ZFNat.zero_in_Nat
+  --     · rwa [π₂_pair]⟩
+  --   let y₁ : ZFNat := ⟨y.π₁, by
+  --     unfold Int at hy
+  --     simp_rw [mem_union, mem_prod, mem_singleton, exists_eq_left] at hy
+  --     rcases hy with ⟨a, ha, rfl⟩ | ⟨b, hb, rfl⟩
+  --     · rwa [π₁_pair]
+  --     · rw [π₁_pair]
+  --       exact ZFNat.zero_in_Nat⟩
+  --   let y₂ : ZFNat := ⟨y.π₂, by
+  --     unfold Int at hy
+  --     simp_rw [mem_union, mem_prod, mem_singleton, exists_eq_left] at hy
+  --     rcases hy with ⟨a, ha, rfl⟩ | ⟨b, hb, rfl⟩
+  --     · rw [π₂_pair]
+  --       exact ZFNat.zero_in_Nat
+  --     · rwa [π₂_pair]⟩
+  --   x₁ + y₂ < x₂ + y₁
+
+  lt x y :=
+    let f := Classical.choice
+      (Function.Embedding.antisymm ZFInt.EmbeddingZFIntInt ZFInt.EmbeddingIntZFInt)
+    f.invFun x < f.invFun y
+
+attribute [-instance] SetLike.instPartialOrder
+
+-- instance instPreorderSubtypeMemInt.{u} : Preorder {x // x ∈ Int} where
+--   le x y := instLTSubtypeMemInt.lt x y ∨ x = y
+--   le_refl := fun _ => Or.inr rfl
+--   le_trans := by
+--     rintro ⟨x, hx⟩ ⟨y, hy⟩ ⟨z, hz⟩ hxy hyz
+--     have (w : {x : ZFSet.{u} // x ∈ Int.{u}}) : ∃ (a b : ZFNat), w = a.val.pair b.val := by
+--       obtain ⟨w, hw⟩ := w
+--       simp_rw [mem_union, mem_prod, mem_singleton, exists_eq_left] at hw
+--       exists ⟨w.π₁, ?_⟩, ⟨w.π₂, ?_⟩
+--       · rcases hw with ⟨a, ha, rfl⟩ | ⟨b, hb, rfl⟩
+--         · rwa [π₁_pair]
+--         · rw [π₁_pair]
+--           exact ZFNat.zero_in_Nat
+--       · rcases hw with ⟨a, ha, rfl⟩ | ⟨b, hb, rfl⟩
+--         · rw [π₂_pair]
+--           exact ZFNat.zero_in_Nat
+--         · rwa [π₂_pair]
+--       · rcases hw with ⟨a, ha, rfl⟩ | ⟨b, hb, rfl⟩ <;>
+--         · dsimp
+--           rw [pair_inj, π₁_pair, π₂_pair]
+--           exact ⟨rfl, rfl⟩
+
+--     obtain ⟨x₁, x₂, rfl⟩ := this ⟨x, hx⟩
+--     obtain ⟨y₁, y₂, rfl⟩ := this ⟨y, hy⟩
+--     obtain ⟨z₁, z₂, rfl⟩ := this ⟨z, hz⟩
+--     unfold LT.lt instLTSubtypeMemInt at hxy hyz ⊢
+--     simp at hxy hyz ⊢
+--     rcases hxy with hxy | ⟨rfl, rfl⟩ <;>
+--     rcases hyz with hyz | ⟨rfl, rfl⟩
+--     · left
+--       have : x₁ + z₂ + y₁ + y₂ < x₂ + z₁ + y₁ + y₂ := by
+--         conv_lhs =>
+--           rw [add_assoc, add_comm y₁, add_assoc, add_comm z₂, add_assoc, ←add_assoc]
+--         conv_rhs =>
+--           rw [add_assoc, add_assoc, add_comm z₁, add_assoc, ←add_assoc]
+--         exact ZFNat.add_lt_add_of_le_of_lt (.inl hxy) hyz
+--       simp_rw [ZFNat.add_lt_add_iff_right] at this
+--       exact this
+--     · left
+--       exact hxy
+--     · left
+--       exact hyz
+--     · right
+--       exact ⟨rfl, rfl⟩
+--   lt_iff_le_not_ge := by
+--     intro x y
+--     constructor
+--     · intro h
+--       and_intros
+--       · left; exact h
+--       · rw [not_or]
+--         and_intros
+--         · unfold LT.lt instLTSubtypeMemInt at h ⊢
+--           simp only [gt_iff_lt, not_lt] at h ⊢
+--           left
+--           conv_lhs => rw [add_comm]
+--           conv_rhs => rw [add_comm]
+--           exact h
+--         · rintro rfl
+--           unfold LT.lt instLTSubtypeMemInt at h
+--           dsimp at h
+--           rw [add_comm] at h
+--           apply ZFNat.lt_irrefl h
+--     · intro ⟨l, r⟩
+--       rcases l with l | rfl
+--       · rw [not_or] at r
+--         exact l
+--       · rw [not_or] at r
+--         nomatch r.2 rfl
+
+/--
+The Schröder-Bernstein theorem provides a bijection between `ZFInt` and `{x // x ∈ Int}`, but we
+need an isomorphism in order to preserve the order structure, so that the order on `ZFInt` and
+`{x // x ∈ Int}` is the same.
+-/
+theorem ZFInt.exists_mono_bij.{u} :
+  Nonempty {f : ZFInt.{u} → {x // x ∈ Int.{u}} // Function.Bijective f ∧ ∀ x y, f x < f y ↔ x < y}
+  := by
+  rw [nonempty_subtype]
+  let f := Classical.choice
+    (Function.Embedding.antisymm ZFInt.EmbeddingZFIntInt ZFInt.EmbeddingIntZFInt)
+  exists f
+  apply And.intro
+  · exact Equiv.bijective f
+  · intro x y
+    unfold f
+    dsimp [LT.lt, instLTSubtypeMemInt, int_lt]
+    apply Eq.to_iff
+    congr
+    · exact Equiv.symm_apply_apply (Classical.choice _) x
+    · exact Equiv.symm_apply_apply (Classical.choice _) y
+
+theorem ZFInt.exists_mono_bij_zero_eq.{u} :
+  Nonempty {f : ZFInt.{u} → {x // x ∈ Int.{u}} //
+    Function.Bijective f ∧ (∀ x y, f x < f y ↔ x < y) ∧ f 0 = ⟨ofInt 0, mem_ofInt_Int 0⟩}
+  := by
+  rw [nonempty_subtype]
+  by_contra!
+  let ⟨f, bij, mono⟩ := Classical.choice ZFInt.exists_mono_bij
+  have ⟨x₀, x₀_def, x₀_unique⟩ := Function.Bijective.existsUnique bij ⟨ofInt 0, mem_ofInt_Int 0⟩
+  beta_reduce at x₀_def x₀_unique
+  let f' : ZFInt → {x // x ∈ Int} := fun x => f (x + x₀)
+  specialize this f' ?_ ?_
+  · and_intros
+    · intro x y eq
+      apply bij.1 at eq
+      rwa [add_right_cancel_iff] at eq
+    · intro y
+      obtain ⟨x, hx⟩ := bij.2 y
+      exists x - x₀
+      unfold f'
+      rwa [sub_add_cancel]
+  · intro x y
+    unfold f'
+    rw [mono _ _, add_lt_add_iff_right]
+  · unfold f' at this
+    rw [zero_add] at this
+    contradiction
+
+/--
+The type `ZFInt` correctly represents the set `ZFSet.Int`.
+
+**NOTE**: There is a constructive proof of the Schröder-Bernstein theorem stating
+the equi-computability of sets. It is called the Myhill isomorphism and applies
+to countable sets only.
+-/
+@[reducible]
+instance instEquivZFIntInt : ZFInt ≃ {x // x ∈ Int} :=
+  let ⟨f, bij, _⟩ := Classical.choice ZFInt.exists_mono_bij_zero_eq
+  Equiv.ofBijective f bij
+
+instance : Coe ZFInt {x // x ∈ Int} := ⟨instEquivZFIntInt.toFun⟩
+instance : Coe {x // x ∈ Int} ZFInt := ⟨instEquivZFIntInt.invFun⟩
+
+theorem instEquivZFIntInt.mono_iff.{u} (x y : { x // x ∈ Int.{u} }) :
+  instEquivZFIntInt.{u}.invFun x < instEquivZFIntInt.{u}.invFun y ↔ x < y := by
+  constructor
+  · intro h
+    dsimp [instEquivZFIntInt] at h
+    split at h
+    rename_i f' f bij mono eq; clear f' eq
+    unfold Equiv.ofBijective at h
+    dsimp at h
+    have := mono.1
+      (Function.surjInv (Function.Bijective.surjective bij) x)
+      (Function.surjInv (Function.Bijective.surjective bij) y) |>.mpr h
+    iterate 2 rw [Function.rightInverse_surjInv (Function.Bijective.surjective bij)] at this
+    exact this
+  · intro h
+    dsimp [instEquivZFIntInt]
+    split
+    rename_i f' f bij mono eq; clear f' eq
+    let f' := Function.surjInv (Function.Bijective.surjective bij)
+    have mono' : ∀ x y, f' x < f' y ↔ x < y := by
+      intro x y
+      have := mono.1 (f' x) (f' y)
+      iterate 2 rw [Function.rightInverse_surjInv (Function.Bijective.surjective bij)] at this
+      exact this.symm
+    unfold Equiv.ofBijective
+    dsimp
+    exact mono' x y |>.mpr h
+
+instance : Preorder {x // x ∈ Int} where
+  le x y := ZFInt.instPartialOrder.le x y
+  le_refl x := ZFInt.instLinearOrder.le_refl x
+  le_trans x y z := ZFInt.instLinearOrder.le_trans x y z
+  lt_iff_le_not_ge x y := by
+    symm
+    trans
+    · exact ZFInt.instLinearOrder.lt_iff_le_not_ge x y |>.symm
+    · exact instEquivZFIntInt.mono_iff x y
+
+instance : LinearOrder {x // x ∈ Int} where
+  le := (ZFInt.instLinearOrder.le · ·)
+  le_refl := (ZFInt.instLinearOrder.le_refl ·)
+  le_trans := (ZFInt.instLinearOrder.le_trans · · ·)
+  le_antisymm x y h h' := by
+    have := ZFInt.instLinearOrder.le_antisymm x y h h'
+    rwa [Equiv.invFun_as_coe, EmbeddingLike.apply_eq_iff_eq] at this
+  le_total := (ZFInt.instLinearOrder.le_total · ·)
+  toDecidableLE := (ZFInt.instLinearOrder.toDecidableLE · ·)
+  lt_iff_le_not_ge _ _ := lt_iff_le_not_ge --instPreorderSubtypeMemInt.lt_iff_le_not_ge
+
+end ZFIntEquivInt
+end Integers
+end ZFSet

--- a/LeanPool/ZFLean/Isomorphisms.lean
+++ b/LeanPool/ZFLean/Isomorphisms.lean
@@ -1,0 +1,1583 @@
+/-
+Copyright (c) 2026 Vincent Trélat. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vincent Trélat
+-/
+
+import LeanPool.ZFLean.Functions
+
+namespace ZFSet
+
+section Isomorphisms
+
+def isIso (A B : ZFSet) : Prop :=
+  ∃ (bij : ZFSet) (is_func : A.IsFunc B bij), bij.IsBijective is_func
+infix:40 " ≅ᶻ " => ZFSet.isIso
+
+theorem isIso_refl : Reflexive ZFSet.isIso :=
+  fun A ↦ ⟨A.Id, Id.IsFunc, Id.IsBijective⟩
+
+instance : Trans ZFSet.isIso ZFSet.isIso ZFSet.isIso where
+  trans := by
+    intro x y z x_iso_y y_iso_z
+    obtain ⟨bij, is_func, is_bij⟩ := x_iso_y
+    obtain ⟨bij', is_func', is_bij'⟩ := y_iso_z
+    set bij'' := ZFSet.composition bij' bij x y z
+    exists bij'', ZFSet.IsFunc_of_composition_IsFunc is_func' is_func
+    exact ZFSet.IsBijective.composition_of_bijective is_bij is_bij'
+
+theorem isIso_symm : Symmetric ZFSet.isIso := by
+  intro x y iso
+  obtain ⟨bij, is_func, is_bij⟩ := iso
+  have := is_func.1
+  use bij⁻¹, ?_
+  exact inv_bijective_of_bijective is_bij
+instance : IsSymm ZFSet isIso where
+  symm := isIso_symm
+
+theorem isIso_trans : Transitive ZFSet.isIso := by
+  intro x y z x_iso_y y_iso_z
+  obtain ⟨bij, is_func, is_bij⟩ := x_iso_y
+  obtain ⟨bij', is_func', is_bij'⟩ := y_iso_z
+  set bij'' := ZFSet.composition bij' bij x y z
+  exists bij'', ZFSet.IsFunc_of_composition_IsFunc is_func' is_func
+  exact ZFSet.IsBijective.composition_of_bijective is_bij is_bij'
+instance : IsTrans ZFSet isIso where
+  trans := isIso_trans
+
+theorem isIso_equiv : Equivalence ZFSet.isIso where
+  refl := isIso_refl
+  symm := @isIso_symm
+  trans := @isIso_trans
+instance : IsEquiv ZFSet isIso where
+  refl := isIso_refl
+
+section Lemmas
+
+private def C (A B u : ZFSet) : ℕ → ZFSet
+  | 0 => A \ B
+  | n + 1 => B.sep fun y ↦ ∃ x ∈ C A B u n, x.pair y ∈ u
+
+open Classical in
+theorem bijective_of_injective_on_subset {A B : ZFSet}
+  (B_sub : B ⊆ A) {u : ZFSet} {hu : A.IsFunc B u} (u_inj : IsInjective u) :
+    ∃ (v : ZFSet) (hv : A.IsFunc B v), IsBijective v := by
+  let C₀ := A \ B
+
+  have C_sub {n} : C A B u n ⊆ A := by
+    induction n with
+    | zero =>
+      intro x x_mem_C
+      rw [C, mem_diff] at x_mem_C
+      exact x_mem_C.1
+    | succ n ih =>
+      intro x x_mem_C
+      rw [C, mem_sep] at x_mem_C
+      exact B_sub x_mem_C.1
+
+  let v := λᶻ : A → B
+              | x ↦ if mem_Cn : ∃ n, x ∈ C A B u n then @ᶻu ⟨x, by
+                      rw [is_func_dom_eq hu]
+                      obtain ⟨_, x_mem_Cn⟩ := mem_Cn
+                      apply C_sub x_mem_Cn⟩
+                    else x
+
+  have hv : A.IsFunc B v := by
+    apply lambda_isFunc
+    intro x xA
+    split_ifs with mem_Cn
+    · apply fapply_mem_range
+    · push_neg at mem_Cn
+      specialize mem_Cn 0
+      rw [C, mem_diff, not_and, not_not] at mem_Cn
+      exact mem_Cn xA
+  have v_inj : IsInjective v := by
+    intro x y z hx hy hz eq₁ eq₂
+    rw [lambda_spec] at eq₁ eq₂
+    split_ifs at eq₁ eq₂ with mem_x mem_y mem_y <;> (
+      obtain ⟨-, -, rfl⟩ := eq₁
+      obtain ⟨-, -, eq⟩ := eq₂)
+    · generalize_proofs u_pfun x_dom y_dom at eq
+      rw [SetLike.coe_eq_coe] at eq
+      obtain ⟨⟩ := IsInjective.apply_inj hu u_inj eq
+      rfl
+    · generalize_proofs u_pfun u_rel x_dom at eq
+      subst y
+      obtain ⟨n, mem_x⟩ := mem_x
+      push_neg at mem_y
+      specialize mem_y (n+1)
+      rw [C, mem_sep, not_and] at mem_y
+      specialize mem_y hz
+      push_neg at mem_y
+      specialize mem_y x mem_x
+      nomatch mem_y <| fapply.def u_pfun x_dom
+    · generalize_proofs u_pfun u_rel y_dom at eq
+      subst z
+      obtain ⟨n, mem_y⟩ := mem_y
+      push_neg at mem_x
+      specialize mem_x (n+1)
+      rw [C, mem_sep, not_and] at mem_x
+      specialize mem_x hz
+      push_neg at mem_x
+      specialize mem_x y mem_y
+      nomatch mem_x <| fapply.def u_pfun y_dom
+    · exact eq
+
+  have v_surj : IsSurjective v := by classical
+    intro y yB
+    by_cases y_mem_C : ∃ n, y ∈ C A B u n
+    · obtain ⟨n, y_mem_Cn⟩ := y_mem_C
+      have : n ≠ 0 := by
+        rintro rfl
+        rw [C, mem_diff] at y_mem_Cn
+        nomatch y_mem_Cn.2 yB
+      obtain ⟨n, rfl⟩ := Nat.exists_eq_succ_of_ne_zero this
+      rw [C, mem_sep] at y_mem_Cn
+      obtain ⟨-, x, x_mem_Cn, x_y_u⟩ := y_mem_Cn
+      use x, C_sub x_mem_Cn
+      rw [lambda_spec]
+      and_intros
+      · exact C_sub x_mem_Cn
+      · exact yB
+      · rw [dite_cond_eq_true <| eq_true ⟨n, x_mem_Cn⟩,
+          fapply.of_pair (is_func_is_pfunc hu) x_y_u]
+    · use y, B_sub yB
+      rw [lambda_spec]
+      and_intros
+      · exact B_sub yB
+      · exact yB
+      · rw [dite_cond_eq_false <| eq_false y_mem_C]
+  use v, hv, v_inj, v_surj
+
+set_option pp.proofs true in
+/--
+Cantor–Bernstein theorem: if there are injective functions
+`f : A → B` and `g : B → A`, then `A` and `B` are isomorphic.
+-/
+theorem isIso_of_biembedding {E F f g : ZFSet} {hf : E.IsFunc F f}
+  (f_inj : IsInjective f) {hg : F.IsFunc E g} (g_inj : IsInjective g hg) : E ≅ᶻ F := by
+  let B := g.Range
+  have B_sub : B ⊆ E := sep_subset_self
+  let u := composition g f E F B
+  have hu : E.IsFunc B u := ZFSet.IsFunc_of_composition_IsFunc (IsFunc.is_func_on_range hg) hf
+  have u_inj : IsInjective u := by
+    intro x y z hx hy hz eq₁ eq₂
+    unfold u at eq₁ eq₂
+    simp only [composition, mem_sep, mem_prod, pair_inj, exists_eq_right_right', existsAndEq,
+      and_true, exists_eq_left'] at eq₁ eq₂
+    obtain ⟨-, x', hx', x_x'_f, x'_z_g⟩ := eq₁
+    obtain ⟨-, y', hy', y_y'_f, y'_z_g⟩ := eq₂
+    obtain rfl := g_inj x' y' z hx' hy' (B_sub hz) x'_z_g y'_z_g
+    exact f_inj x y x' hx hy hx' x_x'_f y_y'_f
+  obtain ⟨v, hv, bij⟩ := bijective_of_injective_on_subset B_sub u_inj
+
+  have hg' : F.IsFunc B g := IsFunc.is_func_on_range hg
+  have g_bij : IsBijective g hg' := bijective_of_injective hg g_inj
+  have h_v_hinv : E.IsFunc F (composition (inv g hg'.1) v E B F) :=
+    IsFunc_of_composition_IsFunc (inv_is_func_of_bijective g_bij) hv
+
+  use composition (inv g hg'.1) v E B F, h_v_hinv
+
+  exact IsBijective.composition_of_bijective bij (inv_bijective_of_bijective g_bij)
+
+alias schroeder_bernstein := isIso_of_biembedding
+
+theorem isIso_of_prod {A B C D : ZFSet} (h : A ≅ᶻ C) (h' : B ≅ᶻ D) : A.prod B ≅ᶻ C.prod D := by
+  obtain ⟨f₁, hf₁, bij₁⟩ := h
+  obtain ⟨f₂, hf₂, bij₂⟩ := h'
+  let F := (A.prod B).prod (C.prod D) |>.sep fun z ↦
+    ∃ (a b c d : ZFSet), z = (a.pair b).pair (c.pair d) ∧ (a.pair c ∈ f₁) ∧ (b.pair d ∈ f₂)
+  use F, ?_
+  · and_intros
+    · intro ab a'b' cd hab ha'b' hcd habcd ha'b'cd
+      simp only [mem_sep, mem_prod, pair_inj, exists_eq_right_right', F] at habcd ha'b'cd
+      obtain ⟨⟨⟨a, ha, b, hb, rfl⟩, c, hc, d, hd, rfl⟩, _, _, _, _, ⟨ab_eq, cd_eq⟩, ac_f₁, bd_f₂⟩ :=
+        habcd
+      rw [pair_inj] at ab_eq cd_eq
+      rcases ab_eq with ⟨rfl, rfl⟩
+      rcases cd_eq with ⟨rfl, rfl⟩
+
+      obtain ⟨⟨⟨a', ha', b', hb', rfl⟩, -⟩, _, _, _, _, ⟨a'b'_eq, cd_eq⟩, a'c_f₁, b'd_f₂⟩ := ha'b'cd
+      rw [pair_inj] at a'b'_eq cd_eq
+      rcases a'b'_eq with ⟨rfl, rfl⟩
+      rcases cd_eq with ⟨rfl, rfl⟩
+      congr
+      · exact bij₁.1 _ _ _ ha ha' hc ac_f₁ a'c_f₁
+      · exact bij₂.1 _ _ _ hb hb' hd bd_f₂ b'd_f₂
+    · intro cd hcd
+      rw [mem_prod] at hcd
+      obtain ⟨c, hc, d, hd, rfl⟩ := hcd
+      obtain ⟨a, ha, ac_f₁⟩ := bij₁.2 c hc
+      obtain ⟨b, hb, bd_f₂⟩ := bij₂.2 d hd
+      use a.pair b
+      and_intros
+      · rw [pair_mem_prod]
+        exact ⟨ha, hb⟩
+      · simp only [mem_sep, mem_prod, pair_inj, exists_eq_right_right', existsAndEq, and_true,
+        exists_eq_left', F]
+        and_intros
+        · exact ha
+        · exact hb
+        · exact hc
+        · exact hd
+        · exact ac_f₁
+        · exact bd_f₂
+  · and_intros
+    · intro z hz
+      rw [mem_sep] at hz
+      exact hz.1
+    · intro z hz
+      rw [mem_prod] at hz
+      obtain ⟨a, ha, b, hb, rfl⟩ := hz
+      obtain ⟨c, hc, c_unq⟩ := hf₁.2 a ha
+      obtain ⟨d, hd, d_unq⟩ := hf₂.2 b hb
+      use c.pair d
+      and_intros <;> beta_reduce
+      · rw [mem_sep, pair_mem_prod, pair_mem_prod, pair_mem_prod]
+        and_intros
+        · exact ha
+        · exact hb
+        · exact hf₁.1 hc |> pair_mem_prod.mp |>.2
+        · exact hf₂.1 hd |> pair_mem_prod.mp |>.2
+        · use a, b, c, d
+      · intro y hy
+        rw [mem_sep, pair_mem_prod] at hy
+        obtain ⟨c', hc', d', hd', rfl⟩ := hy.1.2 |> mem_prod.mp
+        simp only [mem_prod, pair_inj, exists_eq_right_right', existsAndEq, and_true,
+          exists_eq_left'] at hy
+        congr
+        · apply c_unq
+          exact hy.2.1
+        · apply d_unq
+          exact hy.2.2
+
+theorem inv_Image_of_bijective {f A B : ZFSet} {hf : A.IsFunc B f}
+  (bij : f.IsBijective) {X : ZFSet} (hX : X ⊆ A) :
+    f⁻¹[(f[X])] = X := by
+  ext1 x
+  constructor <;> intro hx
+  · simp [mem_Image, mem_inv] at hx
+    obtain ⟨xA, y, ⟨yB, u, uX, fuy⟩, fxy⟩ := hx
+    obtain rfl := bij.1 u x y (hf.1 fuy |> pair_mem_prod.mp |>.1) xA yB fuy fxy
+    exact uX
+  · simp [mem_Image, mem_inv]
+    and_intros
+    · exact hX hx
+    · obtain ⟨y, yB, -⟩ := hf.2 x (hX hx)
+      use y
+      and_intros
+      · exact hf.1 yB |> pair_mem_prod.mp |>.2
+      · use x
+      · exact yB
+
+theorem Image_inv_of_bijective {f A B : ZFSet} {hf : A.IsFunc B f}
+  (bij : f.IsBijective hf) {X : ZFSet} (hX : X ⊆ B) :
+    f[(f⁻¹[X])] = X := by
+  let g := f⁻¹
+  have hg : B.IsFunc A g := inv_is_func_of_bijective bij
+  have gbij : g.IsBijective hg := inv_bijective_of_bijective bij
+  have ginv_eq : g⁻¹ = f := by rw [inv_involutive]
+  have := inv_Image_of_bijective gbij hX
+  dsimp [g] at this
+  conv at this =>
+    enter [1,1]
+    rw [inv_involutive]
+  exact this
+
+theorem IsInjective_of_left_inverse {A B : ZFSet} {f : ZFSet}
+  (hf : A.IsFunc B f) {g : ZFSet} (hg : B.IsFunc A g) (left_inv : g ∘ᶻ f = 𝟙A) :
+    IsInjective f := by
+  intro x y z hx hy hz fxy fxz
+  have x_x : x.pair x ∈ g ∘ᶻ f := by
+    rw [left_inv]
+    exact pair_self_mem_Id hx
+  have y_y : y.pair y ∈ g ∘ᶻ f := by
+    rw [left_inv]
+    exact pair_self_mem_Id hy
+
+  simp only [composition, mem_sep, mem_prod, pair_inj, exists_eq_right_right', and_self,
+    existsAndEq, and_true, exists_eq_left'] at x_x y_y
+  obtain ⟨-, x', hx', x_x'_f, x'_x_g⟩ := x_x
+  obtain ⟨-, y', hy', y_y'_f, y'_y_g⟩ := y_y
+
+  obtain rfl : x' = y' := by
+    trans z
+    · apply hf.2 x hx |>.unique
+      · exact x_x'_f
+      · exact fxy
+    · apply hf.2 y hy |>.unique
+      · exact fxz
+      · exact y_y'_f
+  apply hg.2 x' hx' |>.unique
+  · exact x'_x_g
+  · exact y'_y_g
+
+theorem IsSurjective_of_right_inverse {A B : ZFSet} {f : ZFSet}
+  (hf : A.IsFunc B f) {g : ZFSet} (hg : B.IsFunc A g) (right_inv : f ∘ᶻ g = 𝟙B) :
+    IsSurjective f := by
+  intro y yB
+  have y_y : y.pair y ∈ f ∘ᶻ g := by
+    rw [right_inv]
+    exact pair_self_mem_Id yB
+  simp only [composition, mem_sep, mem_prod, pair_inj, exists_eq_right_right', and_self,
+    existsAndEq, and_true, exists_eq_left'] at y_y
+  obtain ⟨yB, x, xA, gyx, fxy⟩ := y_y
+  use x, xA
+
+theorem isIso_of_two_sided_inverse {A B : ZFSet} {f : ZFSet}
+  {hf : A.IsFunc B f} {g : ZFSet} {hg : B.IsFunc A g}
+  (left_inv : g ∘ᶻ f = 𝟙A) (right_inv : f ∘ᶻ g = 𝟙B) :
+    A ≅ᶻ B := by
+  use f, hf
+  and_intros
+  · exact IsInjective_of_left_inverse _ _ left_inv
+  · exact IsSurjective_of_right_inverse _ _ right_inv
+
+theorem isIso_powerset {A B : ZFSet} (h : A ≅ᶻ B) : A.powerset ≅ᶻ B.powerset := by
+  obtain ⟨f, hf, bij⟩ := h
+  let F := λᶻ : A.powerset → B.powerset | x ↦ f[x]
+  have hF : A.powerset.IsFunc B.powerset F := by
+    apply lambda_isFunc
+    intros
+    rw [mem_powerset]
+    intro y yIm
+    rw [mem_Image] at yIm
+    exact yIm.1
+  let F' := λᶻ : B.powerset → A.powerset | z ↦ f⁻¹[z]
+  have hF' : B.powerset.IsFunc A.powerset F' := by
+    apply lambda_isFunc
+    intros
+    rw [mem_powerset]
+    intro y yIm
+    rw [mem_Image] at yIm
+    exact yIm.1
+  have left_inv : F' ∘ᶻ F = 𝟙A.powerset := by
+    ext1 X
+    rw [fcomp, composition, mem_sep, mem_prod]
+    constructor
+    · rintro ⟨⟨X, hX, Y, hY, rfl⟩, ⟨_, _, eq, Z, hZ, FXZ, F'ZY⟩⟩
+      rw [pair_inj] at eq
+      obtain ⟨rfl, rfl⟩ := eq
+      rw [mem_lambda] at FXZ F'ZY
+      simp only [pair_inj, mem_powerset, existsAndEq, and_true, exists_eq_left'] at FXZ F'ZY
+      obtain ⟨-, -, rfl⟩ := FXZ
+      obtain ⟨-, -, rfl⟩ := F'ZY
+      rw [inv_Image_of_bijective bij (mem_powerset.mp hX), pair_mem_Id_iff hX]
+    · intro hX
+      rw [mem_Id_iff] at hX
+      obtain ⟨X, hX, rfl⟩ := hX
+      simp only [mem_powerset, pair_inj, exists_eq_right_right', and_self, existsAndEq,
+        and_true, exists_eq_left']
+      apply And.intro <| mem_powerset.mp hX
+      use f[X]
+      and_intros
+      · intro z hz
+        rw [mem_Image] at hz
+        exact hz.1
+      · rw [lambda_spec]
+        and_intros
+        · exact hX
+        · rw [mem_powerset]
+          intro y hy
+          rw [mem_Image] at hy
+          exact hy.1
+        · rfl
+      · rw [lambda_spec]
+        and_intros
+        · rw [mem_powerset]
+          intro y hy
+          rw [mem_Image] at hy
+          exact hy.1
+        · exact hX
+        · rw [inv_Image_of_bijective bij (mem_powerset.mp hX)]
+
+  have right_inv : F ∘ᶻ F' = 𝟙B.powerset := by
+    ext1 X
+    rw [fcomp, composition, mem_sep, mem_prod]
+    constructor
+    · rintro ⟨⟨X, hX, Y, hY, rfl⟩, ⟨_, _, eq, Z, hZ, FXZ, F'ZY⟩⟩
+      rw [pair_inj] at eq
+      obtain ⟨rfl, rfl⟩ := eq
+      rw [mem_lambda] at FXZ F'ZY
+      simp only [pair_inj, mem_powerset, existsAndEq, and_true, exists_eq_left'] at FXZ F'ZY
+      obtain ⟨-, -, rfl⟩ := FXZ
+      obtain ⟨-, -, rfl⟩ := F'ZY
+      rw [Image_inv_of_bijective bij (mem_powerset.mp hX), pair_mem_Id_iff hX]
+    · intro hX
+      rw [mem_Id_iff] at hX
+      obtain ⟨X, hX, rfl⟩ := hX
+      simp only [mem_powerset, pair_inj, exists_eq_right_right', and_self, existsAndEq,
+        and_true, exists_eq_left']
+      apply And.intro <| mem_powerset.mp hX
+      have := subset_prod_inv hf.1
+      use f⁻¹[X]
+      and_intros
+      · intro z hz
+        rw [mem_Image] at hz
+        exact hz.1
+      · rw [lambda_spec]
+        and_intros
+        · exact hX
+        · rw [mem_powerset]
+          intro y hy
+          rw [mem_Image] at hy
+          exact hy.1
+        · rfl
+      · rw [lambda_spec]
+        and_intros
+        · rw [mem_powerset]
+          intro y hy
+          rw [mem_Image] at hy
+          exact hy.1
+        · exact hX
+        · rw [Image_inv_of_bijective bij (mem_powerset.mp hX)]
+  apply isIso_of_two_sided_inverse left_inv right_inv
+
+open Classical in
+theorem isIso_funs_to_pow_rel {A B : ZFSet} : A.funs B.powerset ≅ᶻ (A.prod B).powerset := by
+  let F := λᶻ : (A.funs B.powerset) → (A.prod B).powerset
+              |         f           ↦ if hf : A.IsFunc B.powerset f then
+                                        A.prod B |>.sep fun z ↦
+                                          if hz : z ∈ A.prod B then
+                                            have : z.π₁ ∈ A := by
+                                              rw [mem_prod] at hz
+                                              obtain ⟨_, _, _, _, rfl⟩ := hz
+                                              rwa [π₁_pair]
+                                            z.π₂ ∈ (@ᶻf ⟨z.π₁, by rwa [is_func_dom_eq hf]⟩).val
+                                          else False
+                                      else ∅
+  let G := λᶻ : (A.prod B).powerset → (A.funs B.powerset)
+              |         R           ↦ λᶻ: A → B.powerset
+                                        | a ↦ if ha : a ∈ A then
+                                                B.sep fun b ↦ (a.pair b ∈ R) -- {b ∈ B | (a, b) ∈ R}
+                                              else ∅
+
+  have hF : (A.funs B.powerset).IsFunc (A.prod B).powerset F := by
+    apply lambda_isFunc
+    intro f hf
+    rw [mem_funs] at hf
+    rw [dite_cond_eq_true (eq_true hf)]
+    apply sep_mem_powerset
+    rw [mem_powerset]
+  have hG : (A.prod B).powerset.IsFunc (A.funs B.powerset) G := by
+    apply lambda_isFunc
+    intro R hR
+    rw [mem_powerset] at hR
+    apply mem_funs_of_lambda
+    intro a ha
+    rw [dite_cond_eq_true (eq_true ha)]
+    apply sep_mem_powerset
+    rw [mem_powerset]
+
+  apply isIso_of_two_sided_inverse (f := F) (g := G)
+  · ext1 f
+    simp only [mem_composition, mem_funs, mem_powerset, mem_Id_iff]
+    constructor
+    · rintro ⟨f, R, g, rfl, hf, hg, hR, fR_F, Rg_G⟩
+      use f, hf
+      rw [pair_inj, eq_self, true_and]
+      rw [lambda_spec] at fR_F Rg_G
+      obtain ⟨_, _, rfl⟩ := fR_F
+      obtain ⟨_, _, rfl⟩ := Rg_G
+      rw [dite_cond_eq_true (eq_true hf)]
+      conv_rhs => rw [lambda_eta hf]
+      rw [lambda_ext_iff ?_]
+      · intro a ha
+        rw [dite_cond_eq_true (eq_true ha), dite_cond_eq_true (eq_true ha)]
+        ext1 X
+        simp only [mem_prod, dite_else_false, mem_sep, pair_inj, exists_eq_right_right', π₁_pair,
+          π₂_pair, and_exists_self]
+        constructor
+        · rintro ⟨_, _, hX⟩
+          exact hX
+        · intro hX
+          obtain ⟨Y, Y_def, X_unq⟩ := hf.2 a ha
+          have YB := hf.1 Y_def |> pair_mem_prod.mp |>.2
+          rw [Image_of_singleton_pair_mem_iff hf] at Y_def
+          simp_rw [fapply_eq_Image_singleton hf ha, Y_def, sInter_singleton] at hX ⊢
+          rw [mem_powerset] at YB
+          and_intros
+          · exact YB hX
+          · exact ⟨⟨ha, YB hX⟩, hX⟩
+      · intro a ha
+        rw [dite_cond_eq_true (eq_true ha)]
+        apply sep_mem_powerset
+        rw [mem_powerset]
+    · rintro ⟨f, hf, rfl⟩
+      use f, @ᶻF ⟨f, by rwa [is_func_dom_eq hF, mem_funs]⟩, f
+      · rw [eq_self, true_and, ←and_assoc, and_self]
+        and_intros
+        · exact hf.1
+        · exact hf.2
+        · rw [←mem_powerset]
+          apply fapply_mem_range
+        · apply fapply.def
+        · rw [lambda_spec]
+          and_intros
+          · apply fapply_mem_range
+          · rw [mem_funs]
+            exact hf
+          · conv_lhs => rw [lambda_eta hf]
+            rw [lambda_ext_iff ?_]
+            · intro a ha
+              generalize_proofs _ _ ha_f_dom Fpfunc f_Fdom
+              rw [fapply_lambda (ha := by rwa [mem_funs]), dite_cond_eq_true (eq_true ha),
+                dite_cond_eq_true (eq_true ha),
+                dite_cond_eq_true (eq_true hf)]
+              · ext1 z
+                constructor
+                · intro hz
+                  simp only [mem_prod, dite_else_false, mem_sep, pair_inj, exists_eq_right_right',
+                    π₁_pair, π₂_pair, and_exists_self]
+                  have zB : z ∈ B := mem_powerset.mp (fapply_mem_range _ (ha_f_dom ha)) hz
+                  exact ⟨zB, ⟨ha, zB⟩, hz⟩
+                · intro hz
+                  simp only [mem_prod, dite_else_false, mem_sep, pair_inj, exists_eq_right_right',
+                    π₁_pair, π₂_pair, and_exists_self] at hz
+                  obtain ⟨-, _, z_mem⟩ := hz
+                  exact z_mem
+              · intro X hX
+                rw [dite_cond_eq_true (eq_true <| mem_funs.mp hX)]
+                apply sep_mem_powerset
+                rw [mem_powerset]
+            · intro a ha
+              rw [dite_cond_eq_true (eq_true ha)]
+              apply fapply_mem_range
+  · ext1 R
+    simp only [mem_composition, mem_powerset, mem_funs, mem_Id_iff]
+    constructor
+    · rintro ⟨R, f, S, rfl, hR, hf, hS, Rf_G, fS_F⟩
+      use R, hR
+      rw [pair_inj, eq_self, true_and]
+      rw [lambda_spec] at Rf_G fS_F
+      obtain ⟨_, _, rfl⟩ := Rf_G
+      obtain ⟨_, _, rfl⟩ := fS_F
+      rw [dite_cond_eq_true (eq_true hS)]
+      ext1 ab
+      simp only [mem_prod, dite_eq_ite, dite_else_false, mem_sep, and_exists_self]
+      constructor
+      · rintro ⟨⟨a, ha, b, hb, rfl⟩, b_mem⟩
+        simp only [π₁_pair, π₂_pair] at b_mem
+        rw [fapply_lambda] at b_mem
+        · rw [ite_cond_eq_true (h := eq_true ha), mem_sep] at b_mem
+          exact b_mem.2
+        · intro x hx
+          rw [ite_cond_eq_true (h := eq_true hx)]
+          apply sep_mem_powerset
+          rw [mem_powerset]
+        · exact ha
+      · intro hab
+        obtain ⟨a, ha, b, hb, rfl⟩ := hR hab |> mem_prod.mp
+        simp only [π₁_pair, π₂_pair, pair_inj, exists_eq_right_right']
+        use ⟨ha, hb⟩
+        rw [fapply_lambda]
+        · rw [ite_cond_eq_true (h := eq_true ha), mem_sep]
+          exact ⟨hb, hab⟩
+        · intro x hx
+          rw [ite_cond_eq_true (h := eq_true hx)]
+          apply sep_mem_powerset
+          rw [mem_powerset]
+        · exact ha
+    · rintro ⟨S, hS, rfl⟩
+      simp only [pair_inj, existsAndEq, and_true, exists_and_left, exists_eq_left', and_self_left]
+      and_intros
+      · exact hS
+      · use @ᶻG ⟨S, by rwa [is_func_dom_eq hG, mem_powerset]⟩
+        and_intros
+        · exact fapply_mem_range _ _ |> mem_funs.mp |>.1
+        · intro a ha
+          rw [fapply_lambda]
+          · simp only [ha, true_and, dite_true, lambda_spec, mem_powerset]
+            use B.sep fun b ↦ (a.pair b ∈ S)
+            and_intros
+            · exact sep_subset_self
+            · rfl
+            · rintro _ ⟨_, rfl⟩
+              rfl
+          · intros
+            apply mem_funs_of_lambda
+            intro _ ha
+            rw [dite_cond_eq_true (eq_true ha)]
+            apply sep_mem_powerset
+            rw [mem_powerset]
+          · rwa [mem_powerset]
+        · apply fapply.def
+        · rw [lambda_spec]
+          and_intros
+          · apply fapply_mem_range
+          · rwa [mem_powerset]
+          · rw [dite_cond_eq_true (eq_true ?_)]
+            · ext1 ab
+              simp only [mem_prod, dite_else_false, mem_sep, and_exists_self]
+              generalize_proofs G_pfunc _ S_Gdom fapply_pfunc a_dom
+              have fapp_eq :
+                ↑(@ᶻG ⟨S, S_Gdom⟩) =
+                (λᶻ : A → B.powerset
+                    | a ↦ if ha : a ∈ A then B.sep (fun b => a.pair b ∈ S) else ∅)
+                  := by
+                rw [fapply_lambda]
+                · intros
+                  apply mem_funs_of_lambda
+                  intro _ ha
+                  rw [dite_cond_eq_true (eq_true ha)]
+                  apply sep_mem_powerset
+                  rw [mem_powerset]
+                · rwa [mem_powerset]
+              constructor
+              · intro hab
+                obtain ⟨a, ha, b, hb, rfl⟩ := hS hab |> mem_prod.mp
+                simp only [π₁_pair, π₂_pair, pair_inj, exists_eq_right_right']
+                use ⟨ha, hb⟩
+                rw [fapply]
+                generalize_proofs choose₁ choose₂
+                simp [fapp_eq] at *
+                clear fapp_eq
+                generalize_proofs choose₃
+                have choose₃_spec := choose_spec choose₃
+                rw [lambda_spec, ite_cond_eq_true _ _ (eq_true ha)] at choose₃_spec
+                rw [choose₃_spec.2.2.2, mem_sep]
+                exact ⟨hb, hab⟩
+              · rintro ⟨⟨a, ha, b, hb, rfl⟩, h⟩
+                simp only [π₁_pair, π₂_pair] at h
+                simp only [fapply, mem_powerset, mem_funs] at h
+                generalize_proofs choose₁ choose₂ at h
+                have choose₁_spec := choose_spec choose₁
+                have choose₂_spec := choose_spec choose₂
+                have choose₁_eq := choose₁_spec.2 |> lambda_spec.mp |>.2.2
+
+                conv at choose₂_spec =>
+                  enter [2,1]
+                  rw [choose₁_eq]
+                rw [lambda_spec, dite_cond_eq_true (eq_true ha)] at choose₂_spec
+                rw [choose₂_spec.2.2.2, mem_sep] at h
+                exact h.2
+            · rw [fapply_lambda]
+              · apply lambda_isFunc
+                intro a ha
+                rw [dite_cond_eq_true (eq_true ha)]
+                apply sep_mem_powerset
+                rw [mem_powerset]
+              · intros
+                apply mem_funs_of_lambda
+                intro a ha
+                rw [dite_cond_eq_true (eq_true ha)]
+                apply sep_mem_powerset
+                rw [mem_powerset]
+              · rwa [mem_powerset]
+
+  · exact hF
+  · exact hG
+
+theorem isIso_of_funs {A B C D : ZFSet} (h : A ≅ᶻ C) (h' : B ≅ᶻ D) : A.funs B ≅ᶻ C.funs D := by
+  classical
+  obtain ⟨F, hF, Fbij⟩ := h
+  have : F⁻¹ ⊆ C.prod A := by apply subset_prod_inv
+  obtain ⟨G, hG, Gbij⟩ := h'
+
+  let ξ := λᶻ : (A.funs B) → (C.funs D)
+              |     f      ↦ if hf : f ⊆ A.prod B then
+                              λᶻ: C → D
+                                | c ↦ ⋂₀ (G[f[F⁻¹[{c}]]])
+                            else ∅
+  use ξ, ?_
+  · rw [bijective_exists1_iff]
+    intro f hf
+    rw [mem_funs] at hf
+    have Ginv_isfunc := inv_is_func_of_bijective Gbij
+    let g := λᶻ : A → B
+                | a ↦ if ha : a ∈ A then ⋂₀ (G⁻¹[f[F[{a}]]]) else ∅
+    have hg : A.IsFunc B g := by
+      apply lambda_isFunc
+      intro a ha
+      rw [dite_cond_eq_true (eq_true ha),
+        Image_singleton_eq_fapply hF ha,
+        Image_singleton_eq_fapply hf (by apply fapply_mem_range),
+        Image_singleton_eq_fapply Ginv_isfunc (by apply fapply_mem_range),
+        sInter_singleton]
+      apply fapply_mem_range
+    use g
+    and_intros
+    · apply mem_funs_of_lambda
+      intro a ha
+      rw [dite_cond_eq_true (eq_true ha),
+        Image_singleton_eq_fapply hF ha,
+        Image_singleton_eq_fapply hf (by apply fapply_mem_range),
+        Image_singleton_eq_fapply Ginv_isfunc (by apply fapply_mem_range),
+        sInter_singleton]
+      apply fapply_mem_range
+    · rw [lambda_spec]
+      and_intros
+      · rw [mem_funs]
+        exact hg
+      · rw [mem_funs]
+        exact hf
+      · rw [dite_cond_eq_true (eq_true hg.1), lambda_eta hf, lambda_ext_iff]
+        · intro c hc
+          rw [dite_cond_eq_true (eq_true hc)]
+          rw [Image_singleton_eq_fapply (inv_is_func_of_bijective Fbij) hc,
+            Image_singleton_eq_fapply hg (by apply fapply_mem_range),
+            Image_singleton_eq_fapply hG (by apply fapply_mem_range),
+            sInter_singleton]
+          conv =>
+            unfold fapply
+            dsimp
+            rfl
+          congr
+          funext d
+          ext
+          constructor <;> (rintro ⟨xD, h⟩; refine ⟨xD, ?_⟩)
+          · generalize_proofs Frel c_Finv c_Finv_g
+            have ⟨bB, ab_g⟩ := Classical.choose_spec c_Finv_g
+            have ⟨aA, ac_F⟩ := Classical.choose_spec c_Finv
+            set b := Classical.choose c_Finv_g
+            set a := Classical.choose c_Finv
+            rw [mem_inv] at ac_F
+            rw [lambda_spec] at ab_g
+            obtain ⟨-, -, b_eq⟩ := ab_g
+            rw [dite_cond_eq_true (eq_true aA)] at b_eq
+            have Fa := fapply.of_pair (is_func_is_pfunc hF) ac_F
+            have Fc := fapply.of_pair (is_func_is_pfunc hf) h
+            conv at b_eq =>
+              enter [2]
+              rw [Image_singleton_eq_fapply hF aA, Fa, Image_singleton_eq_fapply hf hc, Fc,
+                ←fapply_eq_Image_singleton Ginv_isfunc xD]
+            rw [b_eq, ←mem_inv (is_rel_of_is_func hG)]
+            apply fapply.def
+          · generalize_proofs Frel ac_Finv ab_g_spec at h
+            have ⟨aA, ac_F⟩ := Classical.choose_spec ac_Finv
+            have ⟨bB, ab_g⟩ := Classical.choose_spec ab_g_spec
+            set b := Classical.choose ab_g_spec
+            set a := Classical.choose ac_Finv
+            rw [lambda_spec] at ab_g
+            obtain ⟨-, -, b_eq⟩ := ab_g
+            rw [dite_cond_eq_true (eq_true aA)] at b_eq
+            rw [mem_inv] at ac_F
+            have Fa := fapply.of_pair (is_func_is_pfunc hF) ac_F
+            have Gb := fapply.of_pair (is_func_is_pfunc hG) h
+            conv at b_eq =>
+              enter [2]
+              rw [Image_singleton_eq_fapply hF aA, Fa, Image_singleton_eq_fapply hf hc,
+                Image_singleton_eq_fapply Ginv_isfunc (fapply_mem_range _ _), sInter_singleton]
+            simp only [b_eq, Subtype.ext_iff] at Gb
+            conv at Gb =>
+              enter [1,1]
+              rw [←fapply_composition hG Ginv_isfunc (fapply_mem_range _ _)]
+              unfold fapply
+            dsimp at Gb
+            generalize_proofs Grel cdf cd_GGinv at Gb
+            subst d
+            have ⟨dD, cd_G⟩ := Classical.choose_spec cd_GGinv
+            have ⟨d'D, cd_f⟩ := Classical.choose_spec cdf
+            set d := Classical.choose cd_GGinv
+            set d' := Classical.choose cdf
+            rw [composition_inv_self_of_bijective Gbij, pair_mem_Id_iff d'D] at cd_G
+            rwa [←cd_G]
+        · intro c hc
+          rw [dite_cond_eq_true (eq_true hc)]
+          apply fapply_mem_range
+    · rintro g' ⟨hg', g'f_ξ⟩
+      rw [lambda_spec] at g'f_ξ
+      obtain ⟨-,-,f_eq⟩ := g'f_ξ
+      rw [dite_cond_eq_true (eq_true (by rw [mem_funs] at hg'; exact hg'.1))] at f_eq
+      subst f_eq
+      rw [lambda_eta (mem_funs.mp hg'), lambda_ext_iff]
+      · intro a ha
+        simp only [dite_cond_eq_true (eq_true ha)]
+        rw [Image_singleton_eq_fapply hF ha,
+          Image_singleton_eq_fapply hf (by apply fapply_mem_range),
+          Image_singleton_eq_fapply Ginv_isfunc (by apply fapply_mem_range),
+          sInter_singleton]
+        conv_rhs =>
+          unfold fapply
+        dsimp
+        generalize_proofs g'pfunc g'rel a_g'dom Grel Frel acF dclambda bdGinv
+        have ⟨cC, ac_F⟩ := Classical.choose_spec acF
+        have ⟨bB, db_G⟩ := Classical.choose_spec bdGinv
+        have ⟨dD, dc_eq⟩:= Classical.choose_spec dclambda
+        set! d := Classical.choose dclambda with d_def
+        set! b := Classical.choose bdGinv with b_def
+        set! c := Classical.choose acF with c_def
+        rw [lambda_spec] at dc_eq
+        obtain ⟨-, -, d_eq⟩ := dc_eq
+        conv_lhs at d_eq => rw [←d_def]
+        rw [←mem_inv] at ac_F
+        conv at ac_F =>
+          conv =>
+            lhs
+            change inv F
+          rw [←c_def]
+        conv at d_eq =>
+          conv =>
+            enter [2,1,2]
+            conv =>
+              enter [2]
+              rw [←c_def, Image_singleton_eq_fapply (inv_is_func_of_bijective Fbij) cC]
+              simp only [←c_def, fapply.of_pair _ ac_F]
+          conv =>
+            enter [2]
+            conv =>
+              enter [1,2]
+              rw [Image_singleton_eq_fapply (mem_funs.mp hg') ha]
+            rw [←fapply_eq_Image_singleton hG (fapply_mem_range g'pfunc a_g'dom)]
+        rw [←b_def, ←d_def] at db_G
+        have b_eq := fapply.of_pair (is_func_is_pfunc Ginv_isfunc) db_G
+        rw [Subtype.ext_iff] at b_eq
+        simp [d_eq] at b_eq
+        rw [←fapply_composition Ginv_isfunc hG (fapply_mem_range g'pfunc a_g'dom)] at b_eq
+        conv at b_eq =>
+          unfold fapply
+          dsimp
+        generalize_proofs abg' bb'GGinv at b_eq
+        have ⟨bB', bb'⟩ := Classical.choose_spec bb'GGinv
+        have ⟨g'B, ab_g'⟩ := Classical.choose_spec abg'
+        set b := Classical.choose bb'GGinv
+        set b' := Classical.choose abg'
+        rw [composition_self_inv_of_bijective Gbij, pair_mem_Id_iff g'B] at bb'
+        rw [←b_def, ←b_eq, ←bb']
+        rfl
+      · intro _ h
+        rw [dite_cond_eq_true (eq_true h)]
+        apply fapply_mem_range
+  · and_intros
+    · exact lambda_subset
+    · intro f hf
+      rw [mem_funs] at hf
+      use λᶻ : C → D
+             | c ↦ ⋂₀ (G[f[F⁻¹[{c}]]])
+      and_intros <;> beta_reduce
+      · rw [lambda_spec]
+        and_intros
+        · rwa [mem_funs]
+        · apply mem_funs_of_lambda
+          intro c hc
+          obtain ⟨a, ha, a_def⟩ := eq_singleton_of_bijective_inv_Image_of_singleton Fbij hc
+          obtain ⟨b, hb, b_def⟩ : ∃ b ∈ B, f[{a}] = {b} := by
+            obtain ⟨b, hb, b_unq⟩ := hf.2 a ha
+            use b
+            and_intros
+            · exact hf.1 hb |> pair_mem_prod.mp |>.2
+            · rwa [←Image_of_singleton_pair_mem_iff hf]
+          obtain ⟨d, hd, d_def⟩ : ∃ d ∈ D, G[{b}] = {d} := by
+            obtain ⟨d, hd, d_unq⟩ := hG.2 b hb
+            use d
+            and_intros
+            · exact hG.1 hd |> pair_mem_prod.mp |>.2
+            · rwa [←Image_of_singleton_pair_mem_iff hG]
+          rwa [a_def, b_def, d_def, sInter_singleton]
+        · rw [dite_cond_eq_true (eq_true hf.1)]
+      · intro g hg
+        rw [lambda_spec, dite_cond_eq_true (eq_true hf.1)] at hg
+        exact hg.2.2
+
+theorem isIso_powerset_char_pred {A : ZFSet} : A.powerset ≅ᶻ A.funs 𝔹 := by
+  apply isIso_symm
+  let f := λᶻ : (A.funs 𝔹) → (A.powerset)
+              |         fX ↦ A.sep fun z ↦ z.pair zftrue ∈ fX
+  use f, ?_
+  · and_intros
+    · intro fX fY Z hfX hfY hZ fX_Z fY_Z
+      rw [mem_lambda] at fX_Z fY_Z
+      obtain ⟨_, X, eq, -, _, rfl⟩ := fX_Z
+      rw [pair_inj] at eq
+      obtain ⟨rfl, rfl⟩ := eq
+      obtain ⟨_, Y, eq, -, _, rfl⟩ := fY_Z
+      rw [pair_inj] at eq
+      obtain ⟨rfl, hext⟩ := eq
+      simp only [ZFSet.ext_iff, mem_sep, and_congr_right_iff] at hext
+      ext1 z
+      constructor <;> intro hz
+      · obtain ⟨a, ha, b, hb, rfl⟩ := (mem_funs.mp hfX).1 hz |> mem_prod.mp
+        specialize hext a ha
+        rw [ZFBool.mem_𝔹_iff] at hb
+        obtain rfl | rfl := hb
+        · have : a.pair zftrue ∉ fX := by
+            intro contr
+            rw [mem_funs] at hfX
+            nomatch zftrue_ne_zffalse <| hfX.2 a ha |>.unique contr hz
+          rw [iff_false_left this] at hext
+          rw [mem_funs] at hfY
+          obtain ⟨b', ab', _⟩ := hfY.2 a ha
+          obtain rfl | rfl := hfY.1 ab' |> pair_mem_prod.mp |>.2 |> (ZFBool.mem_𝔹_iff b').mp
+          · exact ab'
+          · contradiction
+        · exact hext.mp hz
+      · obtain ⟨a, ha, b, hb, rfl⟩ := (mem_funs.mp hfY).1 hz |> mem_prod.mp
+        specialize hext a ha
+        rw [ZFBool.mem_𝔹_iff] at hb
+        obtain rfl | rfl := hb
+        · have : a.pair zftrue ∉ fY := by
+            intro contr
+            rw [mem_funs] at hfY
+            nomatch zftrue_ne_zffalse <| hfY.2 a ha |>.unique contr hz
+          rw [iff_false_right this] at hext
+          rw [mem_funs] at hfX
+          obtain ⟨b', ab', _⟩ := hfX.2 a ha
+          obtain rfl | rfl := hfX.1 ab' |> pair_mem_prod.mp |>.2 |> (ZFBool.mem_𝔹_iff b').mp
+          · exact ab'
+          · contradiction
+        · exact hext.mpr hz
+    · intro X hX
+      rw [mem_powerset] at hX
+      let fX := A.prod 𝔹 |>.sep fun ab ↦ ab.π₁ ∈ X ↔ ab.π₂ = zftrue
+      use fX
+      have fX_mem_funs : fX ∈ A.funs 𝔹 := by
+        rw [mem_funs]
+        and_intros
+        · intro z hz
+          rw [mem_sep, mem_prod] at hz
+          obtain ⟨⟨a, ha, b, hb, rfl⟩, _⟩ := hz
+          rw [pair_mem_prod]
+          exact ⟨ha, hb⟩
+        · intro a ha
+          by_cases a_mem_X : a ∈ X
+          · use zftrue
+            and_intros
+            · beta_reduce
+              rw [mem_sep, pair_mem_prod]
+              and_intros
+              · exact ha
+              · rw [ZFBool.mem_𝔹_iff]
+                right
+                rfl
+              · rwa [π₁_pair, π₂_pair, iff_true_right rfl]
+            · intro b hb
+              rw [mem_sep, pair_mem_prod, π₁_pair, π₂_pair] at hb
+              rwa [←hb.2]
+          · use zffalse
+            and_intros
+            · beta_reduce
+              rw [mem_sep, pair_mem_prod]
+              and_intros
+              · exact ha
+              · rw [ZFBool.mem_𝔹_iff]
+                left
+                rfl
+              · rwa [π₁_pair, π₂_pair, iff_false_right zftrue_ne_zffalse.symm]
+            · intro b hb
+              rw [mem_sep, pair_mem_prod, π₁_pair, π₂_pair, ←not_iff_not] at hb
+              exact Or.resolve_right (ZFBool.mem_𝔹_iff b |>.mp hb.1.2) (hb.2.mp a_mem_X)
+      and_intros
+      · exact fX_mem_funs
+      · rw [lambda_spec]
+        and_intros
+        · exact fX_mem_funs
+        · rwa [mem_powerset]
+        · ext1 z
+          rw [mem_sep, mem_sep, pair_mem_prod, π₁_pair, π₂_pair, iff_true_right rfl]
+          constructor
+          · intro hz
+            exact ⟨hX hz, ⟨hX hz, ZFBool.zftrue_mem_𝔹⟩, hz⟩
+          · rintro ⟨_, _, hz⟩
+            exact hz
+  · and_intros
+    · intro z hz
+      rw [mem_lambda] at hz
+      obtain ⟨fX, X, rfl, fX_def, _, rfl⟩ := hz
+      rw [pair_mem_prod]
+      and_intros <;> assumption
+    · intro fX fX_mem
+      use A.sep fun z ↦ z.pair zftrue ∈ fX, ?_
+      · intro y hy
+        unfold f at hy
+        rw [lambda_spec] at hy
+        exact hy.2.2
+      · beta_reduce
+        rw [lambda_spec]
+        and_intros
+        · exact fX_mem
+        · rw [mem_powerset]
+          exact sep_subset_self
+        · rfl
+
+theorem ZFNat.iso_eq_iff {n m : ZFNat} : ↑n ≅ᶻ ↑m ↔ n = m where
+  mp := by classical
+    intro iso
+    induction n generalizing m with
+    | zero =>
+      obtain ⟨bij, isfunc, isbij⟩ := iso
+      ext z
+      simp_rw [ZFNat.nat_zero_eq, notMem_empty, false_iff]
+      intro contr
+      obtain ⟨x, contr, _⟩ := isbij.2 z contr
+      nomatch notMem_empty x contr
+    | succ n ih =>
+      obtain ⟨f, isfunc, bij⟩ := iso
+
+      obtain ⟨ℓ, hℓ, ℓ_unq⟩ := isfunc.2 ↑n <| add_one_eq_succ ▸ lt_succ
+      have ℓ_mem_m := isfunc.1 hℓ |> pair_mem_prod.mp |>.2
+
+      obtain ⟨k, rfl⟩ : ∃ k, m = k + 1 := by
+        simp_rw [ZFNat.add_one_eq_succ]
+        apply ZFNat.not_zero_imp_succ
+        rintro rfl
+        nomatch notMem_empty _ ℓ_mem_m
+
+      rw [add_right_cancel]
+      apply ih
+
+      let f' := ZFSet.prod ↑n (↑(k+1) \ {ℓ}) |>.sep (· ∈ f)
+      have : IsFunc ↑n (↑(k+1) \ {ℓ}) f' := by
+        and_intros
+        · exact sep_subset_self
+        · intro z zn
+          have : z ∈ (↑(n+1) : ZFSet) := by
+            rw [add_one_eq_succ, ZFNat.succ, mem_insert_iff]
+            right
+            exact zn
+          obtain ⟨y, hy, y_unq⟩ := isfunc.2 z this
+          use y
+          and_intros <;> beta_reduce
+          · rw [mem_sep, pair_mem_prod]
+            and_intros
+            · exact zn
+            · rw [mem_diff, mem_singleton]
+              and_intros
+              · exact isfunc.1 hy |> pair_mem_prod.mp |>.2
+              · rintro ⟨⟩
+                rw [bij.1 ↑n z ℓ _ this ℓ_mem_m hℓ hy] at zn
+                · nomatch mem_irrefl _ zn
+                · rw [add_one_eq_succ]
+                  exact lt_succ
+            · exact hy
+          · intro w hzw
+            rw [mem_sep, pair_mem_prod, mem_diff, mem_singleton] at hzw
+            exact y_unq w hzw.2
+      have bij' : IsBijective f' this := by
+        rw [bijective_exists1_iff]
+        intro y hy
+        rw [mem_diff, add_one_eq_succ, mem_singleton, succ, mem_insert_iff] at hy
+        obtain ⟨rfl | y_mem_k, y_ne_ℓ⟩ := hy
+        · rw [bijective_exists1_iff] at bij
+          have := bij k ?_
+          · obtain ⟨x, ⟨x_mem_succ_n, x_k_f⟩, x_unq⟩ := this
+            use x
+            rw [add_one_eq_succ, succ, mem_insert_iff] at x_mem_succ_n
+            rcases x_mem_succ_n with rfl | x_mem_n
+            · nomatch y_ne_ℓ <| isfunc.2 _ (by
+                rw [add_one_eq_succ]; exact lt_succ) |>.unique x_k_f hℓ
+            · and_intros <;> beta_reduce
+              · exact x_mem_n
+              · rw [mem_sep, pair_mem_prod, mem_diff, mem_singleton]
+                and_intros
+                · exact x_mem_n
+                · rw [add_one_eq_succ]
+                  exact lt_succ
+                · exact y_ne_ℓ
+                · exact x_k_f
+              · rintro y ⟨yn, y_k_f⟩
+                rw [mem_sep, pair_mem_prod, mem_diff, mem_singleton] at y_k_f
+                apply bij k (by rw [add_one_eq_succ]; exact lt_succ) |>.unique
+                · and_intros
+                  · rw [add_one_eq_succ, succ, mem_insert_iff]
+                    right
+                    exact y_k_f.1.1
+                  · exact y_k_f.2
+                · and_intros
+                  · rw [add_one_eq_succ, succ, mem_insert_iff]
+                    right
+                    exact x_mem_n
+                  · exact x_k_f
+          · rw [add_one_eq_succ]
+            exact lt_succ
+        · rw [bijective_exists1_iff] at bij
+          have := bij y ?_
+          · obtain ⟨x, ⟨x_mem_succ_n, x_k_f⟩, x_unq⟩ := this
+            use x
+            rw [add_one_eq_succ, succ, mem_insert_iff] at x_mem_succ_n
+            rcases x_mem_succ_n with rfl | x_mem_n
+            · nomatch y_ne_ℓ <| isfunc.2 _ (by
+                rw [add_one_eq_succ]; exact lt_succ) |>.unique x_k_f hℓ
+            · and_intros <;> beta_reduce
+              · exact x_mem_n
+              · rw [mem_sep, pair_mem_prod, mem_diff, mem_singleton]
+                and_intros
+                · exact x_mem_n
+                · rw [add_one_eq_succ, succ, mem_insert_iff]
+                  right
+                  exact y_mem_k
+                · exact y_ne_ℓ
+                · exact x_k_f
+              · rintro z ⟨zn, z_k_f⟩
+                rw [mem_sep, pair_mem_prod, mem_diff, mem_singleton] at z_k_f
+                apply bij y ?_ |>.unique
+                · and_intros
+                  · rw [add_one_eq_succ, succ, mem_insert_iff]
+                    right
+                    exact z_k_f.1.1
+                  · exact z_k_f.2
+                · and_intros
+                  · rw [add_one_eq_succ, succ, mem_insert_iff]
+                    right
+                    exact x_mem_n
+                  · exact x_k_f
+                · rw [add_one_eq_succ, succ, mem_insert_iff]
+                  right
+                  exact y_mem_k
+          · rw [add_one_eq_succ, succ, mem_insert_iff]
+            right
+            exact y_mem_k
+      have k_iso : ↑k ≅ᶻ (↑(k+1) \ {ℓ}) := by
+        let g := ZFSet.prod ↑k (↑(k+1) \ {ℓ}) |>.sep fun xy ↦
+          let x := xy.π₁ -- x ∈ ↑k
+          let y := xy.π₂ -- y ∈ ↑(k+1) \ {ℓ}
+          if x ∈ ℓ then x = y
+          else y = (insert x x)
+        use g, ?_
+        · and_intros
+          · intro x y z hz hy hz g_xz g_yz
+            dsimp [g] at g_xz g_yz
+            simp only [mem_sep, mem_prod, mem_diff, mem_singleton, pair_inj,
+              exists_eq_right_right', π₁_pair, π₂_pair] at g_xz g_yz
+            obtain ⟨⟨mem_x_k, mem_z_succ_k, z_ne_ℓ⟩, z_eq⟩ := g_xz
+            obtain ⟨⟨mem_y_k, -, -⟩, z_eq'⟩ := g_yz
+
+            -- reason into naturals
+            have z_Nat : z ∈ Nat := mem_Nat_of_mem_mem_Nat (k.succ.prop) (by
+              rwa [add_one_eq_succ] at mem_z_succ_k)
+            have x_Nat : x ∈ Nat := mem_Nat_of_mem_mem_Nat (k.prop) mem_x_k
+            have y_Nat : y ∈ Nat := mem_Nat_of_mem_mem_Nat (k.prop) hy
+            have ℓ_Nat : ℓ ∈ Nat := mem_Nat_of_mem_mem_Nat (k.succ.prop) (by
+              rwa [add_one_eq_succ] at ℓ_mem_m)
+            let Z : ZFNat := ⟨z, z_Nat⟩
+            let X : ZFNat := ⟨x, x_Nat⟩
+            let Y : ZFNat := ⟨y, y_Nat⟩
+            let L : ZFNat := ⟨ℓ, ℓ_Nat⟩
+
+            split_ifs at z_eq z_eq' with x_mem_ℓ y_mem_ℓ y_lt_ℓ
+            · subst x y
+              rfl
+            · subst x
+              have Z_eq_succ_Y : Z = Y + 1 := by
+                rw [add_one_eq_succ, succ, Subtype.ext_iff]
+                exact z_eq'
+              change Z < L at x_mem_ℓ
+              change ¬ Y < L at y_mem_ℓ
+              rw [not_lt] at y_mem_ℓ
+              obtain L_lt_Y | L_eq_Y := y_mem_ℓ
+              · have := lt_trans x_mem_ℓ L_lt_Y
+                rw [Z_eq_succ_Y] at this
+                absurd this
+                rw [not_lt, add_one_eq_succ]
+                exact le_succ
+              · rw [L_eq_Y, Z_eq_succ_Y] at x_mem_ℓ
+                absurd x_mem_ℓ
+                rw [not_lt, add_one_eq_succ]
+                exact le_succ
+            · subst y
+              have Z_eq_succ_X : Z = X + 1 := by
+                rw [add_one_eq_succ, succ, Subtype.ext_iff]
+                exact z_eq
+              change ¬ X < L at x_mem_ℓ
+              change Z < L at y_lt_ℓ
+              rw [not_lt] at x_mem_ℓ
+              obtain L_lt_X | L_eq_X := x_mem_ℓ
+              · have := lt_trans y_lt_ℓ L_lt_X
+                rw [Z_eq_succ_X] at this
+                absurd this
+                rw [not_lt, add_one_eq_succ]
+                exact le_succ
+              · rw [L_eq_X, Z_eq_succ_X] at y_lt_ℓ
+                absurd y_lt_ℓ
+                rw [not_lt, add_one_eq_succ]
+                exact le_succ
+            · apply succ_inj_aux'
+              rw [←z_eq, ←z_eq']
+          · intro y hy
+
+            -- reason into naturals
+            have y_Nat : y ∈ Nat := by
+              apply mem_Nat_of_mem_mem_Nat (k.succ.prop)
+              rw [add_one_eq_succ, mem_diff] at hy
+              exact hy.1
+            have ℓ_Nat : ℓ ∈ Nat := mem_Nat_of_mem_mem_Nat (k.succ.prop) (by
+              rwa [add_one_eq_succ] at ℓ_mem_m)
+            let Y : ZFNat := ⟨y, y_Nat⟩
+            let L : ZFNat := ⟨ℓ, ℓ_Nat⟩
+
+            simp only [add_one_eq_succ, succ, mem_insert_iff, mem_diff, mem_singleton] at hy
+            obtain ⟨rfl | y_mem_k, y_ne_ℓ⟩ := hy
+            · have ℓ_Nat : ℓ ∈ Nat := mem_Nat_of_mem_mem_Nat (k.succ.prop) (by
+                rwa [add_one_eq_succ] at ℓ_mem_m)
+              let L : ZFNat := ⟨ℓ, ℓ_Nat⟩
+              change L < k + 1 at ℓ_mem_m
+              rw [add_one_eq_succ, ←lt_le_iff] at ℓ_mem_m
+              rcases ℓ_mem_m with L_lt_k | L_eq_k
+              · have := ZFNat.not_zero_imp_succ (n := k) ?_
+                · obtain ⟨s, rfl⟩ := this
+                  use s, lt_succ
+                  unfold g
+                  simp only [mem_sep, pair_mem_prod, mem_diff, mem_singleton, π₁_pair, π₂_pair]
+                  and_intros
+                  · exact lt_succ
+                  · rw [add_one_eq_succ]
+                    exact lt_succ
+                  · rintro rfl
+                    contradiction
+                  · rw [←lt_le_iff] at L_lt_k
+                    conv =>
+                        enter [1]
+                        change s < L
+                    rcases L_lt_k with L_lt_s | rfl
+                    · rw [
+                        ite_cond_eq_false (h := eq_false (nomatch lt_irrefl <| lt_trans · L_lt_s))]
+                      rfl
+                    · rw [ite_cond_eq_false (h := eq_false lt_irrefl)]
+                      rfl
+                · rintro rfl
+                  nomatch not_lt_zero L_lt_k
+              · nomatch (Subtype.coe_ne_coe.mp y_ne_ℓ) L_eq_k.symm
+            · by_cases y_lt_ℓ : y ∈ ℓ
+              · change Y < L at y_lt_ℓ
+                use y, y_mem_k
+                dsimp [g]
+                simp only [mem_sep, mem_prod, mem_diff, mem_singleton, pair_inj,
+                  exists_eq_right_right', π₁_pair, π₂_pair]
+                split_ifs
+                · and_intros
+                  · exact y_mem_k
+                  · change Y < k + 1
+                    trans L
+                    · exact y_lt_ℓ
+                    · exact ℓ_mem_m
+                  · exact y_ne_ℓ
+                  · trivial
+                · contradiction
+              · change ¬ Y < L at y_lt_ℓ
+                change Y < k at y_mem_k
+                rw [not_lt] at y_lt_ℓ
+                rw [←ne_eq, ne_comm, ne_eq] at y_ne_ℓ
+
+                have := ZFNat.not_zero_imp_succ (n := Y) ?_
+                · obtain ⟨s, Y_eq⟩ := this
+                  use s
+                  and_intros
+                  · change s < k
+                    rw [Y_eq] at y_mem_k
+                    trans s.succ
+                    · exact lt_succ
+                    · exact y_mem_k
+                  · rw [Y_eq] at y_mem_k y_lt_ℓ
+                    unfold Y at Y_eq
+                    rw [succ, Subtype.ext_iff] at Y_eq
+                    dsimp at Y_eq
+                    subst y
+                    replace y_ne_ℓ : ¬ L = s.succ := by
+                      intro eq
+                      unfold L at eq
+                      rw [succ, Subtype.ext_iff] at eq
+                      dsimp at eq
+                      subst ℓ
+                      nomatch y_ne_ℓ
+                    rcases y_lt_ℓ with L_lt_s | L_eq_s
+                    · rw [← lt_le_iff] at L_lt_s
+                      rcases L_lt_s with L_lt_s | L_eq_s
+                      · dsimp [g]
+                        rw [mem_sep, pair_mem_prod, π₁_pair, π₂_pair]
+                        and_intros
+                        · change s < k
+                          exact lt_of_succ_lt y_mem_k
+                        · rw [mem_diff, mem_singleton]
+                          and_intros
+                          · change s.succ < k + 1
+                            rw [add_one_eq_succ, ←succ_mono]
+                            exact lt_of_succ_lt y_mem_k
+                          · intro contr
+                            replace contr : L = s.succ := by
+                              rw [succ, Subtype.ext_iff]
+                              exact contr.symm
+                            contradiction
+                        · conv =>
+                            enter [1]
+                            change s < L
+                          rw [ite_cond_eq_false
+                            (h := eq_false (nomatch lt_irrefl <| lt_trans · L_lt_s))]
+                      · subst s
+                        dsimp [g]
+                        rw [mem_sep, pair_mem_prod, π₁_pair, π₂_pair]
+                        and_intros
+                        · change L < k
+                          exact lt_of_succ_lt y_mem_k
+                        · rw [mem_diff, mem_singleton]
+                          and_intros
+                          · change L.succ < k + 1
+                            rw [add_one_eq_succ, ←succ_mono]
+                            exact lt_of_succ_lt y_mem_k
+                          · intro contr
+                            replace contr : L = L.succ := by
+                              rw [succ, Subtype.ext_iff]
+                              exact contr.symm
+                            contradiction
+                        · conv =>
+                            enter [1]
+                            change L < L
+                          rw [ite_cond_eq_false (h := eq_false lt_irrefl)]
+                    · contradiction
+                · intro eq_zero
+                  have := Or.resolve_right y_lt_ℓ (Subtype.coe_ne_coe.mp y_ne_ℓ)
+                  rw [eq_zero] at this
+                  nomatch ZFNat.not_lt_zero this
+        · dsimp [g]
+          and_intros
+          · exact sep_subset_self
+          · intro x x_mem_k
+            simp only [mem_sep, mem_prod, mem_diff, mem_singleton, pair_inj,
+              exists_eq_right_right', π₁_pair, π₂_pair]
+            split_ifs with x_mem_ℓ
+            · use x
+              and_intros <;> beta_reduce
+              · exact x_mem_k
+              · rw [add_one_eq_succ, succ, mem_insert_iff]
+                right
+                exact x_mem_k
+              · rintro rfl
+                nomatch mem_irrefl _ x_mem_ℓ
+              · rfl
+              · rintro _ ⟨_, rfl⟩
+                rfl
+            · use (insert x x)
+              and_intros <;> beta_reduce
+              · exact x_mem_k
+              · rw [add_one_eq_succ, succ, mem_insert_iff]
+                have hx : x ∈ Nat := mem_Nat_of_mem_mem_Nat k.prop x_mem_k
+                suffices (⟨x, hx⟩ + 1 : ZFNat) = k ∨ (⟨x, hx⟩ + 1 : ZFNat) < k by
+                  rcases this with rfl | h
+                  · left
+                    rw [add_one_eq_succ, succ]
+                  · right
+                    rw [add_one_eq_succ, succ] at h
+                    exact h
+                symm
+                change (⟨x, hx⟩ + 1 : ZFNat) ≤ k
+                change ⟨x, hx⟩ < k at x_mem_k
+                rw [lt_le_iff, ←add_one_eq_succ, add_comm, add_comm k, add_lt_add_iff_left]
+                exact x_mem_k
+              · rintro rfl
+                rw [mem_insert_iff, not_or] at x_mem_ℓ
+                nomatch x_mem_ℓ.1 rfl
+              · rfl
+              · rintro _ ⟨_, rfl⟩
+                rfl
+      trans ↑(k+1) \ {ℓ}
+      · use f', this
+      · apply ZFSet.isIso_symm
+        exact k_iso
+  mpr := by
+    rintro rfl
+    apply isIso_refl
+
+open Classical in
+noncomputable def currify {A B C : ZFSet} (f : ZFSet)
+  (hf : (A.prod B).IsFunc C f := by zfun) : ZFSet :=
+  λᶻ : A   → (B.funs C)
+       | a ↦ if ha : a ∈ A then
+                λᶻ : B → C
+                   | b ↦ if hb : b ∈ B then
+                          @ᶻf ⟨a.pair b, by rw [is_func_dom_eq hf, pair_mem_prod]; exact ⟨ha, hb⟩⟩
+                        else ∅
+              else ∅
+
+@[zfun]
+theorem currify_is_func {A B C : ZFSet} (f : ZFSet)
+  (hf : (A.prod B).IsFunc C f := by zfun) : A.IsFunc (B.funs C) (currify f hf) := by
+  apply lambda_isFunc
+  intro x hx
+  rw [dite_cond_eq_true (eq_true hx), mem_funs]
+  and_intros
+  · exact lambda_subset
+  · intro y hy
+    obtain ⟨z, hz, z_unq⟩ := hf.2 (x.pair y) (by rw [pair_mem_prod]; exact ⟨hx, hy⟩)
+    use z
+    and_intros <;> beta_reduce
+    · rw [lambda_spec]
+      and_intros
+      · exact hy
+      · exact hf.1 hz |> pair_mem_prod.mp |>.2
+      · rw [dite_cond_eq_true (eq_true hy), fapply.of_pair (is_func_is_pfunc hf) hz]
+    · intro w hw
+      rw [lambda_spec, dite_cond_eq_true (eq_true hy)] at hw
+      rw [hw.2.2]
+      apply z_unq
+      apply fapply.def
+
+open Classical in
+noncomputable def uncurrify {A B C : ZFSet} (g : ZFSet)
+  (hg : A.IsFunc (B.funs C) g := by zfun) : ZFSet :=
+  λᶻ : (A.prod B) → C
+       | (a, b) ↦ if hab : a ∈ A ∧ b ∈ B then
+                let f := @ᶻg ⟨a, by
+                    rw [is_func_dom_eq hg]
+                    exact hab.1
+                  ⟩
+                have hf := mem_funs.mp f.2
+                @ᶻf ⟨b, by
+                    rw [is_func_dom_eq hf]
+                    exact hab.2
+                  ⟩
+              else ∅
+
+@[zfun]
+theorem uncurrify_is_func {A B C : ZFSet} (g : ZFSet)
+  (hg : A.IsFunc (B.funs C) g := by zfun) : (A.prod B).IsFunc C (uncurrify g hg) := by
+  apply lambda_isFunc
+  intro z hz
+  rw [mem_prod] at hz
+  obtain ⟨a, ha, b, hb, rfl⟩ := hz
+  rw [dite_cond_eq_true (eq_true (by simp only [π₁_pair, ha, π₂_pair, hb, and_self]))]
+  simp only [π₂_pair, SetLike.coe_mem]
+
+@[simp]
+theorem currify_of_uncurrify {A B C : ZFSet} (f : ZFSet)
+    (hf : (A.IsFunc (B.funs C)) f := by zfun) :
+  currify (uncurrify f) = f := by
+    simp only [currify, uncurrify, lambda_eta hf]
+    rw [lambda_ext_iff]
+    · intro x hx
+      simp_rw [dite_cond_eq_true (eq_true hx)]
+      conv =>
+        enter [2,1]
+        change ?f_x
+      rw [lambda_eta (mem_funs.mp ?f_x.2), lambda_ext_iff]
+      · intro y hy
+        simp_rw [dite_cond_eq_true (eq_true hy)]
+        conv_lhs =>
+          rw [
+            fapply_lambda
+              (by
+                intro _ h
+                rw [pair_eta h, pair_mem_prod] at h
+                rw [dite_cond_eq_true (eq_true h)]
+                apply fapply_mem_range)
+              (by rw [pair_mem_prod]; exact ⟨hx, hy⟩),
+            dite_cond_eq_true (eq_true (by simp only [π₁_pair, π₂_pair, hx, hy, and_self]))]
+          simp only [π₁_pair, π₂_pair]
+        congr 2
+        · simp only [π₁_pair]
+        · apply proof_irrel_heq
+        · congr 1
+          · funext x
+            simp only [π₁_pair, mem_sep]
+          · apply proof_irrel_heq
+      · intro _ h
+        rw [dite_cond_eq_true (eq_true h)]
+        apply fapply_mem_range
+    · intro _ hx
+      rw [dite_cond_eq_true (eq_true hx)]
+      apply mem_funs_of_lambda
+      intro _ hx
+      rw [dite_cond_eq_true (eq_true hx)]
+      apply fapply_mem_range
+
+theorem uncurrify_of_currify {A B C : ZFSet} (g : ZFSet)
+    (hg : (A.prod B).IsFunc C g := by zfun) :
+  uncurrify (currify g) = g := by
+    simp only [currify, uncurrify, lambda_eta hg]
+    rw [lambda_ext_iff]
+    · intro ab hab
+      obtain ⟨a, ha, b, hb, rfl⟩ := mem_prod.mp hab
+      simp_rw [dite_cond_eq_true (eq_true hab), π₂_pair]
+      conv_lhs =>
+        rw [dite_cond_eq_true (eq_true (by simp only [π₁_pair, ha, π₂_pair, hb, and_self]))]
+        rw [fapply_eq_Image_singleton (by rw [←mem_funs]; apply fapply_mem_range) hb]
+        conv =>
+          enter [1,1]
+          simp only [π₁_pair]
+          rw [
+            fapply_lambda (by
+                intro _ h
+                rw [dite_cond_eq_true (eq_true h)]
+                apply mem_funs_of_lambda
+                intro _ hx
+                rw [dite_cond_eq_true (eq_true hx)]
+                apply fapply_mem_range
+              ) ha,
+            dite_cond_eq_true (eq_true ha)]
+        rw [←fapply_eq_Image_singleton (lambda_isFunc (fun h ↦ by
+              rw [dite_cond_eq_true (eq_true h)]
+              apply fapply_mem_range)) hb,
+          fapply_lambda (fun h ↦ by rw [dite_cond_eq_true (eq_true h)]; apply fapply_mem_range) hb,
+          dite_cond_eq_true (eq_true hb)]
+    · intro _ h
+      rw [dite_cond_eq_true (eq_true (by rwa [←pair_mem_prod, ←pair_eta h]))]
+      apply fapply_mem_range
+
+open Classical in
+theorem isIso_curry {A B C : ZFSet} :
+  (A.prod B).funs C ≅ᶻ A.funs (B.funs C) := by
+  let curry  := λᶻ : (A.prod B).funs C → A.funs (B.funs C)
+    | f ↦ if hf : f ∈ (A.prod B).funs C then
+            currify f (mem_funs.mp hf)
+          else ∅
+  let uncurry := λᶻ : A.funs (B.funs C) → (A.prod B).funs C
+    | g ↦ if hg : g ∈ A.funs (B.funs C) then
+            uncurrify g (mem_funs.mp hg)
+          else ∅
+  have hcurry : IsFunc ((A.prod B).funs C) (A.funs (B.funs C)) curry := by
+    apply lambda_isFunc
+    intro f hf
+    rw [dite_cond_eq_true (eq_true hf), mem_funs]
+    apply currify_is_func
+  have huncurry : IsFunc (A.funs (B.funs C)) ((A.prod B).funs C) uncurry := by
+    apply lambda_isFunc
+    intro g hg
+    rw [dite_cond_eq_true (eq_true hg), mem_funs]
+    apply uncurrify_is_func
+
+  have l_inv : (uncurry ∘ᶻ curry) = 𝟙((A.prod B).funs C) := by
+    rw [is_func_ext_iff (IsFunc_of_composition_IsFunc huncurry hcurry) Id.IsFunc]
+    intro f hf
+    rw [←SetLike.coe_eq_coe, fapply_Id hf]
+    conv_lhs =>
+      rw [fapply_composition huncurry hcurry hf]
+      unfold uncurry
+      rw [
+        fapply_lambda (by
+            intro _ h
+            rw [dite_cond_eq_true (eq_true h), mem_funs]
+            apply uncurrify_is_func
+          ) (fapply_mem_range _ _),
+        dite_cond_eq_true (eq_true (fapply_mem_range _ _))]
+      conv =>
+        enter [1]
+        unfold curry
+        rw [
+          fapply_lambda (by
+              intro _ h
+              rw [dite_cond_eq_true (eq_true h), mem_funs]
+              apply currify_is_func
+            ) hf,
+          dite_cond_eq_true (eq_true hf)]
+      rw [uncurrify_of_currify f (mem_funs.mp hf)]
+
+  have r_inv : (curry ∘ᶻ uncurry) = 𝟙(A.funs (B.funs C)) := by
+    rw [is_func_ext_iff (IsFunc_of_composition_IsFunc hcurry huncurry) Id.IsFunc]
+    intro g hg
+    rw [←SetLike.coe_eq_coe, fapply_Id hg]
+    conv_lhs =>
+      rw [fapply_composition hcurry huncurry hg]
+      unfold curry
+      rw [
+        fapply_lambda (by
+            intro _ h
+            rw [dite_cond_eq_true (eq_true h), mem_funs]
+            apply currify_is_func
+          ) (fapply_mem_range _ _),
+        dite_cond_eq_true (eq_true (fapply_mem_range _ _))]
+      conv =>
+        enter [1]
+        unfold uncurry
+        rw [
+          fapply_lambda (by
+              intro _ h
+              rw [dite_cond_eq_true (eq_true h), mem_funs]
+              apply uncurrify_is_func
+            ) hg,
+          dite_cond_eq_true (eq_true hg)]
+      rw [currify_of_uncurrify g (mem_funs.mp hg)]
+
+  exact isIso_of_two_sided_inverse l_inv r_inv
+
+end Lemmas
+
+end Isomorphisms
+
+end ZFSet

--- a/LeanPool/ZFLean/Naturals.lean
+++ b/LeanPool/ZFLean/Naturals.lean
@@ -1,0 +1,1579 @@
+/-
+Copyright (c) 2026 Vincent Trélat. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vincent Trélat
+-/
+
+import LeanPool.ZFLean.Basic
+import Mathlib.Algebra.Ring.Defs
+import Mathlib.Tactic.Ring
+
+/-! # ZFC Natural numbers
+
+This file defines the natural numbers in ZF set theory. The definition is based on the construction
+of the Von Neumann ordinals, where each natural number is represented as the set of all smaller
+natural numbers.
+
+The set of all natural numbers is defined as the smallest inductive set. Because of the axiom of
+separation, the definition relies on the existence of an infinite set, which is provided by the
+`some_inf` constant. It can be shown that the choice of `some_inf` does not affect the definition of
+the natural numbers and leads to isomorphic definitions.
+
+The file also includes the definition of the `ZFNat` type for ZF natural numbers, and provides
+various properties and usual arithmetic operations on natural numbers.
+
+-/
+
+noncomputable section
+
+namespace ZFSet
+
+/-! ## Preliminary definitions -/
+
+section Preamble
+
+/--
+A set `x` is transitive if every element of `x` is a subset of `x`:
+`∀ y ∈ x, y ⊆ x`.
+-/
+def transitive (x : ZFSet) := ∀ y ∈ x, y ⊆ x
+
+/--
+An inductive set is defined as a set that contains the empty set `∅` and is closed
+under successor.
+
+The "successor" of a set `x` is defined as the insertion of `x` into itself.
+-/
+def inductive_set (E : ZFSet) : Prop := ∅ ∈ E ∧ ∀ n, n ∈ E → insert n n ∈ E
+
+theorem trans_imp_insert_trans {x : ZFSet} : transitive x → transitive (insert x x) := by
+  intro trans y
+  rw [mem_insert_iff]
+  rintro ⟨rfl | _⟩
+  · simp_rw [subset_def, mem_insert_iff]
+    exact fun _ => Or.inr
+  · simp_rw [subset_def, mem_insert_iff]
+    exact fun _ _ => Or.inr (trans y ‹_› ‹_›)
+
+theorem inductive_sep {S} (P : ZFSet → Prop) (ind : inductive_set S)
+  (h₀ : P ∅) (h₁ : ∀ n ∈ S, P n → P (insert n n)) : inductive_set <| S.sep P := by
+  unfold inductive_set at *
+  simp_rw [mem_sep]
+  apply And.intro
+  · exact ⟨ind.left, h₀⟩
+  · rintro n ⟨_,_⟩
+    apply And.intro
+    · exact ind.right n ‹_›
+    · exact h₁ n ‹_› ‹_›
+
+theorem inductive_imp_transitive {E : ZFSet} (h : inductive_set E) :
+  inductive_set (E.sep transitive) := by
+  unfold inductive_set
+  rcases h with ⟨_, hind⟩
+  apply And.intro <;> simp_rw [mem_sep]
+  · exact ⟨‹_›, by intro; rw [imp_iff_or_not]; exact Or.inr <| notMem_empty _⟩
+  · rintro n ⟨_,_⟩
+    apply And.intro
+    · exact hind n ‹_›
+    · exact trans_imp_insert_trans ‹_›
+
+notation "ω" => omega
+
+/-- The first Von Neumann ordinal `ω` is an inductive set. -/
+theorem omega_inductive : inductive_set ω := ⟨omega_zero, fun _ => omega_succ⟩
+
+/-- Witness for an infinite set, meant to be used for definitional purpose only. -/
+private abbrev some_inf := @Classical.choose _ inductive_set ⟨_, omega_inductive⟩
+
+/-- The set `some_inf` is inductive. -/
+private lemma inductive_some_inf : inductive_set some_inf := Classical.choose_spec _
+
+private lemma some_inf_nonempty : some_inf ≠ ∅ := by
+  intro h
+  let h' := inductive_some_inf.left
+  rw [h] at h'
+  exact (ZFSet.notMem_empty ∅) h'
+
+private lemma some_inf_mem_sep_inductive_set : some_inf ∈ some_inf.powerset.sep inductive_set := by
+  simp only [mem_sep, mem_powerset, subset_refl, true_and]
+  exact inductive_some_inf
+
+end Preamble
+
+/-! ## Natural numbers -/
+
+section Naturals
+
+/--
+The set of natural numbers `Nat` is defined as the smallest inductive set.
+This definition avoids the use of `ω`, even though `ω` may be thought of as `ℕ`.
+-/
+def Nat : ZFSet := ⋂₀ ((powerset some_inf).sep inductive_set)
+
+/-- The type of natural numbers `ZFNat` is defined as the subtype of `Nat`. -/
+abbrev ZFNat := {x // x ∈ Nat}
+
+namespace ZFNat
+
+/--
+`some_inf` is an inductive subset of `some_inf`:
+`some_inf ∈ { a ⊆ some_inf | inductive_set a }`.
+-/
+private theorem some_inf_mem_powerset_some_inf_ind :
+  some_inf ∈ some_inf.powerset.sep inductive_set :=
+  mem_sep.mpr ⟨mem_powerset.mpr fun _ => id, inductive_some_inf⟩
+
+/-- `Nat` is an infinite inductive set. -/
+theorem Nat_subset_some_inf : Nat ⊆ some_inf := by
+  intro n hn
+  unfold Nat at hn
+  rw [mem_sInter] at hn
+  · have aux :
+      n ∈ (⋃₀ (powerset some_inf).sep inductive_set : ZFSet) ∧
+      (fun b => ∀ c, c ∈ (powerset some_inf).sep inductive_set → b ∈ c) n := by
+        simp only [mem_sUnion, mem_sep, and_imp] at *
+        exact ⟨
+          ⟨some_inf,
+            ⟨mem_powerset.mpr fun _ => id, inductive_some_inf⟩,
+            hn some_inf (mem_powerset.mpr fun _ => id) (inductive_some_inf)⟩,
+          fun _ _ _ => hn _ ‹_› ‹_›⟩
+    simp only [mem_sep, mem_powerset, and_imp, mem_sUnion] at aux
+    obtain ⟨⟨_, ⟨left, _⟩, _⟩, _⟩ := aux
+    apply left
+    assumption
+  · exact ⟨some_inf, some_inf_mem_powerset_some_inf_ind⟩
+
+theorem zero_in_Nat : ∅ ∈ Nat := by
+  unfold Nat
+  rw [mem_sInter]
+  · intro x hx
+    rw [mem_sep] at hx
+    exact hx.right.left
+  · exact ⟨some_inf, some_inf_mem_powerset_some_inf_ind⟩
+
+instance nat_zero : Zero ZFNat := ⟨∅, zero_in_Nat⟩
+lemma nat_zero_eq : (0 : ZFNat) = ⟨∅, zero_in_Nat⟩ := rfl
+
+instance nat_lt : LT ZFNat := ⟨fun x y => x.val ∈ y.val⟩
+instance nat_le : LE ZFNat := ⟨fun x y => x < y ∨ x = y⟩
+
+theorem not_lt_zero {n : ZFNat} : ¬ n < 0 := fun _ => notMem_empty _ ‹_›
+theorem zero_lt_ne_zero {n : ZFNat} : 0 < n → n ≠ 0 := by
+  intro h h'
+  subst h'
+  absurd not_lt_zero h
+  trivial
+
+/-- Any inductive set contains zero. -/
+lemma zero_mem_inductive {a} (h : inductive_set a) : ↑(0 : ZFNat).val ∈ a := h.left
+
+/-- Any inductive set containing an element also contains its successor. -/
+theorem insert_mem_inductive {a n} (h : inductive_set a) (h' : n ∈ a) : insert n n ∈ a :=
+  h.right n h'
+
+theorem some_inf_powerset_sep_inductive_nonempty : (some_inf.powerset.sep inductive_set).Nonempty :=
+  ⟨some_inf, some_inf_mem_powerset_some_inf_ind⟩
+
+/-- Any inductive set is a subset of `some_inf`. -/
+theorem inductive_subset_some_inf_contains_Nat {a} (h : inductive_set a) (h' : a ⊆ some_inf) :
+  Nat ⊆ a := by
+  intro n hn
+  unfold Nat at hn
+  rw [mem_sInter] at hn
+  · have aux :
+      n ∈ (⋃₀ (powerset some_inf).sep inductive_set : ZFSet) ∧
+      (fun b => ∀ c, c ∈ (powerset some_inf).sep inductive_set → b ∈ c) n := by
+        simp only [mem_sUnion, mem_sep, and_imp] at *
+        exact ⟨
+          ⟨some_inf,
+            ⟨mem_powerset.mpr fun _ => id, inductive_some_inf⟩,
+            hn some_inf (mem_powerset.mpr fun _ => id) (inductive_some_inf)⟩,
+            fun _ _ _ => hn _ ‹_› ‹_›⟩
+    simp only [mem_sep, mem_powerset, and_imp, mem_sUnion] at aux
+    exact aux.2 _ h' h
+  · exact some_inf_powerset_sep_inductive_nonempty
+
+theorem succ_mem_Nat' {n} (h : n ∈ Nat) : insert n n ∈ Nat := by
+  have all_sub_ind : ∀ a, a ∈ some_inf.powerset.sep inductive_set → insert n n ∈ a := by
+    intro a ha
+    rw [mem_sep] at ha
+    exact ha.2.2 n (inductive_subset_some_inf_contains_Nat ha.2 (mem_powerset.mp ha.1) h)
+  unfold Nat
+  rw [mem_sInter]
+  · exact (all_sub_ind · ·)
+  · exact some_inf_powerset_sep_inductive_nonempty
+
+/--
+The successor function `succ` is build from the insertion of a set into itself embedded into the
+`ZFNat` type.
+-/
+def succ (n : ZFNat) : ZFNat :=
+  let ⟨n, h⟩ := n
+  have p : insert n n ∈ Nat := succ_mem_Nat' h
+  ⟨insert n n, p⟩
+
+instance nat_one : One ZFNat := ⟨succ 0⟩
+
+theorem nat_one_eq : 1 = succ 0 := rfl
+
+theorem succ_ne_zero : ∀ n, succ n ≠ 0 := by
+  rintro ⟨n, hn⟩ h
+  rw [succ, nat_zero_eq, Subtype.mk.injEq, ZFSet.ext_iff] at h
+  simp only [mem_insert_iff, notMem_empty, iff_false, not_or] at h
+  exact h n |>.1 rfl
+
+theorem succ_inj_aux {m n a : ZFSet} (h : insert m m = insert n n) (h' : a ∈ m) : a ∈ n := by
+  have d' : a ∈ m ∨ a = m ↔ a ∈ n ∨ a = n := by
+    have : a ∈ insert m m ↔ a ∈ n ∨ a = n := by
+      rw [h, mem_insert_iff]
+      exact Or.comm
+    rw [mem_insert_iff, _root_.or_comm] at this
+    assumption
+  let h'' := mem_insert m m
+  rw [h] at h''
+  simp only [mem_insert_iff] at h''
+  rcases h'' with rfl | h''
+  · assumption
+  · rcases d'.mp (Or.inl h') with _ | rfl
+    · assumption
+    · absurd mem_asymm h''
+      assumption
+
+theorem succ_inj_aux' {m n : ZFSet} (h : insert m m = insert n n) : m = n :=
+  ext fun _ => ⟨succ_inj_aux h, succ_inj_aux <| Eq.symm h⟩
+
+theorem succ_inj {m n} (h : succ m = succ n) : m = n := by
+  let ⟨m, hm⟩ := m
+  let ⟨n, hn⟩ := n
+  simp only [succ, Subtype.mk.injEq] at *
+  ext1
+  exact ⟨succ_inj_aux h, succ_inj_aux (Eq.symm h)⟩
+
+/-- Any inductive set `a` separated by an inductive predicate `P` is inductive. -/
+theorem sep_of_ind_is_ind (P : ZFSet → Prop) {a} (h : inductive_set a)
+  (h₀ : P ∅) (ih : ∀ n, n ∈ a → P n → P (insert n n)) : inductive_set (a.sep P) := by
+  unfold inductive_set at *
+  apply And.intro
+  · exact mem_sep.mpr ⟨h.left, h₀⟩
+  · simp only [mem_sep, and_imp]
+    intros
+    exact ⟨h.right _ ‹_›, ih _ ‹_› ‹_›⟩
+
+/-! ## Recursion on natural numbers -/
+
+section Recursion
+
+theorem succ_subrelation_mem' :
+  Subrelation (fun x y => insert x x = y) (fun x y : ZFSet => x ∈ y) := by
+  intro _ _ _
+  subst_eqs
+  rw [mem_insert_iff]
+  left
+  rfl
+
+theorem succ_wf' : @WellFounded ZFSet (fun x y => insert x x = y) := by
+  apply Subrelation.wf
+  · exact succ_subrelation_mem'
+  · exact mem_wf
+
+open Function in
+theorem mem_wf' : @WellFounded ZFNat (·.1 ∈ ·.1) := by
+  have : (fun x y : ZFNat => x.1 ∈ y.1) = ((fun x y : ZFSet => x ∈ y) on Subtype.val) := rfl
+  rw [this]
+  apply WellFounded.onFun
+  exact mem_wf
+
+/-- The relation built over the successor function is a subrelation of the membership relation. -/
+theorem succ_subrelation_mem : Subrelation (succ · = ·) (·.1 ∈ ·.1) := by
+  intro _ _ _
+  simp only [succ] at *
+  subst_eqs
+  rw [mem_insert_iff]
+  left
+  rfl
+
+theorem succ_wf : @WellFounded ZFNat (succ · = ·) := by
+  apply Subrelation.wf
+  · exact succ_subrelation_mem
+  · exact mem_wf'
+
+/--
+The induction principle for sets in `Nat`. This principle is meant to be used for definitional
+purposes only.
+-/
+lemma ind {P : ZFSet → Prop} (n : ZFSet)
+  (h : n ∈ Nat) (zero : P ∅) (succ : ∀ n ∈ Nat, P n → P (insert n n)) : P n := by
+  have : Nat.sep P |>.inductive_set := by
+    unfold inductive_set
+    apply And.intro
+    · exact mem_sep.mpr ⟨zero_in_Nat, ‹_›⟩
+    · simp only [mem_sep, and_imp]
+      intros
+      exact ⟨succ_mem_Nat' ‹_›, succ _ ‹_› ‹_›⟩
+  let p := inductive_subset_some_inf_contains_Nat this
+  let p' := fun x (_ : x ∈ Nat.sep P) => Nat_subset_some_inf (ZFSet.sep_subset_self ‹_›)
+  simp_rw [subset_def, mem_sep] at p
+  simp only [mem_sep] at p'
+  exact p p' h |>.right
+
+/-- The (weak) induction principle for natural numbers. -/
+theorem induction {P : ZFNat → Prop} (n : ZFNat)
+  (zero : P 0) (succ : ∀ n, P n → P (succ n)) : P n := by classical
+  let ⟨n, hn⟩ := n
+  let P' x := if hx : x ∈ Nat then P ⟨x, hx⟩ else unreachable!
+  have : P' n = P ⟨n, hn⟩ := dif_pos hn
+  rw [← this]
+  apply @ind P' n hn
+  · unfold P'
+    simpa [hn, zero_in_Nat, nat_zero_eq] using zero
+  · intro m hm hm'
+    unfold P' at *
+    rw [dif_pos hm] at hm'
+    rw [dif_pos <| succ_mem_Nat' hm]
+    exact succ ⟨m, hm⟩ hm'
+
+@[cases_eliminator]
+theorem cases {P : ZFNat → Prop} (n : ZFNat) (zero : P 0) (succ : ∀ n, P (succ n)) : P n :=
+  induction n zero fun n _ => succ n
+
+theorem every_nat_transitive {n : ZFSet} (h : n ∈ Nat) : transitive n := by
+  unfold transitive
+  apply ind _ h
+  · intros _ _
+    exact False.elim (notMem_empty _ ‹_›)
+  · intros _ _ ih _ hy
+    intro _ _
+    rw [mem_insert_iff] at hy ⊢
+    rcases hy with rfl | _
+    · exact Or.inr ‹_›
+    · exact Or.inr (ih _ ‹_› ‹_›)
+
+theorem lt_succ {n : ZFNat} : n < succ n := mem_insert _ _
+theorem le_succ {n : ZFNat} : n ≤ succ n := Or.inl lt_succ
+
+theorem lt_trans {x y z : ZFNat} : x < y → y < z → x < z :=
+  fun _ _ => every_nat_transitive z.2 _ ‹_› ‹_›
+
+theorem lt_irrefl {n : ZFNat} : ¬ n < n := fun _ => mem_irrefl _ ‹_›
+theorem lt_imp_ne {n m : ZFNat} : n < m → n ≠ m := fun _ _ => by
+  subst_eqs
+  absurd lt_irrefl ‹_›
+  trivial
+
+theorem le_trans {x y z : ZFNat} : x ≤ y → y ≤ z → x ≤ z := by
+  rintro (_ | rfl)  (_ | rfl)
+  · left; exact lt_trans ‹_› ‹_›
+  · left; assumption
+  · left; assumption
+  · right; rfl
+
+theorem le_antisymm {x y : ZFNat} : x ≤ y → y ≤ x → x = y := by
+  rintro (h | rfl) (_ | _)
+  · absurd lt_irrefl <| lt_trans ‹_› ‹_›
+    trivial
+  · symm; assumption
+  · trivial
+  · trivial
+
+theorem lt_le_iff {n m} : n ≤ m ↔ n < succ m := by
+  dsimp [nat_le, ]
+  apply Iff.intro
+  · rintro (_ | rfl)
+    · exact lt_trans ‹_› lt_succ
+    · exact lt_succ
+  · intro h
+    let ⟨n, hn⟩ := n
+    let ⟨m, hm⟩ := m
+    dsimp [nat_lt, succ] at *
+    rw [mem_insert_iff] at h
+    rcases h with rfl | _
+    · right; rfl
+    · left; assumption
+
+theorem lt_mono {x y : ZFNat} : x < y → x.succ < y.succ := by
+  intro h
+  induction y using induction with
+  | zero =>
+    absurd not_lt_zero h
+    trivial
+  | succ y ih =>
+    rcases lt_le_iff.mpr h with (h | rfl)
+    · exact lt_trans (ih h) lt_succ
+    · exact lt_succ
+
+theorem succ_lt_mono {x y : ZFNat} : succ x < succ y → x < y := by
+  intro h
+  induction y using induction with
+  | zero =>
+    rcases lt_le_iff.mpr h with (h | h)
+    · absurd not_lt_zero h; trivial
+    · absurd succ_ne_zero x h; trivial
+  | succ y ih =>
+    rcases lt_le_iff.mpr h with (h | h)
+    · exact lt_trans (ih h) lt_succ
+    · replace h := succ_inj h
+      subst h
+      exact lt_succ
+
+theorem le_mono {x y : ZFNat} : x ≤ y → x.succ ≤ y.succ := by
+  rintro (h | rfl)
+  · left
+    induction y using induction with
+    | zero =>
+      absurd not_lt_zero h
+      trivial
+    | succ y ih =>
+      rcases lt_le_iff.mpr h with (h | rfl)
+      · exact lt_trans (ih h) lt_succ
+      · exact lt_succ
+  · right; rfl
+
+theorem succ_le_mono {x y : ZFNat} : x.succ ≤ y.succ → x ≤ y := by
+  rintro (h | h)
+  · left
+    induction y using induction with
+    | zero =>
+      rcases lt_le_iff.mpr h with (h | h)
+      · absurd not_lt_zero h; trivial
+      · absurd succ_ne_zero x h; trivial
+    | succ y ih =>
+      rcases lt_le_iff.mpr h with (h | h)
+      · exact lt_trans (ih h) lt_succ
+      · rw [← h]; exact lt_succ
+  · replace h := succ_inj h; subst h; right; rfl
+
+theorem le_lt_iff {n m} : succ n ≤ m ↔ n < m := by
+  rw [lt_le_iff]
+  apply Iff.intro
+  · intro; exact succ_lt_mono ‹_›
+  · exact lt_mono
+
+theorem le_total {x y : ZFNat} : x ≤ y ∨ y ≤ x := by
+  induction x using induction with
+  | zero =>
+    left
+    induction y using induction with
+    | zero => right; rfl
+    | succ _ ih => exact le_trans ih (le_succ)
+  | succ x ih =>
+    induction y using induction with
+    | zero =>
+      rcases ih with ((h | _) | (_ | _))
+      · absurd not_lt_zero h; trivial
+      · subst_eqs; right; exact le_succ
+      · right; left; exact lt_trans ‹_› lt_succ
+      · subst_eqs; right; left; exact lt_succ
+    | succ y ih' =>
+      rcases ih with (h | _) | (h | _)
+      · rcases ih' (Or.inl <| lt_le_iff.mpr h) with l | (r | rfl)
+        · left; left; exact lt_le_iff.mp l
+        · right; right; congr; exact le_antisymm (lt_le_iff.mpr r) (lt_le_iff.mpr h)
+        · replace h := lt_le_iff.mpr h
+          left
+          apply le_mono
+          exact h
+      · subst_eqs; right; exact le_succ
+      · right
+        simp only [lt_le_iff]
+        exact lt_trans (lt_trans h lt_succ) lt_succ
+      · subst_eqs
+        right
+        exact le_succ
+
+theorem lt_iff_le_not_ge {x y : ZFNat} : x < y ↔ x ≤ y ∧ ¬ y ≤ x := by
+  apply Iff.intro
+  · intro
+    apply And.intro
+    · left
+      assumption
+    · rintro (_ | rfl)
+      · exact lt_irrefl (lt_trans ‹_› ‹_›)
+      · exact lt_irrefl ‹_›
+  · rintro ⟨h | rfl, h'⟩
+    · assumption
+    · simp only [nat_le, or_true] at h'
+      contradiction
+
+/-- The (strong) induction principle for natural numbers. -/
+theorem strong_induction {P : ZFNat → Prop} (n : ZFNat)
+  (ind : ∀ n, (∀ m, m < n → P m) → P n) : P n := by
+  let Q x := ∀ m < x, P m
+  have aux {x} : Q x := by
+    induction x using induction with
+    | zero =>
+      intros _ _
+      exact False.elim (not_lt_zero ‹_›)
+    | succ n ih =>
+      intros m hm
+      unfold Q at ih
+      by_cases h : m = n
+      · subst h
+        exact ind _ ih
+      · have h' : m < n := by
+          rcases lt_le_iff.mpr hm with (_ | rfl)
+          · assumption
+          · contradiction
+        exact ih m h'
+  exact ind _ aux
+
+theorem mem_Nat_of_mem_mem_Nat {n m : ZFSet} (hn : n ∈ Nat) : m ∈ n → m ∈ Nat := by
+  apply ZFNat.ind n hn
+  · intro h
+    nomatch notMem_empty m h
+  · intro n hn ih hm
+    rw [mem_insert_iff] at hm
+    rcases hm with rfl | hm
+    · exact hn
+    · exact ih hm
+
+theorem not_zero_imp_succ {n : ZFNat} : n ≠ 0 → ∃ m, n = succ m := by
+  induction n using induction with
+  | zero => intro h; contradiction
+  | succ n _ =>
+    intro
+    exact exists_apply_eq_apply' succ n
+
+lemma sUnion_insert_nat {x : ZFSet} (h : x ∈ Nat) : (⋃₀ (insert x x) : ZFSet) = x := by
+  apply ind _ h
+  · rw [sUnion_insert, sUnion_empty]
+    ext1
+    simp only [mem_union, notMem_empty, or_self]
+  · intros n _ ih
+    rw [sUnion_insert, ih]
+    ext1
+    simp only [mem_union, mem_insert_iff, or_self_right]
+
+theorem pred_in_Nat' ⦃x : ZFSet⦄ (h : x ∈ Nat) : (⋃₀ x : ZFSet) ∈ Nat := by
+  apply ind _ h
+  · rw [sUnion_empty]
+    exact zero_in_Nat
+  · intros
+    rw [sUnion_insert_nat] <;> assumption
+
+/-- The predecessor function on natural numbers, defined directly as the union of a set. -/
+def pred (x : ZFNat) : ZFNat := x.map sUnion pred_in_Nat'
+
+theorem pred_eq (n : ZFNat) : pred n = ⟨⋃₀ n.val, pred_in_Nat' n.property⟩ := rfl
+
+@[simp]
+theorem pred_zero : pred 0 = 0 := by
+  unfold pred
+  rw [nat_zero_eq, Subtype.map, Subtype.mk.injEq, sUnion_empty]
+
+@[simp]
+theorem pred_one : pred 1 = 0 := by
+  unfold pred
+  rw [nat_one_eq, nat_zero_eq, Subtype.map, Subtype.mk.injEq]
+  dsimp [succ]
+  rw [LawfulSingleton.insert_empty_eq, sUnion_singleton]
+
+@[simp]
+theorem pred_succ {n : ZFNat} : pred (succ n) = n := by
+  let ⟨_, _⟩ := n
+  simp only [pred, succ, Subtype.map]
+  congr
+  exact sUnion_insert_nat ‹_›
+
+@[simp]
+theorem succ_pred {n : ZFNat} (h : n ≠ 0) : succ (pred n) = n := by
+  induction n using strong_induction with
+  | ind n ih =>
+    obtain ⟨m, hm⟩ := not_zero_imp_succ h
+    subst hm
+    by_cases h' : m = 0 <;> subst_eqs <;> rw [pred_succ]
+
+private theorem succ_lift_eq {x : ZFNat} : ↑(succ x) = insert x.val x.val := by rfl
+
+private theorem succ_eq (n : ZFSet) (n_Nat : n ∈ Nat) :
+  ⟨insert n n, succ_mem_Nat' n_Nat⟩ = succ ⟨n, n_Nat⟩ := by rfl
+
+/--
+The recursion principle for sets in `Nat`. This principle is meant to be used for definitional
+purposes only.
+-/
+def rec'.{u} {motive : ZFSet → Sort u} (n : ZFSet) (h : n ∈ Nat)
+  (zero : motive ∅) (succ : Π x ∈ Nat, motive x → motive (insert x x)) : motive n := by
+  apply succ_wf.fix (C := fun x => motive x.val) (x := ⟨n, h⟩)
+  intro x ih
+  by_cases x_eq_0 : x = 0
+  · subst x_eq_0
+    exact zero
+  · specialize ih _ (succ_pred x_eq_0)
+    specialize succ (pred x) (pred x).2 ih
+    conv at succ =>
+      arg 1
+      rw [← succ_lift_eq, succ_pred x_eq_0]
+    assumption
+
+/-- Provides the base case of the recursion principle for sets in `Nat`. -/
+theorem rec'_zero.{u} {motive : ZFSet → Sort u}
+  (zero : motive ∅) (succ : Π x ∈ Nat, motive x → motive (insert x x)) :
+  ZFNat.rec' ∅ zero_in_Nat zero succ = zero := by
+    unfold ZFNat.rec' WellFounded.fix
+    beta_reduce
+    rw [WellFounded.fixF_eq, dite_cond_eq_true]
+    exact eq_self _
+
+
+/-- Provides the inductive step of the recursion principle for sets in `Nat`. -/
+theorem rec'_succ.{u} {motive : ZFSet → Sort u} (n : ZFSet) (n_Nat : n ∈ Nat)
+  (zero : motive ∅) (succ : Π x ∈ Nat, motive x → motive (insert x x)) :
+  rec' (insert n n) (succ_mem_Nat' n_Nat) zero succ = succ n n_Nat (rec' n n_Nat zero succ) := by
+    unfold ZFNat.rec' WellFounded.fix
+    beta_reduce
+    rw [WellFounded.fixF_eq, dite_cond_eq_false]
+    · apply cast_eq_iff_heq.mpr
+      · congr
+        · conv => enter [1, 1]; rw [succ_eq _ n_Nat, pred_succ]
+        · exact proof_irrel_heq ..
+        · conv =>
+            left
+            conv => arg 1; rw [succ_eq _ n_Nat]
+            rw [pred_succ]
+        · exact proof_irrel_heq ..
+        · apply succ_pred
+          rw [succ_eq _ n_Nat]
+          exact succ_ne_zero _
+      · apply eq_false
+        intro h
+        rw [succ_eq _ n_Nat] at h
+        exact succ_ne_zero _ h
+
+/--
+The recursion principle for natural numbers. This recursor allows inductive
+definitions over natural numbers to be defined in a more natural way.
+-/
+@[induction_eliminator]
+def rec.{u} {motive : ZFNat → Sort u} (n : ZFNat)
+  (zero : motive 0) (succ : Π x, motive x → motive (succ x)) : motive n := by classical
+  let ⟨n, hn⟩ := n
+  let motive' (x : ZFSet) := if hx : x ∈ Nat then motive ⟨x, hx⟩ else unreachable!
+  have : motive' n = motive ⟨n, hn⟩ := dif_pos hn
+  rw [← this]
+  apply @ZFNat.rec' motive' n hn
+  · unfold motive'
+    simpa [hn, zero_in_Nat, nat_zero_eq] using zero
+  · intro m hm hm'
+    unfold motive' at *
+    rw [dif_pos hm] at hm'
+    rw [dif_pos <| succ_mem_Nat' hm]
+    exact succ ⟨m, hm⟩ hm'
+
+/--
+The induction principle of `ZFNat` is a universe-specialized version of the recursion principle.
+-/
+@[simp]
+theorem induction_is_rec_into_Prop {motive : ZFNat → Prop} :
+  induction = ZFNat.rec (motive := motive) := rfl
+
+theorem rec_zero.{u} {motive : ZFNat → Sort u}
+  (zero : motive 0) (succ : Π x, motive x → motive (succ x)) :
+  rec 0 zero succ = zero := by conv => arg 1; simp [ZFNat.rec, ZFNat.rec'_zero]
+
+theorem rec_succ.{u} {motive : ZFNat → Sort u} (n : ZFNat)
+  (zero : motive 0) (succ' : Π x, motive x → motive (succ x)) :
+  rec (succ n) zero succ' = succ' n (ZFNat.rec n zero succ') := by
+    simp [ZFNat.rec, succ, ZFNat.rec'_succ _ n.property]
+
+end Recursion
+
+/--
+The predecessor function `pred'` on natural numbers, defined inductively.
+This definition is equivalent to `pred`, as proven by `pred'_eq_pred`.
+-/
+protected abbrev pred' (m : ZFNat) : ZFNat := ZFNat.rec m 0 (fun x _ : ZFNat => x)
+
+/-- The definitions of `pred` and `pred'` are equivalent. -/
+lemma pred'_eq_pred : pred = ZFNat.pred' := by
+  ext1 n
+  induction n with
+  | zero => rw [pred_zero, ZFNat.pred', ZFNat.rec_zero]
+  | succ _ _ => rw [pred_succ, ZFNat.pred', ZFNat.rec_succ]
+
+/-! ## Arithmetic -/
+
+section Inequalities
+
+theorem zero_lt_succ {n : ZFNat} : 0 < n.succ := by
+  induction n with
+  | zero => exact lt_succ
+  | succ n ih => exact lt_trans ih lt_succ
+
+theorem pos_of_ne_zero {n : ZFNat} : 0 ≠ n → 0 < n := by
+  induction n with
+  | zero => intro h; nomatch h
+  | succ x ih =>
+    intro
+    exact zero_lt_succ
+
+instance : Preorder ZFNat where
+  le := nat_le.le
+  le_trans _ _ _ := le_trans
+  le_refl _ := Or.inr rfl
+  lt_iff_le_not_ge _ _ := lt_iff_le_not_ge
+
+instance : LinearOrder ZFNat where
+  le_refl _ := Or.inr rfl
+  le_trans _ _ _ := le_trans
+  le_antisymm _ _ := le_antisymm
+  le_total _ _ := le_total
+  toDecidableLE := fun _ _ => Classical.propDecidable ((· ≤ ·) _ _)
+  lt_iff_le_not_ge _ _ := lt_iff_le_not_ge
+
+instance : IsStrictTotalOrder ZFNat (·<·) where
+  trichotomous x y := by
+    rcases @le_total x y with (h | rfl) | h | rfl
+    · left; assumption
+    · right; left; rfl
+    · right; right; assumption
+    · right; left; rfl
+  irrefl _ := lt_irrefl
+  trans _ _ _ := lt_trans
+
+end Inequalities
+
+section Arithmetic
+
+/-- The addition function on natural numbers, defined inductively. -/
+protected abbrev add (n m : ZFNat) : ZFNat := ZFNat.rec n m (fun _ : ZFNat => succ)
+
+instance add_inst : Add ZFNat := ⟨ZFNat.add⟩
+lemma add_inst_eq {n m : ZFNat} : n + m = n.add m := rfl
+
+lemma add_one_eq_succ {n : ZFNat} : n + 1 = succ n := by
+  dsimp [add_inst_eq]
+  induction n with
+  | zero => rw [ZFNat.add, ZFNat.rec_zero, nat_one_eq]
+  | succ _ ih => rw [ZFNat.add, ZFNat.rec_succ, ← ZFNat.add, ih]
+
+lemma add_one_eq_succ' {n : ZFNat} : 1 + n = succ n := by
+  rw [add_inst_eq, ZFNat.add, nat_one_eq, rec_succ, rec_zero]
+
+@[simp]
+lemma add_zero {n : ZFNat} : n + 0 = n := by
+  dsimp [add_inst_eq]
+  induction n with
+  | zero => rw [ZFNat.add, rec_zero]
+  | succ _ ih => rw [ZFNat.add, rec_succ, ← ZFNat.add, ih]
+
+@[simp]
+lemma zero_add {n : ZFNat} : 0 + n = n := by
+  rw [add_inst_eq, ZFNat.add, rec_zero]
+
+lemma add_succ {n m : ZFNat} : succ n + m = succ (n + m) := rec_succ n m fun _ => succ
+
+lemma succ_add {n m : ZFNat} : succ (n + m) = n + succ m := by
+  induction n with
+  | zero => rw [add_inst_eq, add_inst_eq, ZFNat.add, rec_zero, ZFNat.add, rec_zero]
+  | succ n ih =>
+    rw [add_succ, ih]
+    dsimp [add_inst_eq]
+    conv => rhs; rw [ZFNat.add, rec_succ]
+
+lemma add_comm (n m : ZFNat) : n + m = m + n := by
+  induction n with
+  | zero => rw [add_zero, add_inst_eq, ZFNat.add, rec_zero]
+  | succ n ih => rw [← succ_add, add_succ, ih]
+
+@[simp]
+lemma add_assoc (n m k : ZFNat) : n + (m + k) = n + m + k := by
+  induction n with
+  | zero => rw [zero_add, zero_add]
+  | succ _ ih => rw [add_succ, add_succ, add_succ, ih]
+
+lemma add_left_comm (n m k : ZFNat) : n + (m + k) = m + (n + k) := by
+  rw [add_assoc, add_assoc, add_comm n]
+
+lemma add_right_comm (n m k : ZFNat) : (n + m) + k = (n + k) + m := by
+  rw [← add_assoc, add_comm m, add_assoc]
+
+theorem add_left_cancel {n m k : ZFNat} : n + m = n + k ↔ m = k := by
+  induction n with
+  | zero => simp only [zero_add]
+  | succ n ih =>
+    simp_rw [add_succ]
+    apply Iff.intro
+    · intro h
+      exact ih.mp (succ_inj h)
+    · intro h
+      rw [h]
+
+theorem add_right_cancel {n m k : ZFNat} : n + m = k + m ↔ n = k := by
+  rw [add_comm n, add_comm k]
+  exact add_left_cancel
+
+theorem eq_zero_of_add_eq_zero : ∀ {n m : ZFNat}, n + m = 0 → n = 0 ∧ m = 0 := by
+  intro n m
+  induction n generalizing m with
+  | zero => simp only [zero_add, true_and, imp_self]
+  | succ n ih =>
+    intro h
+    rw [add_succ, succ_add] at h
+    absurd succ_ne_zero m (ih h).right
+    trivial
+
+theorem eq_zero_of_add_eq_zero_left {n m : ZFNat} (h : n + m = 0) : m = 0 :=
+  eq_zero_of_add_eq_zero h |>.right
+
+@[simp] theorem add_left_eq_self {a b : ZFNat} : a + b = b ↔ a = 0 := by
+  conv => lhs; rhs; rw [← @zero_add b]
+  rw [add_right_cancel]
+@[simp] theorem add_right_eq_self {a b : ZFNat} : a + b = a ↔ b = 0 := by
+  conv => lhs; rhs; rw [← @add_zero a]
+  rw [add_left_cancel]
+@[simp] theorem self_eq_add_right {a b : ZFNat} : a = a + b ↔ b = 0 := by
+  conv => lhs; lhs; rw [← @add_zero a]
+  rw [add_left_cancel]
+  exact eq_comm
+@[simp] theorem self_eq_add_left {a b : ZFNat} : a = b + a ↔ b = 0 := by
+  conv => lhs; lhs; rw [← @zero_add a]
+  rw [add_right_cancel]
+  exact eq_comm
+
+theorem lt_of_succ_le {n m : ZFNat} (h : succ n ≤ m) : n < m := le_lt_iff.mp ‹_›
+theorem succ_le_of_lt {n m : ZFNat} (h : n < m) : succ n ≤ m := le_lt_iff.mpr ‹_›
+
+theorem le.dest {n m : ZFNat} : n ≤ m → ∃ k, n + k = m := by
+  intro h
+  induction n with
+  | zero => exact ⟨m, zero_add⟩
+  | succ n ih =>
+    rcases h with h | rfl
+    · have : n < m := by
+        apply lt_trans (lt_succ)
+        assumption
+      let ⟨k, hk⟩ := ih (Or.inl this)
+      exact ⟨pred k, by
+        rwa [← add_one_eq_succ, ← add_assoc, add_one_eq_succ', ZFNat.succ_pred]
+        intro
+        subst_eqs
+        rw [add_zero] at this
+        exact lt_irrefl this⟩
+    · exact ⟨0, add_zero⟩
+
+theorem le_succ_of_le {n m : ZFNat} (h : n ≤ m) : n ≤ succ m := le_trans h le_succ
+
+@[simp] theorem le_add_right (n k : ZFNat) : n ≤ n + k := by
+  induction k with
+  | zero => rw [add_zero]
+  | succ _ ih =>
+    rw [add_comm, add_succ, ← add_comm]
+    exact le_succ_of_le ih
+
+@[simp] theorem le_add_left (n m : ZFNat) : n ≤ m + n := add_comm .. ▸ le_add_right ..
+
+theorem le.intro {n m k : ZFNat} (h : n + k = m) : n ≤ m := h ▸ le_add_right n k
+
+theorem zero_le {n : ZFNat} : 0 ≤ n := by
+  induction n with
+  | zero => right; rfl
+  | succ n ih => exact le_trans ih le_succ
+
+theorem le_of_add_le_add_left {a b c : ZFNat} (h : a + b ≤ a + c) : b ≤ c := by
+  match le.dest h with
+  | ⟨d, hd⟩ =>
+    apply @le.intro _ _ d
+    rw [← add_assoc] at hd
+    exact add_left_cancel.mp hd
+
+theorem add_le_add_left {n m : ZFNat} (h : n ≤ m) (k : ZFNat) : k + n ≤ k + m :=
+  match le.dest h with
+  | ⟨w, hw⟩ =>
+    have : k + (n + w) = k + m     := congrArg _ hw
+    le.intro <| (Eq.symm <| add_assoc k n w).trans this
+
+@[simp] theorem add_le_add_iff_left {n m k : ZFNat} : n + m ≤ n + k ↔ m ≤ k :=
+  ⟨le_of_add_le_add_left, fun h => add_le_add_left h _⟩
+
+theorem lt_of_add_lt_add_right {n m k : ZFNat} : k + n < m + n → k < m := by
+  induction n with
+  | zero => simp_rw [add_zero]; exact id
+  | succ n ih =>
+    simp_rw [← succ_add]
+    intro h
+    apply succ_lt_mono at h
+    exact ih h
+
+theorem add_lt_add_left {n m : ZFNat} (h : n < m) (k : ZFNat) : k + n < k + m :=
+  lt_of_succ_le <| succ_add ▸ add_le_add_left (succ_le_of_lt h) k
+
+theorem add_lt_add_right {n m : ZFNat} (h : n < m) (k : ZFNat) : n + k < m + k :=
+  add_comm k m ▸ add_comm k n ▸ add_lt_add_left h k
+
+theorem lt_add_of_pos_right {n k : ZFNat} (h : 0 < k) : n < n + k := by
+  let this := add_zero ▸ add_lt_add_left h n;
+  exact this
+
+theorem lt_of_add_lt_add_left {n m k : ZFNat} : n + k < n + m → k < m := by
+  rw [add_comm n, add_comm n]; exact lt_of_add_lt_add_right
+
+@[simp] theorem add_lt_add_iff_left {k n m : ZFNat} : k + n < k + m ↔ n < m :=
+  ⟨lt_of_add_lt_add_left, fun _ => add_lt_add_left ‹_› _⟩
+
+@[simp] theorem add_lt_add_iff_right {k n m : ZFNat} : n + k < m + k ↔ n < m :=
+  ⟨lt_of_add_lt_add_right, fun _ => add_lt_add_right ‹_› _⟩
+
+theorem add_le_add_right {n m : ZFNat} (h : n ≤ m) (k : ZFNat) : n + k ≤ m + k :=
+  add_comm .. ▸ add_comm m k ▸ add_le_add_left h k
+
+theorem add_lt_add_of_le_of_lt {a b c d : ZFNat} (hle : a ≤ b) (hlt : c < d) : a + c < b + d :=
+  lt_of_le_of_lt (add_le_add_right hle _) (add_lt_add_left hlt _)
+
+theorem add_lt_add_of_lt_of_le {a b c d : ZFNat} (hlt : a < b) (hle : c ≤ d) : a + c < b + d :=
+  lt_of_le_of_lt (add_le_add_left hle _) (add_lt_add_right hlt _)
+
+theorem lt_add_of_pos_left {k n : ZFNat} : 0 < k → n < k + n :=
+  add_comm .. ▸ lt_add_of_pos_right
+
+theorem pos_of_lt_add_right {n k : ZFNat} (h : n < n + k) : 0 < k := by
+  apply lt_of_add_lt_add_left
+  rw [add_zero]
+  assumption
+
+theorem pos_of_lt_add_left {n k : ZFNat} : n < k + n → 0 < k := by
+  rw [add_comm]; exact pos_of_lt_add_right
+
+@[simp] theorem lt_add_right_iff_pos {n k : ZFNat} : n < n + k ↔ 0 < k :=
+  ⟨pos_of_lt_add_right, lt_add_of_pos_right⟩
+
+@[simp] theorem lt_add_left_iff_pos {n k : ZFNat} : n < k + n ↔ 0 < k :=
+  ⟨pos_of_lt_add_left, lt_add_of_pos_left⟩
+
+theorem add_pos_left {m : ZFNat} (h : 0 < m) (n : ZFNat) : 0 < m + n :=
+  lt_of_lt_of_le h (le_add_right ..)
+
+theorem add_pos_right {n : ZFNat} (m : ZFNat) (h : 0 < n) : 0 < m + n :=
+  lt_of_lt_of_le h (le_add_left ..)
+
+theorem pred_le_pred {n m : ZFNat} : n ≤ m → (pred n) ≤ (pred m) := by
+  intro h
+  induction n <;> induction m
+  · right; rfl
+  · simp only [pred_zero, pred_succ]
+    rcases h with (_ | _)
+    · exact lt_le_iff.mpr ‹_›
+    · absurd (succ_ne_zero _ (Eq.symm ‹_›))
+      trivial
+  · rcases h with (h | h)
+    · absurd not_lt_zero h
+      trivial
+    · rw [h]
+  · simp only [pred_succ]
+    exact succ_le_mono h
+
+theorem le_of_succ_le_succ {n m : ZFNat} : (succ n) ≤ (succ m) → n ≤ m := by
+  intro h
+  replace h := pred_le_pred h
+  simp only [pred_succ] at h
+  assumption
+
+theorem lt_of_succ_lt_succ {n m : ZFNat} : succ n < succ m → n < m := by
+  intro h
+  rcases le_of_succ_le_succ (Or.inl h) with (h | rfl)
+  · assumption
+  · absurd lt_irrefl h
+    trivial
+
+theorem add_self_ne_one {n : ZFNat} : n + n ≠ 1 := by
+  intro h
+  induction n with
+  | zero =>
+    simp only [zero_add, nat_one_eq] at h
+    absurd succ_ne_zero _ (Eq.symm h)
+    trivial
+  | succ n _ =>
+    rw [add_succ, ← succ_add, nat_one_eq] at h
+    absurd succ_ne_zero _ (succ_inj h)
+    trivial
+
+protected abbrev sub (n m : ZFNat) : ZFNat := ZFNat.rec m n (fun _ => pred)
+instance sub_inst : Sub ZFNat := ⟨ZFNat.sub⟩
+lemma sub_inst_eq {n m : ZFNat} : n - m = n.sub m := rfl
+
+@[simp]
+theorem sub_zero {n : ZFNat} : n - 0 = n := by
+  rw [sub_inst_eq, ZFNat.sub, ZFNat.rec_zero]
+
+theorem sub_one_eq_pred {n : ZFNat} : n - 1 = pred n := by
+  rw [sub_inst_eq, ZFNat.sub, nat_one_eq, ZFNat.rec_succ, ZFNat.rec_zero]
+
+theorem succ_mono {n m : ZFNat} : n < m ↔ succ n < succ m :=
+  ⟨lt_mono, lt_of_succ_lt_succ⟩
+
+theorem sub_succ (n m : ZFNat) : n - succ m = pred (n - m) := by
+  rw [sub_inst_eq, ZFNat.sub, ZFNat.rec_succ, ← ZFNat.sub]
+  rfl
+
+@[simp]
+theorem zero_sub {n : ZFNat} : 0 - n = 0 := by
+  induction n with
+  | zero => rw [sub_zero]
+  | succ n ih => rw [sub_succ, ih, pred_zero]
+
+theorem succ_sub_succ (n m : ZFNat) : succ n - succ m = n - m := by
+  induction m with
+  | zero      => rw [← nat_one_eq, sub_one_eq_pred, pred_succ, sub_zero]
+  | succ m ih => rw [sub_succ, ih, ← sub_succ]
+
+theorem succ_sub_self (n : ZFNat) : succ n - n = 1 := by
+  induction n with
+  | zero => rw [sub_zero, nat_one_eq]
+  | succ n ih => rw [succ_sub_succ, ih]
+
+theorem sub_self {n : ZFNat} : n - n = 0 := by
+  induction n with
+  | zero => rw [sub_zero]
+  | succ n _ => rw [sub_succ, succ_sub_self, pred_one]
+
+theorem sub_add_distrib {n m k : ZFNat} : n - (m + k) = n - m - k := by
+  induction k with
+  | zero => rw [add_zero, sub_zero]
+  | succ k ih => rw [← succ_add, sub_succ, ih, ← sub_succ]
+
+theorem sub_ne_zero_of_lt {a b : ZFNat} : a < b → b - a ≠ 0 := by
+  intro h
+  induction a generalizing b with
+  | zero => rw [sub_zero]; exact zero_lt_ne_zero h
+  | succ a ih =>
+    induction b with
+    | zero => exact absurd h not_lt_zero
+    | succ b _ => rw [succ_sub_succ]; exact ih <| succ_mono.mpr h
+
+theorem le_of_succ_le {n m : ZFNat} (_ : succ n ≤ m) : n ≤ m := le_trans le_succ ‹_›
+theorem lt_of_succ_lt {n m : ZFNat} (h : succ n < m) : n < m := by
+  rcases le_of_succ_le (.inl h) with (h | rfl)
+  · assumption
+  · absurd lt_irrefl (lt_trans lt_succ h); trivial
+theorem le_of_lt {n m : ZFNat} : n < m → n ≤ m := Or.inl
+
+theorem add_sub_of_le {a b : ZFNat} (h : a ≤ b) : a + (b - a) = b := by
+  induction a with
+  | zero => rw [sub_zero, zero_add]
+  | succ a ih =>
+    have hne : b - a ≠ 0 := by
+      apply sub_ne_zero_of_lt
+      exact lt_of_succ_le ‹_›
+    have : a ≤ b := le_of_succ_le ‹_›
+    rw [sub_succ, add_succ, succ_add, succ_pred hne, ih this]
+
+theorem sub_one_cancel {a b : ZFNat} : 0 < a → 0 < b → a - 1 = b - 1 → a = b := by
+  intro ha hb h
+  rw [← succ_pred (zero_lt_ne_zero ha), ← succ_pred (zero_lt_ne_zero hb)]
+  simpa only [← sub_one_eq_pred, ← add_one_eq_succ, add_right_cancel]
+
+@[simp]
+theorem sub_add_cancel {n m : ZFNat} (h : m ≤ n) : n - m + m = n := by
+  rw [add_comm, add_sub_of_le h]
+
+theorem add_sub_add_right (n k m : ZFNat) : (n + k) - (m + k) = n - m := by
+  induction k with
+  | zero => simp_rw [add_zero]
+  | succ k ih => rwa [← succ_add, ← succ_add, succ_sub_succ]
+
+theorem add_sub_add_left (k n m : ZFNat) : (k + n) - (k + m) = n - m := by
+  rw [add_comm k n, add_comm k m, add_sub_add_right]
+
+@[simp] theorem add_sub_cancel (n m : ZFNat) : n + m - m = n :=
+  suffices n + m - (0 + m) = n by rw [zero_add] at this; assumption
+  by rw [add_sub_add_right, sub_zero]
+
+theorem add_sub_cancel_left (n m : ZFNat) : n + m - n = m := by
+  have : n + m - (n + 0) = m := by rw [add_sub_add_left, sub_zero]
+  rwa [add_zero] at this
+
+theorem add_sub_assoc {m k : ZFNat} (h : k ≤ m) (n : ZFNat) : n + m - k = n + (m - k) := by
+ rcases le.dest h with ⟨l, rfl⟩
+ rw [add_assoc, add_comm n, ← add_assoc, add_sub_cancel_left k, add_comm k, add_sub_cancel]
+
+theorem eq_add_of_sub_eq {a b c : ZFNat} (hle : b ≤ a) (h : a - b = c) : a = c + b := by
+  rw [h.symm, sub_add_cancel hle]
+
+theorem sub_eq_of_eq_add {a b c : ZFNat} (h : a = c + b) : a - b = c := by
+  rw [h, add_sub_cancel]
+
+theorem add_eq_add_sub_eq_sub {a b c d : ZFNat} : a + b = c + d → a - c = d - b := by
+  intro h
+  have : a = c + d - b := ZFNat.sub_eq_of_eq_add h.symm |>.symm
+  subst this
+  rw [←ZFNat.sub_add_distrib, ZFNat.add_comm b c, ZFNat.add_sub_add_left c d b]
+
+theorem sub_factor {m k n : ZFNat} (_ : k ≤ m) (_ : m ≤ n) : n - m + k = n - (m - k) := by
+  symm
+  apply sub_eq_of_eq_add
+  rw [← add_assoc, ← add_sub_assoc, add_comm k, add_sub_assoc, sub_self, add_zero, add_comm,
+    ← add_sub_assoc, add_comm, add_sub_assoc, sub_self, add_zero]
+  · trivial
+  · assumption
+  · trivial
+  · assumption
+
+theorem sub_add_comm {m n k : ZFNat} (h : m ≤ n) : n - m + k = n + k - m := by
+  rw [add_comm, add_comm n k, add_sub_assoc h k]
+
+theorem succ_le_succ {n m : ZFNat} : n ≤ m → succ n ≤ succ m
+  | .inl _ => .inl <| succ_mono.mp ‹_›
+  | .inr _ => .inr <| congrArg succ ‹_›
+
+theorem succ_le_succ_iff {a b : ZFNat} : succ a ≤ succ b ↔ a ≤ b where
+  mp := le_of_succ_le_succ
+  mpr := succ_le_succ
+
+theorem le_zero_imp_eq {n : ZFNat} : n ≤ 0 → n = 0 := by
+  rintro (h | rfl)
+  · exact absurd h not_lt_zero
+  · rfl
+
+/-- The multiplication function on natural numbers, defined inductively. -/
+protected abbrev mul (n m : ZFNat) : ZFNat := ZFNat.rec n 0 (fun _ => (· + m))
+instance mul_inst : Mul ZFNat := ⟨ZFNat.mul⟩
+lemma mul_inst_eq {n m : ZFNat} : n * m = n.mul m := rfl
+
+@[simp]
+lemma mul_zero {n : ZFNat} : n * 0 = 0 := by
+  dsimp [mul_inst_eq]
+  induction n using induction with
+  | zero => rw [ZFNat.mul, rec_zero]
+  | succ _ ih => rw [ZFNat.mul, rec_succ, ← ZFNat.mul, ih, add_zero]
+
+@[simp]
+lemma zero_mul {n : ZFNat} : 0 * n = 0 := by
+  rw [mul_inst_eq, ZFNat.mul, rec_zero]
+
+@[simp]
+lemma mul_one {n : ZFNat} : n * 1 = n := by
+  dsimp [mul_inst_eq]
+  induction n using induction with
+  | zero => rw [ZFNat.mul, rec_zero]
+  | succ _ ih => rw [ZFNat.mul, rec_succ, ← ZFNat.mul, ih, add_one_eq_succ]
+
+@[simp]
+lemma one_mul {n : ZFNat} : 1 * n = n := by
+  rw [mul_inst_eq, ZFNat.mul, nat_one_eq, rec_succ, rec_zero, zero_add]
+
+lemma mul_succ {n m : ZFNat} : (n + 1) * m = n * m + m := by
+  induction n with
+  | zero => rw [zero_add, one_mul, zero_mul, zero_add]
+  | succ n ih => rw [add_one_eq_succ, mul_inst_eq, ZFNat.mul, rec_succ, rec_succ, ← ZFNat.mul,
+    ← mul_inst_eq, ← ih, add_one_eq_succ]
+
+lemma succ_mul {n m : ZFNat} : (succ n) * m = n * m + m := by
+  rw [← add_one_eq_succ, mul_succ]
+
+lemma left_distrib {n m k : ZFNat} : n * (m + k) = n * m + n * k := by
+  induction n with
+  | zero => rw [zero_mul, zero_mul, zero_add, zero_mul]
+  | succ n ih =>
+    rw [← add_one_eq_succ]
+    conv_rhs => rw [mul_succ, mul_succ, add_assoc, ← add_assoc, ← add_assoc, add_comm m, add_assoc,
+      add_assoc, ← ih, ← add_assoc, add_comm k m, ← mul_succ]
+
+lemma mul_comm (n m : ZFNat) : n * m = m * n := by
+  induction n using induction with
+  | zero => rw [zero_mul, mul_zero]
+  | succ n ih => rw [← add_one_eq_succ, mul_succ, ih, left_distrib, mul_one]
+
+lemma succ_mul' {n m : ZFNat} : m * (succ n) = m * n + m := by
+  rw [mul_comm, succ_mul, mul_comm]
+
+lemma right_distrib {n m k : ZFNat} : (n + m) * k = n * k + m * k := by
+  rw [mul_comm, left_distrib, mul_comm m, mul_comm k]
+
+lemma mul_assoc (n m k : ZFNat) : n * m * k = n * (m * k) := by
+  induction n using induction with
+  | zero => rw [zero_mul, zero_mul, zero_mul]
+  | succ n ih =>
+    rw [← add_one_eq_succ]
+    conv =>
+      rhs
+      rw [right_distrib, one_mul, ← ih, ← right_distrib, ← mul_succ]
+
+lemma mul_left_comm (n m k : ZFNat) : n * (m * k) = m * (n * k) := by
+  rw [← mul_assoc, mul_comm n m, mul_assoc]
+
+lemma two_mul (n : ZFNat) : (1 + 1) * n = n + n := by rw [mul_succ, one_mul]
+lemma mul_two (n : ZFNat) : n * (1 + 1) = n + n := by rw [mul_comm, two_mul]
+
+lemma sub_lt_eq_zero {n m : ZFNat} (h : n ≤ m) : n - m = 0 := by
+  induction m using induction with
+  | zero => rw [le_zero_imp_eq h, sub_zero]
+  | succ _ ih =>
+    rcases h with _ | rfl
+    · rw [sub_succ, ih]
+      · exact pred_zero
+      · exact lt_le_iff.mpr ‹_›
+    · rw [sub_self]
+
+theorem add_lt_trans {n m p q : ZFNat} : n < m → p < q → n + p < m + q := by
+  intros h h'
+  exact lt_trans (add_lt_add_left h' n) (add_lt_add_right h q)
+
+theorem pos_mul_pos {k n : ZFNat} (h : 0 < k) : 0 < k*n → 0 < n := by
+  intro h'
+  induction n with
+  | zero => rwa [mul_zero] at h'
+  | succ m ih =>
+    obtain ⟨l, rfl⟩ := not_zero_imp_succ (zero_lt_ne_zero h)
+    rcases lt_le_iff.mpr h with (_ | rfl)
+    · by_contra contr
+      rw [not_lt] at contr
+      replace contr := le_zero_imp_eq contr
+      nomatch succ_ne_zero m contr
+    · rw [← nat_one_eq, one_mul] at h'
+      assumption
+
+theorem mul_lt_mono {n m k : ZFNat} (h : 0 < k) : n < m → k*n < k*m := by
+  intro h'
+  induction m using induction with
+  | zero => nomatch not_lt_zero h'
+  | succ m ih =>
+    rw [← add_one_eq_succ, left_distrib, mul_one]
+    rcases lt_le_iff.mpr h' with (h' | rfl)
+    · let this := add_lt_add_of_le_of_lt (@zero_le k) (ih h')
+      rwa [zero_add, add_comm] at this
+    · conv => lhs; rw [← @zero_add (k*n), add_comm]
+      exact add_lt_add_left h (k*n)
+
+theorem mul_le_mono {k m n : ZFNat} : n ≤ m → k*n ≤ k*m := by
+  intro h
+  induction k using induction with
+  | zero => rw [zero_mul, zero_mul]
+  | succ k ih =>
+    rw [succ_mul, succ_mul]
+    by_contra contr
+    rw [not_le, add_comm, add_comm _ n] at contr
+    rcases ih with _ | l
+    · nomatch lt_irrefl <| lt_trans (add_lt_add_of_le_of_lt h ‹_›) contr
+    · rcases h with _ | rfl
+      · rw [l] at contr
+        nomatch lt_irrefl <| lt_trans (lt_of_add_lt_add_right contr) ‹_›
+      · nomatch lt_irrefl ‹_›
+
+theorem mul_lt_cancel {k m n : ZFNat} : k*n < k*m → n < m := by
+  contrapose
+  rw [not_lt, not_lt]
+  exact mul_le_mono
+
+lemma lt_mul_iff {n m k : ZFNat} : n < m ↔ (k+1)*n < (k+1)*m := by
+  apply Iff.intro
+  · induction k using induction with
+    | zero => rw [zero_add, one_mul, one_mul]; exact id
+    | succ k ih =>
+      intro
+      rw [← add_one_eq_succ, mul_succ, mul_succ (m:=m)]
+      exact add_lt_trans (ih ‹_›) ‹_›
+  · exact mul_lt_cancel
+
+lemma left_distrib_mul_sub_one {n m : ZFNat} : n * (m - 1) = n * m - n := by
+  induction m using induction with
+  | zero => rw [zero_sub, mul_zero, zero_sub]
+  | succ _ _ =>
+    rw [nat_one_eq, succ_sub_succ, sub_zero, succ_mul', add_sub_assoc, sub_self, add_zero]
+    right
+    rfl
+
+lemma left_distrib_mul_sub_aux {n m k : ZFNat} (h : k < m) : n * (m - k) = n * m - n * k := by
+  induction k with
+  | zero => rw [sub_zero, mul_zero, sub_zero]
+  | succ k ih =>
+    rw [mul_comm n k.succ, succ_mul, mul_comm k n, sub_add_distrib]
+    specialize ih (lt_trans lt_succ h)
+    rw [← ih, ← left_distrib_mul_sub_one, ← sub_add_distrib, add_one_eq_succ]
+
+lemma sub_eq_zero_imp_le {a b : ZFNat} : a - b = 0 ↔ a ≤ b := by
+  apply Iff.intro
+  · intro h
+    induction b with
+    | zero => rw [sub_zero] at h; right; assumption
+    | succ b ih =>
+      induction a with
+      | zero => exact zero_le
+      | succ a _ =>
+        apply le_mono
+        rw [succ_sub_succ] at h
+        by_contra contr
+        rw [not_le] at contr
+        absurd sub_ne_zero_of_lt contr
+        assumption
+  · intro
+    exact sub_lt_eq_zero ‹_›
+
+lemma sub_eq_zero_mul {n a b : ZFNat} : a - b = 0 → n * a - n * b = 0 := by
+  intro
+  induction n with
+  | zero => rw [zero_mul, zero_mul, sub_zero]
+  | succ _ _ => exact sub_eq_zero_imp_le.mpr (mul_le_mono (sub_eq_zero_imp_le.mp ‹_›))
+
+lemma left_distrib_mul_sub {n m k : ZFNat} : n * (m - k) = n * m - n * k := by
+  rcases @le_total m k with (h | rfl) | _ | rfl
+  · replace h := sub_lt_eq_zero (Or.inl h)
+    rw [h, mul_zero, sub_eq_zero_mul h]
+  · rw [sub_self, sub_self, mul_zero]
+  · exact left_distrib_mul_sub_aux ‹_›
+  · rw [sub_self, sub_self, mul_zero]
+
+lemma right_distrib_mul_sub {n m k : ZFNat} : (m - k)*n = m*n - k*n := by
+  rw [mul_comm, left_distrib_mul_sub, mul_comm, mul_comm k]
+
+lemma add_eq_zero_iff {n m : ZFNat} : n + m = 0 ↔ n = 0 ∧ m = 0 := by
+  constructor
+  · intro h
+    induction n with
+    | zero =>
+      rw [zero_add] at h
+      exact ⟨rfl, h⟩
+    | succ n ih =>
+      induction m with
+      | zero =>
+        rw [add_zero] at h
+        exact ⟨h, rfl⟩
+      | succ m ih' =>
+        rw [add_succ] at h
+        nomatch succ_ne_zero _ h
+  · rintro ⟨rfl, rfl⟩
+    rw [zero_add]
+
+lemma mul_eq_zero_iff {n m : ZFNat} : n * m = 0 ↔ n = 0 ∨ m = 0 := by
+  constructor
+  · intro h
+    induction n with
+    | zero => left; rfl
+    | succ n ih =>
+      induction m with
+      | zero => right; rfl
+      | succ m ih' =>
+        rw [←add_one_eq_succ, mul_succ, add_eq_zero_iff] at h
+        nomatch succ_ne_zero _ h.2
+  · rintro (rfl | rfl)
+    · rw [zero_mul]
+    · rw [mul_zero]
+
+lemma eq_le_le_iff {n m : ZFNat} : n = m ↔ n ≤ m ∧ m ≤ n := by
+  constructor
+  · rintro rfl
+    exact ⟨le_refl _, le_refl _⟩
+  · rintro ⟨n_le_m, m_le_n⟩
+    rcases n_le_m with n_le_m | rfl
+    · rcases m_le_n with m_le_n | rfl
+      · nomatch lt_irrefl <| lt_trans n_le_m m_le_n
+      · rfl
+    · rfl
+
+lemma mul_left_cancel_iff {n m k : ZFNat} (k_pos : k ≠ 0) : k * m = k * n ↔ m = n := by
+  constructor
+  · induction n generalizing m with
+    | zero =>
+      intro hm
+      rw [mul_zero, mul_eq_zero_iff] at hm
+      rcases hm with rfl | rfl
+      · contradiction
+      · rfl
+    | succ n ih =>
+      intro eq
+      cases m with
+      | zero =>
+        symm at eq
+        rw [mul_zero, mul_eq_zero_iff] at eq
+        rcases eq with rfl | eq
+        · contradiction
+        · nomatch succ_ne_zero _ eq
+      | succ m =>
+        congr
+        rw [eq_le_le_iff]
+        and_intros
+        · have := zero_add ▸ @ZFNat.sub_eq_of_eq_add (k * m.succ) (k * n.succ) 0 <| eq
+          rw [←left_distrib_mul_sub, mul_eq_zero_iff] at this
+          rcases this with rfl | this
+          · contradiction
+          · rwa [ZFNat.succ_sub_succ, ZFNat.sub_eq_zero_imp_le] at this
+        · have := zero_add ▸ @ZFNat.sub_eq_of_eq_add (k * n.succ) (k * m.succ) 0 <| eq.symm
+          rw [←left_distrib_mul_sub, mul_eq_zero_iff] at this
+          rcases this with rfl | this
+          · contradiction
+          · rwa [ZFNat.succ_sub_succ, ZFNat.sub_eq_zero_imp_le] at this
+  · rintro rfl
+    rfl
+
+lemma mul_right_cancel_iff {n m k : ZFNat} (k_pos : k ≠ 0) : m * k = n * k ↔ m = n := by
+  rw [mul_comm m k, mul_comm n k]
+  exact mul_left_cancel_iff k_pos
+
+/-- The power function on natural numbers, defined inductively. -/
+protected abbrev pow (n p : ZFNat) : ZFNat := ZFNat.rec p 1 (fun _  => (· * n))
+instance pow_inst : HomogeneousPow ZFNat := ⟨ZFNat.pow⟩
+lemma pow_inst_eq {n p : ZFNat} : n ^ p = n.pow p := rfl
+
+lemma pow_zero {n : ZFNat} : n ^ 0 = 1 := by
+  dsimp [pow_inst_eq]
+  rw [ZFNat.pow, rec_zero]
+
+lemma pow_one {n : ZFNat} : n ^ 1 = n := by
+  rw [pow_inst_eq, ZFNat.pow, nat_one_eq, rec_succ, rec_zero, ← nat_one_eq, one_mul]
+
+end Arithmetic
+
+/--
+Induction principle for `ZFNat`, using natural notations.
+
+Declared as an induction eliminator.
+-/
+@[induction_eliminator]
+theorem induction' {P : ZFNat → Prop} (n : ZFNat)
+  (zero : P 0) (succ : ∀ n, P n → P (n + 1)) : P n := by
+  induction n with
+  | zero => trivial
+  | succ n ih =>
+    rw [← add_one_eq_succ]
+    exact succ n ih
+
+abbrev nsmul : ℕ → ZFNat → ZFNat
+  | 0, _ => 0
+  | n+1, m => m + nsmul n m
+
+instance : Semiring ZFNat where
+  add := .add
+  add_assoc _ _ _ := by rw [add_assoc]
+  zero := 0
+  zero_add _ := zero_add
+  add_zero _ := add_zero
+  nsmul := ZFSet.ZFNat.nsmul
+  nsmul_zero _ := rfl
+  nsmul_succ _ _ := add_comm _ _
+  add_comm := add_comm
+  mul := .mul
+  left_distrib _ _ _ := left_distrib
+  right_distrib _ _ _:= right_distrib
+  zero_mul _ := zero_mul
+  mul_zero _ := mul_zero
+  mul_assoc _ _ _ := by rw [mul_assoc]
+  one := 1
+  one_mul _ := one_mul
+  mul_one _ := mul_one
+
+instance : CommSemiring ZFNat where
+  mul_comm := mul_comm
+
+instance : Std.Associative (α := ZFNat) (· + ·) := ⟨(ZFNat.add_assoc · · · |>.symm)⟩
+instance : Std.Commutative (α := ZFNat) (· + ·) := ⟨ZFNat.add_comm⟩
+
+instance : Std.Associative (α := ZFNat) (· * ·) := ⟨ZFNat.mul_assoc⟩
+instance : Std.Commutative (α := ZFNat) (· * ·) := ⟨ZFNat.mul_comm⟩
+
+
+instance : IsLeftCancelAdd ZFNat where
+  add_left_cancel x y z := by rw [ZFNat.add_left_cancel]; intro; trivial
+
+def toNat (n : ZFNat) : ℕ := ZFNat.rec n 0 (fun _ => Nat.succ)
+def ofNat (n : ℕ) : ZFNat := nsmul n 1
+
+theorem toNat_is_id {n : ℕ} : (n : ZFNat).toNat = n := by
+  induction n with
+  | zero => apply ZFNat.rec_zero
+  | succ n ih => rw [Nat.cast_add, Nat.cast_one, ZFNat.add_one_eq_succ, ZFNat.toNat,
+    ZFNat.rec_succ, ← ZFNat.toNat, ih]
+
+end ZFNat
+
+theorem Nat.is_transitive : transitive Nat := by
+  intro n hn
+  apply ZFNat.rec' n hn
+  case zero => exact empty_subset Nat
+  case succ =>
+    intros x hx hx' z hz
+    rw [mem_insert_iff] at hz
+    rcases hz with rfl | hz
+    · assumption
+    · exact hx' hz
+
+/-- `Nat` is an inductive set. -/
+theorem Nat.is_inductive : inductive_set Nat where
+  left := ZFNat.zero_in_Nat
+  right := fun _ _ => ZFNat.succ_mem_Nat' ‹_›
+
+theorem ZFNat.ofNat_inj {n m : ℕ} : (n : ZFNat) = (m : ZFNat) ↔ n = m where
+  mp := by
+    intro h
+    induction n generalizing m with
+    | zero =>
+      conv_rhs at h =>
+        unfold Nat.cast NatCast.natCast
+      unfold_projs at h
+      unfold Nat.unaryCast at h
+      split at h
+      · rfl
+      · rw [ZFNat.add_one_eq_succ] at h
+        nomatch ZFNat.succ_ne_zero _ h.symm
+    | succ n ih =>
+      cases m with
+      | zero =>
+        simp only [Nat.cast_add, Nat.cast_one, Nat.cast_zero] at h
+        rw [ZFNat.add_one_eq_succ] at h
+        nomatch ZFNat.succ_ne_zero _ h
+      | succ m =>
+        simp only [Nat.cast_add, Nat.cast_one] at h
+        rw [ZFNat.add_one_eq_succ, ZFNat.add_one_eq_succ] at h
+        obtain rfl := ih <| ZFNat.succ_inj h
+        rfl
+  mpr := by
+    rintro rfl
+    rfl
+
+theorem ZFNat.toNat_eq (n : ZFNat) : ZFNat.toNat n = n := by
+  induction n with
+  | zero =>
+    rw [ZFNat.toNat, ZFNat.rec_zero]
+    rfl
+  | succ n ih =>
+    rw [ZFNat.add_one_eq_succ, ZFNat.toNat, ZFNat.rec_succ, ←ZFNat.toNat]
+    unfold Nat.cast
+    simp only [Nat.succ_eq_add_one, Nat.cast_add, ih, Nat.cast_one, Nat.succ_eq_add_one]
+    rw [ZFNat.add_one_eq_succ]
+
+theorem ZFNat.toNat_iff {n m : ZFNat} : n = m ↔ n.toNat = m.toNat where
+  mp := by
+    rintro rfl
+    rfl
+  mpr := by
+    intro h
+    induction n generalizing m with
+    | zero =>
+      cases m with
+      | zero => rfl
+      | succ m =>
+        rw [toNat, ZFNat.rec_zero, toNat, ZFNat.rec_succ] at h
+        nomatch Nat.succ_ne_zero _ h.symm
+    | succ n ih =>
+      rw [add_one_eq_succ, ZFNat.toNat, ZFNat.rec_succ] at h
+      cases m with
+      | zero =>
+        rw [ZFNat.toNat, ZFNat.rec_zero] at h
+        nomatch Nat.succ_ne_zero _ h
+      | succ m =>
+        rw [ZFNat.toNat, ZFNat.rec_succ, _root_.Nat.succ_inj, ←toNat, ←toNat] at h
+        rw [add_one_eq_succ]
+        obtain rfl := ih h
+        rfl
+
+instance ZFNat.instEquivZFNat_Nat : ZFNat ≃ ℕ where
+  toFun := toNat
+  invFun := ofNat
+  left_inv := by
+    intro n
+    induction n with
+    | zero =>
+      rw [toNat, ZFNat.rec_zero]
+      rfl
+    | succ n ih =>
+      rw [toNat, ZFNat.add_one_eq_succ, ZFNat.rec_succ,
+        ←toNat, ofNat, nsmul, ←ofNat, ih, add_one_eq_succ']
+  right_inv := by
+    intro n
+    induction n with
+    | zero =>
+      rw [ofNat, toNat, ZFNat.rec_zero]
+    | succ n ih =>
+      rw [ofNat, nsmul, add_one_eq_succ', ←ofNat, toNat, ZFNat.rec_succ, ←toNat, ih]
+
+
+end Naturals
+end ZFSet
+end

--- a/LeanPool/ZFLean/Rationals.lean
+++ b/LeanPool/ZFLean/Rationals.lean
@@ -1,0 +1,549 @@
+/-
+Copyright (c) 2026 Vincent Trélat. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vincent Trélat
+-/
+
+import LeanPool.ZFLean.Integers
+
+/-! # ZFC Rational Numbers
+
+This file defines the rational numbers in ZFC, based on the integers and using the `ZFInt` type.
+
+-/
+
+namespace ZFSet
+
+section Rationals
+
+abbrev ZFInt' := {x : ZFInt // x ≠ 0}
+
+/-- The equivalence relation on `ℤ × ℤ⋆` that defines the rational numbers. -/
+protected abbrev qrel (p q : ZFInt × ZFInt') : Prop := p.1 * q.2 = p.2 * q.1
+
+protected def qrel_eq : Equivalence ZFSet.qrel where
+  refl x := ZFInt.mul_comm x.1 x.2
+  symm h := by
+    unfold ZFSet.qrel at h ⊢
+    rw [ZFInt.mul_comm, ←h, ZFInt.mul_comm]
+  trans := by
+    rintro ⟨p, q, hq⟩ ⟨u, v, hv⟩ ⟨s, t, ht⟩ hpq huv
+    dsimp [ZFSet.qrel] at hpq huv ⊢
+    -- have : p * v * u * t = q * u * s * v := by
+    have : p * t * u * v = q * s * u * v := by
+      suffices p * v * u * t = q * u * s * v by
+        rw [
+          mul_assoc, mul_assoc,
+          mul_comm t, mul_comm u,
+          ←mul_assoc, ←mul_assoc,
+          this,
+          mul_assoc, mul_assoc,
+          mul_comm u, mul_assoc, mul_comm v,
+          ←mul_assoc, ←mul_assoc]
+      rw [hpq, mul_assoc, huv, mul_comm v s, ← mul_assoc]
+    conv at this =>
+      conv => lhs; rw [mul_assoc]
+      conv => rhs; rw [mul_assoc]
+    by_cases u_mul_v : u * v = 0
+    · rw [ZFInt.mul_comm] at u_mul_v
+      obtain ⟨⟩ := ZFInt.mul_eq_zero_of_ne_zero u_mul_v hv
+      rw [ZFInt.mul_zero, ZFInt.mul_comm] at hpq
+      obtain ⟨⟩ := ZFInt.mul_eq_zero_of_ne_zero hpq hv
+      rw [ZFInt.zero_mul] at huv
+      symm at huv
+      obtain ⟨⟩ := ZFInt.mul_eq_zero_of_ne_zero huv hv
+      rw [ZFInt.mul_zero, ZFInt.zero_mul]
+    · rwa [ZFInt.mul_right_cancel_iff u_mul_v] at this
+
+/-- `ℤ × ℤ⋆` equipped with `qrel` is a setoid. -/
+protected instance instSetoidZFIntZFInt' : Setoid (ZFInt × ZFInt') where
+  r := ZFSet.qrel
+  iseqv := ZFSet.qrel_eq
+
+/-- `ℚ` is defined as `ℤ × ℤ⋆` quotiented by `qrel` -/
+abbrev ZFRat := Quotient ZFSet.instSetoidZFIntZFInt'
+
+namespace ZFRat
+
+section Quotient
+
+def mk : ZFInt × ZFInt' → ZFRat := Quotient.mk''
+
+@[simp]
+theorem mk_eq (x : ZFInt × ZFInt') : @Eq ZFRat ⟦x⟧ (mk x) := rfl
+
+@[simp]
+theorem mk_out : ∀ x : ZFRat, mk x.out = x := Quotient.out_eq
+
+theorem eq {x y : ZFInt × ZFInt'} : mk x = mk y ↔ ZFSet.qrel x y := Quotient.eq
+
+theorem sound {x y : ZFInt × ZFInt'} (h : ZFSet.qrel x y) : mk x = mk y := Quotient.sound h
+theorem exact {x y : ZFInt × ZFInt'} : mk x = mk y → ZFSet.qrel x y := Quotient.exact
+
+abbrev zero : ZFRat := mk (0, ⟨1, ZFInt.one_ne_zero⟩)
+abbrev one : ZFRat := mk (1, ⟨1, ZFInt.one_ne_zero⟩)
+
+protected instance : Zero ZFRat := ⟨zero⟩
+protected instance : One ZFRat := ⟨one⟩
+
+instance : Inhabited ZFRat := ⟨0⟩
+
+theorem zero_eq : (0 : ZFRat) = mk (0, ⟨1, ZFInt.one_ne_zero⟩) := rfl
+theorem one_eq : (1 : ZFRat) = mk (1, ⟨1, ZFInt.one_ne_zero⟩) := rfl
+
+theorem mk_eq_zero_iff {n m} : ZFRat.mk (n,m) = 0 ↔ n = 0 where
+  mp := by
+    intro h
+    rw [zero_eq, eq, ZFSet.qrel] at h
+    simpa only [mul_one, ne_eq, mul_zero] using h
+  mpr := by
+    rintro rfl
+    apply ZFRat.sound
+    rw [ZFSet.qrel, mul_one, mul_zero]
+
+theorem mk_eq_one_iff {n m} : ZFRat.mk (n,m) = 1 ↔ n = m where
+  mp := by
+    intro h
+    rw [one_eq, eq, ZFSet.qrel] at h
+    simpa only [ne_eq, mul_one] using h
+  mpr := by
+    rintro rfl
+    apply ZFRat.sound
+    rw [ZFSet.qrel, mul_one]
+
+theorem one_ne_zero : (1 : ZFRat) ≠ 0 := by
+  intro h
+  rw [one_eq, zero_eq, eq, ZFSet.qrel, mul_one, mul_zero] at h
+  nomatch ZFInt.one_ne_zero h
+
+end Quotient
+section Arithmetic
+section Add
+
+noncomputable abbrev add (n m : ZFRat) : ZFRat :=
+  Quotient.liftOn₂ n m (fun ⟨a, b⟩ ⟨c, d⟩ ↦
+    mk (a * d + b * c, ⟨b.1 * d.1, fun c ↦ nomatch d.2 (ZFInt.mul_eq_zero_of_ne_zero c b.2)⟩))
+    fun ⟨x₁, x₂, hx₂⟩ ⟨y₁, y₂, hy₂⟩ ⟨u₁, u₂, hu₂⟩ ⟨v₁, v₂, hv₂⟩ hxu hyv ↦ sound (by
+      have h1 : x₁ * u₂ = x₂ * u₁ := hxu
+      have h2 : y₁ * v₂ = y₂ * v₁ := hyv
+      simp only [ZFSet.qrel]
+      conv_lhs =>
+        rw [right_distrib]
+        conv =>
+          lhs
+          rw [
+            ←mul_assoc, mul_assoc x₁, mul_comm y₂, ←mul_assoc,
+            h1, mul_assoc x₂, mul_comm u₁, ←mul_assoc, mul_assoc (x₂ * y₂)]
+        conv =>
+          rhs
+          rw [
+            mul_comm u₂, ←mul_assoc, mul_assoc x₂, h2,
+            ←mul_assoc, mul_assoc, mul_comm v₁, ←mul_assoc, mul_assoc (x₂ * y₂)]
+      rw [←left_distrib])
+
+protected noncomputable instance : Add ZFRat := ⟨ZFRat.add⟩
+theorem add_eq (n m : ZFInt × ZFInt') :
+  mk n + mk m = mk (n.1 * m.2 + n.2 * m.1,
+    ⟨n.2.1 * m.2.1, fun c ↦ nomatch m.2.2 (ZFInt.mul_eq_zero_of_ne_zero c n.2.2)⟩) := rfl
+
+theorem add_assoc (n m k : ZFRat) : n + (m + k) = n + m + k := by
+  induction n using Quotient.ind
+  induction m using Quotient.ind
+  induction k using Quotient.ind
+  rename_i n m k
+  obtain ⟨n₁, n₂, hn₂⟩ := n
+  obtain ⟨m₁, m₂, hm₂⟩ := m
+  obtain ⟨k₁, k₂, hk₂⟩ := k
+  apply ZFRat.sound
+  ring
+
+theorem add_comm (n m : ZFRat) : n + m = m + n := by
+  induction n using Quotient.ind
+  induction m using Quotient.ind
+  rename_i n m
+  obtain ⟨n₁, n₂, hn₂⟩ := n
+  obtain ⟨m₁, m₂, hm₂⟩ := m
+  apply ZFRat.sound
+  ring
+
+lemma add_left_comm (n m k : ZFRat) : n + (m + k) = m + (n + k) := by
+  rw [add_assoc, add_assoc, add_comm n]
+
+lemma add_right_comm (n m k : ZFRat) : (n + m) + k = (n + k) + m := by
+  rw [← add_assoc, add_comm m, add_assoc]
+
+@[simp]
+theorem add_zero {x : ZFRat} : x + 0 = x := by
+  induction x using Quotient.ind
+  simp_rw [mk_eq, zero_eq, ZFRat.add_eq, mul_one, ne_eq, mul_zero, ZFInt.add_zero]
+
+@[simp]
+theorem zero_add {x : ZFRat} : 0 + x = x := by
+  rw [add_comm, add_zero]
+end Add
+section Neg
+
+protected abbrev neg (n : ZFRat) : ZFRat := Quotient.liftOn n (fun ⟨x, y⟩ => mk (-x, y))
+  fun ⟨x, y, hy⟩ ⟨u, v, hv⟩ h ↦ sound (ZFSet.qrel_eq.symm (by
+    dsimp [HasEquiv.Equiv, instHasEquivOfSetoid, ZFSet.instSetoidZFIntZFInt'] at h
+    simp only [ZFSet.qrel] at h ⊢
+    rw [←ZFInt.neg_mul_distrib, mul_comm, ←h, ZFInt.neg_mul_distrib, mul_comm]))
+
+protected instance : Neg ZFRat := ⟨ZFRat.neg⟩
+theorem neg_eq (n : ZFInt × ZFInt') : -mk n = mk (-n.1, n.2) := rfl
+
+@[simp]
+theorem neg_neg (n : ZFRat) : -(-n) = n := by
+  induction n using Quotient.ind
+  apply sound
+  rw [_root_.neg_neg]
+  exact eq.mp rfl
+
+@[simp]
+theorem neg_zero : -(0 : ZFRat) = 0 := rfl
+
+theorem neg_inj {a b : ZFRat} : -a = -b ↔ a = b :=
+  ⟨fun h => by rw [← neg_neg a, ← neg_neg b, h], congrArg _⟩
+
+@[simp]
+theorem neg_eq_zero {a : ZFRat} : -a = 0 ↔ a = 0 := ZFRat.neg_inj (b := 0)
+theorem neg_ne_zero {a : ZFRat} : -a ≠ 0 ↔ a ≠ 0 := not_congr neg_eq_zero
+
+theorem add_left_neg {a : ZFRat} : -a + a = 0 := by
+  induction a using Quotient.ind
+  apply sound
+  ring
+
+theorem add_right_neg (a : ZFRat) : a + -a = 0 := by
+  rw [add_comm]
+  exact add_left_neg
+
+theorem neg_eq_of_add_eq_zero {a b : ZFRat} (h : a + b = 0) : -a = b := by
+  rw [← @add_zero (-a), ← h, add_assoc, add_left_neg, zero_add]
+
+theorem eq_neg_of_eq_neg {a b : ZFRat} (h : a = -b) : b = -a := by
+  rw [h, neg_neg]
+
+theorem eq_neg_comm {a b : ZFRat} : a = -b ↔ b = -a := ⟨eq_neg_of_eq_neg, eq_neg_of_eq_neg⟩
+
+theorem neg_eq_comm {a b : ZFRat} : -a = b ↔ -b = a := by
+  rw [eq_comm, eq_neg_comm, eq_comm]
+
+theorem neg_add_cancel_left (a b : ZFRat) : -a + (a + b) = b := by
+  rw [add_assoc, add_left_neg, zero_add]
+
+theorem add_neg_cancel_left (a b : ZFRat) : a + (-a + b) = b := by
+  rw [add_assoc, add_right_neg, zero_add]
+
+theorem add_neg_cancel_right (a b : ZFRat) : a + b + -b = a := by
+  rw [← add_assoc, add_right_neg, add_zero]
+
+theorem neg_add_cancel_right (a b : ZFRat) : a + -b + b = a := by
+  rw [← add_assoc, add_left_neg, add_zero]
+
+theorem add_left_cancel {a b c : ZFRat} (h : a + b = a + c) : b = c := by
+  have h₁ : -a + (a + b) = -a + (a + c) := by rw [h]
+  simp only [add_assoc, add_left_neg, zero_add] at h₁
+  exact h₁
+
+@[simp]
+theorem neg_add {a b : ZFRat} : -(a + b) = -a + -b := by
+  apply add_left_cancel (a := a + b)
+  rw [add_right_neg, add_comm a, add_assoc, ← add_assoc b, add_right_neg, add_zero, add_right_neg]
+
+end Neg
+section Sub
+
+noncomputable abbrev sub (n m : ZFRat) : ZFRat := n + -m
+protected noncomputable instance : Sub ZFRat := ⟨ZFRat.sub⟩
+theorem sub_eq (n m : ZFInt × ZFInt') :
+  mk n - mk m = mk (n.1 * m.2 - m.1 * n.2, ⟨n.2 * m.2,
+    fun c ↦ nomatch m.2.2 (ZFInt.mul_eq_zero_of_ne_zero c n.2.2)⟩) := by
+  apply sound
+  ring
+
+theorem sub_eq_add_neg {a b : ZFRat} : a - b = a + -b := rfl
+
+theorem add_neg_one (i : ZFRat) : i + -1 = i - 1 := rfl
+
+@[simp]
+theorem sub_self (a : ZFRat) : a - a = 0 := by rw [sub_eq_add_neg, add_right_neg]
+
+@[simp]
+theorem sub_zero (a : ZFRat) : a - 0 = a := by simp [sub_eq_add_neg]
+
+@[simp]
+theorem zero_sub (a : ZFRat) : 0 - a = -a := by simp [sub_eq_add_neg]
+
+theorem sub_eq_zero_of_eq {a b : ZFRat} (h : a = b) : a - b = 0 := by rw [h, sub_self]
+
+theorem eq_of_sub_eq_zero {a b : ZFRat} (h : a - b = 0) : a = b := by
+  have : 0 + b = b := by rw [zero_add]
+  have : a - b + b = b := by rwa [h]
+  rwa [sub_eq_add_neg, neg_add_cancel_right] at this
+
+theorem sub_eq_zero {a b : ZFRat} : a - b = 0 ↔ a = b := ⟨eq_of_sub_eq_zero, sub_eq_zero_of_eq⟩
+
+theorem sub_sub (a b c : ZFRat) : a - b - c = a - (b + c) := by
+  simp [sub_eq_add_neg, add_assoc]
+
+theorem neg_sub (a b : ZFRat) : -(a - b) = b - a := by
+  simp [sub_eq_add_neg, add_comm]
+
+theorem sub_sub_self (a b : ZFRat) : a - (a - b) = b := by
+  simp [sub_eq_add_neg, add_assoc, add_right_neg]
+
+@[simp]
+theorem sub_neg (a b : ZFRat) : a - -b = a + b := by simp [sub_eq_add_neg]
+@[simp]
+theorem sub_add_cancel (a b : ZFRat) : a - b + b = a := neg_add_cancel_right a b
+
+@[simp]
+theorem add_sub_cancel (a b : ZFRat) : a + b - b = a := add_neg_cancel_right a b
+
+theorem add_sub_assoc (a b c : ZFRat) : a + b - c = a + (b - c) := by
+  rw [sub_eq_add_neg, ← add_assoc, ← sub_eq_add_neg]
+
+theorem sub_left_cancel (a b c : ZFRat) : a - c = b - c → a = b := by
+  intro h
+  rwa [← sub_eq_zero, sub_sub, sub_eq_zero, ← add_sub_assoc, add_comm, add_sub_cancel] at h
+
+theorem sub_right_cancel (a b c : ZFRat) : c - a = c - b → a = b := by
+  rw [← neg_sub a, ← neg_sub b, neg_inj]
+  apply sub_left_cancel
+
+theorem add_eq_sub_iff {a b c : ZFRat} : a + b = c ↔ a = c - b where
+  mp := fun h => by rw [← h, add_sub_cancel]
+  mpr := fun h => by rw [h, sub_add_cancel]
+
+end Sub
+section Mul
+
+private noncomputable abbrev nsmul : ℕ → ZFRat → ZFRat
+  | 0, _ => 0
+  | n+1, m => m + nsmul n m
+
+private noncomputable abbrev zsmul (n : ℤ) (x : ZFRat) : ZFRat :=
+  match n with
+  | .ofNat n => nsmul n x
+  | .negSucc n => -nsmul (n+1) x
+
+noncomputable abbrev mul (n m : ZFRat) : ZFRat :=
+  Quotient.liftOn₂ n m
+    (fun ⟨a, b, hb⟩ ⟨c, d, hd⟩ ↦ mk (a * c,
+      ⟨b * d, fun c ↦ nomatch hd (ZFInt.mul_eq_zero_of_ne_zero c hb)⟩))
+    fun ⟨a, b, hb⟩ ⟨c, d, hd⟩ ⟨e, f, hf⟩ ⟨i, j, hi⟩ h h' ↦ by
+      apply sound
+      unfold_projs at h h'
+      simp only [ZFSet.qrel] at h h' ⊢
+      ac_change (a * f) * (c * j) = (b * e) * (d * i)
+      rw [h, h']
+
+noncomputable instance : Mul ZFRat := ⟨ZFRat.mul⟩
+theorem mul_eq (n m : ZFInt × ZFInt') :
+  mk n * mk m = mk (n.1 * m.1, ⟨n.2 * m.2,
+    fun c ↦ nomatch m.2.2 (ZFInt.mul_eq_zero_of_ne_zero c n.2.2)⟩) := rfl
+
+theorem mul_comm (n m : ZFRat) : n * m = m * n := by
+  induction n using Quotient.ind
+  induction m using Quotient.ind
+  apply sound
+  ring
+
+theorem left_distrib (a b c : ZFRat) : a * (b + c) = a * b + a * c := by
+  induction a using Quotient.ind
+  induction b using Quotient.ind
+  induction c using Quotient.ind
+  apply sound
+  ring
+
+theorem right_distrib (a b c : ZFRat) : (a + b) * c = a * c + b * c := by
+  rw [mul_comm, left_distrib, mul_comm, mul_comm b c]
+
+@[simp]
+theorem zero_mul (a : ZFRat) : 0 * a = 0 := by
+  induction a using Quotient.ind
+  apply sound
+  ring
+
+@[simp]
+theorem mul_zero (a : ZFRat) : a * 0 = 0 := by
+  rw [mul_comm, zero_mul]
+
+theorem mul_assoc (a b c : ZFRat) : a * b * c = a * (b * c) := by
+  induction a using Quotient.ind
+  induction b using Quotient.ind
+  induction c using Quotient.ind
+  apply sound
+  ring
+
+@[simp]
+theorem one_mul (a : ZFRat) : 1 * a = a := by
+  induction a using Quotient.ind
+  apply sound
+  ring
+
+@[simp]
+theorem mul_one (a : ZFRat) : a * 1 = a := by
+  rw [mul_comm, one_mul]
+
+theorem mul_eq_zero_iff {a b : ZFRat} : a * b = 0 ↔ a = 0 ∨ b = 0 := by
+  constructor
+  · intro h
+    induction a using Quotient.ind
+    induction b using Quotient.ind
+    simp_rw [mk_eq, mul_eq, zero_eq, eq, ZFSet.qrel, ZFInt.mul_zero, ZFInt.mul_one] at h ⊢
+    rwa [←ZFInt.mul_eq_zero_iff]
+  · rintro (h | h)
+    · rw [h, zero_mul]
+    · rw [h, mul_zero]
+
+end Mul
+
+noncomputable instance : CommRing ZFRat where
+  zero := 0
+  one := 1
+  add := add
+  add_assoc _ _ _ := by rw [add_assoc]
+  zero_add _ := zero_add
+  add_zero _ := add_zero
+  nsmul := ZFSet.ZFRat.nsmul
+  nsmul_zero _ := rfl
+  nsmul_succ _ _ := add_comm _ _
+  add_comm := add_comm
+  left_distrib := left_distrib
+  right_distrib := right_distrib
+  zero_mul := zero_mul
+  mul_zero := mul_zero
+  mul_comm := mul_comm
+  mul_assoc := mul_assoc
+  one_mul := one_mul
+  mul_one := mul_one
+  zsmul := ZFSet.ZFRat.zsmul
+  zsmul_zero' _ := rfl
+  zsmul_succ' _ _ := add_comm _ _
+  zsmul_neg' _ _ := rfl
+  neg_add_cancel _ := add_left_neg
+
+section Div
+
+abbrev ZFRat' := {x : ZFRat // x ≠ 0}
+
+protected noncomputable abbrev inv : ZFRat' → ZFRat' := fun ⟨x, hx⟩ ↦ by
+  let a := x.out.1
+  let hb := x.out.2.2
+  set b := x.out.2.1
+  have : a ≠ 0 := by
+    intro contr
+    have : mk (0, ⟨b, hb⟩) = x := by
+      have : x.out = (0, ⟨b, hb⟩) := Prod.ext contr rfl
+      rw [←this]
+      exact mk_out x
+    obtain rfl : x = 0 := by
+      rw [←this, zero_eq, eq, ZFSet.qrel, ZFInt.mul_one, ZFInt.mul_zero]
+    contradiction
+  exact ⟨mk (b, ⟨a, this⟩), by
+    intro h
+    rw [mk_eq_zero_iff] at h
+    contradiction⟩
+
+noncomputable instance : Inv ZFRat' := ⟨ZFRat.inv⟩
+open Classical in
+noncomputable instance : Inv ZFRat where
+  inv x := if hx : x ≠ 0 then ZFRat.inv ⟨x, hx⟩ else 0
+
+theorem inv_eq {a : ZFRat} (ha : a ≠ 0) : a⁻¹ = (⟨a, ha⟩ : ZFRat')⁻¹ := by
+  dsimp [Inv.inv]
+  rw [dif_pos ha]
+
+noncomputable abbrev hdiv (n : ZFRat) (m : ZFRat') : ZFRat := n * m⁻¹
+open Classical in
+noncomputable abbrev div (n m : ZFRat) : ZFRat :=
+  if hm : m ≠ 0 then hdiv n ⟨m, hm⟩ else 0
+noncomputable instance : HDiv ZFRat ZFRat' ZFRat := ⟨hdiv⟩
+noncomputable instance : Div ZFRat := ⟨div⟩
+
+
+theorem div_eq {n m : ZFRat} (hm : m ≠ 0) : n / m = n / (⟨m, hm⟩:ZFRat') := rfl
+theorem div_eq_mul_inv {n m : ZFRat} (hm : m ≠ 0) : n / m = n * (⟨m, hm⟩:ZFRat')⁻¹ := by
+  dsimp [HDiv.hDiv, Div.div]
+  rw [div, dif_pos hm]
+
+@[simp]
+theorem mul_inv' {a : ZFRat'} : a.1 * a⁻¹ = 1 := by
+  obtain ⟨a, ha⟩ := a
+  induction a using Quotient.ind
+  rename_i a
+  apply sound
+  rw [ZFSet.qrel]
+  simp only [mk_eq, ZFInt.mul_one, ne_eq]
+  change ZFSet.qrel ⟨a.1, ⟨a.2.1, a.2.2⟩⟩ (mk a).out
+  rw [←eq]
+  symm
+  apply mk_out
+@[simp]
+theorem mul_inv {a : ZFRat} (ha : a ≠ 0) : a * a⁻¹ = 1 := by
+  rw [inv_eq ha, @mul_inv' (⟨a, ha⟩ : ZFRat')]
+
+@[simp]
+theorem inv_mul' {a : ZFRat'} : a⁻¹ * a.1 = 1 := by
+  rw [mul_comm]
+  exact mul_inv'
+@[simp]
+theorem inv_mul {a : ZFRat} (ha : a ≠ 0) : a⁻¹ * a = 1 := by
+  rw [mul_comm]
+  exact mul_inv ha
+end Div
+
+noncomputable instance : RatCast ZFRat where
+  ratCast q := ((q.num : ZFRat) / (q.den : ZFRat))
+
+private noncomputable def qsmul (k : ℚ) (m : ZFRat) : ZFRat := (k : ZFRat) * m
+
+private noncomputable def nnqsmul : ℚ≥0 → ZFRat → ZFRat :=
+  fun ⟨k, _⟩ m ↦ qsmul k m
+
+open Classical in
+noncomputable instance : DivisionRing ZFRat where
+  exists_pair_ne := ⟨1, 0, one_ne_zero⟩
+  mul_inv_cancel _ := mul_inv
+  inv_zero := by
+    simp only [Inv.inv, ne_eq, not_true_eq_false, dite_false]
+  div_eq_mul_inv := by
+    intro a b
+    by_cases hb : b = 0
+    · subst b
+      dsimp [HDiv.hDiv, Div.div, div, Inv.inv]
+      iterate 2 rw [dite_cond_eq_false (eq_false (fun a ↦ a rfl))]
+      rw [mul_zero]
+    · rw [div_eq_mul_inv hb, ←inv_eq]
+  qsmul := qsmul
+  nnqsmul := nnqsmul
+  ratCast_def _ := rfl
+  qsmul_def _ _ := by rfl
+  nnqsmul_def := by
+    rintro ⟨k, hk⟩ m
+    unfold nnqsmul qsmul
+    dsimp
+    unfold_projs
+    have : (↑k.num.natAbs : ZFRat) = ↑k.num := by
+      unfold Int.natAbs
+      cases k using Rat.casesOn with
+      | mk' n d hd _ =>
+        simp only [Rat.le_iff, Rat.num_ofNat, MulZeroClass.zero_mul, Rat.den_ofNat, Nat.cast_one,
+          _root_.mul_one] at hk
+        dsimp
+        have : n = Int.ofNat n.natAbs := by
+          rw [Int.ofNat_eq_natCast, ←Int.eq_natAbs_of_nonneg hk]
+        rw [this]
+        rfl
+    dsimp [NNRat.cast, NNRatCast.nnratCast, NNRat.castRec]
+    rw [this]
+    rfl
+
+noncomputable instance : Field ZFRat := {}
+
+end Arithmetic
+end ZFRat
+end Rationals
+end ZFSet

--- a/LeanPool/ZFLean/Tactics.lean
+++ b/LeanPool/ZFLean/Tactics.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 Vincent Trélat. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vincent Trélat
+-/
+
+import Mathlib.CategoryTheory.Category.Basic
+
+register_label_attr zrel
+register_label_attr zpfun
+register_label_attr zfun
+
+/-!
+Thanks to Ghilain for the idea of registering specific attributes
+-/
+namespace ZFTactics
+set_option hygiene false
+
+macro "zrel" : tactic => `(tactic|
+  first
+  | sorry_if_sorry
+  | solve_by_elim using zrel, zpfun, zfun)
+
+macro "zpfun" : tactic => `(tactic|
+  first
+  | sorry_if_sorry
+  | solve_by_elim using zpfun, zfun)
+
+macro "zfun" : tactic => `(tactic|
+  first
+  | sorry_if_sorry
+  | solve_by_elim using zfun)
+end ZFTactics


### PR DESCRIPTION
Imported from https://github.com/VTrelat/ZFLean.

**Slug:** `zflean`
**Toolchain target:** `leanprover/lean4:v4.30.0-rc2`
**Branch:** `import/zflean` (auto-generated by `scripts/import-formalization.sh`)
**Agent:** `codex` using `gpt-5.5` at effort `xhigh`, exited with code `143`.

**Commits on this branch:**
- aefdc35 WIP: agent partial progress on zflean import

## Agent flagged this import as blocked

# Import guard failure

The wrapper found forbidden Lean tokens in added LeanPool lines:

- `LeanPool/ZFLean/Functions.lean: set_option linter.unusedVariables false`
- `LeanPool/ZFLean/Functions.lean: partial def interpZBinder (x_def : TSyntax `term) (e : TSyntax `term) :`
- `LeanPool/ZFLean/Functions.lean:   admit`
- `LeanPool/ZFLean/Functions.lean:   admit`
- `LeanPool/ZFLean/Functions.lean:   admit`
- `LeanPool/ZFLean/Functions.lean:   admit`
- `LeanPool/ZFLean/Functions.lean:   admit`
- `LeanPool/ZFLean/Functions.lean:   admit`
- `LeanPool/ZFLean/Functions.lean:     admit`
- `LeanPool/ZFLean/Functions.lean:   admit`
- `LeanPool/ZFLean/Functions.lean:       · admit`
- `LeanPool/ZFLean/Functions.lean:     admit`
- `LeanPool/ZFLean/Isomorphisms.lean: set_option pp.proofs true in`
- `LeanPool/ZFLean/Tactics.lean: set_option hygiene false`

Remove these escape hatches or diagnostics before merging.

---
_Opened automatically by `scripts/import-formalization.sh`. Review the diff carefully before merging — the agent ran unattended._
