### PR TITLE
Import hyper-lean formalization

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -164,6 +164,8 @@ import LeanPool.GrothendieckVanishing.PresheafFilteredColimitCore
 import LeanPool.GrothendieckVanishing.PresheafFilteredColimitGeneral
 import LeanPool.GrothendieckVanishing.TopologicalKrullDim
 import LeanPool.GrothendieckVanishing.ZeroOutside
+import LeanPool.HyperLean
+import LeanPool.HyperLean.HyperLaurent
 import LeanPool.Isoperimetric
 import LeanPool.Isoperimetric.Basic
 import LeanPool.Isoperimetric.BrunnMinkowski

--- a/LeanPool/HyperLean.lean
+++ b/LeanPool/HyperLean.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2026 Pannous. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Pannous
+-/
+
+import LeanPool.HyperLean.HyperLaurent
+
+/-!
+# Hyperreal numbers via Laurent series
+
+Source: url:https://github.com/pannous/hyper-lean
+Authors: Pannous
+Status: verified
+Main declarations: `LeanPool.HyperLean.omega_mul_epsilon`
+Tags: hyperreal-numbers, nonstandard-analysis, laurent-series
+MSC: 26E35, 12J25
+-/

--- a/LeanPool/HyperLean/HyperLaurent.lean
+++ b/LeanPool/HyperLean/HyperLaurent.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2026 Pannous. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Pannous
+-/
+
+import Mathlib.RingTheory.HahnSeries.Lex
+import Mathlib.RingTheory.HahnSeries.Summable
+import Mathlib.RingTheory.LaurentSeries
+import Mathlib.Tactic.Ring
+
+/-!
+# Laurent-Series Hyperreals
+
+This module vendors the constructive Laurent-series core of `pannous/hyper-lean`.
+It models a hyperreal-like ordered field as lexicographically ordered Laurent
+series over `ℝ`, with `epsilon` at exponent `1` and `omega` at exponent `-1`.
+-/
+
+open HahnSeries
+
+namespace LeanPool.HyperLean
+
+/-- Laurent series over `ℝ` with `ℤ`-indexed coefficients. -/
+abbrev LaurentHyperrealRing := LaurentSeries ℝ
+
+/-- Hyperreal-like ordered field: Laurent series with lexicographic order. -/
+abbrev LaurentHyperreal := Lex LaurentHyperrealRing
+
+noncomputable instance : Field LaurentHyperreal := inferInstance
+
+noncomputable instance instLaurentHyperrealLinearOrder : LinearOrder LaurentHyperreal :=
+  inferInstanceAs (LinearOrder (Lex (HahnSeries ℤ ℝ)))
+
+/-- The canonical infinitesimal, with coefficient `1` at exponent `1`. -/
+noncomputable def epsilon : LaurentHyperreal :=
+  toLex (single (1 : ℤ) (1 : ℝ))
+
+/-- The canonical infinite element, with coefficient `1` at exponent `-1`. -/
+noncomputable def omega : LaurentHyperreal :=
+  toLex (single (-1 : ℤ) (1 : ℝ))
+
+/-- Embed `ℝ` as Laurent series supported at exponent `0`. -/
+noncomputable def embedReal (r : ℝ) : LaurentHyperreal :=
+  toLex (single (0 : ℤ) r)
+
+/-- The standard part: the coefficient at exponent `0`. -/
+noncomputable def standardPart (x : LaurentHyperreal) : ℝ :=
+  (ofLex x : LaurentHyperrealRing).coeff 0
+
+/-- The fundamental gauging relation `omega * epsilon = 1`. -/
+theorem omega_mul_epsilon : omega * epsilon = 1 := by
+  change toLex (single (-1 : ℤ) (1 : ℝ) * single 1 1) = 1
+  rw [single_mul_single, show (-1 : ℤ) + 1 = 0 by norm_num, one_mul, single_zero_one]
+  rfl
+
+/-- The commuted fundamental gauging relation `epsilon * omega = 1`. -/
+theorem epsilon_mul_omega : epsilon * omega = 1 := by
+  rw [mul_comm]
+  exact omega_mul_epsilon
+
+/-- The inverse of `1 + epsilon` exists in the Laurent-series field. -/
+theorem one_add_epsilon_ne_zero : (1 : LaurentHyperreal) + epsilon ≠ 0 := by
+  intro h
+  have : (ofLex (1 + epsilon : LaurentHyperreal) : LaurentHyperrealRing).coeff 0 = 0 := by
+    simp [h]
+  simp [epsilon, coeff_one] at this
+
+/-- `(1 + epsilon)⁻¹` is an exact field inverse in Laurent series. -/
+theorem one_add_epsilon_mul_inv : (1 + epsilon) * (1 + epsilon)⁻¹ = (1 : LaurentHyperreal) :=
+  mul_inv_cancel₀ one_add_epsilon_ne_zero
+
+/-- Standard part respects the real embedding. -/
+theorem standardPart_embedReal (r : ℝ) : standardPart (embedReal r) = r := by
+  simp [standardPart, embedReal, coeff_single_same]
+
+/-- The standard part of `epsilon` is zero. -/
+@[simp]
+theorem standardPart_epsilon : standardPart epsilon = 0 := by
+  simp [standardPart, epsilon]
+
+/-- `epsilon` is positive in the lexicographic order. -/
+theorem epsilon_pos : (0 : LaurentHyperreal) < epsilon := by
+  change (0 : Lex (HahnSeries ℤ ℝ)) < toLex (single (1 : ℤ) (1 : ℝ))
+  rw [HahnSeries.lt_iff]
+  exact ⟨1,
+    fun j hj => by simp [coeff_single_of_ne (ne_of_lt hj)],
+    by simp [coeff_single_same]⟩
+
+/-- `epsilon` is smaller than every positive embedded real. -/
+theorem epsilon_lt_embedReal (r : ℝ) (hr : 0 < r) : epsilon < embedReal r := by
+  change toLex (single (1 : ℤ) (1 : ℝ)) < toLex (single (0 : ℤ) r)
+  rw [HahnSeries.lt_iff]
+  refine ⟨0, fun j hj => ?_, ?_⟩
+  · simp [coeff_single_of_ne (by omega : j ≠ 1), coeff_single_of_ne (by omega : j ≠ 0)]
+  · simp only [ofLex_toLex, ne_eq, zero_ne_one, not_false_eq_true, coeff_single_of_ne,
+      coeff_single_same]
+    exact hr
+
+end LeanPool.HyperLean

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -444,3 +444,32 @@ projects:
     msc:
       - "11E25"
       - "11H06"
