### PR TITLE
Import formalization-of-bounded-arithmetic formalization

### DIFF
--- a/LeanPool/FormalizationOfBoundedArithmetic.lean
+++ b/LeanPool/FormalizationOfBoundedArithmetic.lean
@@ -1,0 +1,27 @@
+/-
+Copyright (c) 2026 Mary Jane. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mary Jane
+-/
+
+import LeanPool.FormalizationOfBoundedArithmetic.AxiomSchemes
+import LeanPool.FormalizationOfBoundedArithmetic.BasicSingleSorted
+import LeanPool.FormalizationOfBoundedArithmetic.Complexity
+import LeanPool.FormalizationOfBoundedArithmetic.DisplayedVariables
+import LeanPool.FormalizationOfBoundedArithmetic.IDelta0
+import LeanPool.FormalizationOfBoundedArithmetic.IOPEN
+import LeanPool.FormalizationOfBoundedArithmetic.IsEnum
+import LeanPool.FormalizationOfBoundedArithmetic.LanguagePeano
+import LeanPool.FormalizationOfBoundedArithmetic.LanguageZambella
+import LeanPool.FormalizationOfBoundedArithmetic.MathlibSimps
+import LeanPool.FormalizationOfBoundedArithmetic.Order
+import LeanPool.FormalizationOfBoundedArithmetic.Register
+import LeanPool.FormalizationOfBoundedArithmetic.Semantics
+import LeanPool.FormalizationOfBoundedArithmetic.SimpRules
+import LeanPool.FormalizationOfBoundedArithmetic.Syntax
+
+/-!
+# Formalization of Bounded Arithmetic
+
+Core syntax, semantics, and model-theoretic infrastructure for bounded arithmetic.
+-/

