### PR TITLE
Import lean-cwf formalization

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -171,6 +171,12 @@ import LeanPool.Isoperimetric.Isoperimetric
 import LeanPool.Isoperimetric.PrekopaLeindler
 import LeanPool.LatticeTriangle
 import LeanPool.LatticeTriangle.Solution
+import LeanPool.LeanCwf
+import LeanPool.LeanCwf.Basics
+import LeanPool.LeanCwf.Category
+import LeanPool.LeanCwf.Category.Morphism
+import LeanPool.LeanCwf.Fam
+import LeanPool.LeanCwf.Util
 import LeanPool.PartialRegularity
 import LeanPool.PartialRegularity.Extension
 import LeanPool.RamanujanTauMissesPrimes

--- a/LeanPool/LeanCwf.lean
+++ b/LeanPool/LeanCwf.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2026 Joseph Eremondi. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Eremondi
+-/
+
+import LeanPool.LeanCwf.Fam
+import LeanPool.LeanCwf.Basics
+import LeanPool.LeanCwf.Category
+
+/-!
+# Categories with Families
+
+Source: url:https://github.com/JoeyEremondi/lean-cwf
+Authors: Joseph Eremondi
+Status: verified
+Main declarations: `LeanPool.LeanCwf.CwF.Structure`
+Tags: type-theory, category-theory, categories-with-families
+MSC: 03B15, 18D20
+-/
+
+/-!
+## Mathematical overview
+
+This import develops a categorical presentation of categories with families
+(CwFs). It defines families as arrows in `Type`, packages the type-and-term
+presheaf of a CwF, formalizes context extension and its uniqueness laws, and
+develops morphisms of CwFs preserving that structure strictly.
+
+## Provenance
+
+Imported from <https://github.com/JoeyEremondi/lean-cwf>, originally licensed
+under BSD-3-Clause by Joseph Eremondi, and ported to Lean Pool's Lean
+v4.30.0-rc2 / Mathlib v4.30.0-rc2 target.
+-/