+  - slug: hyper-lean
+    title: Hyperreal numbers via Laurent series
+    summary: Formalizes a Laurent-series model of hyperreal-like numbers with infinitesimal and infinite generators.
+    branch: nonstandard analysis
+    entry_module: LeanPool.HyperLean
+    authors:
+      - Pannous
+    source:
+      url: https://github.com/pannous/hyper-lean
+      github_repo: pannous/hyper-lean
+    status: verified
+    main_declarations:
+      - LeanPool.HyperLean.omega_mul_epsilon
+    main_results:
+      - declaration: LeanPool.HyperLean.omega_mul_epsilon
+        informal: Proves the gauging relation that the infinite generator times the infinitesimal generator is one.
+      - declaration: LeanPool.HyperLean.epsilon_mul_omega
+        informal: Proves the commuted gauging relation for the infinitesimal and infinite generators.
+      - declaration: LeanPool.HyperLean.epsilon_lt_embedReal
+        informal: Proves that the infinitesimal is smaller than every positive embedded real number.
+      - declaration: LeanPool.HyperLean.one_add_epsilon_mul_inv
+        informal: Proves that one plus the infinitesimal has an exact Laurent-series field inverse.
+    tags:
+      - hyperreal-numbers
+      - nonstandard-analysis
+      - laurent-series
+    msc:
+      - "26E35"
+      - "12J25"


### PR DESCRIPTION
Imported from https://github.com/pannous/hyper-lean.

**Slug:** `hyper-lean`
**Toolchain target:** `leanprover/lean4:v4.30.0-rc2`
**Branch:** `import/hyper-lean-retry-20260518-144229` (auto-generated by `scripts/import-formalization.sh`)
**Agent:** `codex` using `gpt-5.5` at effort `xhigh`, exited with code `0`.

**Commits on this branch:**
- cac685b Vendor hyper-lean Laurent model

## Import notes (from agent)

# Import notes for `hyper-lean`

Imported the Laurent-series core from `Hyper/HyperLaurent.lean`. The source is
Apache-2.0 and was ported from Lean 4.27.0 to lean-pool's Lean 4.30.0-rc2
target. Declarations are wrapped in `LeanPool.HyperLean`.

Excluded source files:

- Root-level `test*.lean`, `debug*.lean`, `validate*.lean`, `example_working.lean`,
  `simple_cos.lean`, `cos_issue.lean`, `trace_cos.lean`, `factorials.lean`,
  `fibonacci.lean`, and `check_factorial.lean`: examples, diagnostics, or
  validation scripts with evaluation commands.
- `Hyper/HyperAxioms.lean`, `Hyper/HyperKeisler*.lean`, `Hyper/HyperFacts.lean`,
  and `Hyper/HyperProbability.lean`: abstract sketches relying on unchecked
  assumptions and incomplete proofs.
- `Hyper/HyperGeneralField.lean`: Laurent-polynomial prototype ending with
  incomplete field and ordered-ring instances; these are mathematically replaced
  by the imported Laurent-series construction, where inverses exist.
- `Hyper/HyperList.lean`, `Hyper/HyperQuotient.lean`, `Hyper/HyperFinsuppBAD.lean`,
  `Hyper/HyperFun.lean`, `Hyper/HyperQ.lean`, `Hyper/HyperEasy.lean`, and
  `Hyper/HyperReal.lean`: computational prototypes containing incomplete
  proofs, unchecked equality assumptions, nonterminating definitions, or
  diagnostic commands.
- `Hyper/ProbabilityExamples.lean`, `Hyper/SingletonProbZero.lean`,
  `Hyper/DartPointProbZero.lean`, and `Hyper/StochasticDemo.lean`: standalone
  probability demonstrations rather than the hyperreal construction.

Repair attempts:

- Tested the source `HyperLaurent.lean` against Lean 4.30.0-rc2, built the
  missing Mathlib Hahn/Laurent-series oleans locally, and removed unused simp
  arguments that produced warnings.
- Reviewed the other source modules for forbidden constructs before excluding
  them. The excluded prototypes would require replacing their foundational
  approach, not just repairing changed Mathlib names.

---
_Opened automatically by `scripts/import-formalization.sh`. Review the diff carefully before merging — the agent ran unattended._