--- a/LeanPool/FormalizationOfBoundedArithmetic/AxiomSchemes.lean
+++ b/LeanPool/FormalizationOfBoundedArithmetic/AxiomSchemes.lean
@@ -1,0 +1,191 @@
+/-
+Copyright (c) 2026 Mary Jane. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mary Jane
+-/
+
+import Lean
+
+import Mathlib.ModelTheory.Syntax
+import Mathlib.ModelTheory.Semantics
+
+import LeanPool.FormalizationOfBoundedArithmetic.IsEnum
+import LeanPool.FormalizationOfBoundedArithmetic.DisplayedVariables
+import LeanPool.FormalizationOfBoundedArithmetic.LanguagePeano
+import LeanPool.FormalizationOfBoundedArithmetic.LanguageZambella
+import LeanPool.FormalizationOfBoundedArithmetic.Syntax
+import LeanPool.FormalizationOfBoundedArithmetic.Semantics
+import LeanPool.FormalizationOfBoundedArithmetic.Order
+
+open FirstOrder Language BoundedFormula Formula
+
+
+-- i think that type level is set to 0 because of
+-- Vars1x type is just Type
+-- variable {α disp : Type}
+
+-- Definition 3.4 (Induction Scheme), p. 35 od draft (46 of PDF)
+-- Note that `phi(x)` is permitted to have free variables other than `x`
+-- This means that ultimately we need to take universal closure of the
+-- resulting Bounded Formula, to get a Sentence (no free vars)
+-- expect 1 displayed free variable (`x`), thus DisplayedFV1
+-- but we can have more free vars - we `forall` over them!
+def mkInductionSentence
+  {a} [IsEnum a] {name}
+  {L : Language}
+    [Zero $ L.Term Empty]
+    [One $ L.Term (Vars1 name)]
+    [Add $ L.Term (Vars1 name)]
+  (phi: L.Formula ((Vars1 name) ⊕ a))
+  : L.Sentence :=
+  let univ := phi.iAlls'
+
+  let base := univ.subst (fun _ => 0)
+
+  let step_assumption := univ
+  let step_target := univ.subst (fun _ => (var Vars1.fv1) + 1)
+  let step' : L.Formula (Vars1 name) := step_assumption ⟹ step_target
+  let step := step'.display1.flip.iAlls'
+
+  let forall_x_holds := univ.display1.flip.iAlls'
+  base ⟹ step ⟹ forall_x_holds
+
+syntax (name := simp_induction) "simp_induction" " at " (ppSpace ident)? : tactic
+
+macro_rules
+| `(tactic| simp_induction at $h:ident) =>
+  `(tactic|
+  conv at $h =>
+    unfold Sentence.Realize mkInductionSentence
+    rw [Formula.realize_imp];
+    rw [Formula.realize_imp];
+
+    conv =>
+      lhs
+      unfold Formula.Realize
+      rw [BoundedFormula.realize_subst]
+      change Formula.Realize _ _
+
+    conv =>
+      rhs; lhs
+      rw [realize_iAlls'.Vars1]; ext
+      rw [Formula.realize_flip]
+      rw [realize_display1]
+      rw [Formula.realize_imp];
+
+      conv => lhs -- this is just `univ` already
+      conv =>
+        rhs
+        unfold Formula.Realize
+        rw [BoundedFormula.realize_subst]
+        change Formula.Realize _ _
+    simp only [delta0_simps]
+    unfold Formula.Realize
+    simp only [delta0_simps]
+  )
+
+def _root_.FirstOrder.Language.BoundedFormula.toFormula' {L : Language} {a} (phi : L.BoundedFormula a 0) : L.Formula a := phi
+
+-- This is induction sentence creator which instead of ∀x, φ(x),
+-- gives you ∀x : int, φ(x)
+def mkInductionSentenceTyped
+  {a} [IsEnum a] {name}
+  {n}
+  (phi: zambella.BoundedFormula ((Vars1 name) ⊕ a) n)
+  : zambella.Sentence :=
+  let univ := phi.alls.iAlls'
+
+  let base := univ.subst (fun _ => 0)
+
+  let step_assumption := univ
+  let step_target : zambella.Formula (Vars1 name) := univ.subst (fun _ => (var .fv1) + 1)
+  let step' : zambella.Formula (Vars1 name) := step_assumption ⟹ step_target
+  let step := step'.IsNum.toFormula'.display1.flip.iAlls'
+
+  let forall_x_holds := univ.IsNum.toFormula'.display1.flip.iAlls'
+  base ⟹ step ⟹ forall_x_holds
+
+
+-- Definition V.I.2 (Comprehension Axiom); p. 96 PDF; release of Logical Foundations
+-- `X` cannot occur free in `phi(z)`, but `y` can
+def mkComprehensionSentence {a} [IsEnum a] {name}
+  (phi: zambella.Formula (((Vars1 name) ⊕ (Vars1 .y)) ⊕ a))
+  : zambella.Sentence :=
+    -- now `y` is accessible and nothing else!
+    let univ : zambella.Formula (Vars1 name ⊕ Vars1 FvName.y)
+      := phi.iAlls'
+
+    -- X(z) ↔ φ(z)
+    let iff : zambella.Formula (Vars3 .y .z .X) :=
+      z ∈' X ⇔
+      univ.subst (Sum.elim (fun _ => .var z.name) (fun _ => .var y.name))
+
+    let iff : zambella.Formula (Vars1 .z ⊕ Vars2 .y .X) :=
+      (display3 .z iff.rotate_213)
+
+    let all_z : zambella.Formula (Vars2 .y .X) :=
+      iBdAllNumLt' y iff.flip
+
+    let X_def : zambella.Formula (Vars1 .X ⊕ Vars1 .y) :=
+      (display2 .X (X.IsStr ⊓ all_z).rotate_21)
+
+    let ex_X : zambella.Formula (Vars1 .y) := iExs' X_def.flip
+
+    let ex_X_typed : zambella.Formula (Vars1 .y) :=
+      ex_X.IsNum
+
+    -- quantify over `y`, the length of str created
+    ex_X_typed.mkInl.flip.iAlls'
+
+syntax (name := simp_comp) "simp_comp" " at " (ppSpace ident)? : tactic
+
+macro_rules
+| `(tactic| simp_comp at $h:ident) =>
+  `(tactic|
+  conv at $h =>
+    unfold Sentence.Realize mkComprehensionSentence
+    rw [realize_iAlls'.Vars1]; ext
+    rw [realize_flip]
+    rw [realize_mkInl]
+    unfold Formula.IsNum
+    rw [Formula.realize_imp]
+    conv =>
+      lhs
+      rw [Term.realize_isnum]
+      lhs; arg 1
+      simp only [delta0_simps]
+    rhs
+    rw [realize_iExs'.Vars1]; right; ext
+    rw [realize_flip]
+    rw [realize_display2]
+    rw [realize_rotate_21]
+
+    rw [Formula.realize_inf]
+    conv =>
+      lhs
+      rw [Term.realize_isstr]
+      simp only [delta0_simps]
+    conv =>
+      rhs
+      rw [realize_iBdAllNumLt'.Vars1]; ext
+      conv =>
+        lhs
+        simp only [delta0_simps]
+      ext
+      ext
+      rw [realize_flip]
+      rw [realize_display3]
+      rw [realize_rotate_213]
+      rw [Formula.realize_iff]
+      conv =>
+        lhs
+        unfold Formula.Realize
+        simp only [delta0_simps]
+      rhs
+
+      unfold Formula.Realize
+      rw [realize_subst]
+      rw [Formula.boundedFormula_realize_eq_realize]
+      rw [realize_iAlls'.Vars1]; ext
+      simp only [delta0_simps]
+  )

--- a/LeanPool/FormalizationOfBoundedArithmetic/BasicSingleSorted.lean
+++ b/LeanPool/FormalizationOfBoundedArithmetic/BasicSingleSorted.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 Mary Jane. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mary Jane
+-/
+
+import Mathlib.ModelTheory.Semantics
+import LeanPool.FormalizationOfBoundedArithmetic.LanguagePeano
+
+open FirstOrder FirstOrder.Language
+
+-- Section 3.1 Peano Arithmetic; draft page 34 (45 of pdf)
+-- semi-bundled design! inspired by mathlib Ring
+-- extending peano.Structure instead of One, Add, ... is needed to .Realize
+class BASICModel (num : Type*) extends
+  peano.Structure num
+where
+  B1 : ∀ {x   : num}, (x + 1) ≠ 0
+  B2 : ∀ x y : num, (x + 1) = (y + 1) -> x = y
+  B3 : ∀ x   : num, x + 0 = x
+  B4 : ∀ {x y : num}, x + (y + 1) = (x + y) + 1
+  B5 : ∀ {x   : num}, x * 0 = 0
+  B6 : ∀ {x y : num}, x * (y + 1) = x * y + x
+  -- le_antisymm
+  B7 : ∀ {x y : num}, x <= y -> y <= x -> x = y
+  -- le_self_add
+  B8 : ∀ {x y : num}, x <= x + y
+
+
+class BASICModelExt (num : Type*) extends BASICModel num where
+-- skip this axiom by default
+-- we will use induction anyway for IDelta0, and it is problematic
+-- when defining 2-BASIC axioms and V^i later on
+
+-- it is interesting because BASICModelExt alone implies all
+-- true quantifier-free sentences over `peano` language!
+-- (source: Logical Foundations, release, p. 40 (p. 58 of PDF))
+C  : (0 : num) + 1 = 1
+
+-- instance (M : Type*) [BASICModel M] : Zero M where
+--   zero := 0
+
+-- instance (M : Type*) [BASICModel M] : Add M where
+--   add x y := x + y
+
+-- instance (M : Type*) [BASICModel M] : Mul M where
+--   mul x y := x * y
+
+-- instance (M : Type*) [BASICModel M] : LE M where
+--   le x y := x <= y
+
+-- instance (M : Type*) [BASICModel M] : LT M where
+--   lt x y := x <= y ∧ x ≠ y
+
+variable {M} [BASICModel M]
+
+def natToM : Nat -> M
+| 0 => 0
+| 1 => 1
+| n + 1 => natToM n + 1
+
+instance (n) : OfNat M n where
+  ofNat := natToM n
+
+def pair (x y : M) := (x + y) * (x + y + 1) + (1 + 1) * y
+notation "⟨" i "," j "⟩" => pair i j
+
+notation "⟨" i "," j "," k "⟩" => pair (pair i j) k
+
+namespace BASICModel
+universe u
+variable {M : Type u} [iopen : BASICModel M]
+
+-- this is axctually O9. x ≤ x from Logical Foundations
+theorem le_refl : ∀ a : M, a <= a := by
+  intro x
+  conv => right; rw [<- B3 x]
+  apply B8
+
+theorem zero_ne_add_one : ∀ x : M, x + 1 ≠ 0 := by apply B1
+theorem one_add_right_regular : IsAddRightRegular (1 : M) := by apply B2
+
+
+end BASICModel

--- a/LeanPool/FormalizationOfBoundedArithmetic/Complexity.lean
+++ b/LeanPool/FormalizationOfBoundedArithmetic/Complexity.lean
@@ -1,0 +1,448 @@
+/-
+Copyright (c) 2026 Mary Jane. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mary Jane
+-/
+
+import Mathlib.ModelTheory.Complexity
+import Mathlib.ModelTheory.Syntax
+
+import LeanPool.FormalizationOfBoundedArithmetic.DisplayedVariables
+import LeanPool.FormalizationOfBoundedArithmetic.Order
+import LeanPool.FormalizationOfBoundedArithmetic.LanguagePeano
+import LeanPool.FormalizationOfBoundedArithmetic.LanguageZambella
+import LeanPool.FormalizationOfBoundedArithmetic.Register
+
+open FirstOrder Language
+
+universe u
+variable {L : Language} {α β : Type u} {n : Nat}
+
+namespace FirstOrder.Language
+
+namespace BoundedFormula.IsAtomic
+variable {φ : L.BoundedFormula α n}
+
+theorem relabelEquiv.mpr {f : α ≃ β} (h : φ.IsAtomic)
+  : (φ.relabelEquiv f).IsAtomic
+:=
+  IsAtomic.recOn h (fun _ _ => IsAtomic.equal _ _) fun _ _ => IsAtomic.rel _ _
+
+theorem relabelEquiv.mp {f : α ≃ β} (h : (φ.relabelEquiv f).IsAtomic)
+  : φ.IsAtomic :=
+by
+  cases φ <;> (try cases h) <;> constructor
+
+@[delta0_simps]
+theorem relabelEquiv {f : α ≃ β} :
+  (φ.relabelEquiv f).IsAtomic <-> φ.IsAtomic :=
+  ⟨relabelEquiv.mp, relabelEquiv.mpr⟩
+end BoundedFormula.IsAtomic
+
+namespace Formula.IsAtomic
+open BoundedFormula
+
+@[delta0_simps]
+theorem display1 {n1} {phi : L.Formula (Vars1 n1)}:
+  phi.display1.IsAtomic <-> phi.IsAtomic :=
+by
+  unfold Formula.display1
+  rw [IsAtomic.relabelEquiv]
+
+@[delta0_simps]
+theorem display2 {n1 n2} {phi : L.Formula (Vars2 n1 n2)}:
+  phi.display2.IsAtomic <-> phi.IsAtomic :=
+by
+  unfold Formula.display2
+  rw [IsAtomic.relabelEquiv]
+
+@[delta0_simps]
+theorem display3 {n1 n2 n3} {phi : L.Formula (Vars3 n1 n2 n3)}:
+  phi.display3.IsAtomic <-> phi.IsAtomic :=
+by
+  unfold Formula.display3
+  rw [IsAtomic.relabelEquiv]
+
+end Formula.IsAtomic
+
+namespace BoundedFormula.IsQF
+
+@[delta0_simps]
+theorem imp.mpr {L : Language} {α} {m} {φ ψ : L.BoundedFormula α m} :
+  (φ.imp ψ).IsQF <-> (φ.IsQF ∧ ψ.IsQF) :=
+by
+  constructor
+  · intro h
+    constructor
+    · cases h with
+      | of_isAtomic h' => cases h'
+      | imp pre post => exact pre
+    · cases h with
+      | of_isAtomic h' => cases h'
+      | imp pre post => exact post
+  · intro h
+    apply IsQF.imp h.left h.right
+
+@[delta0_simps]
+theorem relabelEquiv.mp {L : Language} {α β} {m : ℕ} {φ : L.BoundedFormula α m}
+  (f : α ≃ β)
+  (h : φ.IsQF)
+  : (φ.relabelEquiv f).IsQF :=
+by
+  induction φ with
+  | falsum =>
+    constructor
+  | equal lhs rhs =>
+    simp only [relabelEquiv, mapTermRelEquiv, Equiv.coe_refl, Equiv.refl_symm, Equiv.coe_fn_mk,
+      mapTermRel, Term.relabelEquiv_apply]
+    constructor; constructor
+  | rel R ts =>
+    simp only [relabelEquiv, mapTermRelEquiv, Equiv.coe_refl, Equiv.refl_symm, Equiv.coe_fn_mk,
+      mapTermRel, Term.relabelEquiv_apply]
+    constructor; constructor
+  | imp pre post hind_pre hind_post =>
+    cases h with
+    | of_isAtomic hh => cases hh
+    | imp hpre hpost =>
+      rw [relabelEquiv.imp]
+      apply IsQF.imp
+      · exact hind_pre hpre
+      · exact hind_post hpost
+  | all f f_ih =>
+    cases h with
+    | of_isAtomic h' => cases h'
+
+@[delta0_simps]
+theorem relabelEquiv.mpr {L : Language} {α β} {m : ℕ} {φ : L.BoundedFormula α m} (f : α ≃ β)
+  (h : (φ.relabelEquiv f).IsQF)
+  : φ.IsQF :=
+by
+  have h' : relabelEquiv f.symm ((relabelEquiv f) φ) = φ := relabelEquiv.comp_inv f
+  rw [<- h']
+  apply relabelEquiv.mp
+  exact h
+
+@[delta0_simps]
+theorem relabelEquiv {L : Language} {α β} {m : ℕ} {φ : L.BoundedFormula α m} (f : α ≃ β) :
+  (φ.relabelEquiv f).IsQF <-> φ.IsQF := ⟨IsQF.relabelEquiv.mpr f, IsQF.relabelEquiv.mp f⟩
+
+
+end BoundedFormula.IsQF
+
+
+
+
+-- Definition 3.7, page 36 of draft (47 of pdf)
+abbrev BoundedFormula.IsOpen (formula : L.BoundedFormula α n)
+  := IsQF formula
+namespace BoundedFormula.IsOpen
+variable {phi : L.BoundedFormula α n}
+
+@[delta0_simps]
+theorem equal (t1 t2 : L.Term (α ⊕ Fin n))
+  : (t1.bdEqual t2).IsOpen :=
+by
+  constructor
+  apply IsAtomic.equal
+
+@[delta0_simps]
+theorem imp.mpr.left {psi : _}
+  : (phi.imp psi).IsOpen -> phi.IsOpen :=
+by
+  intro h
+  -- TODO: order of constructors in IsQF should be reversed,
+  -- so that `constructor` here works!
+  cases h with
+  | of_isAtomic h => cases h
+  | imp p q => exact p
+
+@[delta0_simps]
+theorem imp.mpr.right {psi : _}
+  : (phi.imp psi).IsOpen -> psi.IsOpen :=
+by
+  intro h
+  cases h with
+  | of_isAtomic h => cases h
+  | imp p q => exact q
+
+@[delta0_simps]
+theorem not
+  : phi.not.IsOpen <-> phi.IsOpen :=
+by
+  constructor <;> (unfold BoundedFormula.not; intro h)
+  · exact imp.mpr.left h
+  · apply IsQF.imp
+    · assumption
+    · exact isQF_bot
+
+@[delta0_simps]
+theorem relabelEquiv {f : α ≃ β}
+  : (phi.relabelEquiv f).IsOpen <-> phi.IsOpen :=
+by
+  apply IsQF.relabelEquiv
+
+end BoundedFormula.IsOpen
+
+namespace Formula.IsOpen
+open BoundedFormula.IsOpen
+
+@[delta0_simps]
+theorem display1 {n1} {phi : L.Formula (Vars1 n1)}:
+    phi.display1.IsOpen <-> phi.IsOpen := by
+  unfold Formula.display1
+  rw [relabelEquiv]
+
+@[delta0_simps]
+theorem display2 {n1 n2} {phi : L.Formula (Vars2 n1 n2)}:
+    phi.display2.IsOpen <-> phi.IsOpen := by
+  unfold Formula.display2
+  rw [relabelEquiv]
+
+@[delta0_simps]
+theorem display3 {n1 n2 n3} {phi : L.Formula (Vars3 n1 n2 n3)}:
+    phi.display3.IsOpen <-> phi.IsOpen := by
+  unfold Formula.display3
+  rw [relabelEquiv]
+
+end Formula.IsOpen
+
+
+
+variable {L : Language} [IsOrdered L] {a : Type u}
+open BoundedFormula Formula
+
+-- Definition 3.7, page 36 of draft (47 of pdf)
+-- + Definition 3.6, page 35 of draft (46 of pdf)
+-- fix level of `a` to 0, because level of `Vars` was fixed to 0!
+inductive BoundedFormula.IsDelta0 : ∀ {a : Type} {n : Nat}, L.BoundedFormula a n -> Prop
+| bdEx {a : Type} {name : FvName}
+  {phi : L.Formula (a ⊕ (Vars1 name))}
+  (t : L.Term (a ⊕ Fin 0))
+  : IsDelta0 phi -> (IsDelta0 <| Formula.iBdEx' (L := L) t phi)
+| bdAll {a : Type} {name : FvName}
+  {phi : L.Formula (a ⊕ (Vars1 name))}
+  (t : L.Term (a ⊕ Fin 0))
+  : IsDelta0 phi -> (IsDelta0 <| Formula.iBdAll' (L := L) t phi)
+| imp {a : Type} {n : Nat} {phi1 phi2 : L.BoundedFormula a n}
+  : IsDelta0 phi1 -> IsDelta0 phi2 -> IsDelta0 (phi1.imp phi2)
+| of_isQF {a : Type} {n : Nat} {phi : L.BoundedFormula a n}
+  : BoundedFormula.IsQF phi -> IsDelta0 phi
+
+
+namespace IsDelta0
+
+@[delta0_simps]
+theorem bot {a n} : (⊥ : L.BoundedFormula a n).IsDelta0  := by
+  constructor
+  exact isQF_bot
+
+@[delta0_simps]
+theorem equal {a n} (t1 t2 : L.Term (a ⊕ Fin n))
+  : (t1.bdEqual t2).IsDelta0 :=
+by
+  constructor
+  constructor
+  apply IsAtomic.equal
+
+section
+
+theorem of_open.imp {a n} {phi psi : L.BoundedFormula a n} (h : phi.IsOpen)
+  : (phi.imp psi).IsDelta0 <-> (phi.IsDelta0 ∧ psi.IsDelta0) :=
+by
+  constructor
+  · intro h
+    cases h with
+    | imp p q =>
+      constructor
+      · exact p
+      · exact q
+    | of_isQF q =>
+      rw [IsQF.imp.mpr] at q
+      constructor <;>
+        apply IsDelta0.of_isQF
+      · exact q.left
+      · exact q.right
+    | bdEx phi t =>
+      cases h with
+      | of_isAtomic h' =>
+        cases h' with
+  · intro h
+    apply IsDelta0.imp
+    exact h.left
+    exact h.right
+
+theorem of_notfalsum.imp {a n} {phi psi : L.BoundedFormula a n} (h : psi ≠ falsum)
+  : (phi.imp psi).IsDelta0 <-> (phi.IsDelta0 ∧ psi.IsDelta0) :=
+by
+  constructor
+  · intro h'
+    cases h' with
+    | imp p q =>
+      constructor
+      · exact p
+      · exact q
+    | of_isQF q =>
+      rw [IsQF.imp.mpr] at q
+      constructor <;>
+        apply IsDelta0.of_isQF
+      · exact q.left
+      · exact q.right
+    | bdEx phi t =>
+      simp only [Bot.bot, ne_eq, not_true_eq_false] at h
+  · intro h
+    apply IsDelta0.imp
+    exact h.left
+    exact h.right
+
+end
+
+
+@[delta0_simps]
+theorem neq {a n} (t1 t2 : L.Term (a ⊕ Fin n))
+  : (t1 ≠' t2).IsDelta0 :=
+by
+  constructor
+  apply equal
+  apply bot
+
+theorem of_open.not {a n} {phi : L.BoundedFormula a n} (h : phi.IsOpen)
+  : phi.not.IsDelta0 <-> phi.IsDelta0 :=
+by
+  unfold BoundedFormula.not
+  rw [of_open.imp h]
+  constructor
+  · intro h
+    exact h.left
+  · intro h
+    constructor
+    · exact h
+    · exact IsDelta0.bot
+
+
+@[delta0_simps]
+theorem relabelEquiv.mp {a b} {n} {phi : peano.BoundedFormula a n}
+  (g : a ≃ b)
+  (h : phi.IsDelta0)
+  : (phi.relabelEquiv g).IsDelta0 :=
+by
+  induction h generalizing b with
+  | bdEx t hphi ih =>
+    rw [iBdEx'.relabelEquiv]
+    constructor
+    exact ih (g.sumCongr (_root_.Equiv.refl _))
+  | bdAll t hphi ih =>
+    rw [iBdAll'.relabelEquiv]
+    constructor
+    exact ih (g.sumCongr (_root_.Equiv.refl _))
+  | imp pre post ih_pre ih_post =>
+    rw [relabelEquiv.imp]
+    constructor
+    · exact ih_pre g
+    · exact ih_post g
+  | of_isQF f =>
+    cases f
+    · simp only [relabelEquiv.falsum]; constructor; constructor
+    · rename_i h2
+      cases h2
+      · simp only [relabelEquiv.eq]
+        constructor; constructor; unfold Term.bdEqual; apply IsAtomic.equal
+      · constructor; constructor; apply IsAtomic.rel
+    · simp only [relabelEquiv.imp]
+      constructor
+      · constructor
+        (expose_names; exact IsOpen.relabelEquiv.mpr h₁)
+      · refine IsDelta0.of_isQF ?_
+        (expose_names; exact IsOpen.relabelEquiv.mpr h₂)
+
+theorem relabelEquiv.gSumCongr
+  {a b c}
+  {phi : peano.Formula (a ⊕ c)}
+  (g : a ≃ b)
+  (h : phi.IsDelta0)
+  : ((relabelEquiv (g.sumCongr (_root_.Equiv.refl c))) phi).IsDelta0 :=
+  relabelEquiv.mp (g.sumCongr (_root_.Equiv.refl c)) h
+
+
+@[delta0_simps]
+theorem relabelEquiv.mpr {α β} {φ : peano.Formula α} (f : α ≃ β)
+  (h : (φ.relabelEquiv f).IsDelta0)
+  : φ.IsDelta0 :=
+by
+  have h' : relabelEquiv f.symm ((relabelEquiv f) φ) = φ := relabelEquiv.comp_inv f
+  rw [<- h']
+  apply relabelEquiv.mp
+  exact h
+
+@[delta0_simps]
+theorem relabelEquiv {α β} (φ : peano.Formula α) {f : α ≃ β} :
+  (φ.relabelEquiv f).IsDelta0 <-> φ.IsDelta0 := ⟨IsDelta0.relabelEquiv.mpr f, IsDelta0.relabelEquiv.mp f⟩
+
+
+@[delta0_simps]
+theorem display1 {n} (phi : peano.Formula (Vars1 n)) :
+  phi.display1.IsDelta0 <-> phi.IsDelta0 :=
+  IsDelta0.relabelEquiv phi
+
+@[delta0_simps]
+theorem display2 {n1 n2} (phi : peano.Formula (Vars2 n1 n2)) :
+  phi.display2.IsDelta0 <-> phi.IsDelta0 :=
+  IsDelta0.relabelEquiv phi
+
+@[delta0_simps]
+theorem display3 {n1 n2 n3} (phi : peano.Formula (Vars3 n1 n2 n3)) :
+  phi.display3.IsDelta0 <-> phi.IsDelta0 :=
+  IsDelta0.relabelEquiv phi
+
+@[delta0_simps]
+theorem flip {a b} (phi : peano.Formula (a ⊕ b)) :
+  phi.flip.IsDelta0 <-> phi.IsDelta0 :=
+  IsDelta0.relabelEquiv phi
+
+end IsDelta0
+
+
+
+
+-- only bounded number quantifiers allowed. and free string vars.
+-- p. 82 of pdf of Logical Foundatoin release
+inductive BoundedFormula.IsSigma0B {a : Type} : {n : Nat} -> zambella.BoundedFormula a n -> Prop
+| imp {phi1 phi2} (h1 : IsSigma0B phi1) (h2 : IsSigma0B phi2)
+  : IsSigma0B (phi1.imp phi2)
+| bdEx
+  {name : FvName}
+  (phi : zambella.Formula (a ⊕ (Vars1 name)))
+  (t : zambella.Term (a ⊕ Fin 0))
+  : IsSigma0B <| Formula.iBdEx' (L := zambella) t
+      ((rel ZambellaRel.isnum ![var <| Sum.inl <| Sum.inr <| .fv1]) ⊓ phi)
+-- TODO: WHICH ONE IS REDUNDANT?
+| bdAll
+  {name : FvName}
+  (phi : zambella.Formula (a ⊕ (Vars1 name)))
+  (t : zambella.Term (a ⊕ Fin 0))
+  : IsSigma0B <| Formula.iBdAllNum' t phi
+| bdAllLt
+  {name : FvName}
+  (phi : zambella.Formula (a ⊕ (Vars1 name)))
+  (t : zambella.Term (a ⊕ Fin 0))
+  : IsSigma0B <| Formula.iBdAllLt' t
+      ((rel ZambellaRel.isnum ![var <| Sum.inl <| Sum.inr <| .fv1]) ⊓ phi)
+
+| of_isQF {phi} (h : IsQF phi) : IsSigma0B phi
+
+
+
+syntax (name := simp_complexity) "simp_complexity" " at " (ppSpace ident)? : tactic
+
+macro_rules
+| `(tactic| simp_complexity at $h:ident) =>
+  `(tactic|
+  conv at $h =>
+    conv =>
+      lhs
+      simp only [delta0_simps]
+    -- this has to work! the `IsOpen` goal has to reduce to `True`.
+    rw [forall_const]
+  )
+
+
+end FirstOrder.Language

--- a/LeanPool/FormalizationOfBoundedArithmetic/DisplayedVariables.lean
+++ b/LeanPool/FormalizationOfBoundedArithmetic/DisplayedVariables.lean
@@ -1,0 +1,343 @@
+/-
+Copyright (c) 2026 Mary Jane. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mary Jane
+-/
+
+import Mathlib.ModelTheory.Syntax
+import Mathlib.ModelTheory.Semantics
+import Mathlib.Tactic.FinCases
+import LeanPool.FormalizationOfBoundedArithmetic.IsEnum
+import LeanPool.FormalizationOfBoundedArithmetic.Register
+
+inductive FvName | x | y | z | X
+
+class HasVar.{u} (n : FvName) (α : Type u)  where fv : α
+
+
+inductive Vars0 : Type
+inductive Vars1 : FvName -> Type
+| fv1 {n1} : Vars1 n1
+inductive Vars2 : FvName -> FvName -> Type
+| fv1 {n1 n2} : Vars2 n1 n2
+| fv2 {n1 n2} : Vars2 n1 n2
+inductive Vars3 : FvName -> FvName -> FvName -> Type
+| fv1 {n1 n2 n3} : Vars3 n1 n2 n3
+| fv2 {n1 n2 n3} : Vars3 n1 n2 n3
+| fv3 {n1 n2 n3} : Vars3 n1 n2 n3
+inductive Vars4 : FvName -> FvName -> FvName -> FvName -> Type
+| fv1 {n1 n2 n3 n4} : Vars4 n1 n2 n3 n4
+| fv2 {n1 n2 n3 n4} : Vars4 n1 n2 n3 n4
+| fv3 {n1 n2 n3 n4} : Vars4 n1 n2 n3 n4
+| fv4 {n1 n2 n3 n4} : Vars4 n1 n2 n3 n4
+
+@[delta0_simps] instance (n1 : FvName): HasVar n1 (Vars1 n1) where fv := .fv1
+@[delta0_simps] instance (n1 n2 : FvName): HasVar n1 (Vars2 n1 n2) where fv := .fv1
+@[delta0_simps] instance (n1 n2 : FvName): HasVar n2 (Vars2 n1 n2) where fv := .fv2
+@[delta0_simps] instance (n1 n2 n3 : FvName): HasVar n1 (Vars3 n1 n2 n3) where fv := .fv1
+@[delta0_simps] instance (n1 n2 n3 : FvName): HasVar n2 (Vars3 n1 n2 n3) where fv := .fv2
+@[delta0_simps] instance (n1 n2 n3 : FvName): HasVar n3 (Vars3 n1 n2 n3) where fv := .fv3
+@[delta0_simps] instance (n1 n2 n3 n4 : FvName): HasVar n1 (Vars4 n1 n2 n3 n4) where fv := .fv1
+@[delta0_simps] instance (n1 n2 n3 n4 : FvName): HasVar n2 (Vars4 n1 n2 n3 n4) where fv := .fv2
+@[delta0_simps] instance (n1 n2 n3 n4 : FvName): HasVar n3 (Vars4 n1 n2 n3 n4) where fv := .fv3
+@[delta0_simps] instance (n1 n2 n3 n4 : FvName): HasVar n4 (Vars4 n1 n2 n3 n4) where fv := .fv4
+
+
+@[delta0_simps] instance : IsEnum Empty where
+  size := 0
+  toIdx := Empty.elim
+  fromIdx := Fin.elim0
+  to_from_id id := Fin.elim0 id
+  from_to_id x := Empty.elim x
+@[delta0_simps] lemma IsEnum.size.Empty : IsEnum.size Empty = 0 := rfl
+
+@[delta0_simps] instance {n1} : IsEnum (Vars1 n1) where
+  size := 1
+  toIdx _ := 0
+  fromIdx _ := .fv1
+  to_from_id id := (Fin.fin_one_eq_zero id).symm
+  from_to_id _ := rfl
+@[delta0_simps] lemma IsEnum.size.Vars1 {n1} : IsEnum.size (Vars1 n1) = 1 := rfl
+@[delta0_simps] lemma IsEnum.toIdx.Vars1 {n1} {x : Vars1 n1}
+  : IsEnum.toIdx x = 0
+  := rfl
+
+@[delta0_simps] instance {n1 n2} : IsEnum (Vars2 n1 n2) where
+  size := 2
+  toIdx | .fv1 => 0 | .fv2 => 1
+  fromIdx | 0 => .fv1 | 1 => .fv2
+  to_from_id id := by
+    fin_cases id <;> rfl
+  from_to_id x := by
+    cases x <;> rfl
+@[delta0_simps] lemma IsEnum.size.Vars2 {n1 n2} : IsEnum.size (Vars2 n1 n2) = 2 := rfl
+@[delta0_simps] lemma IsEnum.toIdx.Vars2 {n1 n2} {x : Vars2 n1 n2}
+  : IsEnum.toIdx x = match x with | .fv1 => 0 | .fv2 => 1
+  := rfl
+
+@[delta0_simps] instance {n1 n2 n3} : IsEnum (Vars3 n1 n2 n3) where
+  size := 3
+  toIdx | .fv1 => 0 | .fv2 => 1 | .fv3 => 2
+  fromIdx | 0 => .fv1 | 1 => .fv2 | 2 => .fv3
+  to_from_id id := by
+    fin_cases id <;> rfl
+  from_to_id x := by
+    cases x <;> rfl
+@[delta0_simps] lemma IsEnum.size.Vars3 {n1 n2 n3} : IsEnum.size (Vars3 n1 n2 n3) = 3 := rfl
+@[delta0_simps] lemma IsEnum.toIdx.Vars3 {n1 n2 n3} {x : Vars3 n1 n2 n3}
+  : IsEnum.toIdx x = match x with | .fv1 => 0 | .fv2 => 1 | .fv3 => 2
+  := rfl
+
+@[delta0_simps] instance {n1 n2 n3 n4} : IsEnum (Vars4 n1 n2 n3 n4) where
+  size := 4
+  toIdx | .fv1 => 0 | .fv2 => 1 | .fv3 => 2 | .fv4 => 3
+  fromIdx | 0 => .fv1 | 1 => .fv2 | 2 => .fv3 | 3 => .fv4
+  to_from_id id := by
+    fin_cases id <;> rfl
+  from_to_id x := by
+    cases x <;> rfl
+@[delta0_simps] lemma IsEnum.size.Vars4 {n1 n2 n3 n4} : IsEnum.size (Vars4 n1 n2 n3 n4) = 4 := rfl
+@[delta0_simps] lemma IsEnum.toIdx.Vars4 {n1 n2 n3 n4} {x : Vars4 n1 n2 n3 n4}
+  : IsEnum.toIdx x = match x with | .fv1 => 0 | .fv2 => 1 | .fv3 => 2 | .fv4 => 3
+  := rfl
+
+universe u
+variable {α : Type u} {L : FirstOrder.Language}
+
+
+@[delta0_simps] def x.name [h : HasVar .x α] := h.fv
+@[delta0_simps] def y.name [h : HasVar .y α] := h.fv
+@[delta0_simps] def z.name [h : HasVar .z α] := h.fv
+@[delta0_simps] def X.name [h : HasVar .X α] := h.fv
+@[delta0_simps] def x {k} [h : HasVar .x α] : L.Term (α ⊕ Fin k) := (L.var $ Sum.inl h.fv)
+@[delta0_simps] def y {k} [h : HasVar .y α] : L.Term (α ⊕ Fin k) := (L.var $ Sum.inl h.fv)
+@[delta0_simps] def z {k} [h : HasVar .z α] : L.Term (α ⊕ Fin k) := (L.var $ Sum.inl h.fv)
+@[delta0_simps] def X {k} [h : HasVar .X α] : L.Term (α ⊕ Fin k) := (L.var $ Sum.inl h.fv)
+
+def FirstOrder.Language.Formula.display1
+  {n1 : FvName}
+  (phi : L.Formula (Vars1 n1))
+  : L.Formula ((Vars1 n1) ⊕ Empty)
+:=
+  phi.relabelEquiv {
+    toFun := (fun fv => match fv with
+    | .fv1 => Sum.inl .fv1
+    )
+    invFun := (fun fv => match fv with | .inl _ => .fv1)
+    right_inv := by
+      intro v; cases v; simp only;
+      apply Empty.elim; assumption
+  }
+
+
+def FirstOrder.Language.Formula.display2
+  (name : FvName)
+  {other : FvName}
+  (phi : L.Formula (Vars2 name other))
+  : L.Formula (Vars1 name ⊕ Vars1 other)
+:=
+  phi.relabelEquiv {
+    toFun := (fun fv => match fv with
+    | .fv1 => Sum.inl .fv1
+    | .fv2 => Sum.inr .fv1
+    ),
+    invFun := (fun fv => match fv with | .inl _ => .fv1 | .inr _ => .fv2)
+    left_inv := by intro v; cases v <;> simp only
+    right_inv := by simp only [Function.RightInverse, Function.LeftInverse, Sum.forall, implies_true, and_self]
+  }
+
+def FirstOrder.Language.Formula.display3
+  (name : FvName)
+  {other1 other2 : FvName}
+  (phi : L.Formula (Vars3 name other1 other2))
+  : L.Formula (Vars1 name ⊕ Vars2 other1 other2)
+:=
+  phi.relabelEquiv {
+    toFun := (fun fv => match fv with
+      | .fv1 => Sum.inl .fv1
+      | .fv2 => Sum.inr .fv1
+      | .fv3 => Sum.inr .fv2)
+    invFun := (fun fv => match fv with
+      | .inl _    => .fv1
+      | .inr .fv1   => .fv2
+      | .inr .fv2   => .fv3)
+    left_inv := by intro v; cases v <;> simp only
+    right_inv := by
+      simp only [Function.RightInverse, Function.LeftInverse, Sum.forall, implies_true, true_and]
+      intro v; cases v <;> simp only
+  }
+
+def FirstOrder.Language.Formula.display4
+  (name : FvName)
+  {o1 o2 o3 : FvName}
+  (phi : L.Formula (Vars4 name o1 o2 o3))
+  : L.Formula (Vars1 name ⊕ Vars3 o1 o2 o3)
+:=
+  phi.relabelEquiv {
+    toFun := (fun fv => match fv with
+      | .fv1 => Sum.inl .fv1
+      | .fv2 => Sum.inr .fv1
+      | .fv3 => Sum.inr .fv2
+      | .fv4 => Sum.inr .fv3)
+    invFun := (fun fv => match fv with
+      | .inl _    => .fv1
+      | .inr .fv1 => .fv2
+      | .inr .fv2 => .fv3
+      | .inr .fv3 => .fv4)
+    left_inv := by intro v; cases v <;> simp only
+    right_inv := by
+      simp only [Function.RightInverse, Function.LeftInverse, Sum.forall, implies_true, true_and]
+      intro v; cases v <;> simp only
+  }
+
+def FirstOrder.Language.Formula.display_swapleft
+  {n1 n2 n3 : FvName}
+  (phi : L.Formula (Vars1 n1 ⊕ Vars2 n2 n3))
+  : L.Formula (Vars2 n1 n2 ⊕ Vars1 n3)
+:=
+  phi.relabelEquiv {
+    toFun := (fun fv => match fv with
+      | .inl .fv1 => .inl .fv1
+      | .inr .fv1 => .inl .fv2
+      | .inr .fv2 => .inr .fv1)
+    invFun := (fun fv => match fv with
+      | .inl .fv1 => .inl .fv1
+      | .inl .fv2 => .inr .fv1
+      | .inr .fv1 => .inr .fv2)
+    left_inv := by
+      intro v;
+      cases v with
+      | inl vl => simp only
+      | inr vr =>
+        cases vr <;> simp only
+    right_inv := by
+      intro v
+      cases v with
+      | inl vl =>
+        cases vl <;> simp only
+      | inr vr => simp only
+  }
+
+def FirstOrder.Language.Formula.display_swapleft'
+  {n1 n2 n3 : FvName}
+  (phi : L.Formula (Vars1 n1 ⊕ Vars2 n2 n3))
+  : L.Formula ((Vars1 n1 ⊕ Vars1 n2) ⊕ Vars1 n3)
+:=
+  phi.relabelEquiv {
+    toFun := (fun fv => match fv with
+      | .inl .fv1 => .inl $ .inl .fv1
+      | .inr .fv1 => .inl $ .inr .fv1
+      | .inr .fv2 => .inr .fv1)
+    invFun := (fun fv => match fv with
+      | .inl $ .inl .fv1 => .inl .fv1
+      | .inl $ .inr .fv1 => .inr .fv1
+      | .inr .fv1 => .inr .fv2)
+    left_inv := by
+      intro v;
+      cases v with
+      | inl vl => simp only
+      | inr vr =>
+        cases vr <;> simp only
+    right_inv := by
+      intro v
+      cases v with
+      | inl vl =>
+        cases vl <;> simp only
+      | inr vr => simp only
+  }
+
+-- Vars2 .x .y -> Vars2 .y .x
+def FirstOrder.Language.Formula.rotate_21
+  {n1 n2 : FvName}
+  (phi : L.Formula (Vars2 n1 n2))
+  : L.Formula (Vars2 n2 n1)
+:=
+  phi.relabelEquiv {
+    toFun := (fun fv => match fv with
+      | .fv1 => .fv2
+      | .fv2 => .fv1)
+    invFun := (fun fv => match fv with
+      | .fv1 => .fv2
+      | .fv2 => .fv1)
+    left_inv := by intro v; cases v <;> simp only
+    right_inv := by
+      simp only [Function.RightInverse, Function.LeftInverse]
+      intro v; cases v <;> simp only
+  }
+
+-- Vars3 .x .y .z -> Vars3 .y .x. .z
+def FirstOrder.Language.Formula.rotate_213
+  (n1 n2 n3 : FvName)
+  (phi : L.Formula (Vars3 n1 n2 n3))
+  : L.Formula (Vars3 n2 n1 n3)
+:=
+  phi.relabelEquiv {
+    toFun := (fun fv => match fv with
+      | .fv1 => .fv2
+      | .fv2 => .fv1
+      | .fv3 => .fv3)
+    invFun := (fun fv => match fv with
+      | .fv1 => .fv2
+      | .fv2 => .fv1
+      | .fv3 => .fv3)
+    left_inv := by intro v; cases v <;> simp only
+    right_inv := by
+      simp only [Function.RightInverse, Function.LeftInverse]
+      intro v; cases v <;> simp only
+  }
+
+-- Vars3 .x .y .z -> Vars3 .y .x. .z
+def FirstOrder.Language.Formula.rotate_231
+  (n1 n2 n3 : FvName)
+  (phi : L.Formula (Vars3 n1 n2 n3))
+  : L.Formula (Vars3 n3 n1 n2)
+:=
+  phi.relabelEquiv {
+    toFun := (fun fv => match fv with
+      | .fv1 => .fv2
+      | .fv2 => .fv3
+      | .fv3 => .fv1)
+    invFun := (fun fv => match fv with
+      | .fv1 => .fv3
+      | .fv2 => .fv1
+      | .fv3 => .fv2)
+    left_inv := by intro v; cases v <;> simp only
+    right_inv := by
+      simp only [Function.RightInverse, Function.LeftInverse]
+      intro v; cases v <;> simp only
+  }
+
+variable {β}
+
+def FirstOrder.Language.BoundedFormula.flip {n} (phi : L.BoundedFormula (α ⊕ β) n) : L.BoundedFormula (β ⊕ α) n:=
+  phi.relabelEquiv {
+    toFun := Sum.swap (α := α) (β := β)
+    invFun := Sum.swap
+    left_inv := Sum.swap_leftInverse
+    right_inv := Sum.swap_rightInverse
+  }
+
+def FirstOrder.Language.Formula.flip (phi : L.Formula (α ⊕ β)) : L.Formula (β ⊕ α) :=
+  phi.relabelEquiv {
+    toFun := Sum.swap (α := α) (β := β)
+    invFun := Sum.swap
+    left_inv := Sum.swap_leftInverse
+    right_inv := Sum.swap_rightInverse
+  }
+
+-- theorem FirstOrder.Language.Formula.realize_flip (phi : L.Formula (α ⊕ β)) {v}
+--   : phi.flip.Realize v <-> phi.Realize (v ∘ )
+
+def FirstOrder.Language.Formula.mkInl (phi : L.Formula α) : L.Formula (α ⊕ Empty) :=
+  phi.relabelEquiv {
+    toFun := Sum.inl
+    invFun := Sum.elim id Empty.elim
+    left_inv := by
+      intro x
+      simp only [Sum.elim_inl, id_eq]
+    right_inv := by
+      intro x
+      cases x with
+      | inl x => simp only [Sum.elim_inl, id_eq]
+      | inr x => apply Empty.elim x
+  }

--- a/LeanPool/FormalizationOfBoundedArithmetic/IDelta0.lean
+++ b/LeanPool/FormalizationOfBoundedArithmetic/IDelta0.lean
@@ -1,0 +1,577 @@
+/-
+Copyright (c) 2026 Mary Jane. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mary Jane
+-/
+
+-- import Mathlib.Algebra.Ring.Defs
+
+import LeanPool.FormalizationOfBoundedArithmetic.DisplayedVariables
+import LeanPool.FormalizationOfBoundedArithmetic.Complexity
+import LeanPool.FormalizationOfBoundedArithmetic.IsEnum
+import LeanPool.FormalizationOfBoundedArithmetic.IOPEN
+
+open FirstOrder Language BoundedFormula
+
+class IDelta0Model (num : Type*) extends IOPENModel num where
+  delta0_induction {n1} {a} [IsEnum a]
+    (phi : peano.BoundedFormula ((Vars1 n1) ⊕ a) 0) :
+    phi.IsDelta0 -> (mkInductionSentence phi).Realize num
+
+namespace IDelta0Model
+
+universe u
+variable {M : Type*} [idelta0 : IDelta0Model M]
+
+-- Example 3.9 Theorems of IΔ0
+open Formula BoundedFormula
+
+open BASICModel IOPENModel
+
+-- D1. x ≠ 0 → ∃ y ≤ x, x = y + 1  (Predecessor)
+-- proof: induction on x
+theorem pred_exists :
+  ∀ {x : M}, x ≠ 0 → ∃ y ≤ x, x = y + 1 :=
+by
+  let ind1 : peano.Formula (Vars2 .y .x) := x =' (y + 1)
+  let ind2 : peano.Formula (Vars1 .x) :=
+    (Formula.iBdEx' x (display2 .y ind1).flip)
+  let ind := idelta0.delta0_induction $ display1 $ (x ≠' 0) ⟹ ind2
+
+  unfold ind2 ind1 at ind
+
+  specialize ind (by
+    rw [IsDelta0.display1]
+    -- TODO: this lemma can't be in @[delta0_simps],
+    -- as it creates a goal 'φ.IsOpen' - which might be not true!
+    rw [IsDelta0.of_open.imp]
+    · constructor
+      · unfold Term.neq
+        rw [IsDelta0.of_open.not]
+        constructor; constructor; constructor
+        constructor; constructor
+      · constructor; rw [IsDelta0.flip]; rw [IsDelta0.display2]; constructor; constructor; constructor
+    · unfold Term.neq
+      rw [IsOpen.not]
+      constructor; constructor
+  )
+  simp_induction at ind
+
+  apply ind ?base ?step <;> clear ind ind1 ind2
+  · simp only [IsEmpty.forall_iff]
+  · intro a hind h
+    exists a
+    constructor
+    · exact B8
+    · rfl
+
+theorem ex_of_bdEx {a} [LE a] {t} {P : a -> Prop} : (∃ x ≤ t, P x) -> ∃ x, P x := by
+  intro h
+  obtain ⟨x, ⟨hx1, hx2⟩⟩ := h
+  exists x
+
+lemma zero_add :
+  ∀ x : M, 0 + x = x :=
+by
+  intro x
+  rw [idelta0.add_comm]
+  exact B3 x
+
+instance : AddZeroClass M where
+  zero_add := zero_add
+  add_zero := B3
+
+
+open IOPENModel BASICModel
+
+-- D2. ∃ z, (x + z = y ∨ y + z = x)
+-- original proof: Induction on x. Base case: B2, O2. Induction step: B3, B4, D1
+-- our proof is different
+theorem add_diff_exists :
+  ∀ x y : M, ∃ z, x + z = y ∨ y + z = x :=
+by
+  let ind1 : peano.Formula (Vars3 .z .x .y) :=
+    ((x + z) =' y) ⊔ ((y + z) =' x)
+  let ind2 : peano.Formula (Vars2 .x .y) := iBdEx' (x + y) (display3 .z ind1).flip
+  let ind3 : peano.Formula (Vars1 .x ⊕ Vars1 .y) := display2 .x ind2
+  let ind := idelta0.delta0_induction ind3
+
+  unfold ind3 ind2 ind1 at ind
+
+  specialize ind (by
+    rw [IsDelta0.display2]
+    constructor
+    rw [IsDelta0.flip]
+    rw [IsDelta0.display3]
+    constructor
+    · constructor
+      · constructor; constructor; constructor
+      · constructor; constructor
+    · constructor; constructor; constructor
+  )
+  simp_induction at ind
+
+  intro x y
+  apply ex_of_bdEx
+  apply ind ?base ?step <;> clear ind1 ind2 ind3 ind
+  · intro z
+    exists z
+    constructor
+    · rw [zero_add z]
+      exact le_refl z
+    · rw [idelta0.add_comm]
+      left
+      rw [B3]
+  · intro L hind R
+    by_cases h_R_zero : R = 0
+    · exists (L + 1)
+      constructor
+      · exact B8
+      · right
+        rw [h_R_zero]
+        rw [idelta0.zero_add]
+    · obtain ⟨pred_R, h_pred_R_le, h_pred_R_eq⟩ := pred_exists h_R_zero
+      specialize hind pred_R
+      obtain ⟨symdiff_pred, h_symdiff_pred_le, h_symdiff_pred_eq⟩ := hind
+      exists symdiff_pred
+      cases h_symdiff_pred_eq with
+      | inl h_LR =>
+        constructor
+        · rw [h_pred_R_eq, <- h_LR]
+          conv =>
+            rhs;
+            rw [idelta0.add_comm]
+            rw [idelta0.add_assoc]
+            lhs
+            rw [idelta0.add_comm]
+          rw [idelta0.add_assoc]
+          apply B8
+        · left
+          rw [h_pred_R_eq]
+          rw [idelta0.add_assoc]
+          conv => lhs; rhs; rw [idelta0.add_comm]
+          rw [<- idelta0.add_assoc]
+          congr
+      | inr h_RL =>
+        constructor
+        · rw [<- h_RL]
+          conv => rhs; left; left; rw [idelta0.add_comm]
+          conv => rhs; left; rw [idelta0.add_comm]; rw [<- idelta0.add_assoc]; left; rw [idelta0.add_comm]
+          conv => rhs; rw [idelta0.add_assoc]; rw [idelta0.add_assoc]
+          apply B8
+        · right
+          rw [<- h_RL]
+          rw [h_pred_R_eq]
+          conv => lhs; rw [idelta0.add_assoc]; rhs; rw [idelta0.add_comm]
+          rw [idelta0.add_assoc]
+
+-- D3. x ≤ y ↔ ∃ z, x + z = y
+theorem le_iff_exists_add :
+  ∀ x y : M, x ≤ y ↔ ∃ z, x + z = y :=
+by
+  intro x y
+  constructor
+  · intro h_xy
+    obtain ⟨diff, hdiff⟩ := add_diff_exists x y
+    cases hdiff with
+    | inl heq => exists diff
+    | inr heq =>
+      exists 0
+      rw [B3]
+      apply B7
+      · exact h_xy
+      · rw [<- heq]
+        apply B8
+  · intro h
+    obtain ⟨z, hz⟩ := h
+    rw [<- hz]
+    apply B8
+
+-- D4. (x ≤ y ∧ y ≤ z) → x ≤ z  (Transitivity)
+theorem le_trans :
+  ∀ {x y z : M}, x ≤ y -> y ≤ z -> x ≤ z :=
+by
+  intro x y z hxy hyz
+  rw [le_iff_exists_add] at hxy hyz ⊢
+  obtain ⟨diff_x_y, hdiff_x_y⟩ := hxy
+  obtain ⟨diff_y_z, hdiff_y_z⟩ := hyz
+  exists (diff_x_y + diff_y_z)
+  rw [<- idelta0.add_assoc]
+  rw [hdiff_x_y]
+  rw [hdiff_y_z]
+
+
+instance : Preorder M where
+  le_refl := by apply @BASICModel.le_refl
+  le_trans := by apply le_trans
+  lt_iff_le_not_ge := by
+    intro a b
+    constructor
+    · intro h
+      constructor
+      · exact h.1
+      · intro contr
+        apply h.2
+        exact contr
+    · intro h
+      exact h
+
+
+-- D5. x ≤ y ∨ y ≤ x  (Total order)
+theorem le_total :
+  ∀ x y : M, x ≤ y ∨ y ≤ x :=
+by
+  intro x y
+  obtain ⟨diff, hdiff⟩ := add_diff_exists x y
+  cases hdiff with
+  | inl h =>
+    left
+    rw [le_iff_exists_add]
+    exists diff
+  | inr h =>
+    right
+    rw [le_iff_exists_add]
+    exists diff
+
+theorem add_rotate
+  : ∀ {a b c : M}, a + b + c = b + c + a :=
+by
+  intro a b c
+  rw [idelta0.add_assoc]
+  rw [idelta0.add_comm]
+
+-- D6. x ≤ y ↔ x + z ≤ y + z
+theorem add_le_add_right :
+  ∀ {x y z : M}, x ≤ y ↔ x + z ≤ y + z :=
+by
+  intro x y z
+  constructor
+  · intro hxy
+    rw [le_iff_exists_add] at hxy ⊢
+    obtain ⟨diff, hdiff⟩ := hxy
+    exists diff
+    rw [<- add_rotate]
+    rw [idelta0.add_comm] at ⊢ hdiff
+    rw [hdiff]
+    rw [idelta0.add_comm]
+  · rw [le_iff_exists_add]
+    rw [le_iff_exists_add]
+    intro h
+    obtain ⟨a, ha⟩ := h
+    exists a
+    apply add_cancel_right.mp
+    conv at ha => rw [idelta0.add_assoc]; lhs; rhs; rw [idelta0.add_comm]
+    rw [idelta0.add_assoc]
+    exact ha
+
+theorem le_cancel_left :
+  ∀ {x y z : M}, x <= y -> z + x <= z + y :=
+by
+  conv =>
+    rhs;rhs;rhs;rhs;
+    rw[idelta0.add_comm];
+    rhs;
+    rw[idelta0.add_comm]
+
+  intro x y z h
+  apply add_le_add_right.mp h
+
+-- D7. x ≤ y → x * z ≤ y * z
+theorem le_mul_right :
+  ∀ {x y z : M}, x ≤ y → x * z ≤ y * z :=
+by
+  intro x y z hxy
+  rw [le_iff_exists_add] at hxy ⊢
+  obtain ⟨diff, hdiff⟩ := hxy
+  rw [<- hdiff]
+  rw [idelta0.add_mul]
+  exists (diff * z)
+
+-- D8. x ≤ y + 1 ↔ (x ≤ y ∨ x = y + 1)  (Discreteness 1)
+theorem le_succ_iff :
+  ∀ {x y : M}, x ≤ y + 1 ↔ (x ≤ y ∨ x = y + 1) :=
+by
+  intro x y
+  constructor
+  · intro hxy
+    rw [le_iff_exists_add] at hxy
+    obtain ⟨diff, hdiff⟩ := hxy
+    by_cases h : diff = 0
+    · rw [h] at hdiff
+      right
+      rw [B3] at hdiff
+      exact hdiff
+    · obtain ⟨pred_diff, hpred_diff_le, hpred_diff_eq⟩
+        := pred_exists h
+      left
+      rw [hpred_diff_eq] at hdiff
+      rw [<- idelta0.add_assoc] at hdiff
+      rw [le_iff_exists_add]
+      exists pred_diff
+      apply B2
+      exact hdiff
+  · intro h
+    cases h with
+    | inl h =>
+      rw [le_iff_exists_add] at h ⊢
+      rcases h with ⟨diff, hdiff⟩
+      refine ⟨diff + 1, ?_⟩
+      rw [<- idelta0.add_assoc]
+      rw [hdiff]
+    | inr h =>
+      rw [h]
+
+-- D4 used
+instance : PartialOrder M where
+  le_refl := idelta0.le_refl
+  le_trans := @idelta0.le_trans
+  le_antisymm := by apply B7
+
+instance : CanonicallyOrderedAdd M where
+  exists_add_of_le := by
+    intro a b hab
+    have diff := idelta0.add_diff_exists a b
+    obtain ⟨diff, hdiff⟩ := diff
+    cases hdiff with
+    | inl h => rw [<- h]; exists diff
+    | inr h =>
+      exists 0
+      rw [B3]
+      apply B7
+      · rw [<- h]
+        apply B8
+      · exact hab
+  le_self_add := by apply B8
+
+noncomputable instance : LinearOrder M where
+  le_refl := idelta0.le_refl
+  le_trans := by apply le_trans
+  le_antisymm := by apply B7
+  le_total := idelta0.le_total
+  min_def := by simp only [implies_true]
+  max_def := by exact fun a b ↦ rfl
+  compare_eq_compareOfLessAndEq := by
+    simp only [implies_true]
+
+  toDecidableLE := by
+    unfold DecidableLE DecidableRel
+    intro a b
+    if ha : a = 0 then
+      apply Decidable.isTrue
+      rw [ha]
+      apply IOPENModel.zero_le b
+    else
+      if hb : b = 0 then
+        apply Decidable.isFalse
+        rw [hb]
+        intro ha'
+        apply ha
+        exact (@nonpos_iff_eq_zero M).mp ha'
+      else
+        -- HERE, WE SHOULD TAKE PREDECESSOR OF
+        -- BOTH AND RECURSE!
+        exact Classical.propDecidable (a ≤ b)
+
+theorem le_of_eq :
+  ∀ {x y : M}, x = y -> x ≤ y :=
+by
+  intro x y hxy
+  rw [hxy]
+
+-- theorem lt_of_not_ge :
+--   ∀ {x y : M}, ¬ x <= y -> y < x :=
+-- by
+--   intro x y h
+--   constructor
+--   · cases le_total x y with
+--     | inl x_le =>
+--       contradiction
+--     | inr y_le =>
+--       exact y_le
+--   · intro h_eq
+--     apply h
+--     apply le_of_eq
+--     apply Eq.symm
+--     exact h_eq
+
+theorem zero_if_sum_zero :
+  ∀ {x y : M}, x + y = 0 -> x = 0 ∧ y = 0 :=
+by
+  intro x y h
+  constructor
+  · apply le_zero_eq
+    have t := @B8 _ _ x y
+    rw [h] at t
+    exact t
+  · apply le_zero_eq
+    have t := @B8 _ _ y x
+    rw [idelta0.add_comm] at t
+    rw [h] at t
+    exact t
+
+theorem lt_one_eq_zero :
+  ∀ {x : M}, x < 1 -> x = 0 :=
+by
+  intro x hx
+  rcases hx with ⟨h_x_le, h_x_neq⟩
+  rw [le_iff_exists_add] at h_x_le
+  rcases h_x_le with ⟨diff, hdiff⟩
+  by_cases h : x = 0
+  · trivial
+  · obtain ⟨pred, hp1, hp2⟩ := pred_exists h
+    rw [hp2] at hdiff
+    rw [idelta0.add_assoc] at hdiff
+    conv at hdiff => lhs; rhs; rw [idelta0.add_comm]
+    rw [<- idelta0.add_assoc] at hdiff
+    conv at hdiff => rhs; rw [<- idelta0.zero_add 1]
+    have hdiff := B2 _ _ hdiff
+    have pred_zero := (zero_if_sum_zero hdiff).left
+    rw [pred_zero, idelta0.zero_add] at hp2
+    exfalso
+    apply h_x_neq
+    rw [hp2]
+
+-- D9. x < y ↔ x + 1 ≤ y  (Discreteness 2)
+-- recall: x < y means x ≤ y ∧ x ≠ y
+theorem lt_iff_succ_le :
+  ∀ {x y : M}, (x < y) ↔ x + 1 ≤ y :=
+by
+  intro x y
+  constructor
+  · intro h
+    rcases h with ⟨h1, h2⟩
+    rw [le_iff_exists_add] at h1
+    obtain ⟨diff, hdiff⟩ := h1
+    rw [<- hdiff]
+    apply le_cancel_left
+
+    by_contra not_one_le_diff
+    apply h2
+    rw [<- hdiff]
+    conv => lhs; rw [<- B3 x]
+    have diff_lt_one := lt_of_not_ge not_one_le_diff
+    rw [lt_one_eq_zero diff_lt_one]
+    rw [@B3]
+    rw [@B3]
+  · rw [le_iff_exists_add]
+    simp only [peano.instLTOfStructure, not_le]
+    rw [le_iff_exists_add]
+    intro h
+    rcases h with ⟨diff, hdiff⟩
+    constructor
+    · exists (1 + diff)
+      rw [<- idelta0.add_assoc]
+      exact hdiff
+    · rw [<- hdiff]
+      simp only [LT.lt]
+      constructor
+      · apply le_add_right
+        apply le_add_right
+        exact le_of_eq rfl
+      · intro absurd
+        have aux : x + 1 + diff = x := by
+          have aux : x + 1 + diff >= x := by
+            refine le_add_of_le_left ?_
+            exact le_self_add
+          apply le_antisymm <;> assumption
+
+
+        conv at aux => lhs; rw [idelta0.add_assoc]
+        conv at aux => rhs; rw [<- B3 x]
+        rw [add_cancel_left] at aux
+        rw [idelta0.add_comm] at aux
+        apply @B1 M
+        exact aux
+
+theorem mul_eq_zero_iff_left :
+  ∀ {x y : M}, x ≠ 0 -> (x * y = 0 ↔ y = 0) :=
+by
+  intro x y hx
+  constructor
+  · intro hxy
+    rcases pred_exists hx with ⟨xp, _, hxp_eq⟩
+    rw [hxp_eq] at hxy
+    rw [idelta0.add_mul] at hxy
+    by_contra hy
+    rcases pred_exists hy with ⟨yp, _, hyp_eq⟩
+    rw [hyp_eq] at hxy
+    conv at hxy => lhs; rhs; rw [idelta0.mul_add]
+    rw [idelta0.mul_one] at hxy
+    rw [<- idelta0.add_assoc] at hxy
+    apply B1 (num := M)
+    exact hxy
+  · intro hy
+    rw [hy]
+    apply B5
+
+-- D10. x * z = y * z ∧ z ≠ 0 → x = y  (Cancellation law for ·)
+theorem mul_cancel_right :
+  ∀ x y z : M, (x * z = y * z ∧ z ≠ 0) → x = y :=
+by
+  let ind1 : peano.Formula (Vars3 .x .y .z)
+    := ((x * z) =' (y * z) ⊓ (z ≠' 0)) ⟹ (x =' y)
+  let ind := idelta0.delta0_induction $ display3 .x ind1
+
+  specialize ind (by
+    rw [IsDelta0.display3]
+    unfold ind1
+    constructor
+    · apply IsDelta0.of_isQF
+      apply IsQF.inf
+      · constructor; constructor
+      · apply IsQF.not; constructor; constructor
+    · constructor; constructor; constructor
+  )
+
+  unfold ind1 at ind
+  simp_induction at ind
+
+  apply ind ?base ?step <;> clear ind ind1
+  · intro y z hyz_z
+    obtain ⟨hyz, hz⟩ := hyz_z
+    by_cases hy : y = 0
+    · exact hy.symm
+    · rcases pred_exists hy with ⟨yp, _, hyp_eq⟩
+      rcases pred_exists hz with ⟨zp, _, hzp_eq⟩
+      rw [hyp_eq, hzp_eq] at hyz
+      rw [idelta0.mul_add] at hyz
+      rw [idelta0.mul_one] at hyz
+      rw [idelta0.zero_mul] at hyz
+      rw [idelta0.zero_add] at hyz
+      rw [idelta0.mul_add] at hyz
+      rw [idelta0.mul_one] at hyz
+      rw [<- idelta0.add_assoc] at hyz
+      symm at hyz
+      exfalso
+      apply @B1 M
+      exact hyz
+  · intro y hind x z hass_hz
+    obtain ⟨hass, hz⟩ := hass_hz
+    -- hind tells us that we can right-cancel
+    -- multiplication by `a_1` if the other factor at RHS is `a`
+
+    -- right-cancel multiplication by `z` in `hass`
+    have hx : x ≠ 0 := by
+      by_contra hx
+      rw [hx] at hass
+      rw [idelta0.zero_mul] at hass
+      rw [mul_eq_zero_iff_left] at hass
+      apply hz
+      exact hass
+      apply @B1 M
+    rcases pred_exists hx with ⟨xp, _, hxp_eq⟩
+    rw [hxp_eq] at hass
+    rw [idelta0.add_mul] at hass
+    rw [idelta0.add_mul] at hass
+    rw [idelta0.one_mul] at hass
+    rw [add_cancel_right] at hass
+    specialize hind xp z
+
+    rw [hxp_eq]
+    rw [hind]
+    constructor
+    · exact hass
+    · exact hz
+
+
+end IDelta0Model

--- a/LeanPool/FormalizationOfBoundedArithmetic/IOPEN.lean
+++ b/LeanPool/FormalizationOfBoundedArithmetic/IOPEN.lean
@@ -1,0 +1,366 @@
+/-
+Copyright (c) 2026 Mary Jane. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mary Jane
+-/
+
+-- for a quick demo, jump straight to `theorem add_assoc`
+import Mathlib.Tactic.Core
+import Mathlib.Logic.Basic
+import Mathlib.Tactic
+
+import Mathlib.ModelTheory.Basic
+import Mathlib.ModelTheory.Syntax
+import Mathlib.ModelTheory.Complexity
+import Mathlib.ModelTheory.Semantics
+
+import LeanPool.FormalizationOfBoundedArithmetic.IsEnum
+import LeanPool.FormalizationOfBoundedArithmetic.AxiomSchemes
+import LeanPool.FormalizationOfBoundedArithmetic.Syntax
+import LeanPool.FormalizationOfBoundedArithmetic.Semantics
+import LeanPool.FormalizationOfBoundedArithmetic.Complexity
+import LeanPool.FormalizationOfBoundedArithmetic.Order
+import LeanPool.FormalizationOfBoundedArithmetic.BasicSingleSorted
+import LeanPool.FormalizationOfBoundedArithmetic.SimpRules
+
+open FirstOrder Language BoundedFormula
+
+class IOPENModel (num : Type*) extends BASICModel num where
+  open_induction {n} {a : Type} [IsEnum a]
+    (phi : peano.BoundedFormula ((Vars1 n) ⊕ a) 0) :
+    phi.IsOpen -> (mkInductionSentence phi).Realize num
+
+namespace IOPENModel
+
+universe u v
+variable {M : Type u} [iopen : IOPENModel M]
+
+
+-- page 36 of draft (47 of pdf)
+-- Example 3.8 The following formulas (and their universal closures) are theorems of IOPEN:
+open BASICModel Formula Term
+
+open Lean Elab Tactic
+
+theorem forall_swap_231 {α β γ} {p : α -> β -> γ -> Prop}
+  : (∀ x y z, p x y z) <-> (∀ z x y, p x y z) :=
+  ⟨fun f z x y  => f x y z, fun f y z x => f x y z⟩
+
+-- O1. (x + y) + z = x + (y + z) (Associativity of +)
+-- proof: induction on z
+theorem add_assoc
+  : ∀ x y z : M, (x + y) + z = x + (y + z) :=
+by
+  -- TODO: how to make Lean infer these formulas?
+  let phi : peano.Formula (Vars3 .z .x .y) :=
+    ((x + y) + z) =' (x + (y + z))
+  have ind := iopen.open_induction $ display3 .z phi
+  unfold phi at ind
+  simp_complexity at ind
+  simp_induction at ind
+
+  rw [forall_swap_231]
+  apply ind ?base ?step; clear ind
+  · intro x y
+    rw [B3 (x + y)]
+    rw [B3 y]
+  · intro z hInd x y
+    rw [B4]
+    rw [B4]
+    rw [B4]
+    rw [<- (B2 (x + y + z) (x + (y + z)))]
+    rw [hInd]
+
+-- lemma for O2; "induction on y, first establishing the special cases y = 0 and y = 1..."
+-- proof: induction on x
+lemma add_zero_comm
+  : ∀ x : M, x + 0 = 0 + x :=
+by
+  have ind := iopen.open_induction $ display1
+    (((x + 0) =' (0 + x)) : Formula _ (Vars1 .x))
+  simp_complexity at ind
+  simp_induction at ind
+
+  apply ind ?base ?step; clear ind
+  · trivial
+  · intro a ha
+    rw [← add_assoc]
+    rw [← ha]
+    rw [B3]
+    rw [B3]
+
+-- this is necessary to prove axiom `C` from BasicExt
+lemma zero_add
+  : ∀ x : M, 0 + x = x :=
+by
+  intro a
+  rw [<- add_zero_comm]
+  exact B3 a
+
+-- lemma for O2; "induction on y, first establishing the special cases y = 0 and y = 1..."
+theorem add_one_comm
+  : ∀ x : M, x + 1 = 1 + x :=
+by
+  have ind := iopen.open_induction $ display1
+    (((x + 1) =' (1 + x)) : Formula _ (Vars1 .x))
+  simp_complexity at ind
+  simp_induction at ind
+
+  apply ind ?base ?step; clear ind
+  · rw [zero_add, B3]
+  · intro a ha
+    rw [<- add_assoc]
+    rw [ha]
+
+-- O2. x + y = y + x (Commutativity of +)
+-- proof : induction on y, first establishing the special cases y = 0 and y = 1
+theorem add_comm
+  : ∀ x y : M, x + y = y + x :=
+by
+  have ind := iopen.open_induction $ display2 .y
+    (((x + y) =' (y + x)) : Formula _ (Vars2 .y .x))
+  simp_complexity at ind
+  simp_induction at ind
+
+  rw [forall_swap]
+  apply ind ?base ?step; clear ind
+  · intro; rw [add_zero_comm]
+  · intro a hInd b
+    rw [<- add_assoc]
+    rw [hInd]
+    rw [add_assoc]
+    rw [add_one_comm]
+    rw [<- add_assoc]
+
+-- O3. x · (y + z) = (x · y) + (x · z) (Distributive law)
+  -- proof: induction on z
+theorem mul_add
+  : ∀ x y z : M, x * (y + z) = (x * y) + (x * z) :=
+by
+  have ind := iopen.open_induction $ display3 .z
+     ((x * (y + z)) =' ((x * y) + (x * z)) : Formula _ (Vars3 .z .x .y))
+  simp_complexity at ind
+  simp_induction at ind
+
+  rw [forall_swap_231]
+  apply ind ?base ?step; clear ind
+  · intro a b
+    rw [B3]
+    rw [B5]
+    rw [B3]
+  · intro b hInd_b a2 a3
+    rw [add_comm]
+    rw [add_assoc]
+    rw [add_comm]
+    rw [hInd_b]
+    conv => lhs; left; rw [add_comm]; rw [B6]
+    rw [B6]
+    conv => rhs; right; rw [add_comm]
+    rw [add_assoc]
+
+theorem mul_one
+  : ∀ x : M, x * 1 = x :=
+by
+  intro x
+  rw [<- zero_add 1]
+  rw [B6]
+  rw [B5]
+  rw [add_comm]
+  rw [B3]
+
+-- O4. (x · y) · z = x · (y · z) (Associativity of ·)
+  -- proof: induction on z, using O3
+theorem mul_assoc
+  : ∀ x y z : M, (x * y) * z = x * (y * z) :=
+by
+  have ind := iopen.open_induction $ display3 .z
+    ((((x * y) * z) =' (x * (y * z))) : Formula _ (Vars3 .z .x .y))
+
+  simp_complexity at ind
+  simp_induction at ind
+
+  rw [forall_swap_231]
+  apply ind ?base ?step; clear ind
+  · intro x y
+    rw [B5]
+    rw [B5]
+    rw [B5]
+  · intro x hInd_x y z
+    rw [mul_add]
+    rw [mul_add]
+    rw [mul_one]
+    rw [mul_one]
+    rw [mul_add]
+    rw [<- hInd_x]
+
+lemma zero_mul
+  : ∀ x : M, 0 * x = 0 :=
+by
+  have ind := iopen.open_induction $ display1
+    (((0 * x) =' 0) : Formula _ (Vars1 .x))
+  simp_complexity at ind
+  simp_induction at ind
+  apply ind ?base ?step; clear ind
+  · rw [B5]
+  · intro x hInd_0_x
+    rw [B6]
+    rw [hInd_0_x]
+    rw [B3]
+
+lemma one_mul
+  : ∀ x : M, 1 * x = x :=
+by
+  have ind := iopen.open_induction $ display1
+    (((1 * x) =' x) : Formula _ (Vars1 .x))
+  simp_complexity at ind
+  simp_induction at ind
+  apply ind ?base ?step; clear ind
+  · rw [B5]
+  · intro x hInd_1_x
+    rw [B6]
+    rw [hInd_1_x]
+
+lemma mul_add_1_left
+  : ∀ x y : M, (x + 1) * y = x * y + y :=
+by
+  have ind := iopen.open_induction $ display2 .y
+    (((x + 1) * y) =' ((x * y) + y) : Formula _ (Vars2 .y .x))
+  simp_complexity at ind
+  simp_induction at ind
+  rw [forall_swap]
+  apply ind ?base ?step; clear ind
+  · intro x
+    rw [B5]
+    rw [B5]
+    rw [B3]
+  · intro y hInd_y x
+    rw [B6]
+    rw [B6]
+    rw [hInd_y]
+    conv => lhs; rw [add_assoc]; right; rw [<- add_assoc]; left; rw [add_comm]
+    conv => rhs; rw [add_assoc]; right; rw [<- add_assoc]
+
+-- O5. x · y = y · x (Commutativity of ·)
+theorem mul_comm
+  : ∀ x y : M, x * y = y * x :=
+by
+  have ind := iopen.open_induction $ display2 .y
+    (((x * y) =' (y * x)) : Formula _ (Vars2 .y .x))
+  simp_complexity at ind
+  simp_induction at ind
+  rw [forall_swap]
+  apply ind ?base ?step; clear ind
+  · intro x
+    rw [B5]
+    rw [zero_mul]
+  · intro x hInd_x y
+    rw [B6]
+    rw [mul_add_1_left]
+    rw [hInd_x]
+
+example : Nonempty (True ∧ True) :=
+  ⟨⟨⟨⟩, ⟨⟩⟩⟩
+
+-- O6. x + z = y + z → x = y (Cancellation law for +)
+theorem add_cancel_right.mp
+  : ∀ {x y z : M}, x + z = y + z → x = y :=
+by
+  have ind := iopen.open_induction $ display3 .z
+    (((x + z) =' (y + z) ⟹ (x =' y)) : Formula _ (Vars3 .z .x .y))
+
+  simp_complexity at ind
+  simp_induction at ind
+
+  rw [forall_swap_231]
+  apply ind ?base ?step; clear ind
+  · intro x y
+    rw [B3]
+    rw [B3]
+    intro h
+    exact h
+  · intro x hInd_x y z
+    conv => lhs; lhs; right; rw [add_comm]
+    conv => lhs; rhs; right; rw [add_comm]
+    rw [<- add_assoc]
+    rw [<- add_assoc]
+    intro h
+    apply B2
+    apply hInd_x
+    exact h
+
+theorem add_cancel_right
+  : ∀ {x y z : M}, x + z = y + z <-> x = y :=
+by
+  intro x y z
+  constructor
+  · exact add_cancel_right.mp
+  · intro h
+    rw [h]
+
+theorem add_cancel_left
+  : ∀ {x y z : M}, z + x = z + y <-> x = y :=
+by
+  intro x y z
+  constructor
+  · conv => rw [add_comm]; lhs; rhs; rw [add_comm]
+    apply add_cancel_right.mp
+  · intro h
+    rw [h]
+
+-- O7. 0 ≤ x
+theorem zero_le
+  : ∀ x : M, 0 ≤ x :=
+by
+  intro x
+  rw [<- B3 x]
+  rw [add_comm]
+  apply B8
+
+-- O8. x ≤ 0 → x = 0
+theorem le_zero_eq
+  : ∀ x : M, x ≤ 0 → x = 0 :=
+by
+  intro x h
+  apply B7
+  · exact h
+  · apply zero_le
+
+-- O9. x ≤ x
+-- This is proved already as BASICModel.le_refl (doesn't need induction)
+-- theorem le_refl
+--   : ∀ x : M, x ≤ x :=
+-- by
+--   intro x
+--   conv => right; rw [<- B3 x]
+--   apply B8
+
+-- O10. x ≠ x + 1
+theorem ne_succ
+  : ∀ x : M, x ≠ x + 1 :=
+by
+  have ind := iopen.open_induction $ display1
+    ((x ≠' (x + 1)) : Formula _ (Vars1 .x))
+  simp_complexity at ind
+  simp_induction at ind
+
+  apply ind ?base ?step; clear ind
+  · intro h
+    -- TODO: why this self is necessary?
+    apply B1 (self := iopen.toBASICModel)
+    apply Eq.symm
+    exact h
+  · intro a h hq
+    apply h
+    apply B2
+    exact hq
+
+theorem add_mul
+  : ∀ x y z : M, (x + y) * z = x * z + y * z :=
+by
+  intro x y z
+  rw [mul_comm]
+  rw [mul_add]
+  rw [mul_comm]
+  conv => lhs; rhs; rw [mul_comm]
+
+end IOPENModel

--- a/LeanPool/FormalizationOfBoundedArithmetic/IsEnum.lean
+++ b/LeanPool/FormalizationOfBoundedArithmetic/IsEnum.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2026 Mary Jane. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mary Jane
+-/
+
+-- Source: the example from https://lean-lang.org/doc/reference/latest/Type-Classes/Deriving-Instances/
+-- extended with case for empty type
+import Lean
+import Mathlib.Logic.IsEmpty
+import Mathlib.Logic.Equiv.Defs
+import Mathlib.Data.Finite.Defs
+import Mathlib.Data.List.Nodup
+import Mathlib.Data.List.OfFn
+
+open Lean Elab Parser Term Command
+
+universe u
+
+class IsEnum (α : Type u) where
+  size : Nat
+  toIdx : α → Fin size
+  fromIdx : Fin size → α
+  to_from_id : ∀ (i : Fin size), toIdx (fromIdx i) = i
+  from_to_id : ∀ (x : α), fromIdx (toIdx x) = x
+
+def deriveIsEnum (declNames : Array Name) : CommandElabM Bool := do
+  if h : declNames.size = 1 then
+    let env ← getEnv
+    if let some (.inductInfo ind) := env.find? declNames[0] then
+      if ind.ctors.isEmpty then
+        let cmd ← `(
+          instance : IsEnum $(mkIdent declNames[0]) where
+            size      := 0
+            toIdx     := Empty.elim
+            fromIdx   := Fin.elim0
+            to_from_id := by simp only [IsEmpty.forall_iff]
+            from_to_id := by simp only [IsEmpty.forall_iff]
+        )
+        elabCommand cmd
+        return true
+      else
+      let mut tos : Array (TSyntax ``matchAlt) := #[]
+      let mut froms := #[]
+      let mut to_froms := #[]
+      let mut from_tos := #[]
+      let mut i := 0
+
+      for ctorName in ind.ctors do
+        let c := mkIdent ctorName
+        let n := Syntax.mkNumLit (toString i)
+
+        tos      := tos.push      (← `(matchAltExpr| | $c => $n))
+        from_tos := from_tos.push (← `(matchAltExpr| | $c => rfl))
+        froms    := froms.push    (← `(matchAltExpr| | $n => $c))
+        to_froms := to_froms.push (← `(matchAltExpr| | $n => rfl))
+
+        i := i + 1
+
+      let cmd ← `(instance : IsEnum $(mkIdent declNames[0]) where
+                    size := $(quote ind.ctors.length)
+                    toIdx $tos:matchAlt*
+                    fromIdx $froms:matchAlt*
+                    to_from_id $to_froms:matchAlt*
+                    from_to_id $from_tos:matchAlt*)
+      elabCommand cmd
+
+      return true
+  return false
+
+initialize
+  registerDerivingHandler ``IsEnum deriveIsEnum
+
+
+namespace IsEnum
+variable {α} {enum : IsEnum α}
+
+
+def left_inv : Function.LeftInverse enum.fromIdx enum.toIdx :=
+  enum.from_to_id
+
+def right_inv : Function.RightInverse enum.fromIdx enum.toIdx :=
+  enum.to_from_id
+
+def equiv : α ≃ Fin (enum.size) where
+  toFun := enum.toIdx
+  invFun := enum.fromIdx
+  left_inv := left_inv
+  right_inv := right_inv
+
+instance : Finite α := @Finite.intro _ (enum.size) equiv
+
+def fromIdx_injective : Function.Injective enum.fromIdx := Function.LeftInverse.injective right_inv
+def toIdx_injective : Function.Injective enum.toIdx := Function.LeftInverse.injective left_inv
+
+-- Inspired by Mathlib.Data.Finset.Dedup.lean; toList, nodup_toList...
+-- https://github.com/leanprover-community/mathlib4/blob/f4506f7151c9057fd9f8714b2a1f13a647fe2352/Mathlib/Data/Finset/Dedup.lean#L162-L164
+section ToList
+def toList : List α := List.ofFn enum.fromIdx
+
+theorem nodup_toList : enum.toList.Nodup := by
+  unfold List.Nodup
+  unfold toList
+  rw [List.pairwise_ofFn]
+  intro i j hij
+  apply Function.Injective.ne fromIdx_injective
+  exact Fin.ne_of_lt hij
+
+end ToList
+
+end IsEnum

--- a/LeanPool/FormalizationOfBoundedArithmetic/LanguagePeano.lean
+++ b/LeanPool/FormalizationOfBoundedArithmetic/LanguagePeano.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 Mary Jane. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mary Jane
+-/
+
+import Mathlib.ModelTheory.Order
+
+import LeanPool.FormalizationOfBoundedArithmetic.Register
+
+universe u v
+
+namespace FirstOrder
+namespace Language
+
+-- this style of definition is inspired by https://github.com/leanprover-community/mathlib4/blob/2cb771d3006e8b7579f66990fed1b433bf2e7fed/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
+-- Definition 2.3, page 12 of draft (23 of pdf);
+--   + remark in section 3.1, top of page 34 of draft (45 of pdf)
+-- note: the equality relation is present by default in Mathlib.ModelTheory
+-- it is explicit in Cook and Nguyen, but it doesn't seem to lead to any inconsistencies
+-- note: checking if 'x = y is not always trivial; if x and y are long bit-strings,
+-- encoded as lists (e.g. 3 encoded as S(S(S(Z)))), checking for their equality
+-- is linear-time, thus not trivial at all. But here we only use equality in proofs
+-- and the only way to assert equality is to prove it from axioms. So it seems like we'll
+-- never run into the problem of having to brute-force checking for equality
+inductive PeanoFunc : Nat -> Type*
+  | zero : PeanoFunc 0
+  | one : PeanoFunc 0
+  | add : PeanoFunc 2
+  | mul : PeanoFunc 2
+  deriving DecidableEq
+
+inductive PeanoRel : Nat -> Type*
+  | leq : PeanoRel 2
+  deriving DecidableEq
+
+def peano : Language :=
+{ Functions := PeanoFunc,
+  Relations := PeanoRel
+}
+
+namespace peano
+variable {a : Type u}
+
+@[delta0_simps]
+instance : Language.IsOrdered peano where
+  leSymb := PeanoRel.leq
+
+@[delta0_simps] instance : Zero (peano.Term a) where
+  zero := Constants.term .zero
+
+@[delta0_simps] instance : One (peano.Term a) where
+  one := Constants.term .one
+
+@[delta0_simps] instance : Add (peano.Term a) where
+  add := Functions.apply₂ .add
+
+@[delta0_simps] instance : Mul (peano.Term a) where
+  mul := Functions.apply₂ .mul
+
+-- inspired by https://github.com/leanprover-community/mathlib4/blob/cff2a6ea669abe2e384ea4c359f20ee90a5dc855/Mathlib/ModelTheory/Syntax.lean#L732
+-- standard precedence of ≤, ≠, <: 50
+-- standard precedence of +: 65; of *: 70
+-- precedence of ⟹ in ModelTheory: 62, of =': 88
+-- the higher precedence the tighter bounding
+@[inherit_doc] scoped[FirstOrder.Language] infixl:89 " <=' " => Term.le
+@[inherit_doc] scoped[FirstOrder.Language] infixl:89 " <' " => Term.lt
+
+/-- The not-equal relation of two terms as a bounded formula -/
+@[delta0_simps]
+def _root_.FirstOrder.Term.neq {a : Type u} {n} {L : Language} (t1 t2 : L.Term (a ⊕ (Fin n))) : L.BoundedFormula a n :=
+  ∼(t1 =' t2)
+@[inherit_doc] scoped[FirstOrder.Language] infixl:88 " ≠' " => Term.neq
+
+
+instance {M} [h : Language.peano.Structure M] : Zero M :=
+  ⟨h.funMap PeanoFunc.zero ![]⟩
+
+instance {M} [h : Language.peano.Structure M] : One M :=
+  ⟨h.funMap PeanoFunc.one ![]⟩
+
+instance {M} [h : Language.peano.Structure M] : Add M :=
+  ⟨fun x y => h.funMap PeanoFunc.add ![x, y]⟩
+
+instance {M} [h : Language.peano.Structure M] : Mul M :=
+  ⟨fun x y => h.funMap PeanoFunc.mul ![x, y]⟩
+
+instance {M} [h : Language.peano.Structure M] : LE M :=
+  ⟨fun x y => h.RelMap PeanoRel.leq ![x, y]⟩
+
+@[simp]
+instance {M} [h : Language.peano.Structure M] : LT M :=
+  ⟨fun x y => x <= y ∧ ¬ y <= x⟩
+
+def natToM {M} [h : Language.peano.Structure M] : Nat -> M
+| 0 => 0
+| 1 => 1
+| n + 1 => natToM n + 1
+
+instance {M} [h : Language.peano.Structure M] (n) : OfNat M n where
+  ofNat := natToM n
+
+end FirstOrder.Language.peano

--- a/LeanPool/FormalizationOfBoundedArithmetic/LanguageZambella.lean
+++ b/LeanPool/FormalizationOfBoundedArithmetic/LanguageZambella.lean
@@ -1,0 +1,234 @@
+/-
+Copyright (c) 2026 Mary Jane. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mary Jane
+-/
+
+import Mathlib.ModelTheory.Syntax
+import Mathlib.ModelTheory.Order
+import Mathlib.ModelTheory.LanguageMap
+
+import LeanPool.FormalizationOfBoundedArithmetic.DisplayedVariables
+import LeanPool.FormalizationOfBoundedArithmetic.LanguagePeano
+
+universe u v
+
+namespace FirstOrder
+namespace Language
+
+-- Definition 4.4, Draft page 70 (page 81 of pdf)
+-- + note about adding the axiom "E" and empty-string constant in a section below
+inductive ZambellaFunc : Nat -> Type u
+| zero :  ZambellaFunc 0
+| one :   ZambellaFunc 0
+| empty : ZambellaFunc 0
+| len :   ZambellaFunc 1
+| add :   ZambellaFunc 2
+| mul :   ZambellaFunc 2
+deriving DecidableEq
+
+inductive ZambellaRel : Nat -> Type u
+-- | eqsort, eqstr -- we will use built-in equality syntax from ModelTheory lib
+| isnum : ZambellaRel 1
+| isstr : ZambellaRel 1
+| leq :   ZambellaRel 2
+| mem :   ZambellaRel 2
+deriving DecidableEq
+
+def zambella : Language :=
+{ Functions := ZambellaFunc,
+  Relations := ZambellaRel
+}
+
+section zambella
+variable {a : Type u}
+
+instance : Language.IsOrdered zambella where
+  leSymb := ZambellaRel.leq
+
+@[simp] instance : Zero (zambella.Term a) where
+  zero := Constants.term .zero
+
+@[simp] instance : One (zambella.Term a) where
+  one := Constants.term .one
+
+class HasEmptySet (α : Type*) where
+  empty : α
+
+@[simp] instance : HasEmptySet (zambella.Term a) where
+  empty := Constants.term .empty
+
+class HasLen (α : Type u) (β : Type v) where
+  len : α -> β
+
+@[simp] instance : HasLen (zambella.Term a) (zambella.Term a) where
+  len := Functions.apply₁ .len
+
+@[simp] instance : Add (zambella.Term a) where
+  add := Functions.apply₂ .add
+
+@[simp] instance : Mul (zambella.Term a) where
+  mul := Functions.apply₂ .mul
+
+class HasTypes_is (α : Type*) where
+  int : α -> Prop
+  str : α -> Prop
+  dec   : ∀ x, int x ∨ str x
+  excl  : ∀ x, (int x -> ¬str x) ∧ (str x -> ¬int x)
+
+
+section Semantics
+
+instance {M} [h : zambella.Structure M] : Zero M :=
+  ⟨h.funMap ZambellaFunc.zero ![]⟩
+
+instance {M} [h : zambella.Structure M] : One M :=
+  ⟨h.funMap ZambellaFunc.one ![]⟩
+
+instance {M} [h : zambella.Structure M] : Add M :=
+  ⟨fun x y => h.funMap ZambellaFunc.add ![x, y]⟩
+
+instance {M} [h : zambella.Structure M] : Mul M :=
+  ⟨fun x y => h.funMap ZambellaFunc.mul ![x, y]⟩
+
+instance {M} [h : zambella.Structure M] : LE M :=
+  ⟨fun x y => h.RelMap ZambellaRel.leq ![x, y]⟩
+
+instance {M} [h : zambella.Structure M] : HasEmptySet M :=
+  ⟨h.funMap ZambellaFunc.empty ![]⟩
+
+instance {M} [h : zambella.Structure M] : HasLen M M :=
+  ⟨fun x => h.funMap ZambellaFunc.len ![x]⟩
+
+instance {M} [h : zambella.Structure M] : Membership M M :=
+  ⟨fun x y => h.RelMap ZambellaRel.mem ![x, y]⟩
+
+instance {M} [h : zambella.Structure M] : peano.Structure M where
+  funMap := fun {arity} f =>
+    match arity, f with
+    | 0, PeanoFunc.zero => fun _ => 0
+    | 0, PeanoFunc.one => fun _ => 1
+    | 2, PeanoFunc.add => fun args => (args 0) + (args 1)
+    | 2, PeanoFunc.mul => fun args => (args 0) * (args 1)
+
+  RelMap := fun {arity} r =>
+    match arity, r with
+    | 2, PeanoRel.leq => fun args => (args 0) <= (args 1)
+
+-- use Zero, One instances explicitly to avoid circular dependency
+instance {M} [h : zambella.Structure M] (n) : OfNat M n where
+  ofNat := aux n
+where
+  aux : Nat -> M
+    | 0 => Zero.zero
+    | 1 => One.one
+    | n + 1 => (aux n) + One.one
+
+@[simp] lemma realize_zero_to_zero {M} [zambella.Structure M] {a} {env : a → M} :
+  Language.Term.realize env (0 : zambella.Term a) = (0 : M) := by
+  simp only [OfNat.ofNat, Zero.zero]
+  simp only [zambella, Term.realize_constants]
+  rfl
+
+-- it is important to define OfNat 1 as 1, not (0+1), as the later needs an axiom to
+-- be asserted equal to 1.
+@[simp] lemma realize_one_to_one {M} [zambella.Structure M] {a} {env : a → M} :
+  Term.realize env (1 : zambella.Term a) = (1 : M) := by
+  simp only [OfNat.ofNat, One.one]
+  simp only [zambella, Term.realize_constants]
+  rfl
+
+@[simp] lemma realize_add_to_add {M} [h : zambella.Structure M] {a} {env : a → M}
+    (t u : zambella.Term a) :
+  Term.realize env (t + u) = Term.realize env t + Term.realize env u := by
+  simp only [zambella, HAdd.hAdd, Add.add]
+  -- TODO: why the below doesn't work without @?
+  rw [@Term.realize_functions_apply₂]
+
+@[simp] lemma realize_mul_to_mul {M} [zambella.Structure M] {a} {env : a → M}
+    (t u : zambella.Term a) :
+  Term.realize env (t * u) = Term.realize env t * Term.realize env u := by
+  simp only [HMul.hMul, Mul.mul]
+  rw [@Term.realize_functions_apply₂]
+
+@[simp] lemma realize_leq_to_leq {M} [h : zambella.Structure M] {a} {env : a → M}
+    {k} (t u : zambella.Term (a ⊕ (Fin k))) {xs} :
+  (t.le u).Realize env xs = (t.realize (Sum.elim env xs) <= u.realize (Sum.elim env xs)) := by
+  simp only [LE.le, Term.le, Relations.boundedFormula₂]
+  rw [← @BoundedFormula.realize_rel₂]
+  unfold Relations.boundedFormula₂
+  rfl
+
+@[simp] lemma realize_leq_to_leq' {M} [h : zambella.Structure M] {a} {env : a → M}
+    {k} (t u : zambella.Term (a ⊕ (Fin k))) {xs} :
+  (BoundedFormula.rel ZambellaRel.leq ![t, u]).Realize env xs = (t.realize (Sum.elim env xs) <= u.realize (Sum.elim env xs)) := by
+  simp only [LE.le]
+  rw [← @BoundedFormula.realize_rel₂]
+  unfold Relations.boundedFormula₂ Relations.boundedFormula
+  rfl
+
+@[simp] lemma realize_leq_to_leq'' {M} [h : zambella.Structure M] {a} {env : a → M}
+    {k} (t u : zambella.Term (a ⊕ (Fin k))) {xs} :
+  h.RelMap ZambellaRel.leq ![t.realize (Sum.elim env xs), u.realize (Sum.elim env xs)] <-> (t.realize (Sum.elim env xs) <= u.realize (Sum.elim env xs)) := by
+  exact Eq.to_iff rfl
+
+end Semantics
+
+def Term.IsNum (t : zambella.Term (a ⊕ Fin 0)) : zambella.Formula a :=
+  Relations.boundedFormula₁ ZambellaRel.isnum t
+
+def Term.IsStr (t : zambella.Term (a ⊕ Fin 0)) : zambella.Formula a :=
+  Relations.boundedFormula₁ ZambellaRel.isstr t
+
+nonrec def Formula.IsNum {n} (phi : zambella.Formula (Vars1 n)) :=
+  (var $ .inl .fv1).IsNum ⟹ phi
+
+/-- The membership relation of two terms as a bounded formula -/
+def _root_.FirstOrder.Term.in {a : Type u} {n} (t1 t2 : zambella.Term (a ⊕ (Fin n))) : zambella.BoundedFormula a n :=
+  Relations.boundedFormula₂ ZambellaRel.mem t2 t1
+@[inherit_doc] scoped[FirstOrder.Language] infixl:88 " ∈' " => Term.in
+
+/-- The not-mem relation of two terms as a bounded formula -/
+@[delta0_simps]
+def _root_.FirstOrder.Term.notin {a : Type u} {n} (t1 t2 : zambella.Term (a ⊕ (Fin n))) : zambella.BoundedFormula a n :=
+  ∼(t1 ∈' t2)
+
+@[inherit_doc] scoped[FirstOrder.Language] infixl:88 " ∉' " => Term.notin
+
+
+class ZambellaModel.{u'} (num str : Type u')
+  extends
+    zambella.Structure (num ⊕ str),
+    Preorder (num ⊕ str),
+    OrderedStructure zambella (num ⊕ str)
+  where
+  ax_realize_isnum {a : Type} {t : zambella.Term (a ⊕ Fin 0)} {v : a -> (num ⊕ str)}:
+    t.IsNum.Realize v
+    <-> (t.realize (Sum.elim v Fin.elim0)).isLeft
+
+  ax_realize_isstr {a : Type} {v : a -> (num ⊕ str)} {t : zambella.Term (a ⊕ Fin 0)} :
+    t.IsStr.Realize v
+    <-> (t.realize (Sum.elim v Fin.elim0)).isRight
+
+  ax_realize_in {a : Type} {n}
+    {t1 t2 : zambella.Term (a ⊕ Fin n)}
+    {v : a -> (num ⊕ str)}
+    {xs : Fin n -> (num ⊕ str)}:
+    (Term.in t1 t2).Realize v xs
+    <-> (t1.realize (Sum.elim v xs)) ∈ (t2.realize (Sum.elim v xs))
+
+
+
+-- LHOM
+instance peanoToZambella : LHom peano zambella where
+  onFunction _ f := match f with
+    | PeanoFunc.zero => ZambellaFunc.zero
+    | PeanoFunc.one => ZambellaFunc.one
+    | PeanoFunc.add => ZambellaFunc.add
+    | PeanoFunc.mul => ZambellaFunc.mul
+  onRelation _ f := match f with
+    | PeanoRel.leq => ZambellaRel.leq
+
+end zambella
+
+end FirstOrder.Language

--- a/LeanPool/FormalizationOfBoundedArithmetic/MathlibSimps.lean
+++ b/LeanPool/FormalizationOfBoundedArithmetic/MathlibSimps.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2026 Mary Jane. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mary Jane
+-/
+
+-- In this file this is crucial to be careful with imports,
+-- as all `simp` lemmas in scope will get our `delta0_simp` attribute!
+import Lean
+import Mathlib.Lean.Meta.Simp
+import Mathlib.Tactic.Simps.Basic
+
+import Mathlib.ModelTheory.Basic
+import Mathlib.ModelTheory.Syntax
+import Mathlib.ModelTheory.Semantics
+import Mathlib.ModelTheory.Order
+import Mathlib.ModelTheory.Complexity
+
+import LeanPool.FormalizationOfBoundedArithmetic.Register
+
+open Lean Elab Command
+
+elab "mkDelta0FromModelTheory" : command => do
+  let targetMod : Name := `FirstOrder.Language
+  -- Collect all declarations under the target module that currently have `[simp]`.
+  for declName in ← liftCoreM <| Lean.Meta.getAllSimpDecls `simp do
+    if targetMod.isPrefixOf declName then
+      elabCommand (← `(attribute [delta0_simps] $(mkIdent declName)))
+
+mkDelta0FromModelTheory

--- a/LeanPool/FormalizationOfBoundedArithmetic/Order.lean
+++ b/LeanPool/FormalizationOfBoundedArithmetic/Order.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2026 Mary Jane. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mary Jane
+-/
+
+import Mathlib.ModelTheory.Syntax
+import Mathlib.ModelTheory.Order
+import Mathlib.Tactic.FinCases
+
+import LeanPool.FormalizationOfBoundedArithmetic.DisplayedVariables
+import LeanPool.FormalizationOfBoundedArithmetic.Syntax
+import LeanPool.FormalizationOfBoundedArithmetic.LanguageZambella
+
+namespace FirstOrder.Language.Formula
+
+open Language BoundedFormula
+
+section IsOrdered
+universe u
+variable {L : Language} [IsOrdered L] {α : Type u}
+
+variable {n r} (a b : L.BoundedFormula n r)
+
+
+def iBdEx' {α n} (bdTerm : L.Term (α ⊕ Fin 0)) (φ : L.Formula (α ⊕ (Vars1 n))) : L.Formula α :=
+  let bd := (var (.inl (Sum.inr (.fv1)))).le $ bdTerm.relabel (Sum.map .inl id)
+  iExs' $ bd ⊓ φ
+
+def iBdAll' {α n} (bdTerm : L.Term (α ⊕ Fin 0)) (φ : L.Formula (α ⊕ (Vars1 n))) : L.Formula α :=
+  let bd := (var (.inl (Sum.inr (.fv1)))).le $ bdTerm.relabel (Sum.map .inl id)
+  iAlls' $ bd ⟹ φ
+
+-- TODO: there should only be Lt constructors in Complexity
+-- and iBd should be an alias to iBdLt with term + 1
+def iBdAllLt' {α n} (bdTerm : L.Term (α ⊕ Fin 0)) (φ : L.Formula (α ⊕ (Vars1 n))) : L.Formula α :=
+  let bd := (var (.inl (Sum.inr (.fv1)))).lt $ bdTerm.relabel (Sum.map .inl id)
+  iAlls' $ bd ⟹ φ
+
+def iBdExNum'
+  {α n}
+  (bdTerm : zambella.Term (α ⊕ Fin 0))
+  (φ : zambella.Formula (α ⊕ (Vars1 n)))
+  : zambella.Formula α :=
+  iBdEx' bdTerm $ (var $ Sum.inl $ Sum.inr $ .fv1).IsNum ⊓ φ
+
+def iBdExStr'
+  {α n}
+  (bdTerm : zambella.Term (α ⊕ Fin 0))
+  (φ : zambella.Formula (α ⊕ (Vars1 n)))
+  : zambella.Formula α :=
+  iBdEx' bdTerm $ (var $ Sum.inl $ Sum.inr $ .fv1).IsStr ⊓ φ
+
+def iBdAllNum'
+  {α n}
+  (bdTerm : zambella.Term (α ⊕ Fin 0))
+  (φ : zambella.Formula (α ⊕ (Vars1 n)))
+  : zambella.Formula α :=
+  iBdAll' bdTerm $ (var $ Sum.inl $ Sum.inr $ .fv1).IsNum ⟹ φ
+
+def iBdAllNumLt'
+  {α n}
+  (bdTerm : zambella.Term (α ⊕ Fin 0))
+  (φ : zambella.Formula (α ⊕ (Vars1 n)))
+  : zambella.Formula α :=
+  iBdAllLt' bdTerm $ (var $ Sum.inl $ Sum.inr $ .fv1).IsNum ⟹ φ
+
+
+
+open Lean Elab Tactic
+
+theorem iBdEx'.relabelEquiv
+  {α β n} (bdTerm : L.Term (α ⊕ Fin 0)) (φ : L.Formula (α ⊕ (Vars1 n)))
+  (f : α ≃ β)
+  : relabelEquiv f (iBdEx' bdTerm φ)
+    = iBdEx'
+        (Term.relabelEquiv (f.sumCongr (_root_.Equiv.refl (Fin 0))) bdTerm)
+        (relabelEquiv (f.sumCongr (_root_.Equiv.refl (Vars1 n))) φ) :=
+by
+  unfold iBdEx'
+  rw [relabelEquiv.iExs']
+  congr
+  rw [relabelEquiv.inf]
+  congr
+  · unfold Term.le Relations.boundedFormula₂ Relations.boundedFormula
+    rw [relabelEquiv.rel]
+    congr
+    funext x
+    simp only [Term.relabelEquiv_apply, Term.relabel_relabel]
+    fin_cases x
+    · simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, Term.relabel.eq_1, Sum.map_inl,
+      Equiv.sumCongr_apply, Equiv.coe_refl, Sum.map_inr, id_eq]
+    · simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one, Matrix.cons_val_fin_one,
+      Term.relabel_relabel, Sum.map_comp_map, Function.comp_id]
+      congr 1
+      funext y
+      cases y <;> rfl
+
+theorem iBdAll'.relabelEquiv
+  {α β n} (bdTerm : L.Term (α ⊕ Fin 0)) (φ : L.Formula (α ⊕ (Vars1 n)))
+  (f : α ≃ β)
+  : relabelEquiv f (iBdAll' bdTerm φ)
+    = iBdAll'
+        (Term.relabelEquiv (f.sumCongr (_root_.Equiv.refl (Fin 0))) bdTerm)
+        (relabelEquiv (f.sumCongr (_root_.Equiv.refl (Vars1 n))) φ) :=
+by
+  unfold iBdAll'
+  rw [relabelEquiv.iAlls']
+  congr
+  rw [relabelEquiv.imp]
+  congr
+  · unfold Term.le Relations.boundedFormula₂ Relations.boundedFormula
+    rw [relabelEquiv.rel]
+    congr
+    funext x
+    simp only [Term.relabelEquiv_apply, Term.relabel_relabel]
+    fin_cases x
+    · simp only [Fin.zero_eta, Fin.isValue, Matrix.cons_val_zero, Term.relabel.eq_1, Sum.map_inl,
+      Equiv.sumCongr_apply, Equiv.coe_refl, Sum.map_inr, id_eq]
+    · simp only [Fin.mk_one, Fin.isValue, Matrix.cons_val_one, Matrix.cons_val_fin_one,
+      Term.relabel_relabel, Sum.map_comp_map, Function.comp_id]
+      congr 1
+      funext y
+      cases y <;> rfl
+
+
+end IsOrdered
+
+end FirstOrder.Language.Formula

--- a/LeanPool/FormalizationOfBoundedArithmetic/Register.lean
+++ b/LeanPool/FormalizationOfBoundedArithmetic/Register.lean
@@ -1,0 +1,10 @@
+/-
+Copyright (c) 2026 Mary Jane. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mary Jane
+-/
+
+-- only here we register simp attributes
+-- details: https://leanprover-community.github.io/mathlib4_docs/Mathlib/Tactic/Attr/Core.html
+import Lean
+register_simp_attr delta0_simps

--- a/LeanPool/FormalizationOfBoundedArithmetic/Semantics.lean
+++ b/LeanPool/FormalizationOfBoundedArithmetic/Semantics.lean
@@ -1,0 +1,670 @@
+/-
+Copyright (c) 2026 Mary Jane. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mary Jane
+-/
+
+import Lean
+
+import Mathlib.ModelTheory.Semantics
+
+import LeanPool.FormalizationOfBoundedArithmetic.Syntax
+import LeanPool.FormalizationOfBoundedArithmetic.DisplayedVariables
+import LeanPool.FormalizationOfBoundedArithmetic.SimpRules
+import LeanPool.FormalizationOfBoundedArithmetic.Order
+import LeanPool.FormalizationOfBoundedArithmetic.LanguagePeano
+import LeanPool.FormalizationOfBoundedArithmetic.LanguageZambella
+
+namespace FirstOrder.Language
+open BoundedFormula
+
+open Lean Elab Tactic Command
+
+
+namespace Term
+
+
+@[delta0_simps] lemma realize_zero {M} [peano.Structure M] {a} {env : a → M} :
+  Language.Term.realize env (0 : peano.Term a) = (0 : M) := by
+  simp only [OfNat.ofNat, Zero.zero]
+  simp only [peano, Term.realize_constants]
+  rfl
+
+-- it is important to define OfNat 1 as 1, not (0+1), as the later needs an axiom to
+-- be asserted equal to 1.
+@[delta0_simps] lemma realize_one {M} [peano.Structure M] {a} {env : a → M} :
+  Term.realize env (1 : peano.Term a) = (1 : M) := by
+  simp only [OfNat.ofNat, One.one]
+  simp only [peano, Term.realize_constants]
+  rfl
+
+@[delta0_simps] lemma realize_add {M} [h : peano.Structure M] {a} {env : a → M}
+    (t u : peano.Term a) :
+  Term.realize env (t + u) = Term.realize env t + Term.realize env u := by
+  simp only [peano, HAdd.hAdd, Add.add]
+  -- TODO: why the below doesn't work without @?
+  rw [@Term.realize_functions_apply₂]
+
+@[delta0_simps] lemma realize_mul {M} [peano.Structure M] {a} {env : a → M}
+    (t u : peano.Term a) :
+  Term.realize env (t * u) = Term.realize env t * Term.realize env u := by
+  simp only [HMul.hMul, Mul.mul]
+  rw [@Term.realize_functions_apply₂]
+
+end Term
+
+
+namespace BoundedFormula
+variable {L : Language} {M : Type*} [L.Structure M] {a b} {n1 n2 n3} {n}
+
+-- important: DON'T make this a simp lemma!
+-- breaks everything
+-- @[delta0_simps]
+-- lemma realize_Formula (phi : L.Formula a) {v : a -> M} {xs}
+--   : BoundedFormula.Realize phi v xs
+--     <->
+--     phi.Realize v
+--   :=
+-- by
+--   exact Formula.boundedFormula_realize_eq_realize phi v xs
+
+-- @[delta0_simps]
+-- lemma realize_flip (phi : L.BoundedFormula (a ⊕ b) n) {v : (b ⊕ a) -> M} {xs}
+--   : phi.flip.Realize v xs
+--     <->
+--     phi.Realize (v ∘ Sum.swap) xs
+--   :=
+-- by
+--   unfold BoundedFormula.flip
+--   rw [realize_relabelEquiv]
+--   dsimp only [Equiv.coe_fn_mk]
+--   exact Eq.to_iff rfl
+
+end BoundedFormula
+
+
+namespace Formula
+
+variable {L : Language} {M : Type*} [L.Structure M] {a b} {n1 n2 n3 n4}
+
+@[delta0_simps]
+lemma realize_flip (phi : L.Formula (a ⊕ b) ) {v : (b ⊕ a) -> M}
+  : phi.flip.Realize v
+    <->
+    phi.Realize (v ∘ Sum.swap)
+  :=
+by
+  unfold Formula.Realize
+  unfold Formula.flip
+  rw [realize_relabelEquiv]
+  dsimp only [Equiv.coe_fn_mk]
+  exact Eq.to_iff rfl
+
+@[delta0_simps]
+lemma realize_rotate_21 (phi : L.Formula (Vars2 n1 n2)) {v : _ -> M}
+  : phi.rotate_21.Realize v
+    <->
+    phi.Realize (v ∘ (fun fv => match fv with
+      | .fv1 => .fv2
+      | .fv2 => .fv1))
+  :=
+by
+  unfold Formula.Realize
+  unfold Formula.rotate_21
+  rw [realize_relabelEquiv]
+  dsimp only [Equiv.coe_fn_mk]
+  exact Eq.to_iff rfl
+
+@[delta0_simps]
+lemma realize_rotate_213 (phi : L.Formula (Vars3 n1 n2 n3)) {v : _ -> M}
+  : phi.rotate_213.Realize v
+    <->
+    phi.Realize (v ∘ (fun fv => match fv with
+      | .fv1 => .fv2
+      | .fv2 => .fv1
+      | .fv3 => .fv3))
+  :=
+by
+  unfold Formula.Realize
+  unfold Formula.rotate_213
+  rw [realize_relabelEquiv]
+  dsimp only [Equiv.coe_fn_mk]
+  exact Eq.to_iff rfl
+
+@[delta0_simps]
+lemma realize_mkInl (phi : L.Formula a) {v : (a ⊕ Empty) -> M}
+  : phi.mkInl.Realize v
+    <->
+    phi.Realize (v ∘ Sum.inl)
+  :=
+by
+  unfold Formula.Realize
+  unfold Formula.mkInl
+  rw [realize_relabelEquiv]
+  dsimp only [Equiv.coe_fn_mk]
+  exact Eq.to_iff rfl
+
+@[delta0_simps]
+lemma realize_display1 (phi : L.Formula (Vars1 n1))  {v : ((Vars1 n1) ⊕ Empty) -> M}
+  : phi.display1.Realize v
+    <->
+    phi.Realize (v ∘ .inl)
+  :=
+by
+  unfold Formula.Realize
+  unfold Formula.display1
+  rw [realize_relabelEquiv]
+  dsimp only [Equiv.coe_fn_mk]
+  exact Eq.to_iff rfl
+
+@[delta0_simps]
+lemma realize_display2 (phi : L.Formula (Vars2 n1 n2)) {v : ((Vars1 n1) ⊕ (Vars1 n2)) -> M}
+  : phi.display2.Realize v
+    <->
+    phi.Realize (v ∘ (fun fv => match fv with | .fv1 => .inl .fv1 | .fv2 => .inr .fv1))
+  :=
+by
+  unfold Formula.Realize
+  unfold Formula.display2
+  rw [realize_relabelEquiv]
+  dsimp only [Equiv.coe_fn_mk]
+  exact Eq.to_iff rfl
+
+@[delta0_simps]
+lemma realize_display3 (phi : L.Formula (Vars3 n1 n2 n3)) {v : ((Vars1 n1) ⊕ (Vars2 n2 n3)) -> M}
+  : phi.display3.Realize v
+    <->
+    phi.Realize (v ∘ (fun fv => match fv with | .fv1 => .inl .fv1 | .fv2 => .inr .fv1 | .fv3 => .inr .fv2))
+  :=
+by
+  unfold Formula.Realize
+  unfold Formula.display3
+  rw [realize_relabelEquiv]
+  dsimp only [Equiv.coe_fn_mk]
+  exact Eq.to_iff rfl
+
+@[delta0_simps]
+lemma realize_display4 (phi : L.Formula (Vars4 n1 n2 n3 n4)) {v : ((Vars1 n1) ⊕ (Vars3 n2 n3 n4)) -> M}
+  : phi.display4.Realize v
+    <->
+    phi.Realize (v ∘ (fun fv => match fv with | .fv1 => .inl .fv1 | .fv2 => .inr .fv1 | .fv3 => .inr .fv2 | .fv4 => .inr .fv3))
+  :=
+by
+  unfold Formula.Realize
+  unfold Formula.display4
+  rw [realize_relabelEquiv]
+  dsimp only [Equiv.coe_fn_mk]
+  exact Eq.to_iff rfl
+
+
+@[delta0_simps]
+lemma realize_display_swapleft (phi : L.Formula (Vars1 n1 ⊕ Vars2 n2 n3)) {v : ((Vars2 n1 n2) ⊕ (Vars1 n3)) -> M}
+  : phi.display_swapleft.Realize v
+    <->
+    phi.Realize (v ∘ (fun fv => match fv with | .inl .fv1 => .inl .fv1 | .inr .fv1 => .inl .fv2 | .inr .fv2 => .inr .fv1))
+  :=
+by
+  unfold Formula.Realize
+  unfold Formula.display_swapleft
+  rw [realize_relabelEquiv]
+  dsimp only [Equiv.coe_fn_mk]
+  exact Eq.to_iff rfl
+
+@[delta0_simps]
+lemma realize_display_swapleft' (phi : L.Formula (Vars1 n1 ⊕ Vars2 n2 n3)) {v : ((Vars1 n1 ⊕ Vars1 n2) ⊕ (Vars1 n3)) -> M}
+  : phi.display_swapleft'.Realize v
+    <->
+    phi.Realize (v ∘ (fun fv => match fv with | .inl .fv1 => .inl $ .inl .fv1 | .inr .fv1 => .inl $ .inr .fv1 | .inr .fv2 => .inr .fv1))
+  :=
+by
+  unfold Formula.Realize
+  unfold Formula.display_swapleft'
+  rw [realize_relabelEquiv]
+  dsimp only [Equiv.coe_fn_mk]
+  exact Eq.to_iff rfl
+
+
+/-- `peel_iAlls' k` rewrites `(iAlls' φ).Realize` by peeling exactly
+    `k` quantifiers (`realize_all; intro`). -/
+syntax (name := peelIAlls) "peel_iAlls' " num : conv
+
+-- TODO: substitute `n` with actual size of `IsEnum`'ed type
+elab_rules : conv
+| `(conv| peel_iAlls' $k:num) => do
+  let some n := k.raw.isNatLit?
+    | throwErrorAt k "peel_iAlls': expected a nonnegative integer literal"
+  Conv.evalUnfold (← `(conv| unfold iAlls'))
+  for _ in [:n + 1] do
+    Conv.evalUnfold (← `(conv| unfold BoundedFormula.alls))
+  for _ in [:n] do
+    Conv.evalRewrite (← `(conv| rw [BoundedFormula.realize_all]))
+    Conv.evalExt (← `(conv| ext))
+  Conv.evalRewrite (← `(conv| rw [BoundedFormula.realize_relabel]))
+
+/-- `peel_iExs' k` rewrites `(iExs' φ).Realize` by peeling exactly
+    `k` quantifiers (`realize_ex; intro`). -/
+syntax (name := peelIExs) "peel_iExs' " num : conv
+
+-- TODO: substitute `n` with actual size of `IsEnum`'ed type
+elab_rules : conv
+| `(conv| peel_iExs' $k:num) => do
+  let some n := k.raw.isNatLit?
+    | throwErrorAt k "peel_iExs': expected a nonnegative integer literal"
+  Conv.evalUnfold (← `(conv| unfold iExs'))
+  for _ in [:n + 1] do
+    Conv.evalUnfold (← `(conv| unfold BoundedFormula.exs))
+
+  Conv.evalUnfold (← `(conv| unfold Formula.Realize))
+  for _ in [:n] do
+    Conv.evalRewrite (← `(conv| rw [BoundedFormula.realize_ex]))
+    Conv.evalEnter (← `(conv| enter [1]))
+    Conv.evalExt (← `(conv| ext))
+  Conv.evalRewrite (← `(conv| rw [BoundedFormula.realize_relabel]))
+
+
+
+@[delta0_simps]
+lemma realize_iAlls'.Empty (phi : L.Formula (a ⊕ Empty) ) {v : a -> M}
+  : phi.iAlls'.Realize v
+    <->
+      phi.Realize
+        (Sum.elim v Empty.elim)
+  :=
+by
+  unfold Formula.Realize
+  conv =>
+    lhs
+    peel_iAlls' 0
+
+  constructor <;>
+    (
+      intro h;
+      convert h;
+      funext;
+      rename_i x;
+      cases x;
+      simp only [Sum.elim_inl, Nat.add_zero, Fin.castAdd_zero, Fin.cast_refl, Function.comp_id,
+        Function.comp_apply, Sum.map_inl, id_eq]
+      apply Empty.elim; assumption
+    )
+
+-- TODO: IT SHOULD HOLD DEFINITIONALLY?... but I couldn't prove without funext
+@[delta0_simps]
+lemma realize_iAlls'.Vars1 (phi : L.Formula (a ⊕ Vars1 n1) ) {v : a -> M}
+  : phi.iAlls'.Realize v
+    <->
+      ∀ x : M, phi.Realize
+        (Sum.elim v (fun fv => match fv with | .fv1 => x))
+  :=
+by
+  unfold Formula.Realize
+  conv =>
+    lhs
+    peel_iAlls' 1
+    -- unfold IsEnum.toIdx instIsEnumVars1; dsimp only
+  -- conv =>
+  --   rhs; rhs; arg 2; arg 2; intro; dsimp only
+  constructor <;>
+    (
+      intro h a;
+      specialize h a;
+      convert h;
+      funext;
+      rename_i x;
+      cases x;
+    ) <;>
+    simp [Fin.snoc]
+
+
+@[delta0_simps]
+lemma realize_iAlls'.Vars2 (phi : L.Formula (a ⊕ Vars2 n1 n2)) {v : a -> M}
+  : phi.iAlls'.Realize v
+    <->
+      ∀ x y : M, phi.Realize
+        (Sum.elim v (fun fv => match fv with | .fv1 => x | .fv2 => y))
+  :=
+by
+  unfold Formula.Realize
+  conv =>
+    lhs
+    peel_iAlls' 2
+
+  constructor <;>
+    intro h x y <;>
+    specialize h x y <;>
+    convert h <;>
+    funext z <;>
+    cases z with
+    | inl z => simp
+    | inr z => cases z <;> simp [Fin.snoc, IsEnum.toIdx.Vars2]
+
+@[delta0_simps]
+lemma realize_iAlls'.Vars3 (phi : L.Formula (a ⊕ Vars3 n1 n2 n3)) {v : a -> M}
+  : phi.iAlls'.Realize v
+    <->
+      ∀ x y z : M, phi.Realize
+        (Sum.elim v (fun fv => match fv with | .fv1 => x | .fv2 => y | .fv3 => z))
+  :=
+by
+  unfold Formula.Realize
+  conv =>
+    lhs
+    peel_iAlls' 3
+
+  constructor <;>
+    intro h x y z <;>
+    specialize h x y z <;>
+    convert h <;>
+    funext w <;>
+    cases w with
+    | inl w => simp
+    | inr w => cases w <;> simp [Fin.snoc, IsEnum.toIdx.Vars3]
+
+@[delta0_simps]
+lemma realize_iExs'.Vars1 (phi : L.Formula (a ⊕ Vars1 n1) ) {v : a -> M}
+  : phi.iExs'.Realize v
+    <->
+      ∃ x : M, phi.Realize
+        (Sum.elim v (fun fv => match fv with | .fv1 => x))
+  :=
+by
+  unfold Formula.Realize
+  conv =>
+    lhs
+    peel_iExs' 1
+  constructor <;>
+    (
+      intro h;
+      obtain ⟨x, hx⟩ := h;
+      exists x
+      convert hx
+      funext
+      rename_i x
+    )
+  · cases x
+    · simp only [Sum.elim_inl, Nat.add_zero, Nat.succ_eq_add_one, Nat.reduceAdd, Fin.castAdd_zero,
+      Fin.cast_refl, Function.comp_id, Function.comp_apply, Sum.map_inl, id_eq]
+    · simp only [Sum.elim_inr, instIsEnumVars1.eq_1, Fin.isValue, IsEnum.size.Vars1, Nat.add_zero,
+      Nat.succ_eq_add_one, Nat.reduceAdd, Fin.castAdd_zero, Fin.cast_refl, Function.comp_id,
+      Function.comp_apply, Sum.map_inr]
+      simp only [Fin.snoc, Nat.reduceAdd, Fin.isValue, Fin.val_eq_zero, lt_self_iff_false,
+        ↓reduceDIte, Fin.reduceLast, cast_eq]
+  · cases x;
+    · simp only [Sum.elim_inl, instIsEnumVars1.eq_1, Fin.isValue, IsEnum.size.Vars1, Nat.add_zero,
+        Nat.succ_eq_add_one, Nat.reduceAdd, Fin.castAdd_zero, Fin.cast_refl, Function.comp_id,
+        Function.comp_apply, Sum.map_inl, id_eq]
+    · simp only [Sum.elim_inr, instIsEnumVars1.eq_1, Fin.isValue, IsEnum.size.Vars1, Nat.add_zero,
+      Nat.succ_eq_add_one, Nat.reduceAdd, Fin.castAdd_zero, Fin.cast_refl, Function.comp_id,
+      Function.comp_apply, Sum.map_inr, Fin.snoc, Fin.val_eq_zero, lt_self_iff_false, ↓reduceDIte,
+      Fin.reduceLast, cast_eq]
+
+
+
+section zambella
+
+universe u
+variable {num str : Type u} [ZambellaModel num str]
+open ZambellaModel
+
+@[delta0_simps]
+theorem _root_.FirstOrder.Term.realize_isnum {a : Type} {t : zambella.Term (a ⊕ Fin 0)} {v : a -> (num ⊕ str)}:
+    t.IsNum.Realize v
+    <-> (t.realize (Sum.elim v Fin.elim0)).isLeft := ax_realize_isnum
+
+@[delta0_simps]
+theorem _root_.FirstOrder.Term.realize_isstr {a : Type} {t : zambella.Term (a ⊕ Fin 0)} {v : a -> (num ⊕ str)}:
+    t.IsStr.Realize v
+    <-> (t.realize (Sum.elim v Fin.elim0)).isRight := ax_realize_isstr
+
+
+-- @[delta0_simps]
+-- lemma realize_IsNum (phi : zambella.Formula a) {v : a -> (num ⊕ str)}
+--   : (Formula.IsNum phi).Realize v
+--     <->
+--     phi.Realize (v ∘ Sum.inl)
+--   :=
+-- by
+--   unfold Formula.Realize
+--   unfold Formula.mkInl
+--   rw [realize_relabelEquiv]
+--   dsimp only [Equiv.coe_fn_mk]
+--   exact Eq.to_iff rfl
+
+
+-- @[delta0_simps]
+-- theorem realize_isstr {a : Type} {v : a -> (num ⊕ str)} {t : zambella.Term (a ⊕ Fin 0)} :
+--     (IsStr t).Realize v
+--     <-> (t.realize (Sum.elim v Fin.elim0)).isRight := ax_realize_isstr
+
+@[delta0_simps]
+theorem _root_.FirstOrder.Term.realize_in {a : Type} {n}
+    {t1 t2 : zambella.Term (a ⊕ Fin n)}
+    {v : a -> (num ⊕ str)}
+    {xs : Fin n -> (num ⊕ str)}:
+    (Term.in t1 t2).Realize v xs
+    <-> (t1.realize (Sum.elim v xs)) ∈ (t2.realize (Sum.elim v xs)) := ax_realize_in
+
+@[delta0_simps]
+theorem realize_in {a : Type}
+  {t1 t2 : zambella.Term (a ⊕ Fin 0)}
+  {v : a -> (num ⊕ str)}:
+  Formula.Realize (Term.in t1 t2) v
+  <-> (t1.realize (Sum.elim v default)) ∈ (t2.realize (Sum.elim v default))
+  :=
+by
+  unfold Formula.Realize
+  rw [Term.realize_in]
+
+@[delta0_simps]
+theorem realize_notin {a : Type}
+    {t1 t2 : zambella.Term (a ⊕ Fin 0)}
+    {v : a -> (num ⊕ str)}
+    {xs : Fin 0 -> (num ⊕ str)}:
+    (Term.notin t1 t2).Realize v xs
+    <-> (t1.realize (Sum.elim v default)) ∉ (t2.realize (Sum.elim v default))
+    := by
+    unfold Term.notin
+    conv =>
+      lhs;
+      unfold Formula.Realize
+      rw [Formula.boundedFormula_realize_eq_realize]
+      rw [realize_not]
+    conv =>
+      rhs
+      unfold Not
+    unfold Formula.Realize
+    rw [Term.realize_in]
+
+
+end zambella
+
+
+
+
+section IsOrdered
+variable {M : Type*}
+
+-- @[irreducible] def iBdEx' {α n} (bdTerm : L.Term (α ⊕ Fin 0)) (φ : L.Formula (α ⊕ (Vars1 n))) : L.Formula α :=
+--   let bd := (var (.inl (Sum.inr (.fv1)))).le $ bdTerm.relabel (Sum.map .inl id)
+--   iExs' $ bd ⊓ φ
+@[delta0_simps]
+theorem realize_iBdEx' [peano.Structure M] {t : peano.Term (a ⊕ Fin 0)} (phi : peano.Formula (a ⊕ Vars1 n1)) {v : a -> M}
+  : (iBdEx' t phi).Realize v
+    <->
+    ∃ x : M, (x <= (t.realize (Sum.elim v Fin.elim0)) ∧ phi.Realize (Sum.elim v (fun _ => x))) :=
+by
+  unfold iBdEx'
+  rw [realize_iExs'.Vars1]
+  conv =>
+    lhs; rhs; intro;
+    rw [realize_inf]
+    conv =>
+      lhs;
+      change BoundedFormula.Realize _ _ _
+      rw [Term.realize_le]
+      simp only [peano.instLEOfStructure, Term.realize_var, Sum.elim_inl, Sum.elim_inr,
+        Term.realize_relabel]
+    conv =>
+      rhs;
+      simp only
+
+  conv =>
+    rhs
+    rhs; intro;
+    lhs;
+
+  -- The below was finished by `gpt-5.3-codex medium`.
+
+  unfold Formula.Realize
+  constructor
+  · intro h
+    rcases h with ⟨x, hx⟩
+    rcases hx with ⟨hxle, hphi⟩
+    have henv :
+        ((Sum.elim (Sum.elim v (fun _ : Vars1 n1 => x)) (default : Fin 0 → M))
+          ∘ (Sum.map (Sum.inl : a → a ⊕ Vars1 n1) (id : Fin 0 → Fin 0))) = Sum.elim v Fin.elim0 := by
+      funext y
+      cases y with
+      | inl y => simp
+      | inr y => exact Fin.elim0 y
+    refine ⟨x, ?_, hphi⟩
+    simpa only [peano.instLEOfStructure, Sum.elim_inl, Sum.elim_inr, Term.realize_relabel,
+      Sum.elim_map, henv] using hxle
+  · intro h
+    rcases h with ⟨x, hxle, hphi⟩
+    have henv :
+        ((Sum.elim (Sum.elim v (fun _ : Vars1 n1 => x)) (default : Fin 0 → M))
+          ∘ (Sum.map (Sum.inl : a → a ⊕ Vars1 n1) (id : Fin 0 → Fin 0))) = Sum.elim v Fin.elim0 := by
+      funext y
+      cases y with
+      | inl y => simp
+      | inr y => exact Fin.elim0 y
+    refine ⟨x, ⟨?_, hphi⟩⟩
+    simpa only [peano.instLEOfStructure, Sum.elim_inl, Sum.elim_inr, Term.realize_relabel,
+      Sum.elim_map, henv] using hxle
+
+@[delta0_simps]
+lemma realize_iBdAll'.Vars1
+  {num str}
+  [inst1 : ZambellaModel num str]
+  (phi : zambella.Formula (a ⊕ Vars1 n1) )
+  {t : zambella.Term (a ⊕ Fin 0)}
+  {v : a -> (num ⊕ str)}
+  : (phi.iBdAll' t).Realize v
+    <->
+      ∀ x : (num ⊕ str),
+      x <= (t.realize (Sum.elim v default))
+      -> phi.Realize
+        (Sum.elim v (fun fv => match fv with | .fv1 => x))
+  :=
+by
+  unfold iBdAll'
+  rw [realize_iAlls'.Vars1]
+  conv =>
+    lhs; ext;
+    rw [realize_imp]
+    unfold Formula.Realize
+    rw [Term.realize_le]
+    simp only [Term.realize_var, Sum.elim_inl, Sum.elim_inr, Term.realize_relabel]
+    conv =>
+      left; right; arg 1
+      unfold Function.comp; intro
+      rw [Sum.elim_map]
+      simp only [Sum.elim_comp_inl, Function.comp_id]
+  conv =>
+    rhs; ext
+    simp only
+  unfold Formula.Realize
+  exact Lex.forall
+
+
+@[delta0_simps]
+lemma realize_iBdAllLt'.Vars1 [IsOrdered L] [L.Structure M] [Preorder M] [h : L.OrderedStructure M]
+  (phi : L.Formula (a ⊕ Vars1 n1) )
+  {t : L.Term (a ⊕ Fin 0)}
+  {v : a -> M}
+  : (phi.iBdAllLt' t).Realize v
+    <->
+      ∀ x : M, x < (t.realize (Sum.elim v default)) -> phi.Realize
+        (Sum.elim v (fun fv => match fv with | .fv1 => x))
+  :=
+by
+  unfold iBdAllLt'
+  rw [realize_iAlls'.Vars1]
+  conv =>
+    lhs; ext;
+    rw [realize_imp]
+    unfold Formula.Realize
+    rw [Term.realize_lt]
+    simp only [Term.realize_var, Sum.elim_inl, Sum.elim_inr, Term.realize_relabel]
+    conv =>
+      left; right; arg 1
+      unfold Function.comp; intro
+      rw [Sum.elim_map]
+      simp only [Sum.elim_comp_inl, Function.comp_id]
+  conv =>
+    rhs; ext
+    simp only
+  unfold Formula.Realize
+  exact Lex.forall
+
+@[delta0_simps]
+lemma realize_iBdAllNum'.Vars1
+  {num str}
+  [inst1 : ZambellaModel num str]
+  (phi : zambella.Formula (a ⊕ Vars1 n1) )
+  {t : zambella.Term (a ⊕ Fin 0)}
+  {v : a -> (num ⊕ str)}
+  : (phi.iBdAllNum' t).Realize v
+    <->
+      ∀ x : (num ⊕ str),
+      x <= (t.realize (Sum.elim v default))
+      -> x.isLeft
+      -> phi.Realize
+        (Sum.elim v (fun fv => match fv with | .fv1 => x))
+  :=
+by
+  unfold iBdAllNum'
+  rw [realize_iBdAll'.Vars1]
+
+  conv =>
+    lhs; ext; rhs;
+    rw [realize_imp]
+    conv =>
+      lhs
+      rw [Term.realize_isnum]
+      simp only [Term.realize_var, Sum.elim_inl, Sum.elim_inr]
+
+-- @[delta0_simps]
+-- lemma realize_iBdAllNumLt'.Vars1
+--   {num str}
+--   [inst1 : ZambellaModel num str]
+--   (phi : zambella.Formula (a ⊕ Vars1 n1) )
+--   {t : zambella.Term (a ⊕ Fin 0)}
+--   {v : a -> (num ⊕ str)}
+--   : (phi.iBdAllNumLt' t).Realize v
+--     <->
+--       ∀ x : (num ⊕ str),
+--       x < (t.realize (Sum.elim v default))
+--       -> x.isLeft
+--       -> phi.Realize
+--         (Sum.elim v (fun fv => match fv with | .fv1 => x))
+--   :=
+-- by
+--   unfold iBdAllNumLt'
+--   rw [realize_iBdAllLt'.Vars1]
+
+--   conv =>
+--     lhs; ext; rhs;
+--     rw [realize_imp]
+--     conv =>
+--       lhs
+--       rw [Term.realize_isnum]
+--       simp only [Term.realize_var, Sum.elim_inl, Sum.elim_inr]
+
+end IsOrdered
+
+
+
+end Formula
+end FirstOrder.Language

--- a/LeanPool/FormalizationOfBoundedArithmetic/SimpRules.lean
+++ b/LeanPool/FormalizationOfBoundedArithmetic/SimpRules.lean
@@ -1,0 +1,16 @@
+/-
+Copyright (c) 2026 Mary Jane. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mary Jane
+-/
+
+import LeanPool.FormalizationOfBoundedArithmetic.MathlibSimps
+
+attribute [delta0_simps]
+  Sum.elim_inl
+  Sum.elim_inr
+  Sum.swap_inl
+  Sum.swap_inr
+  Function.comp_apply
+  and_self
+  not_true_eq_false

--- a/LeanPool/FormalizationOfBoundedArithmetic/Syntax.lean
+++ b/LeanPool/FormalizationOfBoundedArithmetic/Syntax.lean
@@ -1,0 +1,244 @@
+/-
+Copyright (c) 2026 Mary Jane. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mary Jane
+-/
+
+import Mathlib.ModelTheory.Syntax
+
+import LeanPool.FormalizationOfBoundedArithmetic.IsEnum
+
+namespace FirstOrder
+namespace Language
+
+universe u
+variable {L : Language}
+variable {α β : Type u} {n : Nat}
+
+namespace BoundedFormula
+
+-- Computable version of: `iSup`
+def iSup' [enum : IsEnum β] (f : β → L.BoundedFormula α n) : L.BoundedFormula α n :=
+  (enum.toList.map f).foldr (· ⊔ ·) ⊥
+
+-- Computable version of: `iInf`
+def iInf' [enum : IsEnum β] (f : β → L.BoundedFormula α n) : L.BoundedFormula α n :=
+  (enum.toList.map f).foldr (· ⊓ ·) ⊤
+
+end BoundedFormula
+
+namespace Formula
+
+-- Computable version of: `iAlls f φ`
+def iAlls' [enum : IsEnum β] (φ : L.Formula (α ⊕ β)) : L.Formula α :=
+  (BoundedFormula.relabel (fun a => Sum.map id enum.toIdx a) φ).alls
+
+-- Computable version of: `iExs f φ`
+def iExs' [enum : IsEnum β] (φ : L.Formula (α ⊕ β)) : L.Formula α :=
+  (BoundedFormula.relabel (fun a => Sum.map id enum.toIdx a) φ).exs
+
+-- Computable version of: `iExsUnique f φ`
+def iExsUnique' [enum : IsEnum β] (φ : L.Formula (α ⊕ β)) : L.Formula α :=
+  iExs' <| φ ⊓ iAlls'
+    ((φ.relabel (fun a => Sum.elim (.inl ∘ .inl) .inr a)).imp <|
+      .iInf' fun g => Term.equal (var (.inr g)) (var (.inl (.inr g))))
+
+-- Computable version of: iSup
+def iSup' [enum : IsEnum α] (f : α → L.Formula β) : L.Formula β :=
+  BoundedFormula.iSup' f
+
+-- Computable version of: iInf
+def iInf' [enum : IsEnum α] (f : α → L.Formula β) : L.Formula β :=
+  BoundedFormula.iInf' f
+
+end Formula
+
+
+namespace BoundedFormula
+
+
+namespace relabelEquiv
+
+@[simp]
+theorem falsum {α β} (g : α ≃ β) {k} :
+    (falsum : L.BoundedFormula α k).relabelEquiv g = falsum :=
+  rfl
+
+@[simp]
+theorem imp {α β} (g : α ≃ β) {k} (φ ψ : L.BoundedFormula α k) :
+    (φ.imp ψ).relabelEquiv g = (φ.relabelEquiv g).imp (ψ.relabelEquiv g) :=
+  rfl
+
+@[simp]
+theorem nf {α β}(g : α ≃ β) {k} (φ ψ : L.BoundedFormula α k) :
+    (φ ⊓ ψ).relabelEquiv g = (φ.relabelEquiv g) ⊓ (ψ.relabelEquiv g) :=
+  rfl
+
+@[simp]
+theorem sup {α β} (g : α ≃ β) {k} (φ ψ : L.BoundedFormula α k) :
+    (φ ⊔ ψ).relabelEquiv g = (φ.relabelEquiv g) ⊔ (ψ.relabelEquiv g) :=
+  rfl
+
+@[simp]
+theorem rel {L : Language} {a b} {n} (g : a ≃ b) {k} {R : L.Relations k} {ts : Fin k -> L.Term (a ⊕ Fin n)}
+  : ((BoundedFormula.rel R ts).relabelEquiv g : L.BoundedFormula b n) = (BoundedFormula.rel R (fun i => ((ts i).relabel (Sum.map g id : a ⊕ Fin n -> b ⊕ Fin n))) : L.BoundedFormula b n) :=
+by
+  rfl
+
+@[simp]
+theorem eq {L : Language} {a b} {n} (g : a ≃ b) {t1 t2 : L.Term (a ⊕ Fin n)}
+  : ((t1 =' t2).relabelEquiv g : L.BoundedFormula b n)
+    =
+      (
+        (  t1.relabel (Sum.map g id : a ⊕ Fin n -> b ⊕ Fin n)
+        =' t2.relabel (Sum.map g id : a ⊕ Fin n -> b ⊕ Fin n)
+        ) : L.BoundedFormula b n
+      ) :=
+by
+  rfl
+
+@[simp]
+theorem bdEqual {L : Language} {a b} {n} (g : a ≃ b) {t1 t2 : L.Term (a ⊕ Fin n)}
+  : ((t1 =' t2).relabelEquiv g)
+    =
+    (t1.relabel (Sum.map g id)) =' (t2.relabel (Sum.map g id)) :=
+by
+  rfl
+
+-- TODO: this was very hard to prove. simp sets of Equiv and of mapTermRel are bad.
+theorem comp_inv {L : Language} {α β} {m} {φ : L.BoundedFormula α m} (f : α ≃ β)
+  : (relabelEquiv f.symm ((relabelEquiv f) φ)) = φ :=
+by
+  unfold relabelEquiv mapTermRelEquiv
+  dsimp only [Equiv.coe_refl, Equiv.coe_fn_mk]
+  rw [mapTermRel_mapTermRel]
+  unfold Function.comp
+  unfold Equiv.sumCongr
+  simp only [Equiv.coe_refl, _root_.Equiv.symm_symm, Equiv.refl_symm, Term.relabelEquiv_apply,
+    Equiv.coe_fn_mk, Term.relabel_relabel, Sum.map_comp_map, _root_.Equiv.symm_comp_self,
+    Function.comp_id, Sum.map_id_id, Term.relabel_id_eq_id, id_eq]
+  apply mapTermRel_id_id_id
+
+end relabelEquiv
+
+namespace relabel
+
+@[simp]
+theorem sup {L : Language} {α β} {n} (g : α → β ⊕ (Fin n)) {k} (φ ψ : L.BoundedFormula α k) :
+    (φ ⊔ ψ).relabel g = (φ.relabel g) ⊔ (ψ.relabel g) :=
+  rfl
+
+@[simp]
+theorem inf {L : Language} {α β} {n} (g : α → β ⊕ (Fin n)) {k} (φ ψ : L.BoundedFormula α k) :
+    (φ ⊓ ψ).relabel g = (φ.relabel g) ⊓ (ψ.relabel g) :=
+  rfl
+
+end relabel
+
+namespace relabelEquiv
+
+@[simp]
+theorem all {α β} (g : α ≃ β) {k} (φ : L.BoundedFormula α (k + 1)) :
+    φ.all.relabelEquiv g = (φ.relabelEquiv g).all := by
+  rw [relabelEquiv]
+  rw [mapTermRelEquiv]
+  rw [relabelEquiv]
+  rw [mapTermRelEquiv]
+  simp only [Equiv.coe_refl, Equiv.refl_symm, Equiv.coe_fn_mk]
+  conv => lhs; unfold mapTermRel
+  simp
+
+@[simp]
+theorem ex {α β} (g : α ≃ β) {k} (φ : L.BoundedFormula α (k + 1)) :
+    φ.ex.relabelEquiv g = (φ.relabelEquiv g).ex := by
+  simp only [BoundedFormula.ex, BoundedFormula.not]
+  simp only [relabelEquiv.imp, all, imp.injEq, all.injEq, true_and, Bot.bot]
+  constructor
+  · simp only [relabelEquiv.falsum]
+  · simp only [relabelEquiv.falsum]
+
+
+@[simp]
+theorem alls {α β} (g : α ≃ β) {k} (φ : L.BoundedFormula α k) :
+    φ.alls.relabelEquiv g = (φ.relabelEquiv g).alls := by
+  induction k with
+  | zero =>
+    unfold BoundedFormula.alls
+    simp only
+  | succ m ih =>
+    apply ih
+
+
+@[simp]
+theorem exs {α β} (g : α ≃ β) {k} (φ : L.BoundedFormula α k) :
+    φ.exs.relabelEquiv g = (φ.relabelEquiv g).exs := by
+  induction k with
+  | zero =>
+    unfold BoundedFormula.exs
+    simp only
+  | succ m ih =>
+    apply ih
+
+theorem relabel_relabelEquiv_enum {L : Language} {α β γ : Type u} [IsEnum β]
+    (g : α ≃ γ) {m : Nat} (φ : L.BoundedFormula (α ⊕ β) m) :
+    BoundedFormula.relabelEquiv g (BoundedFormula.relabel (fun a => Sum.map id IsEnum.toIdx a) φ) =
+      BoundedFormula.relabel (fun a => Sum.map id IsEnum.toIdx a)
+        (BoundedFormula.relabelEquiv (g.sumCongr (_root_.Equiv.refl β)) φ) := by
+  have hfun : ∀ n,
+      (⇑(g.sumCongr (_root_.Equiv.refl (Fin (IsEnum.size β + n)))) ∘
+          BoundedFormula.relabelAux (fun a : α ⊕ β => Sum.map id IsEnum.toIdx a) n) =
+        (BoundedFormula.relabelAux (fun a : γ ⊕ β => Sum.map id IsEnum.toIdx a) n ∘
+          ⇑((g.sumCongr (_root_.Equiv.refl β)).sumCongr (_root_.Equiv.refl (Fin n)))) := by
+    intro n
+    funext x
+    rcases x with (a | b) | i <;> simp [BoundedFormula.relabelAux, Equiv.sumCongr]
+  induction φ with
+  | falsum => rfl
+  | equal t1 t2 =>
+      simp [BoundedFormula.relabel, BoundedFormula.relabelEquiv,
+        BoundedFormula.mapTermRelEquiv, BoundedFormula.mapTermRel, Term.relabel_relabel, hfun]
+  | rel R ts =>
+      simp [BoundedFormula.relabel, BoundedFormula.relabelEquiv,
+        BoundedFormula.mapTermRelEquiv, BoundedFormula.mapTermRel, Term.relabel_relabel, hfun]
+  | imp φ ψ ihφ ihψ =>
+      simp [BoundedFormula.relabel, BoundedFormula.relabelEquiv,
+        BoundedFormula.mapTermRelEquiv, BoundedFormula.mapTermRel]
+      constructor
+      · exact ihφ
+      · exact ihψ
+  | all φ ih =>
+      simp [BoundedFormula.relabel, BoundedFormula.relabelEquiv,
+        BoundedFormula.mapTermRelEquiv, BoundedFormula.mapTermRel]
+      exact ih
+
+@[simp]
+theorem iExs' {α β γ} [IsEnum β] (g : α ≃ γ) (φ : L.Formula (α ⊕ β)) :
+    BoundedFormula.relabelEquiv g (φ.iExs')
+    = Formula.iExs' (φ.relabelEquiv (Equiv.sumCongr g (_root_.Equiv.refl β))) :=
+by
+  unfold Formula.iExs'
+  rw [exs]
+  exact congrArg BoundedFormula.exs (relabel_relabelEquiv_enum g φ)
+
+@[simp]
+theorem iAlls' {α β γ} [IsEnum β] (g : α ≃ γ) (φ : L.Formula (α ⊕ β)) :
+    BoundedFormula.relabelEquiv g (φ.iAlls')
+    = Formula.iAlls' (φ.relabelEquiv (Equiv.sumCongr g (_root_.Equiv.refl β))) :=
+by
+  unfold Formula.iAlls'
+  rw [alls]
+  exact congrArg BoundedFormula.alls (relabel_relabelEquiv_enum g φ)
+
+@[simp]
+theorem inf {L : Language} {α β} (g : α ≃ β) {k} (φ ψ : L.BoundedFormula α k) :
+    (φ ⊓ ψ).relabelEquiv g = (φ.relabelEquiv g) ⊓ (ψ.relabelEquiv g) :=
+  rfl
+
+
+end relabelEquiv
+
+end BoundedFormula
+
+end Language
+
+end FirstOrder


### PR DESCRIPTION
Imported from https://github.com/ruplet/formalization-of-bounded-arithmetic.

**Slug:** `formalization-of-bounded-arithmetic`
**Toolchain target:** `leanprover/lean4:v4.30.0-rc2`
**Branch:** `import/formalization-of-bounded-arithmetic` (auto-generated by `scripts/import-formalization.sh`)
**Agent:** `codex` using `gpt-5.5` at effort `xhigh`, exited with code `143`.

**Commits on this branch:**
- 3305469 WIP: agent partial progress on formalization-of-bounded-arithmetic import

---
_Opened automatically by `scripts/import-formalization.sh`. Review the diff carefully before merging — the agent ran unattended._