--- a/LeanPool/LeanCwf/Basics.lean
+++ b/LeanPool/LeanCwf/Basics.lean
@@ -1,0 +1,333 @@
+/-
+Copyright (c) 2026 Joseph Eremondi. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Eremondi
+-/
+
+import LeanPool.LeanCwf.Fam
+import Mathlib.CategoryTheory.Category.Basic
+import Mathlib.CategoryTheory.Functor.Basic
+import Mathlib.Data.Opposite
+import Mathlib.CategoryTheory.Limits.Shapes.Terminal
+import Mathlib.Logic.Unique
+
+import LeanPool.LeanCwf.Util
+
+namespace LeanPool.LeanCwf
+
+open CategoryTheory
+open Fam
+
+
+
+namespace CwF
+
+universe u v'
+
+
+/--
+The type-and-term presheaf of a category with families, before adding comprehension structure.
+
+Objects of `Ctx` are contexts. The presheaf is valued in `Fam`, so its indices are types over
+a context and its fibers are terms of those types.
+-/
+class TmTy (Ctx : Type u) [Category.{v'} Ctx] : Type (max (u+1) v') where
+  /-- The family-valued presheaf of types and terms. -/
+  tmTyFam : CategoryTheory.Functor Ctxᵒᵖ Fam.{u}
+
+open TmTy
+
+variable {C : Type u} [cat : Category.{v'} C] [tmTy : TmTy.{u, v'} C]
+
+/-- Types over a context. -/
+def Ty (Γ : C) : Type u := ixSet (tmTyFam.obj (Opposite.op Γ))
+
+/-- The contravariant functor of types over contexts. -/
+def TyFunctor : CategoryTheory.Functor Cᵒᵖ (Type u) :=
+  Functor.comp tmTyFam projIx
+
+/-- Terms of a type over a context. -/
+def Tm {Γ : C} (T : Ty Γ) : Type u :=
+  famFor (tmTyFam.obj (Opposite.op Γ)) T
+
+/-- Substitution of a type along a context morphism. -/
+def tySub {Δ Γ : C} (T : Ty Δ) (θ : Γ ⟶ Δ) : Ty Γ :=
+  mapIx (tmTyFam.map θ.op) T
+
+/-- Notation for substitution of a type along a context morphism. -/
+notation:max T "⦃" θ "⦄" => tySub T θ
+
+/-- Substitution of a term along a context morphism. -/
+def tmSub {Γ Δ : C} {T : Ty Δ} (t : Tm T) (θ : Γ ⟶ Δ) : Tm (T⦃θ⦄) :=
+  mapFam (tmTyFam.map θ.op) t
+
+/-- Notation for substitution of a term along a context morphism. -/
+notation:max t "⦃" θ "⦄" => tmSub t θ
+
+/-- Casts a term across an equality of types over the same context. -/
+abbrev castTm {Γ : C} {S T : Ty Γ} (t : Tm T) (eq : S = T) : Tm S :=
+  cast (by aesop) t
+
+/-- Casts a substituted term across an equality of substitutions. -/
+abbrev castTmSub {Γ Δ : C} {f g : Δ ⟶ Γ} {T : Ty Γ} (t : Tm (T⦃f⦄))
+    (eq : f = g) : Tm (T⦃g⦄) :=
+  cast (by aesop) t
+
+/-- Equality of terms modulo the canonical cast between their types. -/
+abbrev eqModCast {Γ : C} {S T : Ty Γ} (s : Tm S) (t : Tm T) (eq : S = T) :
+    Prop :=
+  s = castTm t (by aesop)
+
+/-- Notation for inserting the canonical term cast. -/
+notation:500 "↑ₜ" t => castTm t (by aesop)
+/-- Notation for equality of terms modulo the canonical term cast. -/
+notation:50 s "=ₜ" t => s = (↑ₜ t)
+
+theorem castSymm {Γ : C} {S T : Ty Γ} {s : Tm S} {t : Tm T} {eq : S = T} :
+    (s =ₜ t) ↔ (t =ₜ s) := by
+  constructor <;> aesop
+
+@[simp]
+theorem castSub {Γ Δ : C} {S T : Ty Γ} {t : Tm T} {eq : S = T} {f : Δ ⟶ Γ} :
+    (castTm t eq)⦃f⦄ = castTm (t⦃f⦄) (by aesop) := by aesop
+
+theorem castCast {Γ : C} {S T U : Ty Γ} {t : Tm U} {eq : S = T} {eq2 : T = U} :
+    castTm (castTm t eq2) eq = castTm t (Eq.trans eq eq2) := by aesop
+
+@[simp]
+theorem castEq {Γ : C} {T : Ty Γ} {s t : Tm T} :
+    castTm s rfl = castTm t rfl ↔ s = t := by aesop
+
+theorem castTrans {Γ : C} {S T U : Ty Γ} {s : Tm S} {t : Tm T} {u : Tm U}
+    {eq1 : S = T} {eq2 : T = U} (eqst : s=ₜt) (eqtu : t=ₜu) : s=ₜu := by
+  aesop
+
+@[simp]
+theorem castCastGen {X Y Z : Type u} {x : X} {y : Y} {eq1 : X = Z} {eq2 : Y = Z} :
+    cast eq1 x = cast eq2 y ↔ x = cast (by aesop) y := by aesop
+
+theorem castTyOutOfSub {Γ1 Γ2 : C} {θ : Δ ⟶ Γ1} {T : Ty Γ2} {eq : Γ1 = Γ2} :
+    T⦃cast (α := Δ ⟶ Γ1) (β := Δ ⟶ Γ2) (by rw [eq]) θ⦄ =
+      tySub (cast (by aesop) T) θ := by aesop
+
+@[simp]
+theorem castOutOfSub {Δ Γ1 Γ2 : C} {θ : Δ ⟶ Γ1} {T : Ty Γ2} {t : Tm T}
+    {eq : Γ1 = Γ2} :
+    t⦃cast (α := Δ ⟶ Γ1) (β := Δ ⟶ Γ2) (by rw [eq]) θ⦄ =ₜ
+      castTm
+        (S := tySub T (cast (by rw [eq]) θ)) (T := tySub (cast (by rw [eq]) T) θ)
+        ((cast (by aesop) t)⦃θ⦄)
+        (by aesop) := by aesop
+
+@[simp]
+theorem tySubId {Γ : C} {T : Ty Γ} : T⦃𝟙 Γ⦄ = T := by
+  simp [tySub]
+
+@[simp]
+theorem tySubComp {Γ Δ Ξ : C} {T : Ty Γ} {g : Δ ⟶ Γ} {f : Ξ ⟶ Δ} :
+    (T⦃g⦄)⦃f⦄ = T⦃f ≫ g⦄ := by
+  simp [tySub]
+
+@[simp]
+theorem tmSubId {Γ : C} {T : Ty Γ} (t : Tm T) : (t⦃𝟙 Γ⦄)=ₜt := by
+  simp only [tySub, tmSub]
+  have eq := mapCast t (symm (tmTyFam.map_id (Opposite.op Γ)))
+  aesop_cat
+
+@[simp]
+theorem tmSubComp {Γ Δ Ξ : C} {T : Ty Γ} {f : Δ ⟶ Γ} {g : Ξ ⟶ Δ} {t : Tm T} :
+    ((t⦃f⦄)⦃g⦄)=ₜ(t⦃g ≫ f⦄) := by
+  simp only [tySub, tmSub]
+  have eq := mapCast t (tmTyFam.map_comp f.op g.op)
+  aesop_cat
+
+@[aesop safe apply]
+theorem tmSubComp' {Γ Δ Ξ : C} {T : Ty Γ} {f : Δ ⟶ Γ} {g : Ξ ⟶ Δ} {t : Tm T} :
+    (t⦃g ≫ f⦄)=ₜ((t⦃f⦄)⦃g⦄) := by simp
+
+theorem tySubExt {Γ Δ Ξ : C} {f : Δ ⟶ Γ} {g : Ξ ⟶ Γ} {T : Ty Γ}
+    (ctxEq : Δ = Ξ) (eq : HEq f g) : HEq T⦃f⦄ T⦃g⦄ := by aesop
+
+theorem tmSubCast {Γ Δ : C} {T : Ty Γ} {f g : Δ ⟶ Γ} {t : Tm T} (eq : f = g) :
+    t⦃f⦄ = ↑ₜ t⦃g⦄ := by aesop
+
+theorem tmHeq {Γ Δ : C} {S : Ty Γ} {T : Ty Δ} (eq : Γ = Δ) (heq : HEq S T) :
+    Tm (Γ := Γ) S = Tm T := by aesop
+
+/-- A context isomorphism induces an isomorphism between the corresponding type fibers. -/
+def ctxIsoToType {Γ Δ : C} (iso : Γ ≅ Δ) : Ty Γ ≅ Ty Δ :=
+  Functor.mapIso TyFunctor iso.symm.op
+
+@[simp]
+theorem ctxIsoTypeSubHom {Γ Δ : C} (iso : Γ ≅ Δ) {T : Ty Γ} :
+    (ctxIsoToType iso).hom T = T⦃iso.inv⦄ := by aesop
+
+@[simp]
+theorem ctxIsoTypeSubInv {Γ Δ : C} (iso : Γ ≅ Δ) {T : Ty Δ} :
+    (ctxIsoToType iso).inv T = T⦃iso.hom⦄ := by aesop
+
+
+/-- Context extension operations for a category with families. -/
+class CwFExt (C : Type u) [Category.{v'} C] [tmTy : TmTy C] : Type _ where
+  /-- Extends a context by a type. -/
+  snoc : (Γ : C) → Ty Γ → C
+  /-- The projection from an extended context to its base context. -/
+  p_ : {Γ : C} → (T : Ty Γ) → snoc Γ T ⟶ Γ
+  /-- The variable introduced by extending a context. -/
+  v_ : {Γ : C} → (T : Ty Γ) → Tm (T⦃p_ T⦄ : Ty (snoc Γ T))
+  /-- Extends a substitution with a term for the newly introduced variable. -/
+  ext : {Γ Δ : C} → {T : Ty Γ} → (f : Δ ⟶ Γ) → (t : Tm (T⦃f⦄)) → Δ ⟶ snoc Γ T
+
+
+open CwFExt
+/-- Notation for extending a context by a type. -/
+notation:max Γ:1000 "▹" T:max => snoc Γ T
+/-- Notation for extending a substitution by a term. -/
+notation:max "⟪" θ "," t "⟫" => ext θ t
+
+
+/-- Notation for the projection from an extended context. -/
+notation:max "p" => p_ _
+/-- Notation for the variable of an extended context. -/
+notation:max "v" => v_ _
+
+
+/-- Binds the variable of an extended context into a type expression. -/
+def bindTy {C : Type u} [Category.{v'} C] [tmTy : TmTy C] [CwFExt C]
+  {Γ : C} {S : Ty Γ}
+  (f : Tm S⦃p_ S⦄ → Ty (Γ▹S))
+  : Ty (Γ▹S) := f (v_ S)
+
+/-- Binds the variable of an extended context into a term expression. -/
+def bindTm {C : Type u} [Category.{v'} C] [tmTy : TmTy C] [CwFExt C]
+  {Γ : C} {S : Ty Γ} {T : Ty (Γ▹S)}
+  (f : Tm S⦃p_ S⦄ → Tm T)
+  : Tm T := f (v_ S)
+
+/-- Binds the variable of an extended context into a dependent pair of type and term. -/
+def bindTmTy {C : Type u} [Category.{v'} C] [tmTy : TmTy C] [CwFExt C]
+  {Γ : C} {S : Ty Γ}
+  (f : Tm S⦃p_ S⦄ → ((T : Ty (Γ▹S)) × Tm T)) :
+  Tm (f v).fst := (f v).snd
+
+-- abbrev p (C : Type u) [Category.{v'} C]  [tmTy : TmTy C] [CwFExt C]
+--   {Γ : C} {T : Ty Γ} : snoc Γ T ⟶ Γ := p_ T
+
+-- abbrev v (C : Type u) [Category.{v'} C]  [tmTy : TmTy C] [CwFExt C]
+--   {Γ : C} {T : Ty Γ} : Tm (T⦃p_ T⦄ : Ty (snoc Γ T)) := v_ T
+
+/-- The defining equations for context extension in a category with families. -/
+class CwFProp (C : Type u) [catInst : Category.{v'} C] [tmTy : TmTy C] [cwf : CwFExt C] :
+    Prop where
+  /-- Extending a substitution and then projecting recovers the original substitution. -/
+  ext_p : {Γ Δ : C} → {T : Ty Γ}
+    → {f : Δ ⟶ Γ} → {t : Tm (T⦃f⦄)}
+    → ⟪f , t⟫ ≫ p = f
+
+  /-- A transport helper derived from the projection law. -/
+  ext_pHelper : {Γ Δ : C} → {S : Ty Γ}
+    → {f : Δ ⟶ Γ} → {t : Tm (S⦃f⦄)} → {T : Ty _}
+    → (T⦃p⦄⦃ext f t⦄) = T⦃f⦄ :=
+    fun {_ _} {_} {f} {_} {T} =>
+      of_eq_true
+        ((congrArg (fun x => x = T⦃f⦄)
+          (tySubComp.trans (congrArg (tySub T) ext_p))).trans (eq_self T⦃f⦄))
+
+  /-- Substituting along an extended substitution sends the new variable to the extension term. -/
+  ext_v : {Γ Δ : C} → {T : Ty Γ} → (f : Δ ⟶ Γ) → (t : Tm (T⦃f⦄))
+    → v⦃⟪f,t⟫⦄ = castTm t (ext_pHelper)
+
+  /-- The extension operation is uniquely determined by the projection and variable laws. -/
+  ext_unique : {Γ Δ : C} → {T : Ty Γ} → (f : Δ ⟶ Γ)
+    → (t : Tm T⦃f⦄) → (g : _)
+    → (peq : g ≫ p = f)
+    → (v⦃g⦄ = castTm t (by rw [tySubComp, peq]))
+    → g = ⟪f,t⟫
+
+attribute [simp] CwFProp.ext_p CwFProp.ext_v
+
+open CwFProp
+
+/-- A category with families, including an empty context and context extension. -/
+class Structure (C : Type u) [cat : Category.{v'} C] : Type _ where
+  /-- The empty context. -/
+  empty : C
+  /-- The empty context is terminal. -/
+  emptyTerminal : Limits.IsTerminal empty
+  /-- The type-and-term presheaf. -/
+  [tmTy : TmTy C]
+  /-- Context extension operations. -/
+  [cwfExt : CwFExt C]
+  /-- Context extension equations. -/
+  [cwfProp : CwFProp C]
+
+
+/-- The unique substitution from a context to the empty context. -/
+def wkAll {C : Type u} [Category.{v'} C] [cwf : Structure C] (Γ : C) : Γ ⟶ cwf.empty :=
+  Limits.IsTerminal.from cwf.emptyTerminal Γ
+
+/-- Notation for the empty context. -/
+notation:max "⬝" => Structure.empty
+/-- Notation for the unique substitution to the empty context. -/
+notation:max "⟨⟩" T => wkAll T
+/-- Notation for the inferred unique substitution to the empty context. -/
+notation:max "‼" => wkAll _
+
+attribute [reducible, instance] Structure.tmTy Structure.cwfExt
+attribute [instance] Structure.cwfProp
+
+
+
+-- Version of ext_p that works better with reassociating
+@[simp]
+theorem ext_p_comp {C : Type u} [Category.{v'} C] [cwf : Structure C] {Γ Δ Ξ : C}
+    {T : Ty Γ} {f : Δ ⟶ Γ} {g : Γ ⟶ Ξ} {t : Tm (T⦃f⦄)} :
+    ⟪f , t⟫ ≫ (p ≫ g) = f ≫ g := by simp [<- Category.assoc]
+
+-- Any CwF is a terminal category
+instance (C : Type u) [Category.{v'} C] [Structure C] : Limits.HasTerminal C :=
+  Limits.IsTerminal.hasTerminal Structure.emptyTerminal
+
+--Not sure why this isn't in mathlib
+
+-- All arrows into ⬝ are equal
+theorem toEmptyUnique {C : Type u} [cat : Category.{v'} C] [cwf : Structure C] {Γ : C}
+    {θ : Γ ⟶ ⬝} :
+    θ = ‼ := (Limits.IsTerminal.hom_ext cwf.emptyTerminal ‼ θ).symm
+
+instance {C : Type u} [cat : Category.{v'} C] [cwf : Structure C] {Γ : C}
+  : Unique (Γ ⟶ ⬝) where
+  default := ‼
+  uniq _ := toEmptyUnique
+
+-- Version of the above that works better with simp
+-- Composing with ‼ produces ‼
+theorem toEmptyComp {C : Type u} [cat : Category.{v'} C] [cwf : Structure C] {Γ Δ : C}
+    {θ : Δ ⟶ Γ} :
+    θ ≫ ‼ = ‼ := by
+  exact toEmptyUnique (θ := θ ≫ (‼ : Γ ⟶ ⬝))
+
+
+@[simp]
+theorem toEmptyCompComp {C : Type u} [cat : Category.{v'} C] [cwf : Structure C] {Γ Δ Ξ : C}
+    {θ : Δ ⟶ Γ} {g : ⬝ ⟶ Ξ} :
+    θ ≫ (‼ ≫ g) = ‼ ≫ g := by
+  rw [← Category.assoc, toEmptyComp]
+
+-- Only one self-arrow into empty
+theorem emptySelfUnique {C : Type u} [cat : Category.{v'} C] [cwf : Structure C]
+  : ‼ = 𝟙 (cwf.empty) := by
+  exact (toEmptyUnique (θ := 𝟙 (cwf.empty))).symm
+
+@[simp]
+theorem emptySelfComp {C : Type u} [cat : Category.{v'} C] [cwf : Structure C] {Γ : C} {f : ⬝ ⟶ Γ}
+  : ‼ ≫ f = f := by
+    rw [emptySelfUnique]
+    simp only [Category.id_comp]
+
+attribute [simp] ext_p ext_v
+
+
+end CwF
+
+end LeanPool.LeanCwf

--- a/LeanPool/LeanCwf/Category.lean
+++ b/LeanPool/LeanCwf/Category.lean
@@ -1,0 +1,13 @@
+/-
+Copyright (c) 2026 Joseph Eremondi. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Eremondi
+-/
+
+import LeanPool.LeanCwf.Category.Morphism
+
+/-!
+# Categories of CwFs
+
+Import-only index for the CwF morphism and category construction.
+-/

--- a/LeanPool/LeanCwf/Category/Morphism.lean
+++ b/LeanPool/LeanCwf/Category/Morphism.lean
@@ -1,0 +1,246 @@
+/-
+Copyright (c) 2026 Joseph Eremondi. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Eremondi
+-/
+
+import Mathlib.CategoryTheory.Functor.Basic
+import Mathlib.CategoryTheory.Functor.Category
+import Mathlib.CategoryTheory.NatTrans
+import Mathlib.CategoryTheory.Comma.Over.Basic
+import Mathlib.CategoryTheory.Comma.Basic
+import Mathlib.Data.Opposite
+import Mathlib.CategoryTheory.Limits.Shapes.Terminal
+import Mathlib.Logic.Unique
+import Mathlib.CategoryTheory.Category.Basic
+import Mathlib.CategoryTheory.Types.Basic
+
+
+
+import LeanPool.LeanCwf.Fam
+import LeanPool.LeanCwf.Basics
+import LeanPool.LeanCwf.Util
+
+namespace LeanPool.LeanCwf
+
+open CategoryTheory
+open NatTrans Category Functor
+open Fam
+
+namespace CwF
+
+open TmTy
+open CwFExt
+
+universe u
+
+
+
+/-- A bundled category equipped with a category-with-families structure. -/
+structure CwFCat : Type (u + 1) where
+  /-- The category of contexts. -/
+  Ctx : Type u
+  /-- The category structure on contexts. -/
+  [exCat : Category.{u} Ctx]
+  /-- The category-with-families structure on the context category. -/
+  [exCwF : Structure Ctx]
+
+
+instance : Coe CwFCat (Type _) where
+  coe C := C.Ctx
+
+attribute [instance] CwFCat.exCat CwFCat.exCwF
+
+/-- A morphism of the type-and-term presheaves underlying two CwFs. -/
+structure TmTyMorphism (C D : CwFCat) : Type _ where
+  /-- The functor on context categories. -/
+  CtxF : CategoryTheory.Functor C.Ctx D.Ctx
+  /-- The natural transformation preserving type-and-term presheaves. -/
+  transSubst :
+    NatTrans
+      (tmTyFam (Ctx := C)) --C's functor
+      (Functor.comp (CtxF.op) (tmTyFam (Ctx := D)) ) -- D's functor
+
+
+
+
+
+
+/-- Applies a CwF morphism to a context. -/
+def MapCtx {C D : CwFCat} (F : TmTyMorphism C D) (Γ : C.Ctx) : D.Ctx :=
+  F.CtxF.obj Γ
+
+/-- Applies a CwF morphism to a substitution. -/
+def MapSub {C D : CwFCat} (F : TmTyMorphism C D) {Γ Δ : C.Ctx}
+  (θ : Δ ⟶ Γ) :
+  (MapCtx F Δ) ⟶ (MapCtx F Γ) :=
+  F.CtxF.map θ
+
+@[simp]
+theorem MapSubComp {C D : CwFCat} (F : TmTyMorphism C D) {Γ Δ Ξ : C.Ctx}
+  (f : Ξ ⟶ Δ) (g : Δ ⟶ Γ) :
+  (MapSub F f) ≫ (MapSub F g) = MapSub F (f ≫ g) :=
+    Eq.symm (F.CtxF.map_comp f g)
+
+theorem MapSubId {C D : CwFCat} (F : TmTyMorphism C D) {Γ : C.Ctx} :
+  MapSub F (𝟙 Γ) = 𝟙 (MapCtx F Γ) :=
+    F.CtxF.map_id Γ
+
+/-- Applies a CwF morphism to a type. -/
+def MapTy {C D : CwFCat} (F : TmTyMorphism C D)
+  {Γ : C.Ctx}
+  (T : Ty Γ) :
+  Ty (MapCtx F Γ) := mapIx (F.transSubst.app (Opposite.op Γ)) T
+
+
+/-- Applies a CwF morphism to a term. -/
+def MapTm {C D : CwFCat} (F : TmTyMorphism C D)
+ {Γ : C.Ctx}
+  {T : Ty Γ}
+  (t : Tm T) :
+  Tm (MapTy F T) := mapFam (F.transSubst.app (Opposite.op Γ)) t
+
+@[simp]
+theorem MapTyCommut {C D : CwFCat} (F : TmTyMorphism C D)
+  {Δ Γ : C.Ctx}
+  {T : Ty Γ}
+  {θ : Δ ⟶ Γ} :
+  MapTy F (T⦃θ⦄) = (MapTy F T)⦃MapSub F θ⦄ :=
+    congrFun (congrArg mapIx (F.transSubst.naturality (Opposite.op θ))) T
+
+@[simp]
+theorem MapTmCommut {C D : CwFCat} {F : TmTyMorphism C D}
+  {Δ Γ : C.Ctx}
+  {T : Ty Γ}
+  {t : Tm T}
+  {θ : Δ ⟶ Γ} :
+  MapTm F (t⦃θ⦄) = castTm ((MapTm F t)⦃MapSub F θ⦄) (by rw [MapTyCommut]) := by
+    symm
+    refine eq_cast_of_heq ?_
+    apply Subtype_HExt
+    · exact
+        (by
+          simpa [MapTm, tmSub, MapTy, tySub, mapFam, Arrow.comp_left,
+            ConcreteCategory.comp_apply, MapSub] using
+            (congrFun
+              (congrArg (fun h => h.left) (F.transSubst.naturality (Opposite.op θ)))
+              t.val).symm)
+    · aesop
+
+@[simp]
+theorem CastMapTmCommut {C D : CwFCat} {F : TmTyMorphism C D}
+  {Γ : C.Ctx}
+  {S T : Ty Γ}
+  {eq : S = T}
+  {t : Tm T} :
+  MapTm F (castTm (S := S) t (by rw [eq])) =ₜ MapTm F t := by aesop
+
+
+/-- Preservation of CwF context extension up to isomorphism. -/
+class IsoPreserveCwF {C D : CwFCat} (F : TmTyMorphism C D) : Type _ where
+  /-- The comparison isomorphism for extended contexts. -/
+  snocIso :
+    {Γ : C.Ctx}
+    → {T : Ty Γ}
+    → MapCtx F (Γ ▹ T) ≅ (MapCtx F Γ) ▹ (MapTy F T) := by aesop_cat
+  /-- The projection map is preserved through the comparison isomorphism. -/
+  pPreserve :
+    {Γ : C.Ctx}
+    → {T : Ty Γ}
+    → MapSub F (p_ T)
+      = snocIso.hom ≫ p
+      := by aesop_cat
+  /-- The variable term is preserved through the comparison isomorphism. -/
+  vPreserve :
+    {Γ : C.Ctx}
+    → {T : Ty Γ}
+    → MapTm F (v_ T) =ₜ (v_ (MapTy F T))⦃snocIso.hom⦄ := by aesop_cat
+
+open IsoPreserveCwF
+
+-- attribute [simp] IsoPreserveCwF.snocIso
+-- attribute [simp] IsoPreserveCwF.pPreserve
+attribute [simp] IsoPreserveCwF.vPreserve
+
+
+
+@[aesop safe apply]
+theorem pPreserve' {C D : CwFCat} {F : TmTyMorphism C D} [IsoPreserveCwF F]
+    {Γ : C.Ctx}
+    {T : Ty Γ}
+    : p_ (MapTy F T) =
+        (IsoPreserveCwF.snocIso (F := F) (Γ := Γ) (T := T)).inv ≫ MapSub F (p_ T) := by
+      rw [IsoPreserveCwF.pPreserve (F := F) (Γ := Γ) (T := T)]
+      simp
+
+/-- Strict preservation of CwF context extension by a morphism. -/
+class StrictPreserveCwF {C D : CwFCat} (F : TmTyMorphism C D) : Prop where
+  /-- Extended contexts are preserved definitionally up to equality. -/
+  snocPreserve:
+    {Γ : C.Ctx}
+    → {T : Ty Γ}
+    → MapCtx F (Γ ▹ T) = (MapCtx F Γ) ▹ (MapTy F T) := by aesop_cat
+  /-- Projections are preserved strictly. -/
+  pPreserveStrict :
+    {Γ : C.Ctx}
+    → {T : Ty Γ}
+    → MapSub F (p_ T)
+      = eqToHom snocPreserve ≫ p := by aesop_cat
+  /-- Variables are preserved strictly. -/
+  vPreserveStrict :
+    {Γ : C.Ctx}
+    → {T : Ty Γ}
+    → MapTm F (v_ T) =ₜ (v_ (MapTy F T))⦃eqToHom snocPreserve⦄ := by aesop_cat
+
+open StrictPreserveCwF
+
+instance strictIsoPreserve {C D : CwFCat} (F : TmTyMorphism C D) [StrictPreserveCwF F] :
+    IsoPreserveCwF F where
+  snocIso := eqToIso snocPreserve
+  pPreserve := pPreserveStrict
+  vPreserve := vPreserveStrict
+
+theorem preserveId {C : CwFCat} : StrictPreserveCwF ⟨Functor.id C, NatTrans.id _⟩ where
+  snocPreserve := by
+    intros
+    rfl
+  pPreserveStrict := by
+    intro Γ T
+    change MapSub { CtxF := 𝟭 C.Ctx, transSubst := NatTrans.id tmTyFam } (p_ T) =
+      eqToHom rfl ≫ p_ T
+    simp [MapSub]
+  vPreserveStrict := by
+    intro Γ T
+    change v_ T = castTm ((v_ T)⦃𝟙 (Γ ▹ T)⦄) (by simp)
+    aesop_cat
+
+/-- Composition of morphisms of type-and-term presheaves. -/
+def tmTyComp {C D E : CwFCat} (F : TmTyMorphism C D) (G : TmTyMorphism D E) : TmTyMorphism C E := by
+  fconstructor
+  · apply Functor.comp F.CtxF G.CtxF
+  · fconstructor
+    · intros Γ
+      apply CategoryStruct.comp
+      · apply F.transSubst.app
+      · apply G.transSubst.app
+    · intro X Y f
+      rw [← Category.assoc, F.transSubst.naturality f]
+      exact congrArg (fun h => F.transSubst.app X ≫ h)
+        (G.transSubst.naturality (F.CtxF.op.map f))
+
+theorem MapCtxComp {C D E : CwFCat} (F : TmTyMorphism C D) (G : TmTyMorphism D E)
+    {Γ : C.Ctx} :
+    MapCtx (tmTyComp F G) Γ = MapCtx G (MapCtx F Γ) := by aesop
+
+
+theorem MapSubTmTyComp {C D E : CwFCat} (F : TmTyMorphism C D) (G : TmTyMorphism D E)
+    {Γ Δ : C.Ctx} {θ : Δ ⟶ Γ} :
+    MapSub (tmTyComp F G) θ = MapSub G (MapSub F θ) := by aesop
+
+theorem MapTm_TmTyComp {C D E : CwFCat} (F : TmTyMorphism C D) (G : TmTyMorphism D E)
+    {Γ : C.Ctx} {T : Ty Γ} {t : Tm T} :
+    MapTm (tmTyComp F G) t = MapTm G (MapTm F t) := by aesop
+
+end CwF
+
+end LeanPool.LeanCwf

--- a/LeanPool/LeanCwf/Fam.lean
+++ b/LeanPool/LeanCwf/Fam.lean
@@ -1,0 +1,229 @@
+/-
+Copyright (c) 2026 Joseph Eremondi. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Eremondi
+-/
+
+import Mathlib.CategoryTheory.Comma.Arrow
+import Mathlib.CategoryTheory.Types.Basic
+import Mathlib.CategoryTheory.Comma.Over.Basic
+import Mathlib.CategoryTheory.Category.Basic
+import Mathlib.CategoryTheory.Functor.Basic
+import Mathlib.Data.Opposite
+import Mathlib.CategoryTheory.Equivalence
+
+open CategoryTheory
+
+namespace LeanPool.LeanCwf
+
+universe u
+
+/-- Families of types, represented as arrows in `Type u`. -/
+abbrev Fam : Type (u + 1) :=
+  Arrow (Type u)
+
+namespace Fam
+
+/-- Builds a family from an index type and a dependent type over it. -/
+def mkFam (A : Type u) (B : A → Type u) : Fam.{u} :=
+  { left := Σ x : A , B x
+    right := A
+    hom := TypeCat.ofHom Sigma.fst }
+
+/-- The index type of a family. -/
+def ixSet (arr : Fam) : Type u :=
+  arr.right
+
+
+/-- The fiber of a family over an index. -/
+def famFor (arr : Fam) (a : ixSet arr) : Type u :=
+  {ab : arr.left // arr.hom ab = a}
+
+--The index projection cancels with the constructor
+@[simp]
+theorem famForIxInv (A : Type u) (B : A → Type u) : ixSet (mkFam.{u} A B) = A :=
+  rfl
+
+/-- Converts an element of the fiber of a constructed family to the original dependent type. -/
+def toFam {A : Type u} {B : A → Type u} {a : A}
+ : (b : famFor (mkFam.{u} A B) a) → B a := fun
+    | .mk ab eq => by
+      rw [<- eq]
+      exact ab.snd
+
+/-- Converts an element of the original dependent type to the fiber of the constructed family. -/
+def fromFam {A : Type u} {B : A → Type u} {a : A}
+  (b : B a) : famFor (mkFam.{u} A B) a where
+    val := .mk a b
+    property := rfl
+
+theorem toFamLeftInv {A : Type u} {B : A → Type u} {a : A}
+  : Function.LeftInverse fromFam.{u} (toFam (A := A) (B := B) (a := a)) := by
+  intros b
+  rcases b with ⟨⟨a', b⟩, h⟩
+  cases h
+  rfl
+
+
+theorem toFamRightInv {A : Type u} {B : A → Type u} {a : A}
+  : Function.RightInverse (fromFam.{u} (A := A) (B := B) (a := a)) toFam := by
+  intro b
+  rfl
+
+/-- Reconstructing a family from its index and fibers gives an isomorphic family. -/
+def mkFamInv (arr : Fam) : mkFam (ixSet arr) (famFor arr) ≅ arr where
+  hom :=
+    Arrow.homMk
+      (TypeCat.ofHom fun a_ab_pf => a_ab_pf.2.1)
+      (𝟙 _)
+      (by
+        ext a_ab_pf
+        exact a_ab_pf.2.2)
+  inv :=
+    Arrow.homMk
+      (TypeCat.ofHom fun b => ⟨arr.hom b, ⟨b, rfl⟩⟩)
+      (𝟙 _)
+      (by
+        ext b
+        rfl)
+  hom_inv_id := by
+    apply Arrow.hom_ext
+    · ext a_ab_pf
+      rcases a_ab_pf with ⟨a, b, h⟩
+      cases h
+      rfl
+    · ext a
+      rfl
+  inv_hom_id := by
+    apply Arrow.hom_ext
+    · ext b
+      rfl
+    · ext a
+      rfl
+
+/-- The function on indices induced by a morphism of families. -/
+def mapIx {AB₁ AB₂ : Fam} (f : AB₁ ⟶ AB₂) : ixSet AB₁ → ixSet AB₂ :=
+  f.right
+
+-- Mapping the identity morphism over a family's index is the identity
+@[simp]
+theorem mapIxId {AB : Fam} {x : ixSet AB} : mapIx (𝟙 AB) x = x := by
+  rfl
+
+-- Mapping a composite arrow over an index gives the composite
+@[simp]
+theorem mapIxComp {AB₁ AB₂ AB₃ : Fam} (f : AB₁ ⟶ AB₂) (g : AB₂ ⟶ AB₃) :
+    mapIx (f ≫ g) = mapIx g ∘ mapIx f := by
+  rfl
+
+
+/-- The functor sending a family to its index type. -/
+def projIx : CategoryTheory.Functor Fam (Type u) where
+  obj := ixSet
+  map f := TypeCat.ofHom (mapIx f)
+  map_id X := by
+    ext x
+    rfl
+  map_comp f g := by
+    ext x
+    rfl
+
+/-- The function on fibers induced by a morphism of families. -/
+def mapFam {AB₁ AB₂ : Fam}
+  (f : AB₁ ⟶ AB₂)
+  {a : ixSet AB₁}
+  (b : famFor AB₁ a)
+  : famFor AB₂ (mapIx f a) :=
+  ⟨f.left b.val,
+    calc
+      AB₂.hom (f.left b.val) = f.right (AB₁.hom b.val) := by
+        change (f.left ≫ AB₂.hom) b.val = (AB₁.hom ≫ f.right) b.val
+        exact ConcreteCategory.congr_hom f.w b.val
+      _ = f.right a := by rw [b.property]⟩
+
+/-- Builds a morphism of families from maps on indices and fibers. -/
+def unmapFam {AB₁ AB₂ : Fam}
+  (ixMap : ixSet AB₁ → ixSet AB₂)
+  (famMap : {a : ixSet AB₁} -> famFor AB₁ a -> famFor AB₂ (ixMap a))
+  : (AB₁ ⟶ AB₂) :=
+  Arrow.homMk
+    (TypeCat.ofHom fun x => (famMap ⟨x, rfl⟩).val)
+    (TypeCat.ofHom ixMap)
+    (by
+      ext x
+      exact (famMap ⟨x, rfl⟩).property)
+
+
+@[simp]
+theorem unmapMap {AB₁ AB₂ : Fam}
+  (f : AB₁ ⟶ AB₂)
+  : unmapFam (mapIx f) (mapFam f) = f := by
+  apply Arrow.hom_ext
+  · ext x
+    rfl
+  · ext x
+    rfl
+
+
+@[simp]
+theorem mapUnmap {AB₁ AB₂ : Fam}
+  (ixMap : ixSet AB₁ → ixSet AB₂)
+  (famMap : {a : ixSet AB₁} -> famFor AB₁ a -> famFor AB₂ (ixMap a))
+  (a : ixSet AB₁)
+  : mapFam (unmapFam ixMap famMap) (a := a) = famMap (a := a) := by
+    funext b
+    cases b with
+    | mk x pf =>
+      cases pf
+      apply Subtype.ext
+      rfl
+
+/-- Casts an element of a family along an equality of indices. -/
+def castFam {AB : Fam} {a a' : ixSet AB} (b : famFor AB a) (eq : a = a') : famFor AB a' :=
+  cast (by aesop) b
+
+@[aesop safe]
+theorem mapCast {AB₁ AB₂ : Fam} {a : ixSet AB₁} {f g : AB₁ ⟶ AB₂} (b : famFor AB₁ a) (eq : g = f)
+  : mapFam f b = castFam (mapFam g b) (congrArg₂ mapIx eq (refl a)) := by
+    subst eq
+    rfl
+
+-- Mapping the idenitity over an element of a family is the identity
+@[simp]
+theorem mapFamId {AB : Fam} {a : ixSet AB} (b : famFor AB a) : mapFam (𝟙 AB) b = b := by
+  apply Subtype.ext
+  rfl
+
+-- Mapping a composite arrow over an element of a family
+-- is the composition of the mappings
+@[simp]
+theorem mapFamComp {AB₁ AB₂ AB₃ : Fam} (f : AB₁ ⟶ AB₂) (g : AB₂ ⟶ AB₃)
+  {a : ixSet AB₁} (b : famFor AB₁ a)
+  : (mapFam (f ≫ g) b) = castFam (mapFam g (mapFam f b)) (by aesop) := by
+  apply Subtype.ext
+  rfl
+
+
+/-- Views a family as an object in the slice category over its index type. -/
+def toSlice (arr : Fam) : Over (ixSet arr) :=
+  Over.mk arr.hom
+
+/-- Views an object of a slice category over a type as a family. -/
+def fromSlice {A : Type u} (arr : Over A) : Fam :=
+  Arrow.mk arr.hom
+
+@[simp]
+theorem fromToSlice {arr : Fam} : fromSlice (toSlice arr) = arr :=
+  rfl
+
+
+@[simp]
+theorem toFromSlice {A : Type u} (arr : Over A) : toSlice (fromSlice arr) = arr := by
+  cases arr with
+  | mk left hom => rfl
+
+
+
+end Fam
+
+end LeanPool.LeanCwf

--- a/LeanPool/LeanCwf/Util.lean
+++ b/LeanPool/LeanCwf/Util.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 Joseph Eremondi. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Eremondi
+-/
+
+import Mathlib.CategoryTheory.Category.Basic
+import Mathlib.CategoryTheory.Iso
+import Mathlib.CategoryTheory.Types.Basic
+import Mathlib.Logic.Function.Basic
+
+namespace LeanPool.LeanCwf
+
+theorem heq_type_eq {a a_1 : Sort u_1} {x : a} {y : a_1}
+  (eq : HEq x y) : a = a_1 := by
+  cases eq
+  rfl
+
+theorem eq_cast_of_heq {a a_1 : Sort u_1} {a_2 : a} {a' : a_1}
+  (heq : HEq a_2 a') : cast (heq_type_eq heq) a_2 = a' := by
+  cases heq
+  rfl
+
+
+theorem cast_moveR {A B : Sort u_1} {a : A} {b : B}
+  {eq : A = B} (abeq : cast eq a = b) : a = cast (by rw [eq]) b := by aesop
+
+
+theorem cast_moveL {A B : Sort u_1} {a : A} {b : B}
+  {eq : B = A} (abeq : a = cast eq b) : cast (by rw [eq]) a = b := by aesop
+
+theorem hCong {A : Type u} {B : A → Type v} {f g : (a : A) → B a} {x y : A}
+    (funEq : f = g) (argEq : x = y) :
+      HEq (f x) (g y) := by aesop
+
+theorem castSymmL {A B : Type u} {eq : A = B} {x : A} {y : B}
+  (pf : cast eq x = y) :
+  x = cast (symm eq) y := by aesop
+
+
+theorem castSymmR {A B : Type u} {eq : B = A} {x : A} {y : B}
+  (pf : x = cast eq y) :
+  cast (symm eq) x = y := by aesop
+
+theorem hCongFun {A : Type u} {B C : A → Type v} {f : (a : A) → B a} {g : (a : A) → C a}
+    (x : A)
+    (eq : B = C)
+    (funEq : HEq f g) :
+    HEq (f x) (g x) := by aesop
+
+
+theorem hCongArg {A : Type u} {B : A → Type v} {f : (a : A) → B a}
+    {x y : A}
+    (eq : x = y) :
+    HEq (f x) (f y) := by aesop
+
+
+-- theorem hCongArg2 {A A' : Type u}
+--     {B : A → Type v}
+--     {B' : A' → Type v}
+--     {C : (a : A) → B a → Type v}
+--     {C' : (a : A') -> B' a -> Type v}
+--     {f : (a : A) → (b : B a) → C a b}
+--     {g : (a : A') → (b : B' a) → C' a b}
+--     {x : A} {y : A'}
+--     {bx : B x} {byy : B' y}
+--     (feq : HEq f g)
+--     (eq : HEq x y)
+--     (heq : HEq bx byy):
+--       HEq (f x bx) (g y byy) := by
+--     cases eq
+--     let teq := heq_type_eq heq
+--     apply heq_of_cast_eq <;> aesop_cat
+--     cases teq
+--     cases heq
+
+theorem hCongFunImplicit {A : Type u} {B C : A → Type v} {f : {a : A} → B a} {g : {a : A} → C a}
+    (x : A)
+    (eq : B = C)
+    (funEq : HEq @f @g) :
+    HEq (f (a := x)) (g (a := x)) := by aesop
+
+
+theorem hCongFunSimp {A : Type u} {B C : Type v} {f : (a : A) → B} {g : (a : A) → C}
+    (x : A)
+    (eq : B = C)
+    (funEq : HEq f g) :
+    HEq (f x) (g x) := by aesop
+
+
+theorem hFunExt {A B C : Type u}
+  {f : A -> B} {g : A -> C}
+  (eq : B = C)
+  (extEq : (a : A) -> HEq (f a) (g a))
+  : HEq f g := by
+    let funEq : (A -> B) = (A -> C) := by aesop
+    fapply heq_of_cast_eq funEq
+    funext x
+    let fxEq : HEq (cast funEq f x) (f x) := by aesop
+    fapply eq_of_heq
+    fapply HEq.trans fxEq
+    fapply extEq
+
+
+theorem insertBothCasts {A B C : Type u}
+  {x : A} {y : B} {eq1 : A = C} {eq2 : B = C}
+  (eq : cast eq1 x = cast eq2 y)
+  : HEq x y := by aesop
+
+
+theorem deleteBothCasts {A B C : Type u}
+  {x : A} {y : B} {eq1 : A = C} {eq2 : B = C}
+  (eq : HEq x y)
+  : cast eq1 x = cast eq2 y := by aesop
+
+-- Helper module for a Sigma lemma we need over and over again
+-- Helps dealing with HEq for sigma types
+theorem Sigma_HExt
+  {α : Type u_1} {β : α → Type u_2} {x y : Sigma β}
+  (eq : x.fst = y.fst) (heq : x.fst = y.fst -> HEq x.snd y.snd)
+  : x = y := Sigma.ext eq (heq eq)
+
+theorem Subtype_Sigma_ext
+  {A : Type u}
+  {B : A -> Type u}
+  {P : {a : A} -> B a -> Prop}
+  {x y : (a : A) × @Subtype (B a) P}
+  (eq1 : x.fst = y.fst)
+  (eq2 : HEq x.snd.val y.snd.val)
+  : x = y := by cases x with
+  | mk x1 x2 => cases y with
+  | mk y1 y2 =>
+    fapply Sigma.ext
+    · exact eq1
+    · cases eq1
+      exact heq_of_eq (Subtype.ext (eq_of_heq eq2))
+
+theorem Subtype_HExtEq {A : Type u} {P Q : A -> Prop}
+ {x : Subtype P} {y : Subtype Q}
+ (eq : x.val = y.val)
+ (equiv : P = Q)
+ : HEq x y := by aesop
+
+theorem Subtype_HExt {A : Type u} {P Q : A -> Prop}
+ {x : Subtype P} {y : Subtype Q}
+ (eq : x.val = y.val)
+ (equiv : (x : A) -> P x ↔ Q x)
+ : HEq x y :=  by
+   let PeqQ : P = Q := by
+     funext x
+     apply propext
+     apply equiv x
+   apply Subtype_HExtEq <;> assumption
+
+theorem HEq_iff {P : Prop}
+  (p : P)
+  (t : True)
+  : HEq p t := by aesop
+
+end LeanPool.LeanCwf

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -444,3 +444,25 @@ projects:
     msc:
       - "11E25"
       - "11H06"
+  - slug: lean-cwf
+    title: Categories with Families
+    summary: Formalizes categories with families, their type-and-term presheaves, context extension, and strict morphisms.
+    branch: type theory
+    entry_module: LeanPool.LeanCwf
+    authors:
+      - Joseph Eremondi
+    source:
+      url: https://github.com/JoeyEremondi/lean-cwf
+    status: verified
+    main_declarations:
+      - LeanPool.LeanCwf.CwF.Structure
+    main_results:
+      - declaration: LeanPool.LeanCwf.CwF.Structure
+        informal: Defines a category with families using a type-and-term presheaf, context extension, and terminal empty context.
+    tags:
+      - type-theory
+      - category-theory
+      - categories-with-families
+    msc:
+      - "03B15"
+      - "18D20"


### PR DESCRIPTION
Imported from https://github.com/JoeyEremondi/lean-cwf.

**Slug:** `lean-cwf`
**Toolchain target:** `leanprover/lean4:v4.30.0-rc2`
**Branch:** `import/lean-cwf-retry-20260518-144229` (retry run `20260518-144229`)
**Agent:** `codex` using `gpt-5.5` at effort `xhigh`.

**Commits on this branch:**
- 505f30d Vendor lean-cwf into LeanPool

---
Opened manually after `scripts/import-formalization.sh` finished the agent run but exited before PR creation due to the running wrapper script seeing `main` change under it. The branch was rebased onto current `origin/main` and checked for content-only diff before push.
