### PR TITLE
Import lean-poly-abc formalization

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -327,6 +327,16 @@ import LeanPool.LeanComplexAnalysis.Harmonic.Positive.HerglotzRieszRepresentatio
 import LeanPool.LeanComplexAnalysis.Harmonic.Positive.HerglotzRieszUnique
 import LeanPool.LeanComplexAnalysis.UnivalentFunctions
 import LeanPool.LeanComplexAnalysis.UnivalentFunctions.ClassS
+import LeanPool.LeanPolyABC
+import LeanPool.LeanPolyABC.All
+import LeanPool.LeanPolyABC.Corollaries.Davenport
+import LeanPool.LeanPolyABC.Corollaries.FltCatalan
+import LeanPool.LeanPolyABC.Corollaries.NoParametrization
+import LeanPool.LeanPolyABC.Lib.DivRadical
+import LeanPool.LeanPolyABC.Lib.Max3
+import LeanPool.LeanPolyABC.Lib.Radical
+import LeanPool.LeanPolyABC.Lib.Wronskian
+import LeanPool.LeanPolyABC.MasonStothers
 import LeanPool.LowDimSolvClassification
 import LeanPool.LowDimSolvClassification.Classification1
 import LeanPool.LowDimSolvClassification.Classification2

--- a/LeanPool/LeanPolyABC.lean
+++ b/LeanPool/LeanPolyABC.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2026 Seewoo Lee. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Seewoo Lee
+-/
+
+import LeanPool.LeanPolyABC.All
+
+/-!
+# Polynomial ABC (Mason–Stothers) and its corollaries
+
+Source: url:https://github.com/seewoo5/lean-poly-abc
+Authors: Seewoo Lee
+Status: verified
+Main declarations: `Polynomial.abc`, `Polynomial.flt`
+Tags: number-theory, polynomials, algebra, mason-stothers
+MSC: 11C08, 12E05
+-/
+
+/-!
+## Mathematical overview
+
+A formalization of the **Mason–Stothers theorem** — the polynomial analogue of
+the ABC conjecture — together with its classical consequences.
+
+- `Polynomial.abc`: for coprime polynomials `a + b = c` over a field, not all
+  constant, `max (deg a) (deg b) (deg c) < deg (rad (a*b*c))`.
+- `Polynomial.flt`: the polynomial Fermat's Last Theorem — no nontrivial coprime
+  polynomial solutions of `aⁿ + bⁿ = cⁿ` for `n ≥ 3`.
+- The `Corollaries` modules also derive the Fermat–Catalan inequality and
+  Davenport's theorem, and rule out polynomial parametrizations.
+-/

--- a/LeanPool/LeanPolyABC.lean
+++ b/LeanPool/LeanPolyABC.lean
@@ -12,7 +12,7 @@ import LeanPool.LeanPolyABC.All
 Source: url:https://github.com/seewoo5/lean-poly-abc
 Authors: Seewoo Lee
 Status: verified
-Main declarations: `Polynomial.abc`, `Polynomial.flt`
+Main declarations: `LeanPolyABC.Polynomial.abc`, `LeanPolyABC.Polynomial.flt`
 Tags: number-theory, polynomials, algebra, mason-stothers
 MSC: 11C08, 12E05
 -/
@@ -23,10 +23,10 @@ MSC: 11C08, 12E05
 A formalization of the **Mason–Stothers theorem** — the polynomial analogue of
 the ABC conjecture — together with its classical consequences.
 
-- `Polynomial.abc`: for coprime polynomials `a + b = c` over a field, not all
-  constant, `max (deg a) (deg b) (deg c) < deg (rad (a*b*c))`.
-- `Polynomial.flt`: the polynomial Fermat's Last Theorem — no nontrivial coprime
-  polynomial solutions of `aⁿ + bⁿ = cⁿ` for `n ≥ 3`.
+- `LeanPolyABC.Polynomial.abc`: for coprime polynomials `a + b = c` over a field,
+  not all constant, `max (deg a) (deg b) (deg c) < deg (rad (a*b*c))`.
+- `LeanPolyABC.Polynomial.flt`: the polynomial Fermat's Last Theorem — no
+  nontrivial coprime polynomial solutions of `aⁿ + bⁿ = cⁿ` for `n ≥ 3`.
 - The `Corollaries` modules also derive the Fermat–Catalan inequality and
   Davenport's theorem, and rule out polynomial parametrizations.
 -/

--- a/LeanPool/LeanPolyABC/All.lean
+++ b/LeanPool/LeanPolyABC/All.lean
@@ -1,0 +1,14 @@
+/-
+Copyright (c) 2026 Seewoo Lee. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Seewoo Lee
+-/
+
+import LeanPool.LeanPolyABC.MasonStothers
+import LeanPool.LeanPolyABC.Lib.DivRadical
+import LeanPool.LeanPolyABC.Lib.Max3
+import LeanPool.LeanPolyABC.Lib.Wronskian
+import LeanPool.LeanPolyABC.Lib.Radical
+import LeanPool.LeanPolyABC.Corollaries.FltCatalan
+import LeanPool.LeanPolyABC.Corollaries.Davenport
+import LeanPool.LeanPolyABC.Corollaries.NoParametrization

--- a/LeanPool/LeanPolyABC/Corollaries/Davenport.lean
+++ b/LeanPool/LeanPolyABC/Corollaries/Davenport.lean
@@ -10,29 +10,33 @@ import LeanPool.LeanPolyABC.MasonStothers
 
 noncomputable section
 
-open scoped Polynomial Classical
+open scoped Polynomial
 
-open Polynomial
+open Polynomial UniqueFactorizationMonoid
 
-open UniqueFactorizationMonoid
+namespace LeanPolyABC
 
-variable {k : Type _} [Field k]
+variable {k : Type _} [Field k] [DecidableEq k]
 
+omit [DecidableEq k] in
+lemma ne_zero_of_natDegree_gt_0 {a : k[X]} (ha : a.natDegree > 0) : a ≠ 0 := fun h => by
+  simp only [h, natDegree_zero, gt_iff_lt, lt_self_iff_false] at ha
+
+omit [DecidableEq k] in
 /-- Davenport's theorem
 
-For any nonzero polynomial a, b ∈ k[t] with k of characteristic zero, deg(a) + 2 ≤ 2 * deg(a^3 - b^2).
+For any nonzero polynomial a, b ∈ k[t] with k of characteristic zero,
+deg(a) + 2 ≤ 2 * deg(a^3 - b^2).
 
 Proof) Apply ABC for (-a^3, b^2, a^3 - b^2).
 -/
-lemma ne_zero_of_natDegree_gt_0 {a : k[X]} (ha : a.natDegree > 0) : a ≠ 0 := λ h ↦ by
-  simp only [h, natDegree_zero, gt_iff_lt, lt_self_iff_false] at ha
-
 theorem Polynomial.davenport [CharZero k] {a b : k[X]}
     (ha : a.natDegree > 0) (hb : b.natDegree > 0) (hnz : a ^ 3 - b ^ 2 ≠ 0) :
     a.natDegree + 2 ≤ 2 * (a ^ 3 - b ^ 2).natDegree := by
-  have ha3 : -a^3 ≠ 0 := neg_ne_zero.mpr <| pow_ne_zero 3 <| ne_zero_of_natDegree_gt_0 ha
-  have hb2 : b^2 ≠ 0 := pow_ne_zero 2 <| ne_zero_of_natDegree_gt_0 hb
-  cases' abc'_char0 ha3 hb2 hnz (by ring_nf) with heq hineq
+  classical
+  have ha3 : -a ^ 3 ≠ 0 := neg_ne_zero.mpr <| pow_ne_zero 3 <| ne_zero_of_natDegree_gt_0 ha
+  have hb2 : b ^ 2 ≠ 0 := pow_ne_zero 2 <| ne_zero_of_natDegree_gt_0 hb
+  rcases Polynomial.abc'_char0 ha3 hb2 hnz (by ring_nf) with heq | hineq
   · simp only [natDegree_neg, natDegree_pow] at heq
     omega
   · rw [Nat.succ_le_iff] at hineq
@@ -40,6 +44,7 @@ theorem Polynomial.davenport [CharZero k] {a b : k[X]}
       radical_neg, Nat.ofNat_pos, radical_pow, max_lt_iff] at hineq
     nlinarith only [hineq.1, hineq.2, radical_natDegree_le a, radical_natDegree_le b]
 
+omit [DecidableEq k] in
 -- Auxiliary lemma to remove nonzero hypothesis using coprimality and a' ≠ 0.
 theorem isCoprime_nonzero_c {a b : k[X]} (h : IsCoprime a b) (ha : derivative a ≠ 0) :
     a ^ 3 - b ^ 2 ≠ 0 := by
@@ -47,18 +52,20 @@ theorem isCoprime_nonzero_c {a b : k[X]} (h : IsCoprime a b) (ha : derivative a 
   rw [sub_eq_zero] at h_eq_zero
   have hp : IsCoprime (a ^ 3) (b ^ 2) := h.pow
   rw [← h_eq_zero, isCoprime_self, isUnit_pow_iff, isUnit_iff] at hp
-  rcases hp with ⟨r, r_unit, eq_a⟩
-  rw [← eq_a] at ha; exact ha derivative_C
-  norm_num
+  · rcases hp with ⟨r, _, eq_a⟩
+    rw [← eq_a] at ha; exact ha derivative_C
+  · norm_num
 
+omit [DecidableEq k] in
 /-- Davenport's theorem for general field k of any characteristic
 
-For any coprime polynomial a, b ∈ k[t] with nonzero derivatives, deg(a) + 2 ≤ 2 * deg(a^3 - b^2).
+For any coprime polynomial a, b ∈ k[t] with nonzero derivatives,
+deg(a) + 2 ≤ 2 * deg(a^3 - b^2).
 Proof) Apply ABC for (-a^3, b^2, a^3 - b^2).
 -/
 theorem Polynomial.davenport' {a b : k[X]} (hab : IsCoprime a b) (haderiv : derivative a ≠ 0)
-    (hbderiv : derivative b ≠ 0) : a.natDegree + 2 ≤ 2 * (a ^ 3 - b ^ 2).natDegree :=
-  by
+    (hbderiv : derivative b ≠ 0) : a.natDegree + 2 ≤ 2 * (a ^ 3 - b ^ 2).natDegree := by
+  classical
   have hnz : a ^ 3 - b ^ 2 ≠ 0 := isCoprime_nonzero_c hab haderiv
   have ha : a ≠ 0 := fun ha => haderiv (ha.symm ▸ derivative_zero)
   have hb : b ≠ 0 := fun hb => hbderiv (hb.symm ▸ derivative_zero)
@@ -68,11 +75,12 @@ theorem Polynomial.davenport' {a b : k[X]} (hab : IsCoprime a b) (haderiv : deri
   have h2 : IsCoprime (b ^ 2) (a ^ 3 - b ^ 2) := by
     rwa [sub_eq_add_neg, neg_eq_neg_one_mul, IsCoprime.add_mul_right_right_iff,
       IsCoprime.pow_iff two_pos three_pos, isCoprime_comm]
-  cases'
-    abc (neg_ne_zero.mpr (pow_ne_zero 3 ha)) (pow_ne_zero 2 hb) hnz hab.pow.neg_left
-      (by rw [sub_eq_add_neg, add_add_add_comm, neg_add_self, add_neg_self, add_zero]) with
-    h h
-  · -- When we have vanishing derivatives. This condition implies 3 = 0 = 2, which is impossible for any field k.
+  rcases
+    Polynomial.abc (neg_ne_zero.mpr (pow_ne_zero 3 ha)) (pow_ne_zero 2 hb) hnz hab.pow.neg_left
+      (by rw [sub_eq_add_neg, add_add_add_comm, neg_add_cancel, add_neg_cancel, add_zero]) with
+    h | h
+  · -- When we have vanishing derivatives. This condition implies 3 = 0 = 2, which is impossible for
+    -- any field k.
     rw [derivative_neg, neg_eq_zero, derivative_pow, derivative_pow, Nat.add_one_sub_one,
       Nat.add_one_sub_one, mul_eq_zero, mul_eq_zero, mul_eq_zero, mul_eq_zero, or_iff_left haderiv,
       or_iff_left hbderiv, or_iff_left (pow_ne_zero 2 ha), or_iff_left (pow_ne_zero 1 hb)] at h
@@ -88,7 +96,10 @@ theorem Polynomial.davenport' {a b : k[X]} (hab : IsCoprime a b) (haderiv : deri
       max_add_add_right] at h
     replace h :=
       le_trans h
-        (add_le_add (add_le_add (radical_natDegree_le _) (radical_natDegree_le _)) <| radical_natDegree_le _)
+        (add_le_add (add_le_add (radical_natDegree_le _) (radical_natDegree_le _)) <|
+          radical_natDegree_le _)
     rw [max_le_iff] at h
     -- Add two inequalities and simplifying it gives the desired inequality.
     nlinarith only [add_le_add h.1 h.2]
+
+end LeanPolyABC

--- a/LeanPool/LeanPolyABC/Corollaries/Davenport.lean
+++ b/LeanPool/LeanPolyABC/Corollaries/Davenport.lean
@@ -22,6 +22,8 @@ omit [DecidableEq k] in
 lemma ne_zero_of_natDegree_gt_0 {a : k[X]} (ha : a.natDegree > 0) : a ≠ 0 := fun h => by
   simp only [h, natDegree_zero, gt_iff_lt, lt_self_iff_false] at ha
 
+namespace Polynomial
+
 omit [DecidableEq k] in
 /-- Davenport's theorem
 
@@ -30,7 +32,7 @@ deg(a) + 2 ≤ 2 * deg(a^3 - b^2).
 
 Proof) Apply ABC for (-a^3, b^2, a^3 - b^2).
 -/
-theorem Polynomial.davenport [CharZero k] {a b : k[X]}
+theorem davenport [CharZero k] {a b : k[X]}
     (ha : a.natDegree > 0) (hb : b.natDegree > 0) (hnz : a ^ 3 - b ^ 2 ≠ 0) :
     a.natDegree + 2 ≤ 2 * (a ^ 3 - b ^ 2).natDegree := by
   classical
@@ -44,6 +46,8 @@ theorem Polynomial.davenport [CharZero k] {a b : k[X]}
       radical_neg, Nat.ofNat_pos, radical_pow, max_lt_iff] at hineq
     nlinarith only [hineq.1, hineq.2, radical_natDegree_le a, radical_natDegree_le b]
 
+end Polynomial
+
 omit [DecidableEq k] in
 -- Auxiliary lemma to remove nonzero hypothesis using coprimality and a' ≠ 0.
 theorem isCoprime_nonzero_c {a b : k[X]} (h : IsCoprime a b) (ha : derivative a ≠ 0) :
@@ -56,6 +60,8 @@ theorem isCoprime_nonzero_c {a b : k[X]} (h : IsCoprime a b) (ha : derivative a 
     rw [← eq_a] at ha; exact ha derivative_C
   · norm_num
 
+namespace Polynomial
+
 omit [DecidableEq k] in
 /-- Davenport's theorem for general field k of any characteristic
 
@@ -63,7 +69,7 @@ For any coprime polynomial a, b ∈ k[t] with nonzero derivatives,
 deg(a) + 2 ≤ 2 * deg(a^3 - b^2).
 Proof) Apply ABC for (-a^3, b^2, a^3 - b^2).
 -/
-theorem Polynomial.davenport' {a b : k[X]} (hab : IsCoprime a b) (haderiv : derivative a ≠ 0)
+theorem davenport' {a b : k[X]} (hab : IsCoprime a b) (haderiv : derivative a ≠ 0)
     (hbderiv : derivative b ≠ 0) : a.natDegree + 2 ≤ 2 * (a ^ 3 - b ^ 2).natDegree := by
   classical
   have hnz : a ^ 3 - b ^ 2 ≠ 0 := isCoprime_nonzero_c hab haderiv
@@ -101,5 +107,7 @@ theorem Polynomial.davenport' {a b : k[X]} (hab : IsCoprime a b) (haderiv : deri
     rw [max_le_iff] at h
     -- Add two inequalities and simplifying it gives the desired inequality.
     nlinarith only [add_le_add h.1 h.2]
+
+end Polynomial
 
 end LeanPolyABC

--- a/LeanPool/LeanPolyABC/Corollaries/Davenport.lean
+++ b/LeanPool/LeanPolyABC/Corollaries/Davenport.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 Seewoo Lee. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Seewoo Lee
+-/
+
+import Mathlib.Algebra.CharP.Defs
+import Mathlib.Algebra.EuclideanDomain.Defs
+import LeanPool.LeanPolyABC.MasonStothers
+
+noncomputable section
+
+open scoped Polynomial Classical
+
+open Polynomial
+
+open UniqueFactorizationMonoid
+
+variable {k : Type _} [Field k]
+
+/-- Davenport's theorem
+
+For any nonzero polynomial a, b ∈ k[t] with k of characteristic zero, deg(a) + 2 ≤ 2 * deg(a^3 - b^2).
+
+Proof) Apply ABC for (-a^3, b^2, a^3 - b^2).
+-/
+lemma ne_zero_of_natDegree_gt_0 {a : k[X]} (ha : a.natDegree > 0) : a ≠ 0 := λ h ↦ by
+  simp only [h, natDegree_zero, gt_iff_lt, lt_self_iff_false] at ha
+
+theorem Polynomial.davenport [CharZero k] {a b : k[X]}
+    (ha : a.natDegree > 0) (hb : b.natDegree > 0) (hnz : a ^ 3 - b ^ 2 ≠ 0) :
+    a.natDegree + 2 ≤ 2 * (a ^ 3 - b ^ 2).natDegree := by
+  have ha3 : -a^3 ≠ 0 := neg_ne_zero.mpr <| pow_ne_zero 3 <| ne_zero_of_natDegree_gt_0 ha
+  have hb2 : b^2 ≠ 0 := pow_ne_zero 2 <| ne_zero_of_natDegree_gt_0 hb
+  cases' abc'_char0 ha3 hb2 hnz (by ring_nf) with heq hineq
+  · simp only [natDegree_neg, natDegree_pow] at heq
+    omega
+  · rw [Nat.succ_le_iff] at hineq
+    simp only [Nat.max₃, natDegree_neg, natDegree_pow,
+      radical_neg, Nat.ofNat_pos, radical_pow, max_lt_iff] at hineq
+    nlinarith only [hineq.1, hineq.2, radical_natDegree_le a, radical_natDegree_le b]
+
+-- Auxiliary lemma to remove nonzero hypothesis using coprimality and a' ≠ 0.
+theorem isCoprime_nonzero_c {a b : k[X]} (h : IsCoprime a b) (ha : derivative a ≠ 0) :
+    a ^ 3 - b ^ 2 ≠ 0 := by
+  by_contra h_eq_zero
+  rw [sub_eq_zero] at h_eq_zero
+  have hp : IsCoprime (a ^ 3) (b ^ 2) := h.pow
+  rw [← h_eq_zero, isCoprime_self, isUnit_pow_iff, isUnit_iff] at hp
+  rcases hp with ⟨r, r_unit, eq_a⟩
+  rw [← eq_a] at ha; exact ha derivative_C
+  norm_num
+
+/-- Davenport's theorem for general field k of any characteristic
+
+For any coprime polynomial a, b ∈ k[t] with nonzero derivatives, deg(a) + 2 ≤ 2 * deg(a^3 - b^2).
+Proof) Apply ABC for (-a^3, b^2, a^3 - b^2).
+-/
+theorem Polynomial.davenport' {a b : k[X]} (hab : IsCoprime a b) (haderiv : derivative a ≠ 0)
+    (hbderiv : derivative b ≠ 0) : a.natDegree + 2 ≤ 2 * (a ^ 3 - b ^ 2).natDegree :=
+  by
+  have hnz : a ^ 3 - b ^ 2 ≠ 0 := isCoprime_nonzero_c hab haderiv
+  have ha : a ≠ 0 := fun ha => haderiv (ha.symm ▸ derivative_zero)
+  have hb : b ≠ 0 := fun hb => hbderiv (hb.symm ▸ derivative_zero)
+  have h1 : IsCoprime (a ^ 3) (a ^ 3 - b ^ 2) := by
+    rwa [← IsCoprime.neg_right_iff, neg_sub, sub_eq_add_neg, neg_eq_neg_one_mul,
+      IsCoprime.add_mul_right_right_iff, IsCoprime.pow_iff three_pos two_pos]
+  have h2 : IsCoprime (b ^ 2) (a ^ 3 - b ^ 2) := by
+    rwa [sub_eq_add_neg, neg_eq_neg_one_mul, IsCoprime.add_mul_right_right_iff,
+      IsCoprime.pow_iff two_pos three_pos, isCoprime_comm]
+  cases'
+    abc (neg_ne_zero.mpr (pow_ne_zero 3 ha)) (pow_ne_zero 2 hb) hnz hab.pow.neg_left
+      (by rw [sub_eq_add_neg, add_add_add_comm, neg_add_self, add_neg_self, add_zero]) with
+    h h
+  · -- When we have vanishing derivatives. This condition implies 3 = 0 = 2, which is impossible for any field k.
+    rw [derivative_neg, neg_eq_zero, derivative_pow, derivative_pow, Nat.add_one_sub_one,
+      Nat.add_one_sub_one, mul_eq_zero, mul_eq_zero, mul_eq_zero, mul_eq_zero, or_iff_left haderiv,
+      or_iff_left hbderiv, or_iff_left (pow_ne_zero 2 ha), or_iff_left (pow_ne_zero 1 hb)] at h
+    replace h := h.1.trans h.2.1.symm
+    rw [← sub_eq_zero, ← C_sub, ← Nat.cast_sub (Nat.le_succ 2), Nat.cast_one, C_1] at h
+    exact (one_ne_zero h).elim
+  · -- When we have inequality from ABC.
+    rw [natDegree_neg, Nat.max₃, max_eq_left (natDegree_sub_le _ _), neg_mul, neg_mul, radical_neg,
+      radical_hMul (h1.mul_left h2), radical_hMul hab.pow, radical_pow a three_pos,
+      radical_pow b two_pos,
+      natDegree_mul (mul_ne_zero (radical_ne_zero a) (radical_ne_zero b)) (radical_ne_zero _),
+      natDegree_mul (radical_ne_zero a) (radical_ne_zero b), natDegree_pow, natDegree_pow, ←
+      max_add_add_right] at h
+    replace h :=
+      le_trans h
+        (add_le_add (add_le_add (radical_natDegree_le _) (radical_natDegree_le _)) <| radical_natDegree_le _)
+    rw [max_le_iff] at h
+    -- Add two inequalities and simplifying it gives the desired inequality.
+    nlinarith only [add_le_add h.1 h.2]

--- a/LeanPool/LeanPolyABC/Corollaries/FltCatalan.lean
+++ b/LeanPool/LeanPolyABC/Corollaries/FltCatalan.lean
@@ -77,8 +77,10 @@ theorem mul_eq_zero_left_iff
   rw [mul_eq_zero]
   tauto
 
+namespace Polynomial
+
 omit [DecidableEq k] in
-theorem Polynomial.flt_catalan_deriv
+theorem flt_catalan_deriv
     {p q r : ℕ} (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
     (hineq : q * r + r * p + p * q ≤ p * q * r)
     (chp : ¬ringChar k ∣ p) (chq : ¬ringChar k ∣ q) (chr : ¬ringChar k ∣ r)
@@ -132,6 +134,8 @@ theorem Polynomial.flt_catalan_deriv
     convert weighted_average_le_max₃ using 1
     ring_nf
 
+end Polynomial
+
 omit [DecidableEq k] in
 private theorem expcont {a : k[X]} (ha : a ≠ 0) (hda : derivative a = 0) (chn0 : ringChar k ≠ 0) :
     ∃ ca, ca ≠ 0 ∧ a = expand k (ringChar k) ca ∧ a.natDegree = ca.natDegree * ringChar k := by
@@ -159,8 +163,10 @@ private theorem is_coprime_of_expand {a b : k[X]} {n : ℕ} (hn : n ≠ 0) :
   obtain ⟨zz, yy⟩ := tt; rw [eq_comm, expand_eq_C (zero_lt_iff.mpr hn), eq_comm] at yy
   exact ⟨zz, yy⟩
 
+namespace Polynomial
+
 omit [DecidableEq k] in
-theorem Polynomial.flt_catalan_aux
+theorem flt_catalan_aux
     {p q r : ℕ} (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
     (hineq : q * r + r * p + p * q ≤ p * q * r)
     (chp : ¬ringChar k ∣ p) (chq : ¬ringChar k ∣ q) (chr : ¬ringChar k ∣ r)
@@ -212,7 +218,7 @@ theorem Polynomial.flt_catalan_aux
         nlinarith [hdeg, hca1, hch2]
 
 omit [DecidableEq k] in
-theorem Polynomial.flt_catalan
+theorem flt_catalan
     {p q r : ℕ} (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
     (hineq : q * r + r * p + p * q ≤ p * q * r)
     (chp : ¬ringChar k ∣ p) (chq : ¬ringChar k ∣ q) (chr : ¬ringChar k ∣ r)
@@ -234,7 +240,7 @@ theorem Polynomial.flt_catalan
 Take p = q = r = n and u = v = 1, w = -1.
 -/
 omit [DecidableEq k] in
-theorem Polynomial.flt
+theorem flt
     {n : ℕ} (hn : 3 ≤ n) (chn : ¬ringChar k ∣ n)
     {a b c : k[X]} (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0)
     (hab : IsCoprime a b) (heq : a ^ n + b ^ n = c ^ n) :
@@ -250,5 +256,7 @@ theorem Polynomial.flt
   have eq_lhs : n * n + n * n + n * n = 3 * n * n := by ring_nf
   rw [eq_lhs]; rw [mul_assoc, mul_assoc]
   exact Nat.mul_le_mul_right (n * n) hn
+
+end Polynomial
 
 end LeanPolyABC

--- a/LeanPool/LeanPolyABC/Corollaries/FltCatalan.lean
+++ b/LeanPool/LeanPolyABC/Corollaries/FltCatalan.lean
@@ -15,34 +15,31 @@ import Mathlib.RingTheory.Coprime.Basic
 
 noncomputable section
 
-open scoped Polynomial Classical
+open scoped Polynomial
 
-open Polynomial
+open Polynomial UniqueFactorizationMonoid
 
-open UniqueFactorizationMonoid
+namespace LeanPolyABC
 
-variable {k : Type _} [Field k]
+variable {k : Type _} [Field k] [DecidableEq k]
 
+omit [DecidableEq k] in
 -- Multiplying units preserve coprimality
 private theorem isCoprime_mul_units_left {a b : k[X]} {u v : k} (hu : u ≠ 0) (hv : v ≠ 0) :
     IsCoprime (C u * a) (C v * b) ↔ IsCoprime a b :=
   Iff.trans
-    (isCoprime_mul_unit_left_left hu.isUnit_C _ _)
-    (isCoprime_mul_unit_left_right hv.isUnit_C _ _)
+    (isCoprime_mul_unit_left_left (Ne.isUnit_C hu) _ _)
+    (isCoprime_mul_unit_left_right (Ne.isUnit_C hv) _ _)
 
+omit [DecidableEq k] in
 private theorem rot_coprime {p q r : ℕ} {a b c : k[X]} {u v w : k}
     (heq : C u * a ^ p + C v * b ^ q + C w * c ^ r = 0) (hab : IsCoprime a b)
     (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
     (hu : u ≠ 0) (hv : v ≠ 0) (hw : w ≠ 0) : IsCoprime b c := by
-  have uu := hu.isUnit_C
-  have uv := hv.isUnit_C
-  have uw := hw.isUnit_C
-
-  rw [←IsCoprime.pow_iff hp hq, ←isCoprime_mul_units_left hu hv] at hab
-  rw [←IsCoprime.pow_iff hq hr, ←isCoprime_mul_units_left hv hw]
-
+  rw [← IsCoprime.pow_iff hp hq, ← isCoprime_mul_units_left hu hv] at hab
+  rw [← IsCoprime.pow_iff hq hr, ← isCoprime_mul_units_left hv hw]
   rw [add_eq_zero_iff_neg_eq] at heq
-  rw [←heq, IsCoprime.neg_right_iff]
+  rw [← heq, IsCoprime.neg_right_iff]
   convert IsCoprime.add_mul_left_right hab.symm 1 using 2
   rw [mul_one]
 
@@ -52,41 +49,35 @@ private theorem rot3_add {α : Type _} [AddCommMonoid α] {a b c : α} : a + b +
 private theorem mul3_add {α : Type _} [CommMonoid α] {a b c : α} : a * b * c = b * c * a := by
   rw [mul_comm (b * c) a]; exact mul_assoc _ _ _
 
-lemma weighted_average_le_max₃ {p q r a b c : Nat} :
-    p * a + q * b + r * c ≤ (p + q + r) * Nat.max₃ a b c :=
-  by
+theorem weighted_average_le_max₃ {p q r a b c : Nat} :
+    p * a + q * b + r * c ≤ (p + q + r) * Nat.max₃ a b c := by
   rw [add_mul, add_mul]
-  apply Nat.add_le_add
-  apply Nat.add_le_add
-  exact Nat.mul_le_mul (Nat.le_refl _) (Nat.le_max₃_left _ _ _)
-  exact Nat.mul_le_mul (Nat.le_refl _) (Nat.le_max₃_middle _ _ _)
-  exact Nat.mul_le_mul (Nat.le_refl _) (Nat.le_max₃_right _ _ _)
+  refine Nat.add_le_add (Nat.add_le_add ?_ ?_) ?_
+  · exact Nat.mul_le_mul (Nat.le_refl _) (Nat.le_max₃_left _ _ _)
+  · exact Nat.mul_le_mul (Nat.le_refl _) (Nat.le_max₃_middle _ _ _)
+  · exact Nat.mul_le_mul (Nat.le_refl _) (Nat.le_max₃_right _ _ _)
 
-theorem Polynomial.derivative_C_mul {R : Type u}  [Semiring R]  (a : R) (p : R[X]) :
-    derivative (C a * p) = C a * derivative p := by
-  rw [←smul_eq_C_mul, derivative.map_smul _ _, smul_eq_C_mul]
-
-theorem derivative_pow_eq_zero_iff {n : ℕ} (chn : ¬ringChar k ∣ n) {a : k[X]}  :
-    derivative (a ^ n) = 0 ↔ derivative a = 0 :=
-  by
+omit [DecidableEq k] in
+theorem derivative_pow_eq_zero_iff {n : ℕ} (chn : ¬ringChar k ∣ n) {a : k[X]} :
+    derivative (a ^ n) = 0 ↔ derivative a = 0 := by
   constructor
   · intro apd
     rw [derivative_pow, C_eq_natCast, mul_eq_zero, mul_eq_zero] at apd
     rcases apd with (nz | powz) | goal
-    . rw [←C_eq_natCast, C_eq_zero] at nz
-      exfalso
-      exact chn (ringChar.dvd nz)
-    . have az : a = 0 := pow_eq_zero powz
+    · rw [← C_eq_natCast, C_eq_zero] at nz
+      exact absurd (ringChar.dvd nz) chn
+    · have az : a = 0 := (pow_eq_zero_iff'.mp powz).1
       rw [az, map_zero]
-    . exact goal
+    · exact goal
   · intro hd; rw [derivative_pow, hd, MulZeroClass.mul_zero]
 
 theorem mul_eq_zero_left_iff
     {M₀ : Type*} [MulZeroClass M₀] [NoZeroDivisors M₀]
-    {a : M₀} {b : M₀}  (ha : a ≠ 0) : a * b = 0 ↔ b = 0 := by
+    {a : M₀} {b : M₀} (ha : a ≠ 0) : a * b = 0 ↔ b = 0 := by
   rw [mul_eq_zero]
   tauto
 
+omit [DecidableEq k] in
 theorem Polynomial.flt_catalan_deriv
     {p q r : ℕ} (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
     (hineq : q * r + r * p + p * q ≤ p * q * r)
@@ -95,11 +86,12 @@ theorem Polynomial.flt_catalan_deriv
     (hab : IsCoprime a b) {u v w : k} (hu : u ≠ 0) (hv : v ≠ 0) (hw : w ≠ 0)
     (heq : C u * a ^ p + C v * b ^ q + C w * c ^ r = 0) :
     derivative a = 0 ∧ derivative b = 0 ∧ derivative c = 0 := by
+  classical
   have hbc : IsCoprime b c := by apply rot_coprime heq <;> assumption
   have hca : IsCoprime c a := by apply rot_coprime (rot3_add.symm.trans heq) <;> assumption
-  have hap := mul_ne_zero hu.C_ne_zero (pow_ne_zero p ha)
-  have hbp := mul_ne_zero hv.C_ne_zero (pow_ne_zero q hb)
-  have hcp := mul_ne_zero hw.C_ne_zero (pow_ne_zero r hc)
+  have hap := mul_ne_zero (Ne.C_ne_zero hu) (pow_ne_zero p ha)
+  have hbp := mul_ne_zero (Ne.C_ne_zero hv) (pow_ne_zero q hb)
+  have hcp := mul_ne_zero (Ne.C_ne_zero hw) (pow_ne_zero r hc)
   have habp : IsCoprime (C u * a ^ p) (C v * b ^ q) :=
     (isCoprime_mul_units_left hu hv).mpr hab.pow
   have hbcp : IsCoprime (C v * b ^ q) (C w * c ^ r) :=
@@ -107,24 +99,22 @@ theorem Polynomial.flt_catalan_deriv
   have hcap : IsCoprime (C w * c ^ r) (C u * a ^ p) :=
     (isCoprime_mul_units_left hw hu).mpr hca.pow
   have habcp := hcap.symm.mul_left hbcp
-  cases' Polynomial.abc hap hbp hcp habp heq with dr0 ineq
-  case inl dr0 =>
-    simp only [derivative_C_mul] at dr0
-    rw [mul_eq_zero_left_iff hu.C_ne_zero,
-        mul_eq_zero_left_iff hv.C_ne_zero,
-        mul_eq_zero_left_iff hw.C_ne_zero,
+  rcases LeanPolyABC.Polynomial.abc hap hbp hcp habp heq with dr0 | ineq
+  · simp only [derivative_C_mul] at dr0
+    rw [mul_eq_zero_left_iff (Ne.C_ne_zero hu),
+        mul_eq_zero_left_iff (Ne.C_ne_zero hv),
+        mul_eq_zero_left_iff (Ne.C_ne_zero hw),
         derivative_pow_eq_zero_iff chp,
         derivative_pow_eq_zero_iff chq,
         derivative_pow_eq_zero_iff chr] at dr0
     exact dr0
-  case inr ineq =>
-    rw [Nat.add_one_le_iff] at ineq
-    exfalso; apply not_le_of_lt ineq; clear ineq
+  · rw [Nat.add_one_le_iff] at ineq
+    exfalso; apply Nat.not_lt_of_le _ ineq
     -- work on lhs
     rw [radical_hMul habcp, radical_hMul habp]
-    rw [radical_mul_unit_left hu.isUnit_C,
-        radical_mul_unit_left hv.isUnit_C,
-        radical_mul_unit_left hw.isUnit_C]
+    rw [radical_mul_unit_left (Ne.isUnit_C hu),
+        radical_mul_unit_left (Ne.isUnit_C hv),
+        radical_mul_unit_left (Ne.isUnit_C hw)]
     rw [radical_pow a hp, radical_pow b hq, radical_pow c hr]
     rw [← radical_hMul hab, ← radical_hMul (hca.symm.mul_left hbc)]
     apply le_trans <| radical_natDegree_le _
@@ -137,36 +127,39 @@ theorem Polynomial.flt_catalan_deriv
     rw [natDegree_mul hcp.left hcp.right]
     simp only [natDegree_C, natDegree_pow, zero_add]
     have hpqr : 0 < p * q * r := Nat.mul_le_mul (Nat.mul_le_mul hp hq) hr
-    apply le_of_mul_le_mul_left _ hpqr
+    apply Nat.le_of_mul_le_mul_left _ hpqr
     apply le_trans _ (Nat.mul_le_mul_right _ hineq)
     convert weighted_average_le_max₃ using 1
     ring_nf
 
+omit [DecidableEq k] in
 private theorem expcont {a : k[X]} (ha : a ≠ 0) (hda : derivative a = 0) (chn0 : ringChar k ≠ 0) :
-    ∃ ca, ca ≠ 0 ∧ a = expand k (ringChar k) ca ∧ a.natDegree = ca.natDegree * ringChar k :=
-  by
-  have heq := (expand_contract (ringChar k) hda chn0).symm
-  refine' ⟨_, _, heq, _⟩
+    ∃ ca, ca ≠ 0 ∧ a = expand k (ringChar k) ca ∧ a.natDegree = ca.natDegree * ringChar k := by
+  have heq := (expand_contract (p := ringChar k) hda chn0).symm
+  refine ⟨contract (ringChar k) a, ?_, heq, ?_⟩
   · intro h; rw [h] at heq; simp only [map_zero] at heq; solve_by_elim
-  · rw [←natDegree_expand, ←heq]
+  · rw [← natDegree_expand, ← heq]
 
-private theorem expand_dvd {a b : k[X]} {n : ℕ} (hn : n ≠ 0) (h : a ∣ b) :
+omit [DecidableEq k] in
+private theorem expand_dvd {a b : k[X]} {n : ℕ} (_hn : n ≠ 0) (h : a ∣ b) :
     expand k n a ∣ expand k n b := by
   rcases h with ⟨t, eqn⟩
-  use expand k n t; rw [eqn, map_mul]
+  exact ⟨expand k n t, by rw [eqn, map_mul]⟩
 
+omit [DecidableEq k] in
 private theorem is_coprime_of_expand {a b : k[X]} {n : ℕ} (hn : n ≠ 0) :
-    IsCoprime (expand k n a) (expand k n b) → IsCoprime a b :=
-  by
+    IsCoprime (expand k n a) (expand k n b) → IsCoprime a b := by
+  classical
   simp_rw [← EuclideanDomain.gcd_isUnit_iff]
   rw [← not_imp_not]; intro h
-  cases' EuclideanDomain.gcd_dvd a b with ha hb
+  obtain ⟨ha, hb⟩ := EuclideanDomain.gcd_dvd a b
   have hh := EuclideanDomain.dvd_gcd (expand_dvd hn ha) (expand_dvd hn hb)
   intro h'; apply h; have tt := isUnit_of_dvd_unit hh h'
   rw [Polynomial.isUnit_iff] at tt ⊢
-  rcases tt with ⟨zz, yy⟩; rw [eq_comm, expand_eq_C (zero_lt_iff.mpr hn), eq_comm] at yy
-  refine' ⟨zz, yy⟩
+  obtain ⟨zz, yy⟩ := tt; rw [eq_comm, expand_eq_C (zero_lt_iff.mpr hn), eq_comm] at yy
+  exact ⟨zz, yy⟩
 
+omit [DecidableEq k] in
 theorem Polynomial.flt_catalan_aux
     {p q r : ℕ} (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
     (hineq : q * r + r * p + p * q ≤ p * q * r)
@@ -174,13 +167,8 @@ theorem Polynomial.flt_catalan_aux
     {a b c : k[X]} (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0) (hab : IsCoprime a b)
     {u v w : k} (hu : u ≠ 0) (hv : v ≠ 0) (hw : w ≠ 0)
     (heq : C u * a ^ p + C v * b ^ q + C w * c ^ r = 0) :
-    a.natDegree = 0 :=
-  by
-  have hbc : IsCoprime b c := by
-    apply rot_coprime <;> assumption
-  have hbc : IsCoprime c a := by
-    apply rot_coprime (rot3_add.symm.trans heq) <;> assumption
-  cases' eq_or_ne (ringChar k) 0 with ch0 chn0
+    a.natDegree = 0 := by
+  rcases eq_or_ne (ringChar k) 0 with ch0 | chn0
   -- Characteristic zero
   · have hderiv : derivative a = 0 ∧ derivative b = 0 ∧ derivative c = 0 := by
       apply Polynomial.flt_catalan_deriv hp hq hr hineq _ _ _ ha hb hc _ hu hv hw <;> assumption
@@ -194,71 +182,64 @@ theorem Polynomial.flt_catalan_aux
     We use proof by contradiction (`by_contra`) combined with strong induction
     (`Nat.case_strong_induction_on`) to formalize the proof.
     -/
-  . set d := a.natDegree with eq_d;
-    clear_value d; by_contra hd
-    revert a b c eq_d hd
-    induction' d using Nat.case_strong_induction_on with d ih_d
-    · intros; tauto
-    intros a b c ha hb hc hab heq hbc hca eq_d hd
-    have hderiv : derivative a = 0 ∧ derivative b = 0 ∧ derivative c = 0 := by
-      apply Polynomial.flt_catalan_deriv hp hq hr _ _ _ _ ha hb hc _ hu hv hw <;> assumption
-    rcases hderiv with ⟨ad, bd, cd⟩
-    rcases expcont ha ad chn0 with ⟨ca, ca_nz, eq_a, eq_deg_a⟩
-    rcases expcont hb bd chn0 with ⟨cb, cb_nz, eq_b, eq_deg_b⟩
-    rcases expcont hc cd chn0 with ⟨cc, cc_nz, eq_c, eq_deg_c⟩
-    set ch := ringChar k with eq_ch
-    apply @ih_d ca.natDegree _ ca cb cc ca_nz cb_nz cc_nz <;> clear ih_d <;> try rfl
-    · apply is_coprime_of_expand chn0; rw [← eq_a, ← eq_b]; exact hab
-    · rw [eq_a, eq_b, eq_c, ←expand_C ch u, ←expand_C ch v, ←expand_C ch w] at heq
-      simp_rw [← map_pow, ← map_mul, ← map_add] at heq
-      rw [Polynomial.expand_eq_zero (zero_lt_iff.mpr chn0)] at heq
-      exact heq
-    · apply is_coprime_of_expand chn0; rw [← eq_b, ← eq_c]; exact hbc
-    · apply is_coprime_of_expand chn0; rw [← eq_c, ← eq_a]; exact hca
-    . rw [eq_d, eq_deg_a] at hd; exact (mul_ne_zero_iff.mp hd).1
-    . have hch1 : ch ≠ 1 := by rw [eq_ch]; exact CharP.ringChar_ne_one
-      clear eq_ch; clear_value ch
-      have hch2 : 2 ≤ ch := by omega
-      -- Why can't a single omega handle things from here?
-      rw [←Nat.succ_le_succ_iff]
-      rw [eq_d, eq_deg_a] at hd ⊢
-      rw [mul_eq_zero, not_or] at hd
-      rcases hd with ⟨ca_nz, _⟩
-      rw [Nat.succ_le_iff]
-      rewrite (config := {occs := .pos [1]}) [←Nat.mul_one ca.natDegree]
-      rw [Nat.mul_lt_mul_left]
-      tauto
-      omega
+  · generalize eq_d : a.natDegree = d
+    induction d using Nat.case_strong_induction_on
+      generalizing a b c ha hb hc hab heq with
+    | hz => rfl
+    | hi d ih_d =>
+      have hderiv : derivative a = 0 ∧ derivative b = 0 ∧ derivative c = 0 := by
+        apply Polynomial.flt_catalan_deriv hp hq hr hineq _ _ _ ha hb hc _ hu hv hw <;> assumption
+      rcases hderiv with ⟨ad, bd, cd⟩
+      rcases expcont ha ad chn0 with ⟨ca, ca_nz, eq_a, eq_deg_a⟩
+      rcases expcont hb bd chn0 with ⟨cb, cb_nz, eq_b, eq_deg_b⟩
+      rcases expcont hc cd chn0 with ⟨cc, cc_nz, eq_c, eq_deg_c⟩
+      set ch := ringChar k with eq_ch
+      suffices hca : ca.natDegree = 0 by
+        rw [← eq_d, eq_deg_a, hca, zero_mul]
+      by_contra hnca; apply hnca
+      apply ih_d ca.natDegree _ ca_nz cb_nz cc_nz <;> clear ih_d <;> try rfl
+      · apply is_coprime_of_expand chn0; rw [← eq_a, ← eq_b]; exact hab
+      · rw [eq_a, eq_b, eq_c, ← expand_C ch u, ← expand_C ch v, ← expand_C ch w] at heq
+        simp_rw [← map_pow, ← map_mul, ← map_add] at heq
+        rw [Polynomial.expand_eq_zero (zero_lt_iff.mpr chn0)] at heq
+        exact heq
+      · have hch1 : ch ≠ 1 := by rw [eq_ch]; exact CharP.ringChar_ne_one
+        clear eq_ch; clear_value ch
+        have hch2 : 2 ≤ ch := by omega
+        have hca1 : 1 ≤ ca.natDegree := Nat.one_le_iff_ne_zero.mpr hnca
+        have hdeg : a.natDegree = ca.natDegree * ch := eq_deg_a
+        rw [eq_d] at hdeg
+        nlinarith [hdeg, hca1, hch2]
 
-  theorem Polynomial.flt_catalan
-      {p q r : ℕ} (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
-      (hineq : q * r + r * p + p * q ≤ p * q * r)
-      (chp : ¬ringChar k ∣ p) (chq : ¬ringChar k ∣ q) (chr : ¬ringChar k ∣ r)
-      {a b c : k[X]} (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0) (hab : IsCoprime a b)
-      {u v w : k} (hu : u ≠ 0) (hv : v ≠ 0) (hw : w ≠ 0)
-      (heq : C u * a ^ p + C v * b ^ q + C w * c ^ r = 0) :
-      a.natDegree = 0 ∧ b.natDegree = 0 ∧ c.natDegree = 0 :=
-    by
-    -- WLOG argument: essentially three times flt_catalan_aux
-    have hbc : IsCoprime b c := by apply rot_coprime heq hab <;> assumption
-    have hca : IsCoprime c a := by apply rot_coprime (rot3_add.symm.trans heq) hbc <;> assumption
-    refine' ⟨_, _, _⟩
-    · apply Polynomial.flt_catalan_aux _ _ _ _ _ _ _ _ _ _ _ _ _ _ heq <;> try assumption
-    · rw [rot3_add] at heq hineq; rw [mul3_add] at hineq
-      apply Polynomial.flt_catalan_aux _ _ _ _ _ _ _ _ _ _ _ _ _ _ heq <;> try assumption
-    · rw [← rot3_add] at heq hineq; rw [← mul3_add] at hineq
-      apply Polynomial.flt_catalan_aux _ _ _ _ _ _ _ _ _ _ _ _ _ _ heq <;> try assumption
+omit [DecidableEq k] in
+theorem Polynomial.flt_catalan
+    {p q r : ℕ} (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
+    (hineq : q * r + r * p + p * q ≤ p * q * r)
+    (chp : ¬ringChar k ∣ p) (chq : ¬ringChar k ∣ q) (chr : ¬ringChar k ∣ r)
+    {a b c : k[X]} (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0) (hab : IsCoprime a b)
+    {u v w : k} (hu : u ≠ 0) (hv : v ≠ 0) (hw : w ≠ 0)
+    (heq : C u * a ^ p + C v * b ^ q + C w * c ^ r = 0) :
+    a.natDegree = 0 ∧ b.natDegree = 0 ∧ c.natDegree = 0 := by
+  -- WLOG argument: essentially three times flt_catalan_aux
+  have hbc : IsCoprime b c := by apply rot_coprime heq hab <;> assumption
+  have hca : IsCoprime c a := by apply rot_coprime (rot3_add.symm.trans heq) hbc <;> assumption
+  refine ⟨?_, ?_, ?_⟩
+  · apply Polynomial.flt_catalan_aux _ _ _ _ _ _ _ _ _ _ _ _ _ _ heq <;> try assumption
+  · rw [rot3_add] at heq hineq; rw [mul3_add] at hineq
+    apply Polynomial.flt_catalan_aux _ _ _ _ _ _ _ _ _ _ _ _ _ _ heq <;> try assumption
+  · rw [← rot3_add] at heq hineq; rw [← mul3_add] at hineq
+    apply Polynomial.flt_catalan_aux _ _ _ _ _ _ _ _ _ _ _ _ _ _ heq <;> try assumption
 
 /- FLT is special case of nonsolvability of Fermat-Catalan equation.
 Take p = q = r = n and u = v = 1, w = -1.
 -/
+omit [DecidableEq k] in
 theorem Polynomial.flt
     {n : ℕ} (hn : 3 ≤ n) (chn : ¬ringChar k ∣ n)
     {a b c : k[X]} (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0)
     (hab : IsCoprime a b) (heq : a ^ n + b ^ n = c ^ n) :
-    a.natDegree = 0 ∧ b.natDegree = 0 ∧ c.natDegree = 0 :=
-  by
-  have hn' : 0 < n := by linarith
+    a.natDegree = 0 ∧ b.natDegree = 0 ∧ c.natDegree = 0 := by
+  have hn' : 0 < n := by lia
   rw [← sub_eq_zero, ← one_mul (a ^ n), ← one_mul (b ^ n), ← one_mul (c ^ n), sub_eq_add_neg, ←
     neg_mul] at heq
   have hone : (1 : k[X]) = C 1 := by rfl
@@ -268,4 +249,6 @@ theorem Polynomial.flt
     chn chn chn ha hb hc hab one_ne_zero one_ne_zero (neg_ne_zero.mpr one_ne_zero) heq
   have eq_lhs : n * n + n * n + n * n = 3 * n * n := by ring_nf
   rw [eq_lhs]; rw [mul_assoc, mul_assoc]
-  apply Nat.mul_le_mul_right (n * n); exact hn
+  exact Nat.mul_le_mul_right (n * n) hn
+
+end LeanPolyABC

--- a/LeanPool/LeanPolyABC/Corollaries/FltCatalan.lean
+++ b/LeanPool/LeanPolyABC/Corollaries/FltCatalan.lean
@@ -1,0 +1,271 @@
+/-
+Copyright (c) 2026 Seewoo Lee. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Seewoo Lee
+-/
+
+import Mathlib.Algebra.CharP.Defs
+import Mathlib.Algebra.EuclideanDomain.Defs
+import Mathlib.RingTheory.MvPowerSeries.Basic
+import Mathlib.Algebra.Polynomial.Expand
+import Mathlib.Algebra.Polynomial.Coeff
+import Mathlib.Logic.Lemmas
+import LeanPool.LeanPolyABC.MasonStothers
+import Mathlib.RingTheory.Coprime.Basic
+
+noncomputable section
+
+open scoped Polynomial Classical
+
+open Polynomial
+
+open UniqueFactorizationMonoid
+
+variable {k : Type _} [Field k]
+
+-- Multiplying units preserve coprimality
+private theorem isCoprime_mul_units_left {a b : k[X]} {u v : k} (hu : u ≠ 0) (hv : v ≠ 0) :
+    IsCoprime (C u * a) (C v * b) ↔ IsCoprime a b :=
+  Iff.trans
+    (isCoprime_mul_unit_left_left hu.isUnit_C _ _)
+    (isCoprime_mul_unit_left_right hv.isUnit_C _ _)
+
+private theorem rot_coprime {p q r : ℕ} {a b c : k[X]} {u v w : k}
+    (heq : C u * a ^ p + C v * b ^ q + C w * c ^ r = 0) (hab : IsCoprime a b)
+    (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
+    (hu : u ≠ 0) (hv : v ≠ 0) (hw : w ≠ 0) : IsCoprime b c := by
+  have uu := hu.isUnit_C
+  have uv := hv.isUnit_C
+  have uw := hw.isUnit_C
+
+  rw [←IsCoprime.pow_iff hp hq, ←isCoprime_mul_units_left hu hv] at hab
+  rw [←IsCoprime.pow_iff hq hr, ←isCoprime_mul_units_left hv hw]
+
+  rw [add_eq_zero_iff_neg_eq] at heq
+  rw [←heq, IsCoprime.neg_right_iff]
+  convert IsCoprime.add_mul_left_right hab.symm 1 using 2
+  rw [mul_one]
+
+private theorem rot3_add {α : Type _} [AddCommMonoid α] {a b c : α} : a + b + c = b + c + a := by
+  rw [add_comm (b + c) a]; exact add_assoc _ _ _
+
+private theorem mul3_add {α : Type _} [CommMonoid α] {a b c : α} : a * b * c = b * c * a := by
+  rw [mul_comm (b * c) a]; exact mul_assoc _ _ _
+
+lemma weighted_average_le_max₃ {p q r a b c : Nat} :
+    p * a + q * b + r * c ≤ (p + q + r) * Nat.max₃ a b c :=
+  by
+  rw [add_mul, add_mul]
+  apply Nat.add_le_add
+  apply Nat.add_le_add
+  exact Nat.mul_le_mul (Nat.le_refl _) (Nat.le_max₃_left _ _ _)
+  exact Nat.mul_le_mul (Nat.le_refl _) (Nat.le_max₃_middle _ _ _)
+  exact Nat.mul_le_mul (Nat.le_refl _) (Nat.le_max₃_right _ _ _)
+
+theorem Polynomial.derivative_C_mul {R : Type u}  [Semiring R]  (a : R) (p : R[X]) :
+    derivative (C a * p) = C a * derivative p := by
+  rw [←smul_eq_C_mul, derivative.map_smul _ _, smul_eq_C_mul]
+
+theorem derivative_pow_eq_zero_iff {n : ℕ} (chn : ¬ringChar k ∣ n) {a : k[X]}  :
+    derivative (a ^ n) = 0 ↔ derivative a = 0 :=
+  by
+  constructor
+  · intro apd
+    rw [derivative_pow, C_eq_natCast, mul_eq_zero, mul_eq_zero] at apd
+    rcases apd with (nz | powz) | goal
+    . rw [←C_eq_natCast, C_eq_zero] at nz
+      exfalso
+      exact chn (ringChar.dvd nz)
+    . have az : a = 0 := pow_eq_zero powz
+      rw [az, map_zero]
+    . exact goal
+  · intro hd; rw [derivative_pow, hd, MulZeroClass.mul_zero]
+
+theorem mul_eq_zero_left_iff
+    {M₀ : Type*} [MulZeroClass M₀] [NoZeroDivisors M₀]
+    {a : M₀} {b : M₀}  (ha : a ≠ 0) : a * b = 0 ↔ b = 0 := by
+  rw [mul_eq_zero]
+  tauto
+
+theorem Polynomial.flt_catalan_deriv
+    {p q r : ℕ} (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
+    (hineq : q * r + r * p + p * q ≤ p * q * r)
+    (chp : ¬ringChar k ∣ p) (chq : ¬ringChar k ∣ q) (chr : ¬ringChar k ∣ r)
+    {a b c : k[X]} (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0)
+    (hab : IsCoprime a b) {u v w : k} (hu : u ≠ 0) (hv : v ≠ 0) (hw : w ≠ 0)
+    (heq : C u * a ^ p + C v * b ^ q + C w * c ^ r = 0) :
+    derivative a = 0 ∧ derivative b = 0 ∧ derivative c = 0 := by
+  have hbc : IsCoprime b c := by apply rot_coprime heq <;> assumption
+  have hca : IsCoprime c a := by apply rot_coprime (rot3_add.symm.trans heq) <;> assumption
+  have hap := mul_ne_zero hu.C_ne_zero (pow_ne_zero p ha)
+  have hbp := mul_ne_zero hv.C_ne_zero (pow_ne_zero q hb)
+  have hcp := mul_ne_zero hw.C_ne_zero (pow_ne_zero r hc)
+  have habp : IsCoprime (C u * a ^ p) (C v * b ^ q) :=
+    (isCoprime_mul_units_left hu hv).mpr hab.pow
+  have hbcp : IsCoprime (C v * b ^ q) (C w * c ^ r) :=
+    (isCoprime_mul_units_left hv hw).mpr hbc.pow
+  have hcap : IsCoprime (C w * c ^ r) (C u * a ^ p) :=
+    (isCoprime_mul_units_left hw hu).mpr hca.pow
+  have habcp := hcap.symm.mul_left hbcp
+  cases' Polynomial.abc hap hbp hcp habp heq with dr0 ineq
+  case inl dr0 =>
+    simp only [derivative_C_mul] at dr0
+    rw [mul_eq_zero_left_iff hu.C_ne_zero,
+        mul_eq_zero_left_iff hv.C_ne_zero,
+        mul_eq_zero_left_iff hw.C_ne_zero,
+        derivative_pow_eq_zero_iff chp,
+        derivative_pow_eq_zero_iff chq,
+        derivative_pow_eq_zero_iff chr] at dr0
+    exact dr0
+  case inr ineq =>
+    rw [Nat.add_one_le_iff] at ineq
+    exfalso; apply not_le_of_lt ineq; clear ineq
+    -- work on lhs
+    rw [radical_hMul habcp, radical_hMul habp]
+    rw [radical_mul_unit_left hu.isUnit_C,
+        radical_mul_unit_left hv.isUnit_C,
+        radical_mul_unit_left hw.isUnit_C]
+    rw [radical_pow a hp, radical_pow b hq, radical_pow c hr]
+    rw [← radical_hMul hab, ← radical_hMul (hca.symm.mul_left hbc)]
+    apply le_trans <| radical_natDegree_le _
+    rw [natDegree_mul (mul_ne_zero ha hb) hc]
+    rw [natDegree_mul ha hb]
+    -- work on rhs
+    rw [mul_ne_zero_iff] at hap hbp hcp
+    rw [natDegree_mul hap.left hap.right]
+    rw [natDegree_mul hbp.left hbp.right]
+    rw [natDegree_mul hcp.left hcp.right]
+    simp only [natDegree_C, natDegree_pow, zero_add]
+    have hpqr : 0 < p * q * r := Nat.mul_le_mul (Nat.mul_le_mul hp hq) hr
+    apply le_of_mul_le_mul_left _ hpqr
+    apply le_trans _ (Nat.mul_le_mul_right _ hineq)
+    convert weighted_average_le_max₃ using 1
+    ring_nf
+
+private theorem expcont {a : k[X]} (ha : a ≠ 0) (hda : derivative a = 0) (chn0 : ringChar k ≠ 0) :
+    ∃ ca, ca ≠ 0 ∧ a = expand k (ringChar k) ca ∧ a.natDegree = ca.natDegree * ringChar k :=
+  by
+  have heq := (expand_contract (ringChar k) hda chn0).symm
+  refine' ⟨_, _, heq, _⟩
+  · intro h; rw [h] at heq; simp only [map_zero] at heq; solve_by_elim
+  · rw [←natDegree_expand, ←heq]
+
+private theorem expand_dvd {a b : k[X]} {n : ℕ} (hn : n ≠ 0) (h : a ∣ b) :
+    expand k n a ∣ expand k n b := by
+  rcases h with ⟨t, eqn⟩
+  use expand k n t; rw [eqn, map_mul]
+
+private theorem is_coprime_of_expand {a b : k[X]} {n : ℕ} (hn : n ≠ 0) :
+    IsCoprime (expand k n a) (expand k n b) → IsCoprime a b :=
+  by
+  simp_rw [← EuclideanDomain.gcd_isUnit_iff]
+  rw [← not_imp_not]; intro h
+  cases' EuclideanDomain.gcd_dvd a b with ha hb
+  have hh := EuclideanDomain.dvd_gcd (expand_dvd hn ha) (expand_dvd hn hb)
+  intro h'; apply h; have tt := isUnit_of_dvd_unit hh h'
+  rw [Polynomial.isUnit_iff] at tt ⊢
+  rcases tt with ⟨zz, yy⟩; rw [eq_comm, expand_eq_C (zero_lt_iff.mpr hn), eq_comm] at yy
+  refine' ⟨zz, yy⟩
+
+theorem Polynomial.flt_catalan_aux
+    {p q r : ℕ} (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
+    (hineq : q * r + r * p + p * q ≤ p * q * r)
+    (chp : ¬ringChar k ∣ p) (chq : ¬ringChar k ∣ q) (chr : ¬ringChar k ∣ r)
+    {a b c : k[X]} (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0) (hab : IsCoprime a b)
+    {u v w : k} (hu : u ≠ 0) (hv : v ≠ 0) (hw : w ≠ 0)
+    (heq : C u * a ^ p + C v * b ^ q + C w * c ^ r = 0) :
+    a.natDegree = 0 :=
+  by
+  have hbc : IsCoprime b c := by
+    apply rot_coprime <;> assumption
+  have hbc : IsCoprime c a := by
+    apply rot_coprime (rot3_add.symm.trans heq) <;> assumption
+  cases' eq_or_ne (ringChar k) 0 with ch0 chn0
+  -- Characteristic zero
+  · have hderiv : derivative a = 0 ∧ derivative b = 0 ∧ derivative c = 0 := by
+      apply Polynomial.flt_catalan_deriv hp hq hr hineq _ _ _ ha hb hc _ hu hv hw <;> assumption
+    rcases hderiv with ⟨da, -, -⟩
+    have ii : CharZero k := by
+      apply charZero_of_inj_zero; intro n; rw [ringChar.spec]
+      rw [ch0]; exact zero_dvd_iff.mp
+    have tt := eq_C_of_derivative_eq_zero da
+    rw [tt]; exact natDegree_C _
+  /- Characteristic ch ≠ 0, where we use infinite descent.
+    We use proof by contradiction (`by_contra`) combined with strong induction
+    (`Nat.case_strong_induction_on`) to formalize the proof.
+    -/
+  . set d := a.natDegree with eq_d;
+    clear_value d; by_contra hd
+    revert a b c eq_d hd
+    induction' d using Nat.case_strong_induction_on with d ih_d
+    · intros; tauto
+    intros a b c ha hb hc hab heq hbc hca eq_d hd
+    have hderiv : derivative a = 0 ∧ derivative b = 0 ∧ derivative c = 0 := by
+      apply Polynomial.flt_catalan_deriv hp hq hr _ _ _ _ ha hb hc _ hu hv hw <;> assumption
+    rcases hderiv with ⟨ad, bd, cd⟩
+    rcases expcont ha ad chn0 with ⟨ca, ca_nz, eq_a, eq_deg_a⟩
+    rcases expcont hb bd chn0 with ⟨cb, cb_nz, eq_b, eq_deg_b⟩
+    rcases expcont hc cd chn0 with ⟨cc, cc_nz, eq_c, eq_deg_c⟩
+    set ch := ringChar k with eq_ch
+    apply @ih_d ca.natDegree _ ca cb cc ca_nz cb_nz cc_nz <;> clear ih_d <;> try rfl
+    · apply is_coprime_of_expand chn0; rw [← eq_a, ← eq_b]; exact hab
+    · rw [eq_a, eq_b, eq_c, ←expand_C ch u, ←expand_C ch v, ←expand_C ch w] at heq
+      simp_rw [← map_pow, ← map_mul, ← map_add] at heq
+      rw [Polynomial.expand_eq_zero (zero_lt_iff.mpr chn0)] at heq
+      exact heq
+    · apply is_coprime_of_expand chn0; rw [← eq_b, ← eq_c]; exact hbc
+    · apply is_coprime_of_expand chn0; rw [← eq_c, ← eq_a]; exact hca
+    . rw [eq_d, eq_deg_a] at hd; exact (mul_ne_zero_iff.mp hd).1
+    . have hch1 : ch ≠ 1 := by rw [eq_ch]; exact CharP.ringChar_ne_one
+      clear eq_ch; clear_value ch
+      have hch2 : 2 ≤ ch := by omega
+      -- Why can't a single omega handle things from here?
+      rw [←Nat.succ_le_succ_iff]
+      rw [eq_d, eq_deg_a] at hd ⊢
+      rw [mul_eq_zero, not_or] at hd
+      rcases hd with ⟨ca_nz, _⟩
+      rw [Nat.succ_le_iff]
+      rewrite (config := {occs := .pos [1]}) [←Nat.mul_one ca.natDegree]
+      rw [Nat.mul_lt_mul_left]
+      tauto
+      omega
+
+  theorem Polynomial.flt_catalan
+      {p q r : ℕ} (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
+      (hineq : q * r + r * p + p * q ≤ p * q * r)
+      (chp : ¬ringChar k ∣ p) (chq : ¬ringChar k ∣ q) (chr : ¬ringChar k ∣ r)
+      {a b c : k[X]} (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0) (hab : IsCoprime a b)
+      {u v w : k} (hu : u ≠ 0) (hv : v ≠ 0) (hw : w ≠ 0)
+      (heq : C u * a ^ p + C v * b ^ q + C w * c ^ r = 0) :
+      a.natDegree = 0 ∧ b.natDegree = 0 ∧ c.natDegree = 0 :=
+    by
+    -- WLOG argument: essentially three times flt_catalan_aux
+    have hbc : IsCoprime b c := by apply rot_coprime heq hab <;> assumption
+    have hca : IsCoprime c a := by apply rot_coprime (rot3_add.symm.trans heq) hbc <;> assumption
+    refine' ⟨_, _, _⟩
+    · apply Polynomial.flt_catalan_aux _ _ _ _ _ _ _ _ _ _ _ _ _ _ heq <;> try assumption
+    · rw [rot3_add] at heq hineq; rw [mul3_add] at hineq
+      apply Polynomial.flt_catalan_aux _ _ _ _ _ _ _ _ _ _ _ _ _ _ heq <;> try assumption
+    · rw [← rot3_add] at heq hineq; rw [← mul3_add] at hineq
+      apply Polynomial.flt_catalan_aux _ _ _ _ _ _ _ _ _ _ _ _ _ _ heq <;> try assumption
+
+/- FLT is special case of nonsolvability of Fermat-Catalan equation.
+Take p = q = r = n and u = v = 1, w = -1.
+-/
+theorem Polynomial.flt
+    {n : ℕ} (hn : 3 ≤ n) (chn : ¬ringChar k ∣ n)
+    {a b c : k[X]} (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0)
+    (hab : IsCoprime a b) (heq : a ^ n + b ^ n = c ^ n) :
+    a.natDegree = 0 ∧ b.natDegree = 0 ∧ c.natDegree = 0 :=
+  by
+  have hn' : 0 < n := by linarith
+  rw [← sub_eq_zero, ← one_mul (a ^ n), ← one_mul (b ^ n), ← one_mul (c ^ n), sub_eq_add_neg, ←
+    neg_mul] at heq
+  have hone : (1 : k[X]) = C 1 := by rfl
+  have hneg_one : (-1 : k[X]) = C (-1) := by simp only [map_neg, map_one]
+  simp_rw [hneg_one, hone] at heq
+  apply Polynomial.flt_catalan hn' hn' hn' _
+    chn chn chn ha hb hc hab one_ne_zero one_ne_zero (neg_ne_zero.mpr one_ne_zero) heq
+  have eq_lhs : n * n + n * n + n * n = 3 * n * n := by ring_nf
+  rw [eq_lhs]; rw [mul_assoc, mul_assoc]
+  apply Nat.mul_le_mul_right (n * n); exact hn

--- a/LeanPool/LeanPolyABC/Corollaries/NoParametrization.lean
+++ b/LeanPool/LeanPolyABC/Corollaries/NoParametrization.lean
@@ -10,58 +10,61 @@ import LeanPool.LeanPolyABC.Corollaries.FltCatalan
 
 noncomputable section
 
-open scoped Classical Polynomial
+open scoped Polynomial
 
 open RatFunc
 
+namespace LeanPolyABC
+
 variable {k : Type _} [Field k]
 
--- Auxiliary definitions and theorems for rational functions
+/-- A rational function is constant if it equals `RatFunc.C c` for some scalar `c`. -/
 def IsConst (x : RatFunc k) :=
   ∃ c : k, x = RatFunc.C c
 
 theorem associates_pow_eq_pow_iff {A B : Associates k[X]} {n : ℕ} (hn : n ≠ 0) :
     A ^ n = B ^ n ↔ A = B := by
+  classical
   by_cases hA : A = 0
   · subst hA
     rw [zero_pow hn, eq_comm, pow_eq_zero_iff hn, eq_comm]
   by_cases hB : B = 0
   · subst hB
     rw [zero_pow hn, pow_eq_zero_iff hn]
-  · constructor; swap
-    . intro h; subst h; rfl
-    . intro h
+  · constructor
+    swap
+    · intro h; subst h; rfl
+    · intro h
       apply Associates.eq_of_eq_counts hA hB
       intro p hp
       apply Nat.eq_of_mul_eq_mul_left (Nat.zero_lt_of_ne_zero hn)
       rw [← Associates.count_pow hA hp n, ← Associates.count_pow hB hp n, h]
 
-theorem isConst_of_associated {f : RatFunc k} (h : Associated f.num f.denom) : IsConst f :=
-  by
+theorem isConst_of_associated {f : RatFunc k} (h : Associated f.num f.denom) : IsConst f := by
   rcases h.symm with ⟨u, heq⟩
-  rcases Polynomial.isUnit_iff.mp u.isUnit with ⟨c, uc, eq_c⟩
+  rcases Polynomial.isUnit_iff.mp u.isUnit with ⟨c, _, eq_c⟩
   rw [← eq_c] at heq
   have tt := congr_arg (algebraMap (Polynomial k) (RatFunc k)) heq.symm
   rw [map_mul, mul_comm] at tt
   have uu := div_eq_of_eq_mul (algebraMap_ne_zero f.denom_ne_zero) tt
   rw [f.num_div_denom, RatFunc.algebraMap_C] at uu
-  use c
+  exact ⟨c, uu⟩
 
-theorem isConst_of_root_unity {n : ℕ} (hn : n ≠ 0) {f : RatFunc k} (h : f ^ n = 1) : IsConst f :=
-  by
+theorem isConst_of_root_unity {n : ℕ} (hn : n ≠ 0) {f : RatFunc k} (h : f ^ n = 1) : IsConst f := by
   rw [← f.num_div_denom, div_pow, ← map_pow, ← map_pow] at h
   have nz : algebraMap k[X] (RatFunc k) (f.denom ^ n) ≠ 0 := by
     apply algebraMap_ne_zero; apply pow_ne_zero; exact f.denom_ne_zero
-  rw [← mul_left_inj' nz, div_mul_cancel₀ (algebraMap k[X] (RatFunc k) (f.num ^ n)) nz, one_mul] at h
+  rw [← mul_left_inj' nz, div_mul_cancel₀ (algebraMap k[X] (RatFunc k) (f.num ^ n)) nz,
+    one_mul] at h
   have hh := congr_arg Associates.mk (algebraMap_injective k h)
   rw [Associates.mk_pow, Associates.mk_pow, associates_pow_eq_pow_iff hn,
     Associates.mk_eq_mk_iff_associated] at hh
   exact isConst_of_associated hh
 
-theorem associated_pow_pow_coprime_iff {a b : k[X]} {m n : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) (hm : m ≠ 0)
-    (hn : n ≠ 0) (h : Associated (a ^ m) (b ^ n)) (hcp : m.Coprime n) :
-    ∃ c : k[X], c ≠ 0 ∧ Associated a (c ^ n) ∧ Associated b (c ^ m) :=
-  by
+theorem associated_pow_pow_coprime_iff {a b : k[X]} {m n : ℕ} (ha : a ≠ 0) (hb : b ≠ 0)
+    (_hm : m ≠ 0) (hn : n ≠ 0) (h : Associated (a ^ m) (b ^ n)) (hcp : m.Coprime n) :
+    ∃ c : k[X], c ≠ 0 ∧ Associated a (c ^ n) ∧ Associated b (c ^ m) := by
+  classical
   -- change to associates
   simp_rw [← Associates.mk_eq_mk_iff_associated, Associates.mk_pow] at h ⊢
   rw [← Associates.mk_ne_zero] at ha hb
@@ -71,19 +74,18 @@ theorem associated_pow_pow_coprime_iff {a b : k[X]} {m n : ℕ} (ha : a ≠ 0) (
   clear_value A B; clear eq_A eq_B
   suffices goal : ∃ C, A = C ^ n ∧ B = C ^ m by
     rcases goal with ⟨C, hC⟩
-    use C.out; simp only [Associates.mk_out]
-    refine' ⟨_, hC⟩
-    rw [← Associates.mk_ne_zero, Associates.mk_out, ← pow_ne_zero_iff hn, ← hC.1]
-    exact hA
-  have subgoal : ∃ C, A = C ^ n :=
-    by
+    refine ⟨C.out, ?_, ?_⟩
+    · rw [← Associates.mk_ne_zero, Associates.mk_out, ← pow_ne_zero_iff hn, ← hC.1]
+      exact hA
+    · simp only [Associates.mk_out]; exact hC
+  have subgoal : ∃ C, A = C ^ n := by
     apply Associates.is_pow_of_dvd_count hA
     intro p hp
     apply hcp.symm.dvd_of_dvd_mul_left
     rw [← Associates.count_pow hA hp, h, Associates.count_pow hB hp]
     exact Nat.dvd_mul_right _ _
   rcases subgoal with ⟨C, eq_ACn⟩
-  refine' ⟨C, eq_ACn, _⟩
+  refine ⟨C, eq_ACn, ?_⟩
   rw [eq_ACn, pow_right_comm, associates_pow_eq_pow_iff hn] at h
   exact h.symm
 
@@ -92,8 +94,7 @@ theorem calcstep {n N m M : k[X]} (nz_M : M ≠ 0) (nz_N : N ≠ 0)
     (eqn :
       (algebraMap _ (RatFunc k)) n ^ 2 / (algebraMap _ (RatFunc k)) N ^ 2 =
         (algebraMap _ (RatFunc k)) m ^ 3 / (algebraMap _ (RatFunc k)) M ^ 3 + 1) :
-    n ^ 2 * M ^ 3 = (m ^ 3 + M ^ 3) * N ^ 2 :=
-  by
+    n ^ 2 * M ^ 3 = (m ^ 3 + M ^ 3) * N ^ 2 := by
   have nz_rM := RatFunc.algebraMap_ne_zero nz_M
   have nz_rN := RatFunc.algebraMap_ne_zero nz_N
   rw [← (RatFunc.algebraMap_injective k).eq_iff]
@@ -112,16 +113,14 @@ theorem calcstep {n N m M : k[X]} (nz_M : M ≠ 0) (nz_N : N ≠ 0)
       rw [add_mul, div_mul_cancel₀ _ (pow_ne_zero 3 nz_rM), one_mul]
 
 theorem calcstep2 {m M n N : k[X]} (nz_M : M ≠ 0) (nz_N : N ≠ 0) (cp_mM : IsCoprime m M)
-    (cp_nN : IsCoprime n N) (nz_m : m ≠ 0) (nz_n : n ≠ 0)
+    (cp_nN : IsCoprime n N) (_nz_m : m ≠ 0) (_nz_n : n ≠ 0)
     (flat_eqn : n ^ 2 * M ^ 3 = (m ^ 3 + M ^ 3) * N ^ 2) :
     ∃ (w : k[X]) (u v : k[X]ˣ),
       w ≠ 0 ∧
         ↑u * w ^ 2 = M ∧
           ↑v * w ^ 3 = N ∧
-            IsCoprime m w ∧ (↑u) ^ 3 * n ^ 2 = (↑v) ^ 2 * m ^ 3 + (↑v) ^ 2 * (↑u) ^ 3 * w ^ 6 :=
-  by
-  have assoc_M3_N2 : Associated (M ^ 3) (N ^ 2) :=
-    by
+            IsCoprime m w ∧ (↑u) ^ 3 * n ^ 2 = (↑v) ^ 2 * m ^ 3 + (↑v) ^ 2 * (↑u) ^ 3 * w ^ 6 := by
+  have assoc_M3_N2 : Associated (M ^ 3) (N ^ 2) := by
     refine associated_of_dvd_dvd ?_ ?_
     · have cp : IsCoprime (M ^ 3) (m ^ 3 + 1 * M ^ 3) := cp_mM.symm.pow.add_mul_right_right 1
       rw [one_mul] at cp
@@ -130,37 +129,34 @@ theorem calcstep2 {m M n N : k[X]} (nz_M : M ≠ 0) (nz_N : N ≠ 0) (cp_mM : Is
     · have cp : IsCoprime (N ^ 2) (n ^ 2) := cp_nN.symm.pow
       apply cp.dvd_of_dvd_mul_left
       rw [flat_eqn]; exact dvd_mul_left _ _
-  rcases associated_pow_pow_coprime_iff nz_M nz_N (by decide) (by decide) assoc_M3_N2 (by decide) with
-    ⟨w, nz_w, assoc_M_w2, assoc_N_w3⟩
+  rcases associated_pow_pow_coprime_iff nz_M nz_N (by decide) (by decide) assoc_M3_N2 (by decide)
+    with ⟨w, nz_w, assoc_M_w2, assoc_N_w3⟩
   rcases assoc_M_w2.symm with ⟨u, eq_Mw⟩; rw [mul_comm] at eq_Mw
   rcases assoc_N_w3.symm with ⟨v, eq_Nw⟩; rw [mul_comm] at eq_Nw
-  refine' ⟨w, u, v, nz_w, eq_Mw, eq_Nw, _⟩
+  refine ⟨w, u, v, nz_w, eq_Mw, eq_Nw, ?_⟩
   simp_rw [← eq_Mw, ← eq_Nw, mul_pow, ← pow_mul, ← mul_assoc] at flat_eqn
   simp only [Nat.reduceMul, mul_eq_mul_right_iff, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true,
     pow_eq_zero_iff] at flat_eqn
   constructor
-  . rw [← eq_Mw, isCoprime_mul_unit_left_right u.isUnit, IsCoprime.pow_right_iff] at cp_mM
-    exact cp_mM; decide
-  . rcases flat_eqn with eqn | w0
-    . convert eqn using 1 <;> ring_nf
-    . contradiction
+  · rw [← eq_Mw, isCoprime_mul_unit_left_right u.isUnit, IsCoprime.pow_right_iff] at cp_mM
+    · exact cp_mM
+    · decide
+  · rcases flat_eqn with eqn | w0
+    · convert eqn using 1 <;> ring_nf
+    · contradiction
 
 -- Main corollary
 theorem no_parametrization_y2_x3_1 (chk : ¬ringChar k ∣ 6) {x y : RatFunc k}
-    (eqn : y ^ 2 = x ^ 3 + 1) : IsConst x ∧ IsConst y :=
-  by
-  cases' eq_or_ne x 0 with eq_x nz_x
+    (eqn : y ^ 2 = x ^ 3 + 1) : IsConst x ∧ IsConst y := by
+  rcases eq_or_ne x 0 with eq_x | nz_x
   · subst x
-    rw [zero_pow, zero_add] at eqn; swap; decide
-    refine' ⟨⟨0, (map_zero _).symm⟩, isConst_of_root_unity _ eqn⟩
-    decide
-  cases' eq_or_ne y 0 with eq_y nz_y
-  · subst y; rw [eq_comm, zero_pow, ← eq_neg_iff_add_eq_zero] at eqn
-    swap; decide
+    rw [zero_pow (by decide), zero_add] at eqn
+    refine ⟨⟨0, (map_zero _).symm⟩, isConst_of_root_unity (by decide) eqn⟩
+  rcases eq_or_ne y 0 with eq_y | nz_y
+  · subst y; rw [eq_comm, zero_pow (by decide), ← eq_neg_iff_add_eq_zero] at eqn
     have tt : (x ^ 3) ^ 2 = 1 := by rw [sq_eq_one_iff]; right; exact eqn
     ring_nf at tt
-    refine' ⟨isConst_of_root_unity _ tt, ⟨0, (map_zero _).symm⟩⟩
-    decide
+    refine ⟨isConst_of_root_unity (by decide) tt, ⟨0, (map_zero _).symm⟩⟩
   have eq_x := x.num_div_denom.symm
   have eq_y := y.num_div_denom.symm
   have nz_m := num_ne_zero nz_x
@@ -184,12 +180,12 @@ theorem no_parametrization_y2_x3_1 (chk : ¬ringChar k ∣ 6) {x y : RatFunc k}
       w ≠ 0 ∧
         ↑u * w ^ 2 = M ∧
           ↑v * w ^ 3 = N ∧
-            IsCoprime m w ∧ (↑u) ^ 3 * n ^ 2 = (↑v) ^ 2 * m ^ 3 + (↑v) ^ 2 * (↑u) ^ 3 * w ^ 6 :=
-    by apply calcstep2 <;> assumption
+            IsCoprime m w ∧ (↑u) ^ 3 * n ^ 2 = (↑v) ^ 2 * m ^ 3 + (↑v) ^ 2 * (↑u) ^ 3 * w ^ 6 := by
+    apply calcstep2 <;> assumption
   clear flat_eqn
   rcases eqn2 with ⟨w, u, v, nz_w, eq_M, eq_N, cp_mw, eqn2⟩
-  have chk2 : ¬ringChar k ∣ 2 := by intro h; apply chk; apply h.trans; use 3; norm_num
-  have chk3 : ¬ringChar k ∣ 3 := by intro h; apply chk; apply h.trans; use 2; norm_num
+  have chk2 : ¬ringChar k ∣ 2 := by intro h; apply chk; apply h.trans; exact ⟨3, by norm_num⟩
+  have chk3 : ¬ringChar k ∣ 3 := by intro h; apply chk; apply h.trans; exact ⟨2, by norm_num⟩
   rw [eq_comm, ← sub_eq_zero, sub_eq_add_neg, ← neg_mul] at eqn2
   obtain ⟨u0, hu0, eq_u0⟩ := Polynomial.isUnit_iff.mp u.isUnit
   obtain ⟨v0, hv0, eq_v0⟩ := Polynomial.isUnit_iff.mp v.isUnit
@@ -199,20 +195,22 @@ theorem no_parametrization_y2_x3_1 (chk : ¬ringChar k ∣ 6) {x y : RatFunc k}
     (by decide) (by decide) (by decide) (by decide)
     chk3 chk chk2 nz_m nz_w nz_n cp_mw ?nz0 ?nz1 ?nz2
     (by convert eqn2)
-  case nz0 := pow_ne_zero 2 hv0
-  case nz1 := mul_ne_zero (pow_ne_zero 2 hv0) (pow_ne_zero 3 hu0)
-  case nz2 := neg_ne_zero.mpr (pow_ne_zero 3 hu0)
+  case nz0 => exact pow_ne_zero 2 hv0
+  case nz1 => exact mul_ne_zero (pow_ne_zero 2 hv0) (pow_ne_zero 3 hu0)
+  case nz2 => exact neg_ne_zero.mpr (pow_ne_zero 3 hu0)
   rcases deriv_eq_zero with ⟨eq_dm, eq_dw, eq_dn⟩
   constructor
   · rw [Polynomial.eq_C_of_natDegree_eq_zero eq_dm]
     rw [← eq_M]; rw [Polynomial.eq_C_of_natDegree_eq_zero eq_dw]
     rcases Polynomial.isUnit_iff.mp u.isUnit with ⟨cu, -, eq_cu⟩
-    rw [← eq_cu];
+    rw [← eq_cu]
     rw [← map_pow, ← map_mul, RatFunc.algebraMap_C, RatFunc.algebraMap_C, ← map_div₀, IsConst]
-    refine ⟨_, rfl⟩
+    exact ⟨_, rfl⟩
   · rw [Polynomial.eq_C_of_natDegree_eq_zero eq_dn]
     rw [← eq_N]; rw [Polynomial.eq_C_of_natDegree_eq_zero eq_dw]
     rcases Polynomial.isUnit_iff.mp v.isUnit with ⟨cv, -, eq_cv⟩
-    rw [← eq_cv];
+    rw [← eq_cv]
     rw [← map_pow, ← map_mul, RatFunc.algebraMap_C, RatFunc.algebraMap_C, ← map_div₀, IsConst]
-    refine ⟨_, rfl⟩
+    exact ⟨_, rfl⟩
+
+end LeanPolyABC

--- a/LeanPool/LeanPolyABC/Corollaries/NoParametrization.lean
+++ b/LeanPool/LeanPolyABC/Corollaries/NoParametrization.lean
@@ -1,0 +1,218 @@
+/-
+Copyright (c) 2026 Seewoo Lee. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Seewoo Lee
+-/
+
+import Mathlib.FieldTheory.RatFunc.AsPolynomial
+
+import LeanPool.LeanPolyABC.Corollaries.FltCatalan
+
+noncomputable section
+
+open scoped Classical Polynomial
+
+open RatFunc
+
+variable {k : Type _} [Field k]
+
+-- Auxiliary definitions and theorems for rational functions
+def IsConst (x : RatFunc k) :=
+  ∃ c : k, x = RatFunc.C c
+
+theorem associates_pow_eq_pow_iff {A B : Associates k[X]} {n : ℕ} (hn : n ≠ 0) :
+    A ^ n = B ^ n ↔ A = B := by
+  by_cases hA : A = 0
+  · subst hA
+    rw [zero_pow hn, eq_comm, pow_eq_zero_iff hn, eq_comm]
+  by_cases hB : B = 0
+  · subst hB
+    rw [zero_pow hn, pow_eq_zero_iff hn]
+  · constructor; swap
+    . intro h; subst h; rfl
+    . intro h
+      apply Associates.eq_of_eq_counts hA hB
+      intro p hp
+      apply Nat.eq_of_mul_eq_mul_left (Nat.zero_lt_of_ne_zero hn)
+      rw [← Associates.count_pow hA hp n, ← Associates.count_pow hB hp n, h]
+
+theorem isConst_of_associated {f : RatFunc k} (h : Associated f.num f.denom) : IsConst f :=
+  by
+  rcases h.symm with ⟨u, heq⟩
+  rcases Polynomial.isUnit_iff.mp u.isUnit with ⟨c, uc, eq_c⟩
+  rw [← eq_c] at heq
+  have tt := congr_arg (algebraMap (Polynomial k) (RatFunc k)) heq.symm
+  rw [map_mul, mul_comm] at tt
+  have uu := div_eq_of_eq_mul (algebraMap_ne_zero f.denom_ne_zero) tt
+  rw [f.num_div_denom, RatFunc.algebraMap_C] at uu
+  use c
+
+theorem isConst_of_root_unity {n : ℕ} (hn : n ≠ 0) {f : RatFunc k} (h : f ^ n = 1) : IsConst f :=
+  by
+  rw [← f.num_div_denom, div_pow, ← map_pow, ← map_pow] at h
+  have nz : algebraMap k[X] (RatFunc k) (f.denom ^ n) ≠ 0 := by
+    apply algebraMap_ne_zero; apply pow_ne_zero; exact f.denom_ne_zero
+  rw [← mul_left_inj' nz, div_mul_cancel₀ (algebraMap k[X] (RatFunc k) (f.num ^ n)) nz, one_mul] at h
+  have hh := congr_arg Associates.mk (algebraMap_injective k h)
+  rw [Associates.mk_pow, Associates.mk_pow, associates_pow_eq_pow_iff hn,
+    Associates.mk_eq_mk_iff_associated] at hh
+  exact isConst_of_associated hh
+
+theorem associated_pow_pow_coprime_iff {a b : k[X]} {m n : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) (hm : m ≠ 0)
+    (hn : n ≠ 0) (h : Associated (a ^ m) (b ^ n)) (hcp : m.Coprime n) :
+    ∃ c : k[X], c ≠ 0 ∧ Associated a (c ^ n) ∧ Associated b (c ^ m) :=
+  by
+  -- change to associates
+  simp_rw [← Associates.mk_eq_mk_iff_associated, Associates.mk_pow] at h ⊢
+  rw [← Associates.mk_ne_zero] at ha hb
+  set A := Associates.mk a with eq_A
+  set B := Associates.mk b with eq_B
+  rename' ha => hA; rename' hb => hB
+  clear_value A B; clear eq_A eq_B
+  suffices goal : ∃ C, A = C ^ n ∧ B = C ^ m by
+    rcases goal with ⟨C, hC⟩
+    use C.out; simp only [Associates.mk_out]
+    refine' ⟨_, hC⟩
+    rw [← Associates.mk_ne_zero, Associates.mk_out, ← pow_ne_zero_iff hn, ← hC.1]
+    exact hA
+  have subgoal : ∃ C, A = C ^ n :=
+    by
+    apply Associates.is_pow_of_dvd_count hA
+    intro p hp
+    apply hcp.symm.dvd_of_dvd_mul_left
+    rw [← Associates.count_pow hA hp, h, Associates.count_pow hB hp]
+    exact Nat.dvd_mul_right _ _
+  rcases subgoal with ⟨C, eq_ACn⟩
+  refine' ⟨C, eq_ACn, _⟩
+  rw [eq_ACn, pow_right_comm, associates_pow_eq_pow_iff hn] at h
+  exact h.symm
+
+-- Auxiliary steps
+theorem calcstep {n N m M : k[X]} (nz_M : M ≠ 0) (nz_N : N ≠ 0)
+    (eqn :
+      (algebraMap _ (RatFunc k)) n ^ 2 / (algebraMap _ (RatFunc k)) N ^ 2 =
+        (algebraMap _ (RatFunc k)) m ^ 3 / (algebraMap _ (RatFunc k)) M ^ 3 + 1) :
+    n ^ 2 * M ^ 3 = (m ^ 3 + M ^ 3) * N ^ 2 :=
+  by
+  have nz_rM := RatFunc.algebraMap_ne_zero nz_M
+  have nz_rN := RatFunc.algebraMap_ne_zero nz_N
+  rw [← (RatFunc.algebraMap_injective k).eq_iff]
+  simp_rw [RingHom.map_mul, RingHom.map_add, RingHom.map_pow]
+  set rm := algebraMap k[X] (RatFunc k) m with eq_rm
+  set rM := algebraMap k[X] (RatFunc k) M with eq_rM
+  set rn := algebraMap k[X] (RatFunc k) n with eq_rn
+  set rN := algebraMap k[X] (RatFunc k) N with eq_rN
+  rw [eq_rm, eq_rM, eq_rn, eq_rN]
+  calc
+    rn ^ 2 * rM ^ 3 = rn ^ 2 / rN ^ 2 * rN ^ 2 * rM ^ 3 := by
+      rw [div_mul_cancel₀ _ (pow_ne_zero 2 nz_rN)]
+    _ = (rm ^ 3 / rM ^ 3 + 1) * rM ^ 3 * rN ^ 2 := by
+      rw [eqn, mul_assoc, mul_assoc, mul_comm (rN ^ 2) _]
+    _ = (rm ^ 3 + rM ^ 3) * rN ^ 2 := by
+      rw [add_mul, div_mul_cancel₀ _ (pow_ne_zero 3 nz_rM), one_mul]
+
+theorem calcstep2 {m M n N : k[X]} (nz_M : M ≠ 0) (nz_N : N ≠ 0) (cp_mM : IsCoprime m M)
+    (cp_nN : IsCoprime n N) (nz_m : m ≠ 0) (nz_n : n ≠ 0)
+    (flat_eqn : n ^ 2 * M ^ 3 = (m ^ 3 + M ^ 3) * N ^ 2) :
+    ∃ (w : k[X]) (u v : k[X]ˣ),
+      w ≠ 0 ∧
+        ↑u * w ^ 2 = M ∧
+          ↑v * w ^ 3 = N ∧
+            IsCoprime m w ∧ (↑u) ^ 3 * n ^ 2 = (↑v) ^ 2 * m ^ 3 + (↑v) ^ 2 * (↑u) ^ 3 * w ^ 6 :=
+  by
+  have assoc_M3_N2 : Associated (M ^ 3) (N ^ 2) :=
+    by
+    refine associated_of_dvd_dvd ?_ ?_
+    · have cp : IsCoprime (M ^ 3) (m ^ 3 + 1 * M ^ 3) := cp_mM.symm.pow.add_mul_right_right 1
+      rw [one_mul] at cp
+      apply cp.dvd_of_dvd_mul_left
+      rw [← flat_eqn]; exact dvd_mul_left _ _
+    · have cp : IsCoprime (N ^ 2) (n ^ 2) := cp_nN.symm.pow
+      apply cp.dvd_of_dvd_mul_left
+      rw [flat_eqn]; exact dvd_mul_left _ _
+  rcases associated_pow_pow_coprime_iff nz_M nz_N (by decide) (by decide) assoc_M3_N2 (by decide) with
+    ⟨w, nz_w, assoc_M_w2, assoc_N_w3⟩
+  rcases assoc_M_w2.symm with ⟨u, eq_Mw⟩; rw [mul_comm] at eq_Mw
+  rcases assoc_N_w3.symm with ⟨v, eq_Nw⟩; rw [mul_comm] at eq_Nw
+  refine' ⟨w, u, v, nz_w, eq_Mw, eq_Nw, _⟩
+  simp_rw [← eq_Mw, ← eq_Nw, mul_pow, ← pow_mul, ← mul_assoc] at flat_eqn
+  simp only [Nat.reduceMul, mul_eq_mul_right_iff, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true,
+    pow_eq_zero_iff] at flat_eqn
+  constructor
+  . rw [← eq_Mw, isCoprime_mul_unit_left_right u.isUnit, IsCoprime.pow_right_iff] at cp_mM
+    exact cp_mM; decide
+  . rcases flat_eqn with eqn | w0
+    . convert eqn using 1 <;> ring_nf
+    . contradiction
+
+-- Main corollary
+theorem no_parametrization_y2_x3_1 (chk : ¬ringChar k ∣ 6) {x y : RatFunc k}
+    (eqn : y ^ 2 = x ^ 3 + 1) : IsConst x ∧ IsConst y :=
+  by
+  cases' eq_or_ne x 0 with eq_x nz_x
+  · subst x
+    rw [zero_pow, zero_add] at eqn; swap; decide
+    refine' ⟨⟨0, (map_zero _).symm⟩, isConst_of_root_unity _ eqn⟩
+    decide
+  cases' eq_or_ne y 0 with eq_y nz_y
+  · subst y; rw [eq_comm, zero_pow, ← eq_neg_iff_add_eq_zero] at eqn
+    swap; decide
+    have tt : (x ^ 3) ^ 2 = 1 := by rw [sq_eq_one_iff]; right; exact eqn
+    ring_nf at tt
+    refine' ⟨isConst_of_root_unity _ tt, ⟨0, (map_zero _).symm⟩⟩
+    decide
+  have eq_x := x.num_div_denom.symm
+  have eq_y := y.num_div_denom.symm
+  have nz_m := num_ne_zero nz_x
+  have nz_n := num_ne_zero nz_y
+  have nz_M := x.denom_ne_zero
+  have nz_N := y.denom_ne_zero
+  have cp_mM := isCoprime_num_denom x
+  have cp_nN := isCoprime_num_denom y
+  set m := x.num
+  set M := x.denom
+  set n := y.num
+  set N := y.denom
+  clear_value m M n N
+  rw [eq_x, eq_y] at eqn
+  simp only [div_pow] at eqn
+  subst eq_x; subst eq_y
+  have flat_eqn : n ^ 2 * M ^ 3 = (m ^ 3 + M ^ 3) * N ^ 2 := by apply calcstep <;> assumption
+  clear eqn
+  have eqn2 :
+    ∃ (w : k[X]) (u v : k[X]ˣ),
+      w ≠ 0 ∧
+        ↑u * w ^ 2 = M ∧
+          ↑v * w ^ 3 = N ∧
+            IsCoprime m w ∧ (↑u) ^ 3 * n ^ 2 = (↑v) ^ 2 * m ^ 3 + (↑v) ^ 2 * (↑u) ^ 3 * w ^ 6 :=
+    by apply calcstep2 <;> assumption
+  clear flat_eqn
+  rcases eqn2 with ⟨w, u, v, nz_w, eq_M, eq_N, cp_mw, eqn2⟩
+  have chk2 : ¬ringChar k ∣ 2 := by intro h; apply chk; apply h.trans; use 3; norm_num
+  have chk3 : ¬ringChar k ∣ 3 := by intro h; apply chk; apply h.trans; use 2; norm_num
+  rw [eq_comm, ← sub_eq_zero, sub_eq_add_neg, ← neg_mul] at eqn2
+  obtain ⟨u0, hu0, eq_u0⟩ := Polynomial.isUnit_iff.mp u.isUnit
+  obtain ⟨v0, hv0, eq_v0⟩ := Polynomial.isUnit_iff.mp v.isUnit
+  rw [isUnit_iff_ne_zero] at hu0 hv0
+  simp_rw [← eq_u0, ← eq_v0, ← map_pow, ← map_mul, ← map_neg] at eqn2
+  have deriv_eq_zero := Polynomial.flt_catalan
+    (by decide) (by decide) (by decide) (by decide)
+    chk3 chk chk2 nz_m nz_w nz_n cp_mw ?nz0 ?nz1 ?nz2
+    (by convert eqn2)
+  case nz0 := pow_ne_zero 2 hv0
+  case nz1 := mul_ne_zero (pow_ne_zero 2 hv0) (pow_ne_zero 3 hu0)
+  case nz2 := neg_ne_zero.mpr (pow_ne_zero 3 hu0)
+  rcases deriv_eq_zero with ⟨eq_dm, eq_dw, eq_dn⟩
+  constructor
+  · rw [Polynomial.eq_C_of_natDegree_eq_zero eq_dm]
+    rw [← eq_M]; rw [Polynomial.eq_C_of_natDegree_eq_zero eq_dw]
+    rcases Polynomial.isUnit_iff.mp u.isUnit with ⟨cu, -, eq_cu⟩
+    rw [← eq_cu];
+    rw [← map_pow, ← map_mul, RatFunc.algebraMap_C, RatFunc.algebraMap_C, ← map_div₀, IsConst]
+    refine ⟨_, rfl⟩
+  · rw [Polynomial.eq_C_of_natDegree_eq_zero eq_dn]
+    rw [← eq_N]; rw [Polynomial.eq_C_of_natDegree_eq_zero eq_dw]
+    rcases Polynomial.isUnit_iff.mp v.isUnit with ⟨cv, -, eq_cv⟩
+    rw [← eq_cv];
+    rw [← map_pow, ← map_mul, RatFunc.algebraMap_C, RatFunc.algebraMap_C, ← map_div₀, IsConst]
+    refine ⟨_, rfl⟩

--- a/LeanPool/LeanPolyABC/Lib/DivRadical.lean
+++ b/LeanPool/LeanPolyABC/Lib/DivRadical.lean
@@ -4,54 +4,53 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Seewoo Lee
 -/
 
-import Mathlib.Algebra.Polynomial.RingDivision
+import Mathlib.Algebra.Polynomial.FieldDivision
 import Mathlib.Algebra.Ring.Regular
+import Mathlib.RingTheory.UniqueFactorizationDomain.Multiplicative
 import LeanPool.LeanPolyABC.Lib.Radical
 import LeanPool.LeanPolyABC.Lib.Wronskian
 
 /-
-On `a.divRadical = a / radical a`. The purpose of this file is to prove our "main lemma" that `a.divRadical` divides `a'` for any nonzero polynomial `a`.
+On `a.divRadical = a / radical a`. The purpose of this file is to prove our "main lemma" that
+`a.divRadical` divides `a'` for any nonzero polynomial `a`.
 The proof is based on induction (`UniqueFactorizationMonoid.induction_on_coprime`).
 -/
 noncomputable section
 
-open scoped Polynomial Classical
+open scoped Polynomial
+
+open Polynomial UniqueFactorizationMonoid
+
+namespace LeanPolyABC
 
 namespace Polynomial
 
-open UniqueFactorizationMonoid
-
-variable {k : Type _} [Field k]
+variable {k : Type _} [Field k] [DecidableEq k]
 
 /--
-For a given polynomial `a`, `a.divRadical` is `a` divided by its radical `radical a`. This is the key to our implementation. -/
+For a given polynomial `a`, `a.divRadical` is `a` divided by its radical `radical a`.
+This is the key to our implementation. -/
 def divRadical (a : k[X]) : k[X] :=
   a / radical a
 
-theorem hMul_radical_divRadical (a : k[X]) : (radical a) * (divRadical a) = a :=
-  by
+theorem hMul_radical_divRadical (a : k[X]) : radical a * divRadical a = a := by
   rw [divRadical]
-  rw [← EuclideanDomain.mul_div_assoc]
-  refine' mul_div_cancel_left₀ _ _
-  exact radical_ne_zero a
-  exact radical_dvd_self a
+  rw [← EuclideanDomain.mul_div_assoc _ (radical_dvd_self a)]
+  exact mul_div_cancel_left₀ a (radical_ne_zero a)
 
-theorem divRadical_ne_zero {a : k[X]} (ha : a ≠ 0) : divRadical a ≠ 0 :=
-  by
+theorem divRadical_ne_zero {a : k[X]} (ha : a ≠ 0) : divRadical a ≠ 0 := by
   rw [← hMul_radical_divRadical a] at ha
   exact right_ne_zero_of_mul ha
 
 theorem divRadical_isUnit {u : k[X]} (hu : IsUnit u) : IsUnit (divRadical u) := by
   rwa [divRadical, radical_unit_eq_one hu, EuclideanDomain.div_one]
 
-theorem eq_divRadical {a x : k[X]} (h : (radical a) * x = a) : x = divRadical a :=
-  by
+theorem eq_divRadical {a x : k[X]} (h : radical a * x = a) : x = divRadical a := by
   apply EuclideanDomain.eq_div_of_mul_eq_left (radical_ne_zero a)
   rwa [mul_comm]
 
 theorem divRadical_hMul {a b : k[X]} (hc : IsCoprime a b) :
-    divRadical (a * b) = (divRadical a) * (divRadical b) :=
-  by
+    divRadical (a * b) = divRadical a * divRadical b := by
   by_cases ha : a = 0
   · rw [ha, MulZeroClass.zero_mul, divRadical, EuclideanDomain.zero_div, MulZeroClass.zero_mul]
   by_cases hb : b = 0
@@ -60,8 +59,7 @@ theorem divRadical_hMul {a b : k[X]} (hc : IsCoprime a b) :
   rw [radical_hMul hc]
   rw [mul_mul_mul_comm, hMul_radical_divRadical, hMul_radical_divRadical]
 
-theorem divRadical_dvd_self (a : k[X]) : (divRadical a) ∣ a :=
-  by
+theorem divRadical_dvd_self (a : k[X]) : divRadical a ∣ a := by
   rw [divRadical]
   apply EuclideanDomain.div_dvd_of_dvd
   exact radical_dvd_self a
@@ -70,36 +68,36 @@ theorem divRadical_dvd_self (a : k[X]) : (divRadical a) ∣ a :=
 Proof uses `induction_on_coprime` of `UniqueFactorizationMonoid`.
 -/
 
-theorem divRadical_dvd_derivative (a : k[X]) : (divRadical a) ∣ (derivative a) :=
-  by
-  induction a using induction_on_coprime
-  . case h0 =>
+theorem divRadical_dvd_derivative (a : k[X]) : divRadical a ∣ derivative a := by
+  induction a using induction_on_coprime with
+  | h0 =>
     rw [derivative_zero]
     apply dvd_zero
-  · case h1 a ha =>
+  | @h1 a ha =>
     exact (divRadical_isUnit ha).dvd
-  · case hpr p i hp =>
-    cases i
-    · rw [pow_zero, derivative_one]
+  | @hpr p i hp =>
+    cases i with
+    | zero =>
+      rw [pow_zero, derivative_one]
       apply dvd_zero
-    . case succ i =>
+    | succ i =>
       rw [← mul_dvd_mul_iff_left (radical_ne_zero (p ^ i.succ)), hMul_radical_divRadical,
         radical_prime_pow hp i.succ_pos, derivative_pow_succ, ← mul_assoc]
       apply dvd_mul_of_dvd_left
       rw [mul_comm, mul_assoc]
       apply dvd_mul_of_dvd_right
       rw [pow_succ, mul_dvd_mul_iff_left (pow_ne_zero i hp.ne_zero), dvd_normalize_iff]
-  · -- If it holds for coprime pair a and b, then it also holds for a * b.
-    case hcp x y hpxy hx hy =>
+  | @hcp x y hpxy hx hy =>
+    -- If it holds for coprime pair a and b, then it also holds for a * b.
     have hc : IsCoprime x y :=
       EuclideanDomain.isCoprime_of_dvd
         (fun ⟨hx, hy⟩ => not_isUnit_zero (hpxy (zero_dvd_iff.mpr hx) (zero_dvd_iff.mpr hy)))
         fun p hp _ hpx hpy => hp (hpxy hpx hpy)
     rw [divRadical_hMul hc, derivative_mul]
-    exact dvd_add (mul_dvd_mul hx y.divRadical_dvd_self) (mul_dvd_mul x.divRadical_dvd_self hy)
+    exact dvd_add (mul_dvd_mul hx (divRadical_dvd_self y))
+      (mul_dvd_mul (divRadical_dvd_self x) hy)
 
-theorem divRadical_dvd_wronskian_left (a b : k[X]) : a.divRadical ∣ wronskian a b :=
-  by
+theorem divRadical_dvd_wronskian_left (a b : k[X]) : divRadical a ∣ wronskian a b := by
   rw [wronskian]
   apply dvd_sub
   · apply dvd_mul_of_dvd_left
@@ -107,9 +105,10 @@ theorem divRadical_dvd_wronskian_left (a b : k[X]) : a.divRadical ∣ wronskian 
   · apply dvd_mul_of_dvd_left
     exact divRadical_dvd_derivative a
 
-theorem divRadical_dvd_wronskian_right (a b : k[X]) : b.divRadical ∣ wronskian a b :=
-  by
+theorem divRadical_dvd_wronskian_right (a b : k[X]) : divRadical b ∣ wronskian a b := by
   rw [wronskian_anticomm, dvd_neg]
-  exact b.divRadical_dvd_wronskian_left _
+  exact divRadical_dvd_wronskian_left b a
 
 end Polynomial
+
+end LeanPolyABC

--- a/LeanPool/LeanPolyABC/Lib/DivRadical.lean
+++ b/LeanPool/LeanPolyABC/Lib/DivRadical.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2026 Seewoo Lee. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Seewoo Lee
+-/
+
+import Mathlib.Algebra.Polynomial.RingDivision
+import Mathlib.Algebra.Ring.Regular
+import LeanPool.LeanPolyABC.Lib.Radical
+import LeanPool.LeanPolyABC.Lib.Wronskian
+
+/-
+On `a.divRadical = a / radical a`. The purpose of this file is to prove our "main lemma" that `a.divRadical` divides `a'` for any nonzero polynomial `a`.
+The proof is based on induction (`UniqueFactorizationMonoid.induction_on_coprime`).
+-/
+noncomputable section
+
+open scoped Polynomial Classical
+
+namespace Polynomial
+
+open UniqueFactorizationMonoid
+
+variable {k : Type _} [Field k]
+
+/--
+For a given polynomial `a`, `a.divRadical` is `a` divided by its radical `radical a`. This is the key to our implementation. -/
+def divRadical (a : k[X]) : k[X] :=
+  a / radical a
+
+theorem hMul_radical_divRadical (a : k[X]) : (radical a) * (divRadical a) = a :=
+  by
+  rw [divRadical]
+  rw [← EuclideanDomain.mul_div_assoc]
+  refine' mul_div_cancel_left₀ _ _
+  exact radical_ne_zero a
+  exact radical_dvd_self a
+
+theorem divRadical_ne_zero {a : k[X]} (ha : a ≠ 0) : divRadical a ≠ 0 :=
+  by
+  rw [← hMul_radical_divRadical a] at ha
+  exact right_ne_zero_of_mul ha
+
+theorem divRadical_isUnit {u : k[X]} (hu : IsUnit u) : IsUnit (divRadical u) := by
+  rwa [divRadical, radical_unit_eq_one hu, EuclideanDomain.div_one]
+
+theorem eq_divRadical {a x : k[X]} (h : (radical a) * x = a) : x = divRadical a :=
+  by
+  apply EuclideanDomain.eq_div_of_mul_eq_left (radical_ne_zero a)
+  rwa [mul_comm]
+
+theorem divRadical_hMul {a b : k[X]} (hc : IsCoprime a b) :
+    divRadical (a * b) = (divRadical a) * (divRadical b) :=
+  by
+  by_cases ha : a = 0
+  · rw [ha, MulZeroClass.zero_mul, divRadical, EuclideanDomain.zero_div, MulZeroClass.zero_mul]
+  by_cases hb : b = 0
+  · rw [hb, MulZeroClass.mul_zero, divRadical, EuclideanDomain.zero_div, MulZeroClass.mul_zero]
+  symm; apply eq_divRadical
+  rw [radical_hMul hc]
+  rw [mul_mul_mul_comm, hMul_radical_divRadical, hMul_radical_divRadical]
+
+theorem divRadical_dvd_self (a : k[X]) : (divRadical a) ∣ a :=
+  by
+  rw [divRadical]
+  apply EuclideanDomain.div_dvd_of_dvd
+  exact radical_dvd_self a
+
+/- Main lemma: a / rad(a) ∣ a'.
+Proof uses `induction_on_coprime` of `UniqueFactorizationMonoid`.
+-/
+
+theorem divRadical_dvd_derivative (a : k[X]) : (divRadical a) ∣ (derivative a) :=
+  by
+  induction a using induction_on_coprime
+  . case h0 =>
+    rw [derivative_zero]
+    apply dvd_zero
+  · case h1 a ha =>
+    exact (divRadical_isUnit ha).dvd
+  · case hpr p i hp =>
+    cases i
+    · rw [pow_zero, derivative_one]
+      apply dvd_zero
+    . case succ i =>
+      rw [← mul_dvd_mul_iff_left (radical_ne_zero (p ^ i.succ)), hMul_radical_divRadical,
+        radical_prime_pow hp i.succ_pos, derivative_pow_succ, ← mul_assoc]
+      apply dvd_mul_of_dvd_left
+      rw [mul_comm, mul_assoc]
+      apply dvd_mul_of_dvd_right
+      rw [pow_succ, mul_dvd_mul_iff_left (pow_ne_zero i hp.ne_zero), dvd_normalize_iff]
+  · -- If it holds for coprime pair a and b, then it also holds for a * b.
+    case hcp x y hpxy hx hy =>
+    have hc : IsCoprime x y :=
+      EuclideanDomain.isCoprime_of_dvd
+        (fun ⟨hx, hy⟩ => not_isUnit_zero (hpxy (zero_dvd_iff.mpr hx) (zero_dvd_iff.mpr hy)))
+        fun p hp _ hpx hpy => hp (hpxy hpx hpy)
+    rw [divRadical_hMul hc, derivative_mul]
+    exact dvd_add (mul_dvd_mul hx y.divRadical_dvd_self) (mul_dvd_mul x.divRadical_dvd_self hy)
+
+theorem divRadical_dvd_wronskian_left (a b : k[X]) : a.divRadical ∣ wronskian a b :=
+  by
+  rw [wronskian]
+  apply dvd_sub
+  · apply dvd_mul_of_dvd_left
+    exact divRadical_dvd_self a
+  · apply dvd_mul_of_dvd_left
+    exact divRadical_dvd_derivative a
+
+theorem divRadical_dvd_wronskian_right (a b : k[X]) : b.divRadical ∣ wronskian a b :=
+  by
+  rw [wronskian_anticomm, dvd_neg]
+  exact b.divRadical_dvd_wronskian_left _
+
+end Polynomial

--- a/LeanPool/LeanPolyABC/Lib/Max3.lean
+++ b/LeanPool/LeanPolyABC/Lib/Max3.lean
@@ -8,6 +8,7 @@ import Init.Data.Nat.Lemmas
 
 namespace Nat
 
+/-- The maximum of three natural numbers, `max (max a b) c`. -/
 def max₃ (a b c : Nat) : Nat :=
   max (max a b) c
 

--- a/LeanPool/LeanPolyABC/Lib/Max3.lean
+++ b/LeanPool/LeanPolyABC/Lib/Max3.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 Seewoo Lee. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Seewoo Lee
+-/
+
+import Init.Data.Nat.Lemmas
+
+namespace Nat
+
+def max₃ (a b c : Nat) : Nat :=
+  max (max a b) c
+
+theorem max₃_mul_distrib_left (a b c d : Nat) : a * max₃ b c d = max₃ (a * b) (a * c) (a * d) := by
+  rw [max₃, max₃, Nat.mul_max_mul_left, Nat.mul_max_mul_left]
+
+theorem max₃_add_distrib_left (a b c d : Nat) : d + max₃ a b c = max₃ (d + a) (d + b) (d + c) := by
+  rw [max₃, max₃, Nat.add_max_add_left, Nat.add_max_add_left]
+
+theorem max₃_add_distrib_right (a b c d : Nat) : max₃ a b c + d = max₃ (a + d) (b + d) (c + d) := by
+  rw [max₃, max₃, Nat.add_max_add_right, Nat.add_max_add_right]
+
+theorem le_max₃_left (a b c : Nat) : a ≤ max₃ a b c :=
+  Nat.le_trans (Nat.le_max_left a b) (Nat.le_max_left _ _)
+
+theorem le_max₃_middle (a b c : Nat) : b ≤ max₃ a b c :=
+  Nat.le_trans (Nat.le_max_right a b) (Nat.le_max_left _ _)
+
+theorem le_max₃_right (a b c : Nat) : c ≤ max₃ a b c :=
+  Nat.le_max_right _ c
+
+theorem max₃_lt {a b c d : Nat} : max₃ a b c < d ↔ a < d ∧ b < d ∧ c < d := by
+  rw [max₃, Nat.max_lt, Nat.max_lt, and_assoc]
+
+theorem max₃_le {a b c d : Nat} : max₃ a b c ≤ d ↔ a ≤ d ∧ b ≤ d ∧ c ≤ d := by
+  rw [max₃, Nat.max_le, Nat.max_le, and_assoc]
+
+end Nat

--- a/LeanPool/LeanPolyABC/Lib/Radical.lean
+++ b/LeanPool/LeanPolyABC/Lib/Radical.lean
@@ -4,35 +4,41 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Seewoo Lee
 -/
 
+import Mathlib.Algebra.Polynomial.FieldDivision
 import Mathlib.Algebra.Ring.Regular
 import Mathlib.RingTheory.Polynomial.Content
-import Mathlib.RingTheory.UniqueFactorizationDomain
+import Mathlib.RingTheory.UniqueFactorizationDomain.Basic
+import Mathlib.RingTheory.UniqueFactorizationDomain.NormalizedFactors
 
 noncomputable section
 
-open scoped Classical
-
 open Polynomial UniqueFactorizationMonoid
 
-variable {k : Type*} [Field k]
-variable {α : Type*} [CancelCommMonoidWithZero α] [UniqueFactorizationMonoid α]  [NormalizationMonoid α]
+namespace LeanPolyABC
 
+variable {k : Type*} [Field k] [DecidableEq k]
+variable {α : Type*} [CommMonoidWithZero α] [NormalizationMonoid α] [UniqueFactorizationMonoid α]
+
+open scoped Classical in
 /-- Prime factors of `a` are monic factors of `a` without duplication. -/
 def primeFactors (a : α) : Finset α :=
   (normalizedFactors a).toFinset
 
+open scoped Classical in
 /-- Radical of `a` is a product of prime factors of `a`. -/
 def radical (a : α) : α :=
   (primeFactors a).prod id
 
 theorem radical_zero_eq_one : radical (0 : α) = 1 := by
+  classical
   rw [radical, primeFactors, normalizedFactors_zero, Multiset.toFinset_zero, Finset.prod_empty]
 
 theorem radical_one_eq_one : radical (1 : α) = 1 := by
+  classical
   rw [radical, primeFactors, normalizedFactors_one, Multiset.toFinset_zero, Finset.prod_empty]
 
-theorem radical_associated_eq {a b : α} (h : Associated a b) : radical a = radical b :=
-  by
+theorem radical_associated_eq {a b : α} (h : Associated a b) : radical a = radical b := by
+  classical
   rcases iff_iff_and_or_not_and_not.mp h.eq_zero_iff with (⟨rfl, rfl⟩ | ⟨ha, hb⟩)
   · rfl
   · simp_rw [radical, primeFactors]
@@ -47,8 +53,8 @@ theorem radical_mul_unit_left {u a : α} (h : IsUnit u) : radical (u * a) = radi
 theorem radical_mul_unit_right {u a : α} (h : IsUnit u) : radical (a * u) = radical a :=
   radical_associated_eq (associated_mul_unit_left _ _ h)
 
-theorem primeFactors_pow (a : α) {n : ℕ} (hn : 0 < n) : primeFactors (a ^ n) = primeFactors a :=
-  by
+theorem primeFactors_pow (a : α) {n : ℕ} (hn : 0 < n) : primeFactors (a ^ n) = primeFactors a := by
+  classical
   simp_rw [primeFactors]
   simp only [normalizedFactors_pow]
   rw [Multiset.toFinset_nsmul]
@@ -57,17 +63,18 @@ theorem primeFactors_pow (a : α) {n : ℕ} (hn : 0 < n) : primeFactors (a ^ n) 
 theorem radical_pow (a : α) {n : Nat} (hn : 0 < n) : radical (a ^ n) = radical a := by
   simp_rw [radical, primeFactors_pow a hn]
 
-theorem radical_dvd_self (a : α) : radical a ∣ a :=
-  by
+theorem radical_dvd_self (a : α) : radical a ∣ a := by
+  classical
   by_cases ha : a = 0
   · rw [ha]
     apply dvd_zero
-  · rw [radical, ← Finset.prod_val, ← (normalizedFactors_prod ha).dvd_iff_dvd_right]
+  · rw [radical, ← Finset.prod_val, ← (prod_normalizedFactors ha).dvd_iff_dvd_right]
     apply Multiset.prod_dvd_prod_of_le
     rw [primeFactors, Multiset.toFinset_val]
     apply Multiset.dedup_le
 
 theorem radical_dvd_radical_self_mul {a b : α} (hb : b ≠ 0) : radical a ∣ radical (a * b) := by
+  classical
   by_cases ha : a = 0
   · rw [ha, zero_mul]
   · rw [radical, ← Finset.prod_val, radical, ← Finset.prod_val]
@@ -87,23 +94,22 @@ theorem radical_dvd_radical_of_dvd {a b : α} (hb : b ≠ 0) (h : a ∣ b) :
   rw [hc, mul_ne_zero_iff] at hb
   exact radical_dvd_radical_self_mul hb.right
 
-theorem radical_mul_dvd_mul_radical (a b : α) : radical (a * b) ∣ (radical a) * (radical b) := by
+theorem radical_mul_dvd_mul_radical (a b : α) : radical (a * b) ∣ radical a * radical b := by
+  classical
   by_cases ha : a = 0
-  . rw [ha]
+  · rw [ha]
     simp only [zero_mul, dvd_mul_right]
   by_cases hb : b = 0
-  . rw [hb]
+  · rw [hb]
     simp only [mul_zero, dvd_mul_left]
   rw [radical, primeFactors, normalizedFactors_mul ha hb, Multiset.toFinset_add]
   rw [radical, primeFactors]
   rw [radical, primeFactors]
-  refine ⟨?mult, ?tt⟩
-  swap
-  symm
-  convert Finset.prod_union_inter using 2
+  exact ⟨((normalizedFactors a).toFinset ∩ (normalizedFactors b).toFinset).prod id,
+    (Finset.prod_union_inter).symm⟩
 
-theorem radical_prime {a : α} (ha : Prime a) : radical a = normalize a :=
-  by
+theorem radical_prime {a : α} (ha : Prime a) : radical a = normalize a := by
+  classical
   rw [radical, primeFactors]
   rw [normalizedFactors_irreducible ha.irreducible]
   simp only [Multiset.toFinset_singleton, id, Finset.prod_singleton]
@@ -115,9 +121,10 @@ theorem radical_prime_pow {a : α} (ha : Prime a) {n : ℕ} (hn : 1 ≤ n) :
 
 theorem prime_dvd_radical_iff {a p : α} (ha : a ≠ 0) (hp : Prime p) :
     p ∣ radical a ↔ p ∣ a := by
+  classical
   constructor
-  . exact λ h => h.trans <| radical_dvd_self a
-  . intro hpa
+  · exact fun h => h.trans <| radical_dvd_self a
+  · intro hpa
     rcases exists_mem_normalizedFactors_of_dvd ha hp.irreducible hpa with ⟨q, ⟨hqf, hpq⟩⟩
     rw [hpq.dvd_iff_dvd_left]
     rw [radical, primeFactors]
@@ -127,7 +134,7 @@ theorem prime_dvd_radical_iff {a p : α} (ha : a ≠ 0) (hp : Prime p) :
 
 theorem radical_isUnit_iff {a : α} (h : a ≠ 0) : IsUnit (radical a) ↔ IsUnit a := by
   constructor
-  . contrapose
+  · contrapose
     intro ha
     rcases exists_mem_factors h ha with ⟨p, hpf⟩
     have hpp := prime_of_factor _ hpf
@@ -135,43 +142,56 @@ theorem radical_isUnit_iff {a : α} (h : a ≠ 0) : IsUnit (radical a) ↔ IsUni
     apply not_isUnit_of_not_isUnit_dvd hpp.not_unit
     rw [prime_dvd_radical_iff h hpp]
     exact hpd
-  . intro ha
+  · intro ha
     rw [radical_unit_eq_one ha]
     exact isUnit_one
 
 -- Theorems for commutative rings
-variable {R : Type _} [CommRing R] [IsDomain R] [NormalizationMonoid R] [UniqueFactorizationMonoid R]
+variable {R : Type _} [CommRing R] [IsDomain R] [NormalizationMonoid R]
+  [UniqueFactorizationMonoid R]
 
+namespace IsCoprime
+
+omit [IsDomain R] in
 /-- coprime polynomials have disjoint prime factors (as multisets). -/
-private theorem IsCoprime.disjoint_normalizedFactors {a b : R} (hc : IsCoprime a b) :
-    (normalizedFactors a).Disjoint (normalizedFactors b) :=
-  by
+private theorem disjoint_normalizedFactors {a b : R} (hc : IsCoprime a b) :
+    Disjoint (normalizedFactors a) (normalizedFactors b) := by
+  rw [Multiset.disjoint_left]
   intro x hxa hxb
   have x_dvd_a := dvd_of_mem_normalizedFactors hxa
   have x_dvd_b := dvd_of_mem_normalizedFactors hxb
   have xp := prime_of_normalized_factor x hxa
   exact xp.not_unit (hc.isUnit_of_dvd' x_dvd_a x_dvd_b)
 
+omit [IsDomain R] in
 -- coprime polynomials have disjoint prime factors (as finsets)
-private theorem IsCoprime.disjoint_primeFactors {a b : R} (hc : IsCoprime a b) :
-    Disjoint (primeFactors a) (primeFactors b) :=
-  Multiset.disjoint_toFinset.mpr (hc.disjoint_normalizedFactors)
+private theorem disjoint_primeFactors {a b : R} (hc : IsCoprime a b) :
+    Disjoint (primeFactors a) (primeFactors b) := by
+  classical
+  exact Multiset.disjoint_toFinset.mpr (disjoint_normalizedFactors hc)
 
-private theorem IsCoprime.hMul_primeFactors_disjUnion {a b : R} (ha : a ≠ 0) (hb : b ≠ 0)
+omit [IsDomain R] in
+private theorem hMul_primeFactors_disjUnion {a b : R} (ha : a ≠ 0) (hb : b ≠ 0)
     (hc : IsCoprime a b) :
-    primeFactors (a * b) = (primeFactors a).disjUnion (primeFactors b) hc.disjoint_primeFactors :=
-  by
+    primeFactors (a * b) =
+      (primeFactors a).disjUnion (primeFactors b) (disjoint_primeFactors hc) := by
+  classical
   rw [Finset.disjUnion_eq_union]
   simp_rw [primeFactors]
   rw [normalizedFactors_mul ha hb, Multiset.toFinset_add]
 
+end IsCoprime
+
+omit [IsDomain R] in
 -- possible TODO: the proof is unnecessarily long
 @[simp]
 theorem radical_neg_one : radical (-1 : R) = 1 :=
   radical_unit_eq_one isUnit_one.neg
 
-theorem radical_hMul {a b : R} (hc : IsCoprime a b) : radical (a * b) = (radical a) * (radical b) :=
-  by
+omit [IsDomain R] in
+theorem radical_hMul {a b : R} (hc : IsCoprime a b) :
+    radical (a * b) = radical a * radical b := by
+  classical
   by_cases ha : a = 0
   · subst ha; rw [isCoprime_zero_left] at hc
     simp only [MulZeroClass.zero_mul, radical_zero_eq_one, one_mul, radical_unit_eq_one hc]
@@ -179,20 +199,21 @@ theorem radical_hMul {a b : R} (hc : IsCoprime a b) : radical (a * b) = (radical
   · subst hb; rw [isCoprime_zero_right] at hc
     simp only [MulZeroClass.mul_zero, radical_zero_eq_one, mul_one, radical_unit_eq_one hc]
   simp_rw [radical]
-  rw [hc.hMul_primeFactors_disjUnion ha hb]
-  rw [Finset.prod_disjUnion hc.disjoint_primeFactors]
+  rw [IsCoprime.hMul_primeFactors_disjUnion ha hb hc]
+  rw [Finset.prod_disjUnion (IsCoprime.disjoint_primeFactors hc)]
 
+omit [IsDomain R] in
 theorem radical_neg {a : R} : radical (-a) = radical a :=
   neg_one_mul a ▸ (radical_associated_eq <| associated_unit_mul_left a (-1) isUnit_one.neg)
 
 -- This actually holds for nontrivial monoids - do not need ring assumption.
-theorem radical_ne_zero (a : R) : radical a ≠ 0 :=
-  by
+theorem radical_ne_zero (a : R) : radical a ≠ 0 := by
+  classical
   rw [radical, ← Finset.prod_val]
   apply Multiset.prod_ne_zero
   rw [primeFactors]
   simp only [Multiset.toFinset_val, Multiset.mem_dedup]
-  exact zero_not_mem_normalizedFactors _
+  exact zero_notMem_normalizedFactors _
 
 namespace Polynomial
 
@@ -206,10 +227,12 @@ theorem radical_natDegree_le (a : k[X]) : (radical a).natDegree ≤ a.natDegree 
 
 theorem radical_natDegree_mul_le (a b : k[X]) :
     (radical (a * b)).natDegree ≤ (radical a).natDegree + (radical b).natDegree := by
-  rw [←natDegree_mul (radical_ne_zero _) (radical_ne_zero _)]
+  rw [← natDegree_mul (radical_ne_zero _) (radical_ne_zero _)]
   apply natDegree_le_of_dvd (radical_mul_dvd_mul_radical a b)
   apply mul_ne_zero
-  exact radical_ne_zero _
-  exact radical_ne_zero _
+  · exact radical_ne_zero _
+  · exact radical_ne_zero _
 
 end Polynomial
+
+end LeanPolyABC

--- a/LeanPool/LeanPolyABC/Lib/Radical.lean
+++ b/LeanPool/LeanPolyABC/Lib/Radical.lean
@@ -1,0 +1,215 @@
+/-
+Copyright (c) 2026 Seewoo Lee. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Seewoo Lee
+-/
+
+import Mathlib.Algebra.Ring.Regular
+import Mathlib.RingTheory.Polynomial.Content
+import Mathlib.RingTheory.UniqueFactorizationDomain
+
+noncomputable section
+
+open scoped Classical
+
+open Polynomial UniqueFactorizationMonoid
+
+variable {k : Type*} [Field k]
+variable {α : Type*} [CancelCommMonoidWithZero α] [UniqueFactorizationMonoid α]  [NormalizationMonoid α]
+
+/-- Prime factors of `a` are monic factors of `a` without duplication. -/
+def primeFactors (a : α) : Finset α :=
+  (normalizedFactors a).toFinset
+
+/-- Radical of `a` is a product of prime factors of `a`. -/
+def radical (a : α) : α :=
+  (primeFactors a).prod id
+
+theorem radical_zero_eq_one : radical (0 : α) = 1 := by
+  rw [radical, primeFactors, normalizedFactors_zero, Multiset.toFinset_zero, Finset.prod_empty]
+
+theorem radical_one_eq_one : radical (1 : α) = 1 := by
+  rw [radical, primeFactors, normalizedFactors_one, Multiset.toFinset_zero, Finset.prod_empty]
+
+theorem radical_associated_eq {a b : α} (h : Associated a b) : radical a = radical b :=
+  by
+  rcases iff_iff_and_or_not_and_not.mp h.eq_zero_iff with (⟨rfl, rfl⟩ | ⟨ha, hb⟩)
+  · rfl
+  · simp_rw [radical, primeFactors]
+    rw [(associated_iff_normalizedFactors_eq_normalizedFactors ha hb).mp h]
+
+theorem radical_unit_eq_one {a : α} (h : IsUnit a) : radical a = 1 :=
+  (radical_associated_eq (associated_one_iff_isUnit.mpr h)).trans radical_one_eq_one
+
+theorem radical_mul_unit_left {u a : α} (h : IsUnit u) : radical (u * a) = radical a :=
+  radical_associated_eq (associated_unit_mul_left _ _ h)
+
+theorem radical_mul_unit_right {u a : α} (h : IsUnit u) : radical (a * u) = radical a :=
+  radical_associated_eq (associated_mul_unit_left _ _ h)
+
+theorem primeFactors_pow (a : α) {n : ℕ} (hn : 0 < n) : primeFactors (a ^ n) = primeFactors a :=
+  by
+  simp_rw [primeFactors]
+  simp only [normalizedFactors_pow]
+  rw [Multiset.toFinset_nsmul]
+  exact ne_of_gt hn
+
+theorem radical_pow (a : α) {n : Nat} (hn : 0 < n) : radical (a ^ n) = radical a := by
+  simp_rw [radical, primeFactors_pow a hn]
+
+theorem radical_dvd_self (a : α) : radical a ∣ a :=
+  by
+  by_cases ha : a = 0
+  · rw [ha]
+    apply dvd_zero
+  · rw [radical, ← Finset.prod_val, ← (normalizedFactors_prod ha).dvd_iff_dvd_right]
+    apply Multiset.prod_dvd_prod_of_le
+    rw [primeFactors, Multiset.toFinset_val]
+    apply Multiset.dedup_le
+
+theorem radical_dvd_radical_self_mul {a b : α} (hb : b ≠ 0) : radical a ∣ radical (a * b) := by
+  by_cases ha : a = 0
+  · rw [ha, zero_mul]
+  · rw [radical, ← Finset.prod_val, radical, ← Finset.prod_val]
+    apply Multiset.prod_dvd_prod_of_le
+    repeat rw [primeFactors]
+    rw [normalizedFactors_mul ha hb, Finset.val_le_iff, Multiset.toFinset_add]
+    exact Finset.subset_union_left
+
+theorem radical_dvd_radical_mul_self {a b : α} (hb : b ≠ 0) : radical a ∣ radical (b * a) := by
+  rw [mul_comm b a]
+  exact radical_dvd_radical_self_mul hb
+
+theorem radical_dvd_radical_of_dvd {a b : α} (hb : b ≠ 0) (h : a ∣ b) :
+    radical a ∣ radical b := by
+  rcases h with ⟨c, hc⟩
+  rw [hc]
+  rw [hc, mul_ne_zero_iff] at hb
+  exact radical_dvd_radical_self_mul hb.right
+
+theorem radical_mul_dvd_mul_radical (a b : α) : radical (a * b) ∣ (radical a) * (radical b) := by
+  by_cases ha : a = 0
+  . rw [ha]
+    simp only [zero_mul, dvd_mul_right]
+  by_cases hb : b = 0
+  . rw [hb]
+    simp only [mul_zero, dvd_mul_left]
+  rw [radical, primeFactors, normalizedFactors_mul ha hb, Multiset.toFinset_add]
+  rw [radical, primeFactors]
+  rw [radical, primeFactors]
+  refine ⟨?mult, ?tt⟩
+  swap
+  symm
+  convert Finset.prod_union_inter using 2
+
+theorem radical_prime {a : α} (ha : Prime a) : radical a = normalize a :=
+  by
+  rw [radical, primeFactors]
+  rw [normalizedFactors_irreducible ha.irreducible]
+  simp only [Multiset.toFinset_singleton, id, Finset.prod_singleton]
+
+theorem radical_prime_pow {a : α} (ha : Prime a) {n : ℕ} (hn : 1 ≤ n) :
+    radical (a ^ n) = normalize a := by
+  rw [radical_pow a hn]
+  exact radical_prime ha
+
+theorem prime_dvd_radical_iff {a p : α} (ha : a ≠ 0) (hp : Prime p) :
+    p ∣ radical a ↔ p ∣ a := by
+  constructor
+  . exact λ h => h.trans <| radical_dvd_self a
+  . intro hpa
+    rcases exists_mem_normalizedFactors_of_dvd ha hp.irreducible hpa with ⟨q, ⟨hqf, hpq⟩⟩
+    rw [hpq.dvd_iff_dvd_left]
+    rw [radical, primeFactors]
+    apply Finset.dvd_prod_of_mem id
+    rw [Multiset.mem_toFinset]
+    exact hqf
+
+theorem radical_isUnit_iff {a : α} (h : a ≠ 0) : IsUnit (radical a) ↔ IsUnit a := by
+  constructor
+  . contrapose
+    intro ha
+    rcases exists_mem_factors h ha with ⟨p, hpf⟩
+    have hpp := prime_of_factor _ hpf
+    have hpd := dvd_of_mem_factors hpf
+    apply not_isUnit_of_not_isUnit_dvd hpp.not_unit
+    rw [prime_dvd_radical_iff h hpp]
+    exact hpd
+  . intro ha
+    rw [radical_unit_eq_one ha]
+    exact isUnit_one
+
+-- Theorems for commutative rings
+variable {R : Type _} [CommRing R] [IsDomain R] [NormalizationMonoid R] [UniqueFactorizationMonoid R]
+
+/-- coprime polynomials have disjoint prime factors (as multisets). -/
+private theorem IsCoprime.disjoint_normalizedFactors {a b : R} (hc : IsCoprime a b) :
+    (normalizedFactors a).Disjoint (normalizedFactors b) :=
+  by
+  intro x hxa hxb
+  have x_dvd_a := dvd_of_mem_normalizedFactors hxa
+  have x_dvd_b := dvd_of_mem_normalizedFactors hxb
+  have xp := prime_of_normalized_factor x hxa
+  exact xp.not_unit (hc.isUnit_of_dvd' x_dvd_a x_dvd_b)
+
+-- coprime polynomials have disjoint prime factors (as finsets)
+private theorem IsCoprime.disjoint_primeFactors {a b : R} (hc : IsCoprime a b) :
+    Disjoint (primeFactors a) (primeFactors b) :=
+  Multiset.disjoint_toFinset.mpr (hc.disjoint_normalizedFactors)
+
+private theorem IsCoprime.hMul_primeFactors_disjUnion {a b : R} (ha : a ≠ 0) (hb : b ≠ 0)
+    (hc : IsCoprime a b) :
+    primeFactors (a * b) = (primeFactors a).disjUnion (primeFactors b) hc.disjoint_primeFactors :=
+  by
+  rw [Finset.disjUnion_eq_union]
+  simp_rw [primeFactors]
+  rw [normalizedFactors_mul ha hb, Multiset.toFinset_add]
+
+-- possible TODO: the proof is unnecessarily long
+@[simp]
+theorem radical_neg_one : radical (-1 : R) = 1 :=
+  radical_unit_eq_one isUnit_one.neg
+
+theorem radical_hMul {a b : R} (hc : IsCoprime a b) : radical (a * b) = (radical a) * (radical b) :=
+  by
+  by_cases ha : a = 0
+  · subst ha; rw [isCoprime_zero_left] at hc
+    simp only [MulZeroClass.zero_mul, radical_zero_eq_one, one_mul, radical_unit_eq_one hc]
+  by_cases hb : b = 0
+  · subst hb; rw [isCoprime_zero_right] at hc
+    simp only [MulZeroClass.mul_zero, radical_zero_eq_one, mul_one, radical_unit_eq_one hc]
+  simp_rw [radical]
+  rw [hc.hMul_primeFactors_disjUnion ha hb]
+  rw [Finset.prod_disjUnion hc.disjoint_primeFactors]
+
+theorem radical_neg {a : R} : radical (-a) = radical a :=
+  neg_one_mul a ▸ (radical_associated_eq <| associated_unit_mul_left a (-1) isUnit_one.neg)
+
+-- This actually holds for nontrivial monoids - do not need ring assumption.
+theorem radical_ne_zero (a : R) : radical a ≠ 0 :=
+  by
+  rw [radical, ← Finset.prod_val]
+  apply Multiset.prod_ne_zero
+  rw [primeFactors]
+  simp only [Multiset.toFinset_val, Multiset.mem_dedup]
+  exact zero_not_mem_normalizedFactors _
+
+namespace Polynomial
+
+theorem radical_degree_le {a : k[X]} (ha : a ≠ 0) : (radical a).degree ≤ a.degree :=
+  degree_le_of_dvd (radical_dvd_self a) ha
+
+theorem radical_natDegree_le (a : k[X]) : (radical a).natDegree ≤ a.natDegree := by
+  by_cases ha : a = 0
+  · rw [ha, radical_zero_eq_one, natDegree_one, natDegree_zero]
+  · exact natDegree_le_of_dvd (radical_dvd_self a) ha
+
+theorem radical_natDegree_mul_le (a b : k[X]) :
+    (radical (a * b)).natDegree ≤ (radical a).natDegree + (radical b).natDegree := by
+  rw [←natDegree_mul (radical_ne_zero _) (radical_ne_zero _)]
+  apply natDegree_le_of_dvd (radical_mul_dvd_mul_radical a b)
+  apply mul_ne_zero
+  exact radical_ne_zero _
+  exact radical_ne_zero _
+
+end Polynomial

--- a/LeanPool/LeanPolyABC/Lib/Wronskian.lean
+++ b/LeanPool/LeanPolyABC/Lib/Wronskian.lean
@@ -8,15 +8,17 @@ import Mathlib.Algebra.Polynomial.Derivative
 
 noncomputable section
 
-open scoped Polynomial Classical
+open scoped Polynomial
 
 open Polynomial
+
+namespace LeanPolyABC
 
 variable {R : Type _} [CommRing R]
 
 /-- Wronskian: W(a, b) = ab' - a'b. -/
 def wronskian (a b : R[X]) : R[X] :=
-  a * (derivative b) - (derivative a) * b
+  a * derivative b - derivative a * b
 
 @[simp]
 theorem wronskian_zero_left (a : R[X]) : wronskian 0 a = 0 := by
@@ -32,8 +34,9 @@ theorem wronskian_neg_left (a b : R[X]) : wronskian (-a) b = -wronskian a b := b
 theorem wronskian_neg_right (a b : R[X]) : wronskian a (-b) = -wronskian a b := by
   simp_rw [wronskian, derivative_neg]; ring
 
-theorem wronskian_add_right (a b c : R[X]) : wronskian a (b + c) = wronskian a b + wronskian a c :=
-  by simp_rw [wronskian, derivative_add]; ring
+theorem wronskian_add_right (a b c : R[X]) :
+    wronskian a (b + c) = wronskian a b + wronskian a c := by
+  simp_rw [wronskian, derivative_add]; ring
 
 theorem wronskian_self (a : R[X]) : wronskian a a = 0 := by rw [wronskian, mul_comm, sub_self]
 
@@ -41,58 +44,39 @@ theorem wronskian_anticomm (a b : R[X]) : wronskian a b = -wronskian b a := by
   rw [wronskian, wronskian]; ring
 
 theorem wronskian_eq_of_sum_zero {a b c : R[X]} (h : a + b + c = 0) :
-    wronskian a b = wronskian b c :=
-  by
+    wronskian a b = wronskian b c := by
   rw [← neg_eq_iff_add_eq_zero] at h
-  rw [← h]
-  rw [wronskian_neg_right]
-  rw [wronskian_add_right]
-  rw [wronskian_self]
-  rw [add_zero]
-  rw [← wronskian_anticomm]
+  rw [← h, wronskian_neg_right, wronskian_add_right, wronskian_self, add_zero, ← wronskian_anticomm]
 
 private theorem degree_ne_bot {a : R[X]} (ha : a ≠ 0) : a.degree ≠ ⊥ := by
   intro h; rw [Polynomial.degree_eq_bot] at h; exact ha h
 
 theorem wronskian.degree_lt_add {a b : R[X]} (ha : a ≠ 0) (hb : b ≠ 0) :
-    (wronskian a b).degree < a.degree + b.degree :=
-  by
+    (wronskian a b).degree < a.degree + b.degree := by
   calc
     (wronskian a b).degree ≤ max (a * derivative b).degree (derivative a * b).degree :=
       Polynomial.degree_sub_le _ _
     _ < a.degree + b.degree := by
       rw [max_lt_iff]
-      constructor
-      case left => .
-      {
-        apply lt_of_le_of_lt
-        exact degree_mul_le a (derivative b)
+      refine ⟨?_, ?_⟩
+      · apply lt_of_le_of_lt (degree_mul_le a (derivative b))
         rw [WithBot.add_lt_add_iff_left (degree_ne_bot ha)]
         exact Polynomial.degree_derivative_lt hb
-      }
-      case right => .
-      {
-        apply lt_of_le_of_lt
-        exact degree_mul_le (derivative a) b
+      · apply lt_of_le_of_lt (degree_mul_le (derivative a) b)
         rw [WithBot.add_lt_add_iff_right (degree_ne_bot hb)]
         exact Polynomial.degree_derivative_lt ha
-      }
 
 -- Note: the following is false!
 -- Counterexample: b = a = 1 →
 -- (wronskian a b).natDegree = a.natDegree = b.natDegree = 0
-/-
-lemma wronskian.natDegree_lt_add {a b : R[X]}
-  (ha : a ≠ 0) (hb : b ≠ 0) :
-  (wronskian a b).natDegree < a.natDegree + b.natDegree := sorry
--/
 theorem wronskian.natDegree_lt_add {a b : R[X]} (hw : wronskian a b ≠ 0) :
-    (wronskian a b).natDegree < a.natDegree + b.natDegree :=
-  by
+    (wronskian a b).natDegree < a.natDegree + b.natDegree := by
   have ha : a ≠ 0 := by intro h; subst h; rw [wronskian_zero_left] at hw; exact hw rfl
   have hb : b ≠ 0 := by intro h; subst h; rw [wronskian_zero_right] at hw; exact hw rfl
   rw [← WithBot.coe_lt_coe, WithBot.coe_add]
   convert ← wronskian.degree_lt_add ha hb
-  exact Polynomial.degree_eq_natDegree hw
-  exact Polynomial.degree_eq_natDegree ha
-  exact Polynomial.degree_eq_natDegree hb
+  · exact Polynomial.degree_eq_natDegree hw
+  · exact Polynomial.degree_eq_natDegree ha
+  · exact Polynomial.degree_eq_natDegree hb
+
+end LeanPolyABC

--- a/LeanPool/LeanPolyABC/Lib/Wronskian.lean
+++ b/LeanPool/LeanPolyABC/Lib/Wronskian.lean
@@ -51,7 +51,9 @@ theorem wronskian_eq_of_sum_zero {a b c : R[X]} (h : a + b + c = 0) :
 private theorem degree_ne_bot {a : R[X]} (ha : a ≠ 0) : a.degree ≠ ⊥ := by
   intro h; rw [Polynomial.degree_eq_bot] at h; exact ha h
 
-theorem wronskian.degree_lt_add {a b : R[X]} (ha : a ≠ 0) (hb : b ≠ 0) :
+namespace wronskian
+
+theorem degree_lt_add {a b : R[X]} (ha : a ≠ 0) (hb : b ≠ 0) :
     (wronskian a b).degree < a.degree + b.degree := by
   calc
     (wronskian a b).degree ≤ max (a * derivative b).degree (derivative a * b).degree :=
@@ -69,7 +71,7 @@ theorem wronskian.degree_lt_add {a b : R[X]} (ha : a ≠ 0) (hb : b ≠ 0) :
 -- Note: the following is false!
 -- Counterexample: b = a = 1 →
 -- (wronskian a b).natDegree = a.natDegree = b.natDegree = 0
-theorem wronskian.natDegree_lt_add {a b : R[X]} (hw : wronskian a b ≠ 0) :
+theorem natDegree_lt_add {a b : R[X]} (hw : wronskian a b ≠ 0) :
     (wronskian a b).natDegree < a.natDegree + b.natDegree := by
   have ha : a ≠ 0 := by intro h; subst h; rw [wronskian_zero_left] at hw; exact hw rfl
   have hb : b ≠ 0 := by intro h; subst h; rw [wronskian_zero_right] at hw; exact hw rfl
@@ -78,5 +80,7 @@ theorem wronskian.natDegree_lt_add {a b : R[X]} (hw : wronskian a b ≠ 0) :
   · exact Polynomial.degree_eq_natDegree hw
   · exact Polynomial.degree_eq_natDegree ha
   · exact Polynomial.degree_eq_natDegree hb
+
+end wronskian
 
 end LeanPolyABC

--- a/LeanPool/LeanPolyABC/Lib/Wronskian.lean
+++ b/LeanPool/LeanPolyABC/Lib/Wronskian.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 Seewoo Lee. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Seewoo Lee
+-/
+
+import Mathlib.Algebra.Polynomial.Derivative
+
+noncomputable section
+
+open scoped Polynomial Classical
+
+open Polynomial
+
+variable {R : Type _} [CommRing R]
+
+/-- Wronskian: W(a, b) = ab' - a'b. -/
+def wronskian (a b : R[X]) : R[X] :=
+  a * (derivative b) - (derivative a) * b
+
+@[simp]
+theorem wronskian_zero_left (a : R[X]) : wronskian 0 a = 0 := by
+  simp_rw [wronskian]; simp only [MulZeroClass.zero_mul, derivative_zero, sub_self]
+
+@[simp]
+theorem wronskian_zero_right (a : R[X]) : wronskian a 0 = 0 := by
+  simp_rw [wronskian]; simp only [derivative_zero, MulZeroClass.mul_zero, sub_self]
+
+theorem wronskian_neg_left (a b : R[X]) : wronskian (-a) b = -wronskian a b := by
+  simp_rw [wronskian, derivative_neg]; ring
+
+theorem wronskian_neg_right (a b : R[X]) : wronskian a (-b) = -wronskian a b := by
+  simp_rw [wronskian, derivative_neg]; ring
+
+theorem wronskian_add_right (a b c : R[X]) : wronskian a (b + c) = wronskian a b + wronskian a c :=
+  by simp_rw [wronskian, derivative_add]; ring
+
+theorem wronskian_self (a : R[X]) : wronskian a a = 0 := by rw [wronskian, mul_comm, sub_self]
+
+theorem wronskian_anticomm (a b : R[X]) : wronskian a b = -wronskian b a := by
+  rw [wronskian, wronskian]; ring
+
+theorem wronskian_eq_of_sum_zero {a b c : R[X]} (h : a + b + c = 0) :
+    wronskian a b = wronskian b c :=
+  by
+  rw [← neg_eq_iff_add_eq_zero] at h
+  rw [← h]
+  rw [wronskian_neg_right]
+  rw [wronskian_add_right]
+  rw [wronskian_self]
+  rw [add_zero]
+  rw [← wronskian_anticomm]
+
+private theorem degree_ne_bot {a : R[X]} (ha : a ≠ 0) : a.degree ≠ ⊥ := by
+  intro h; rw [Polynomial.degree_eq_bot] at h; exact ha h
+
+theorem wronskian.degree_lt_add {a b : R[X]} (ha : a ≠ 0) (hb : b ≠ 0) :
+    (wronskian a b).degree < a.degree + b.degree :=
+  by
+  calc
+    (wronskian a b).degree ≤ max (a * derivative b).degree (derivative a * b).degree :=
+      Polynomial.degree_sub_le _ _
+    _ < a.degree + b.degree := by
+      rw [max_lt_iff]
+      constructor
+      case left => .
+      {
+        apply lt_of_le_of_lt
+        exact degree_mul_le a (derivative b)
+        rw [WithBot.add_lt_add_iff_left (degree_ne_bot ha)]
+        exact Polynomial.degree_derivative_lt hb
+      }
+      case right => .
+      {
+        apply lt_of_le_of_lt
+        exact degree_mul_le (derivative a) b
+        rw [WithBot.add_lt_add_iff_right (degree_ne_bot hb)]
+        exact Polynomial.degree_derivative_lt ha
+      }
+
+-- Note: the following is false!
+-- Counterexample: b = a = 1 →
+-- (wronskian a b).natDegree = a.natDegree = b.natDegree = 0
+/-
+lemma wronskian.natDegree_lt_add {a b : R[X]}
+  (ha : a ≠ 0) (hb : b ≠ 0) :
+  (wronskian a b).natDegree < a.natDegree + b.natDegree := sorry
+-/
+theorem wronskian.natDegree_lt_add {a b : R[X]} (hw : wronskian a b ≠ 0) :
+    (wronskian a b).natDegree < a.natDegree + b.natDegree :=
+  by
+  have ha : a ≠ 0 := by intro h; subst h; rw [wronskian_zero_left] at hw; exact hw rfl
+  have hb : b ≠ 0 := by intro h; subst h; rw [wronskian_zero_right] at hw; exact hw rfl
+  rw [← WithBot.coe_lt_coe, WithBot.coe_add]
+  convert ← wronskian.degree_lt_add ha hb
+  exact Polynomial.degree_eq_natDegree hw
+  exact Polynomial.degree_eq_natDegree ha
+  exact Polynomial.degree_eq_natDegree hb

--- a/LeanPool/LeanPolyABC/MasonStothers.lean
+++ b/LeanPool/LeanPolyABC/MasonStothers.lean
@@ -1,0 +1,262 @@
+/-
+Copyright (c) 2026 Seewoo Lee. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Seewoo Lee
+-/
+
+import Mathlib.Algebra.CharP.Defs
+import Mathlib.Algebra.EuclideanDomain.Defs
+import Mathlib.Algebra.Polynomial.FieldDivision
+import LeanPool.LeanPolyABC.Lib.Wronskian
+import LeanPool.LeanPolyABC.Lib.DivRadical
+import LeanPool.LeanPolyABC.Lib.Max3
+
+noncomputable section
+
+open scoped Polynomial Classical
+
+open Polynomial
+
+open UniqueFactorizationMonoid
+
+variable {k : Type _} [Field k]
+
+theorem Ne.isUnit_C {u : k} (hu : u ≠ 0) : IsUnit (C u) :=
+  isUnit_C.mpr hu.isUnit
+
+theorem Ne.C_ne_zero {u : k} (hu : u ≠ 0) : C u ≠ 0 :=
+  C_ne_zero.mpr hu
+
+@[simp]
+theorem dvd_derivative_iff {a : k[X]} : a ∣ derivative a ↔ derivative a = 0 :=
+  by
+  constructor
+  intro h
+  by_cases a_nz : a = 0
+  · rw [a_nz]; simp only [derivative_zero]
+  by_contra deriv_nz
+  have deriv_lt := degree_derivative_lt a_nz
+  have le_deriv := Polynomial.degree_le_of_dvd h deriv_nz
+  have lt_self := le_deriv.trans_lt deriv_lt
+  simp only [lt_self_iff_false] at lt_self
+  intro h; rw [h]; simp
+
+theorem IsCoprime.wronskian_eq_zero_iff {a b : k[X]} (hc : IsCoprime a b) :
+    wronskian a b = 0 ↔ derivative a = 0 ∧ derivative b = 0 :=
+  by
+  constructor
+  intro hw
+  rw [wronskian, sub_eq_iff_eq_add, zero_add] at hw
+  constructor
+  · rw [← dvd_derivative_iff]
+    apply hc.dvd_of_dvd_mul_right
+    rw [← hw]; exact dvd_mul_right _ _
+  · rw [← dvd_derivative_iff]
+    apply hc.symm.dvd_of_dvd_mul_left
+    rw [hw]; exact dvd_mul_left _ _
+  intro hdab
+  cases' hdab with hda hdb
+  rw [wronskian]
+  rw [hda, hdb]; simp only [MulZeroClass.mul_zero, MulZeroClass.zero_mul, sub_self]
+
+/- ABC for polynomials (Mason-Stothers theorem)
+
+For coprime polynomials a, b, c satisfying a + b + c = 0 and deg(a) ≥ deg(rad(abc)), we have a' = b' = c' = 0.
+
+Proof is based on this online note by Franz Lemmermeyer http://www.fen.bilkent.edu.tr/~franz/ag05/ag-02.pdf, which is essentially based on Noah Snyder's proof ("An Alternative Proof of Mason's Theorem"), but slightly different.
+
+1. Show that W(a, b) = W(b, c) = W(c, a) =: W. `wronskian_eq_of_sum_zero`
+2. (a / rad(a)) | W, and same for b and c. `poly_mod_rad_div_diff`
+3. a / rad(a), b / rad(b), c / rad(c) are all coprime, so their product abc / rad(abc) also divides W. `poly_coprime_div_mul_div`
+4. Using the assumption on degrees, deduce that deg (abc / rad(abc)) > deg W.
+5. By `polynomial.degree_le_of_dvd`, W = 0.
+6. Since W(a, b) = ab' - a'b = 0 and a and b are coprime, a' = 0. Similarly we have b' = c' = 0. `coprime_wronskian_eq_zero_const`
+-/
+protected theorem IsCoprime.divRadical {a b : k[X]} (h : IsCoprime a b) :
+    IsCoprime a.divRadical b.divRadical :=
+  by
+  rw [← Polynomial.hMul_radical_divRadical a] at h
+  rw [← Polynomial.hMul_radical_divRadical b] at h
+  exact h.of_mul_left_right.of_mul_right_right
+
+private theorem abc_subcall
+    {a b c w : k[X]} {hw : w ≠ 0} (wab : w = wronskian a b)
+    (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0)
+    (hab : IsCoprime a b) (hbc : IsCoprime b c) (hca : IsCoprime c a)
+    (abc_dr_dvd_w : (a * b * c).divRadical ∣ w) : c.natDegree + 1 ≤ (radical (a * b * c)).natDegree :=
+  by
+  have hab := mul_ne_zero ha hb
+  have habc := mul_ne_zero hab hc
+  set abc_dr_nd := (divRadical (a * b * c)).natDegree with def_abc_dr_nd
+  set abc_r_nd := (radical (a * b * c)).natDegree with def_abc_r_nd
+  have t11 : abc_dr_nd < a.natDegree + b.natDegree := by
+    calc
+      abc_dr_nd ≤ w.natDegree := Polynomial.natDegree_le_of_dvd abc_dr_dvd_w hw
+      _ < a.natDegree + b.natDegree := by rw [wab] at hw ⊢; exact wronskian.natDegree_lt_add hw
+  have t4 : abc_dr_nd + abc_r_nd < a.natDegree + b.natDegree + abc_r_nd :=
+    Nat.add_lt_add_right t11 abc_r_nd
+  have t3 : abc_dr_nd + abc_r_nd = a.natDegree + b.natDegree + c.natDegree := by
+    calc
+      abc_dr_nd + abc_r_nd = ((divRadical (a * b * c)) * (radical (a * b * c))).natDegree := by
+        rw [←
+          Polynomial.natDegree_mul (Polynomial.divRadical_ne_zero habc) (radical_ne_zero (a * b * c))]
+      _ = (a * b * c).natDegree := by
+        rw [mul_comm _ (radical _)]; rw [hMul_radical_divRadical (a * b * c)]
+      _ = a.natDegree + b.natDegree + c.natDegree := by
+        rw [Polynomial.natDegree_mul hab hc, Polynomial.natDegree_mul ha hb]
+  rw [t3] at t4
+  exact Nat.lt_of_add_lt_add_left t4
+
+private theorem rot3_add {a b c : k[X]} : a + b + c = b + c + a := by ring
+
+private theorem rot3_mul {a b c : k[X]} : a * b * c = b * c * a := by ring
+
+private theorem rot3_isCoprime {a b c : k[X]}
+    (h : a + b + c = 0) (hab : IsCoprime a b) : IsCoprime b c := by
+  rw [add_eq_zero_iff_neg_eq] at h
+  rw [←h, IsCoprime.neg_right_iff]
+  convert IsCoprime.add_mul_left_right hab.symm 1
+  rw [mul_one]
+
+theorem Polynomial.abc {a b c : k[X]}
+    (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0)
+    (hab : IsCoprime a b) (hsum : a + b + c = 0) :
+    (derivative a = 0 ∧ derivative b = 0 ∧ derivative c = 0) ∨
+      Nat.max₃ a.natDegree b.natDegree c.natDegree + 1 ≤ (radical (a * b * c)).natDegree :=
+  by
+  -- Utility assertions
+  have hbc : IsCoprime b c := rot3_isCoprime hsum hab
+  have hca : IsCoprime c a := rot3_isCoprime (by rw [←rot3_add]; exact hsum) hbc
+  have wbc := wronskian_eq_of_sum_zero hsum
+  set w := wronskian a b with wab
+  have wca : w = wronskian c a := by
+    rw [rot3_add] at hsum
+    have h := wronskian_eq_of_sum_zero hsum
+    rw [← wbc] at h; exact h
+  have abc_dr_dvd_w : (a * b * c).divRadical ∣ w :=
+    by
+    have adr_dvd_w := a.divRadical_dvd_wronskian_left b
+    have bdr_dvd_w := a.divRadical_dvd_wronskian_right b
+    have cdr_dvd_w := b.divRadical_dvd_wronskian_right c
+    rw [← wab] at adr_dvd_w bdr_dvd_w
+    rw [← wbc] at cdr_dvd_w
+    have cop_ab_dr := hab.divRadical
+    have cop_bc_dr := hbc.divRadical
+    have cop_ca_dr := hca.divRadical
+    have cop_abc_dr := cop_ca_dr.symm.mul_left cop_bc_dr
+    have abdr_dvd_w := cop_ab_dr.mul_dvd adr_dvd_w bdr_dvd_w
+    have abcdr_dvd_w := cop_abc_dr.mul_dvd abdr_dvd_w cdr_dvd_w
+    convert abcdr_dvd_w using 1
+    rw [← Polynomial.divRadical_hMul hab]
+    rw [← Polynomial.divRadical_hMul _]
+    exact hca.symm.mul_left hbc
+  by_cases hw : w = 0
+  · left
+    rw [hw] at wab wbc
+    cases' hab.wronskian_eq_zero_iff.mp wab.symm with ga gb
+    cases' hbc.wronskian_eq_zero_iff.mp wbc.symm with _ gc
+    refine' ⟨ga, gb, gc⟩
+  · right
+    rw [Nat.max₃_add_distrib_right, Nat.max₃_le]
+    refine' ⟨_, _, _⟩
+    · rw [rot3_mul] at abc_dr_dvd_w ⊢
+      apply abc_subcall wbc <;> assumption
+    · rw [rot3_mul, rot3_mul] at abc_dr_dvd_w ⊢
+      apply abc_subcall wca <;> assumption
+    · apply abc_subcall wab <;> assumption
+
+theorem Polynomial.abc_char0 [CharZero k] {a b c : k[X]}
+    (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0)
+    (hab : IsCoprime a b) (hsum : a + b + c = 0) :
+    (a.natDegree = 0 ∧ b.natDegree = 0 ∧ c.natDegree = 0) ∨
+      Nat.max₃ a.natDegree b.natDegree c.natDegree + 1 ≤ (radical (a * b * c)).natDegree := by
+  rcases Polynomial.abc ha hb hc hab hsum with _ | h
+  . left
+    repeat (any_goals constructor)
+    all_goals (apply natDegree_eq_zero_of_derivative_eq_zero; tauto)
+  . tauto
+
+lemma isUnit_iff_natDegree_eq_zero {a : k[X]} (ha : a ≠ 0) :
+    IsUnit a ↔ a.natDegree = 0 := by
+  rw [isUnit_iff_degree_eq_zero, degree_eq_natDegree ha]
+  simp only [Nat.cast_eq_zero]
+
+lemma natDegree_radical_eq_zero_iff {a : k[X]} :
+    (radical a).natDegree = 0 ↔ a.natDegree = 0 := by
+  by_cases ha : a = 0
+  . rw [ha]
+    simp only [radical_zero_eq_one, natDegree_zero, natDegree_one, iff_true]
+  . rw [←isUnit_iff_natDegree_eq_zero ha, ←isUnit_iff_natDegree_eq_zero (radical_ne_zero _)]
+    rw [radical_isUnit_iff ha]
+
+-- Variant of Mason--Stothers not requiring coprimality of `a` and `b`
+theorem Polynomial.abc'_char0 [CharZero k]
+    {a b c : k[X]} (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0) (hsum : a + b + c = 0) :
+    (a.natDegree = 0 ∧ b.natDegree = 0 ∧ c.natDegree = 0) ∨
+      Nat.max₃ a.natDegree b.natDegree c.natDegree + 1 ≤
+      (radical a).natDegree + (radical b).natDegree + c.natDegree := by
+  rcases gcd_dvd_left a b with ⟨a', eq_a'⟩
+  rcases gcd_dvd_right a b with ⟨b', eq_b'⟩
+  have hab : IsCoprime a' b' := by
+    rw [←gcd_isUnit_iff]
+    apply isUnit_gcd_of_eq_mul_gcd eq_a' eq_b'
+    apply gcd_ne_zero_of_right
+    assumption
+  rw [eq_a', mul_ne_zero_iff] at ha
+  rcases ha with ⟨hd, ha'⟩
+  rw [eq_b', mul_ne_zero_iff] at hb
+  rcases hb with ⟨_, hb'⟩
+  set d := gcd a b with def_d
+  set c' := -(a' + b') with def_c'
+  have eq_c' : c = d * c' := by
+    rw [def_c', mul_neg, eq_neg_iff_add_eq_zero,
+        mul_add, add_comm c _, ←eq_a', ←eq_b']
+    exact hsum
+  have hc' : c' ≠ 0 := by
+    rw [eq_c', mul_ne_zero_iff] at hc; exact hc.right
+  have hsum' : a' + b' + c' = 0 := by
+    rw [eq_a', eq_b', eq_c', ←mul_add, ←mul_add, mul_eq_zero] at hsum
+    rcases hsum with dz | goal
+    . exfalso; exact hd dz
+    . exact goal
+  have hbc := rot3_isCoprime hsum' hab
+  have hca := rot3_isCoprime (by rw [←rot3_add]; exact hsum') hbc
+  rcases (Polynomial.abc_char0 ha' hb' hc' hab hsum') with heq | hineq
+  . by_cases hd' : (natDegree d) = 0
+    . left
+      rw [eq_a', eq_b', eq_c']
+      (repeat rw [Polynomial.natDegree_mul _ _]) <;> try assumption
+      simp only [hd', zero_add]
+      exact heq
+    . right
+      simp only [Polynomial.natDegree_eq_zero] at heq
+      rcases heq with ⟨⟨ca', eq_ca'⟩, ⟨cb', eq_cb'⟩, ⟨cc', eq_cc'⟩⟩
+      rw [eq_comm] at eq_ca' eq_cb' eq_cc'
+      rw [eq_a', eq_b', eq_c']
+      rw [natDegree_mul hd ha', natDegree_mul hd hb', natDegree_mul hd hc']
+      rw [←Nat.max₃_add_distrib_left _ _ _ _]
+      simp_rw [eq_ca', eq_cb', eq_cc', C_ne_zero] at ha' hb' hc' ⊢
+      simp only [Nat.max₃, natDegree_C, max_self, add_zero]
+      rw [add_comm _ 1, add_le_add_iff_right]
+      rw [radical_mul_unit_right ha'.isUnit_C,
+          radical_mul_unit_right hb'.isUnit_C]
+      revert hd'
+      rw [not_imp_comm]
+      simp only [not_le, Nat.lt_one_iff, add_eq_zero, and_self]
+      exact natDegree_radical_eq_zero_iff.mp
+  . right
+    rw [eq_a', eq_b', eq_c']
+    (repeat rw [mul_comm d _, Polynomial.natDegree_mul _ hd]) <;> try assumption
+    rw [←Nat.max₃_add_distrib_right _ _ _ _]
+    rw [add_right_comm, ←add_assoc, Nat.add_le_add_iff_right]
+    have habc := hca.symm.mul_left hbc
+    rw [radical_hMul habc, natDegree_mul (radical_ne_zero _) (radical_ne_zero _)] at hineq
+    rw [radical_hMul hab, natDegree_mul (radical_ne_zero _) (radical_ne_zero _)] at hineq
+    apply le_trans hineq
+    apply add_le_add_three <;> apply natDegree_le_of_dvd
+    . exact radical_dvd_radical_self_mul hd
+    . exact radical_ne_zero _
+    . exact radical_dvd_radical_self_mul hd
+    . exact radical_ne_zero _
+    . exact radical_dvd_self _
+    . exact hc'

--- a/LeanPool/LeanPolyABC/MasonStothers.lean
+++ b/LeanPool/LeanPolyABC/MasonStothers.lean
@@ -21,13 +21,17 @@ namespace LeanPolyABC
 
 variable {k : Type _} [Field k] [DecidableEq k]
 
+namespace Ne
+
 omit [DecidableEq k] in
-theorem Ne.isUnit_C {u : k} (hu : u ≠ 0) : IsUnit (C u) :=
+theorem isUnit_C {u : k} (hu : u ≠ 0) : IsUnit (C u) :=
   Polynomial.isUnit_C.mpr hu.isUnit
 
 omit [DecidableEq k] in
-theorem Ne.C_ne_zero {u : k} (hu : u ≠ 0) : C u ≠ 0 :=
+theorem C_ne_zero {u : k} (hu : u ≠ 0) : C u ≠ 0 :=
   Polynomial.C_ne_zero.mpr hu
+
+end Ne
 
 omit [DecidableEq k] in
 theorem dvd_derivative_iff {a : k[X]} : a ∣ derivative a ↔ derivative a = 0 := by
@@ -42,8 +46,10 @@ theorem dvd_derivative_iff {a : k[X]} : a ∣ derivative a ↔ derivative a = 0 
     simp only [lt_self_iff_false] at lt_self
   · intro h; rw [h]; simp
 
+namespace IsCoprime
+
 omit [DecidableEq k] in
-theorem IsCoprime.wronskian_eq_zero_iff {a b : k[X]} (hc : IsCoprime a b) :
+theorem wronskian_eq_zero_iff {a b : k[X]} (hc : IsCoprime a b) :
     wronskian a b = 0 ↔ derivative a = 0 ∧ derivative b = 0 := by
   constructor
   · intro hw
@@ -59,6 +65,8 @@ theorem IsCoprime.wronskian_eq_zero_iff {a b : k[X]} (hc : IsCoprime a b) :
     obtain ⟨hda, hdb⟩ := hdab
     rw [wronskian]
     rw [hda, hdb]; simp only [MulZeroClass.mul_zero, MulZeroClass.zero_mul, sub_self]
+
+end IsCoprime
 
 /- ABC for polynomials (Mason-Stothers theorem)
 
@@ -78,11 +86,15 @@ proof ("An Alternative Proof of Mason's Theorem"), but slightly different.
 6. Since W(a, b) = ab' - a'b = 0 and a and b are coprime, a' = 0. Similarly we have b' = c' = 0.
    `coprime_wronskian_eq_zero_const`
 -/
-protected theorem IsCoprime.divRadical {a b : k[X]} (h : IsCoprime a b) :
+namespace IsCoprime
+
+protected theorem divRadical {a b : k[X]} (h : IsCoprime a b) :
     IsCoprime (Polynomial.divRadical a) (Polynomial.divRadical b) := by
   rw [← Polynomial.hMul_radical_divRadical a] at h
   rw [← Polynomial.hMul_radical_divRadical b] at h
   exact h.of_mul_left_right.of_mul_right_right
+
+end IsCoprime
 
 private theorem abc_subcall
     {a b c w : k[X]} {hw : w ≠ 0} (wab : w = wronskian a b)
@@ -128,7 +140,9 @@ private theorem rot3_isCoprime {a b c : k[X]}
   convert IsCoprime.add_mul_left_right hab.symm 1
   rw [mul_one]
 
-theorem Polynomial.abc {a b c : k[X]}
+namespace Polynomial
+
+theorem abc {a b c : k[X]}
     (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0)
     (hab : IsCoprime a b) (hsum : a + b + c = 0) :
     (derivative a = 0 ∧ derivative b = 0 ∧ derivative c = 0) ∨
@@ -173,7 +187,7 @@ theorem Polynomial.abc {a b c : k[X]}
       apply abc_subcall wca <;> assumption
     · apply abc_subcall wab <;> assumption
 
-theorem Polynomial.abc_char0 [CharZero k] {a b c : k[X]}
+theorem abc_char0 [CharZero k] {a b c : k[X]}
     (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0)
     (hab : IsCoprime a b) (hsum : a + b + c = 0) :
     (a.natDegree = 0 ∧ b.natDegree = 0 ∧ c.natDegree = 0) ∨
@@ -183,6 +197,8 @@ theorem Polynomial.abc_char0 [CharZero k] {a b c : k[X]}
     repeat (any_goals constructor)
     all_goals (apply natDegree_eq_zero_of_derivative_eq_zero; tauto)
   · tauto
+
+end Polynomial
 
 omit [DecidableEq k] in
 theorem isUnit_iff_natDegree_eq_zero {a : k[X]} (ha : a ≠ 0) :
@@ -198,8 +214,10 @@ theorem natDegree_radical_eq_zero_iff {a : k[X]} :
   · rw [← isUnit_iff_natDegree_eq_zero ha, ← isUnit_iff_natDegree_eq_zero (radical_ne_zero _)]
     rw [radical_isUnit_iff ha]
 
+namespace Polynomial
+
 -- Variant of Mason--Stothers not requiring coprimality of `a` and `b`
-theorem Polynomial.abc'_char0 [CharZero k]
+theorem abc'_char0 [CharZero k]
     {a b c : k[X]} (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0) (hsum : a + b + c = 0) :
     (a.natDegree = 0 ∧ b.natDegree = 0 ∧ c.natDegree = 0) ∨
       Nat.max₃ a.natDegree b.natDegree c.natDegree + 1 ≤
@@ -269,5 +287,7 @@ theorem Polynomial.abc'_char0 [CharZero k]
     · exact radical_ne_zero _
     · exact radical_dvd_self _
     · exact hc'
+
+end Polynomial
 
 end LeanPolyABC

--- a/LeanPool/LeanPolyABC/MasonStothers.lean
+++ b/LeanPool/LeanPolyABC/MasonStothers.lean
@@ -13,68 +13,73 @@ import LeanPool.LeanPolyABC.Lib.Max3
 
 noncomputable section
 
-open scoped Polynomial Classical
+open scoped Polynomial
 
-open Polynomial
+open Polynomial UniqueFactorizationMonoid
 
-open UniqueFactorizationMonoid
+namespace LeanPolyABC
 
-variable {k : Type _} [Field k]
+variable {k : Type _} [Field k] [DecidableEq k]
 
+omit [DecidableEq k] in
 theorem Ne.isUnit_C {u : k} (hu : u ≠ 0) : IsUnit (C u) :=
-  isUnit_C.mpr hu.isUnit
+  Polynomial.isUnit_C.mpr hu.isUnit
 
+omit [DecidableEq k] in
 theorem Ne.C_ne_zero {u : k} (hu : u ≠ 0) : C u ≠ 0 :=
-  C_ne_zero.mpr hu
+  Polynomial.C_ne_zero.mpr hu
 
-@[simp]
-theorem dvd_derivative_iff {a : k[X]} : a ∣ derivative a ↔ derivative a = 0 :=
-  by
+omit [DecidableEq k] in
+theorem dvd_derivative_iff {a : k[X]} : a ∣ derivative a ↔ derivative a = 0 := by
   constructor
-  intro h
-  by_cases a_nz : a = 0
-  · rw [a_nz]; simp only [derivative_zero]
-  by_contra deriv_nz
-  have deriv_lt := degree_derivative_lt a_nz
-  have le_deriv := Polynomial.degree_le_of_dvd h deriv_nz
-  have lt_self := le_deriv.trans_lt deriv_lt
-  simp only [lt_self_iff_false] at lt_self
-  intro h; rw [h]; simp
+  · intro h
+    by_cases a_nz : a = 0
+    · rw [a_nz]; simp only [derivative_zero]
+    by_contra deriv_nz
+    have deriv_lt := degree_derivative_lt a_nz
+    have le_deriv := Polynomial.degree_le_of_dvd h deriv_nz
+    have lt_self := le_deriv.trans_lt deriv_lt
+    simp only [lt_self_iff_false] at lt_self
+  · intro h; rw [h]; simp
 
+omit [DecidableEq k] in
 theorem IsCoprime.wronskian_eq_zero_iff {a b : k[X]} (hc : IsCoprime a b) :
-    wronskian a b = 0 ↔ derivative a = 0 ∧ derivative b = 0 :=
-  by
+    wronskian a b = 0 ↔ derivative a = 0 ∧ derivative b = 0 := by
   constructor
-  intro hw
-  rw [wronskian, sub_eq_iff_eq_add, zero_add] at hw
-  constructor
-  · rw [← dvd_derivative_iff]
-    apply hc.dvd_of_dvd_mul_right
-    rw [← hw]; exact dvd_mul_right _ _
-  · rw [← dvd_derivative_iff]
-    apply hc.symm.dvd_of_dvd_mul_left
-    rw [hw]; exact dvd_mul_left _ _
-  intro hdab
-  cases' hdab with hda hdb
-  rw [wronskian]
-  rw [hda, hdb]; simp only [MulZeroClass.mul_zero, MulZeroClass.zero_mul, sub_self]
+  · intro hw
+    rw [wronskian, sub_eq_iff_eq_add, zero_add] at hw
+    constructor
+    · rw [← dvd_derivative_iff]
+      apply hc.dvd_of_dvd_mul_right
+      rw [← hw]; exact dvd_mul_right _ _
+    · rw [← dvd_derivative_iff]
+      apply hc.symm.dvd_of_dvd_mul_left
+      rw [hw]; exact dvd_mul_left _ _
+  · intro hdab
+    obtain ⟨hda, hdb⟩ := hdab
+    rw [wronskian]
+    rw [hda, hdb]; simp only [MulZeroClass.mul_zero, MulZeroClass.zero_mul, sub_self]
 
 /- ABC for polynomials (Mason-Stothers theorem)
 
-For coprime polynomials a, b, c satisfying a + b + c = 0 and deg(a) ≥ deg(rad(abc)), we have a' = b' = c' = 0.
+For coprime polynomials a, b, c satisfying a + b + c = 0 and deg(a) ≥ deg(rad(abc)), we have
+a' = b' = c' = 0.
 
-Proof is based on this online note by Franz Lemmermeyer http://www.fen.bilkent.edu.tr/~franz/ag05/ag-02.pdf, which is essentially based on Noah Snyder's proof ("An Alternative Proof of Mason's Theorem"), but slightly different.
+Proof is based on this online note by Franz Lemmermeyer
+http://www.fen.bilkent.edu.tr/~franz/ag05/ag-02.pdf, which is essentially based on Noah Snyder's
+proof ("An Alternative Proof of Mason's Theorem"), but slightly different.
 
 1. Show that W(a, b) = W(b, c) = W(c, a) =: W. `wronskian_eq_of_sum_zero`
 2. (a / rad(a)) | W, and same for b and c. `poly_mod_rad_div_diff`
-3. a / rad(a), b / rad(b), c / rad(c) are all coprime, so their product abc / rad(abc) also divides W. `poly_coprime_div_mul_div`
+3. a / rad(a), b / rad(b), c / rad(c) are all coprime, so their product abc / rad(abc) also divides
+   W. `poly_coprime_div_mul_div`
 4. Using the assumption on degrees, deduce that deg (abc / rad(abc)) > deg W.
 5. By `polynomial.degree_le_of_dvd`, W = 0.
-6. Since W(a, b) = ab' - a'b = 0 and a and b are coprime, a' = 0. Similarly we have b' = c' = 0. `coprime_wronskian_eq_zero_const`
+6. Since W(a, b) = ab' - a'b = 0 and a and b are coprime, a' = 0. Similarly we have b' = c' = 0.
+   `coprime_wronskian_eq_zero_const`
 -/
 protected theorem IsCoprime.divRadical {a b : k[X]} (h : IsCoprime a b) :
-    IsCoprime a.divRadical b.divRadical :=
-  by
+    IsCoprime (Polynomial.divRadical a) (Polynomial.divRadical b) := by
   rw [← Polynomial.hMul_radical_divRadical a] at h
   rw [← Polynomial.hMul_radical_divRadical b] at h
   exact h.of_mul_left_right.of_mul_right_right
@@ -82,39 +87,44 @@ protected theorem IsCoprime.divRadical {a b : k[X]} (h : IsCoprime a b) :
 private theorem abc_subcall
     {a b c w : k[X]} {hw : w ≠ 0} (wab : w = wronskian a b)
     (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0)
-    (hab : IsCoprime a b) (hbc : IsCoprime b c) (hca : IsCoprime c a)
-    (abc_dr_dvd_w : (a * b * c).divRadical ∣ w) : c.natDegree + 1 ≤ (radical (a * b * c)).natDegree :=
-  by
+    (_hab : IsCoprime a b) (_hbc : IsCoprime b c) (_hca : IsCoprime c a)
+    (abc_dr_dvd_w : Polynomial.divRadical (a * b * c) ∣ w) :
+    c.natDegree + 1 ≤ (radical (a * b * c)).natDegree := by
   have hab := mul_ne_zero ha hb
   have habc := mul_ne_zero hab hc
-  set abc_dr_nd := (divRadical (a * b * c)).natDegree with def_abc_dr_nd
+  set abc_dr_nd := (Polynomial.divRadical (a * b * c)).natDegree with def_abc_dr_nd
   set abc_r_nd := (radical (a * b * c)).natDegree with def_abc_r_nd
   have t11 : abc_dr_nd < a.natDegree + b.natDegree := by
     calc
       abc_dr_nd ≤ w.natDegree := Polynomial.natDegree_le_of_dvd abc_dr_dvd_w hw
-      _ < a.natDegree + b.natDegree := by rw [wab] at hw ⊢; exact wronskian.natDegree_lt_add hw
+      _ < a.natDegree + b.natDegree := by
+        rw [wab] at hw ⊢; exact wronskian.natDegree_lt_add hw
   have t4 : abc_dr_nd + abc_r_nd < a.natDegree + b.natDegree + abc_r_nd :=
     Nat.add_lt_add_right t11 abc_r_nd
   have t3 : abc_dr_nd + abc_r_nd = a.natDegree + b.natDegree + c.natDegree := by
     calc
-      abc_dr_nd + abc_r_nd = ((divRadical (a * b * c)) * (radical (a * b * c))).natDegree := by
-        rw [←
-          Polynomial.natDegree_mul (Polynomial.divRadical_ne_zero habc) (radical_ne_zero (a * b * c))]
+      abc_dr_nd + abc_r_nd =
+          (Polynomial.divRadical (a * b * c) * radical (a * b * c)).natDegree := by
+        rw [← Polynomial.natDegree_mul (Polynomial.divRadical_ne_zero habc)
+          (radical_ne_zero (a * b * c))]
       _ = (a * b * c).natDegree := by
-        rw [mul_comm _ (radical _)]; rw [hMul_radical_divRadical (a * b * c)]
+        rw [mul_comm _ (radical _)]; rw [Polynomial.hMul_radical_divRadical (a * b * c)]
       _ = a.natDegree + b.natDegree + c.natDegree := by
         rw [Polynomial.natDegree_mul hab hc, Polynomial.natDegree_mul ha hb]
   rw [t3] at t4
   exact Nat.lt_of_add_lt_add_left t4
 
+omit [DecidableEq k] in
 private theorem rot3_add {a b c : k[X]} : a + b + c = b + c + a := by ring
 
+omit [DecidableEq k] in
 private theorem rot3_mul {a b c : k[X]} : a * b * c = b * c * a := by ring
 
+omit [DecidableEq k] in
 private theorem rot3_isCoprime {a b c : k[X]}
     (h : a + b + c = 0) (hab : IsCoprime a b) : IsCoprime b c := by
   rw [add_eq_zero_iff_neg_eq] at h
-  rw [←h, IsCoprime.neg_right_iff]
+  rw [← h, IsCoprime.neg_right_iff]
   convert IsCoprime.add_mul_left_right hab.symm 1
   rw [mul_one]
 
@@ -122,27 +132,25 @@ theorem Polynomial.abc {a b c : k[X]}
     (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0)
     (hab : IsCoprime a b) (hsum : a + b + c = 0) :
     (derivative a = 0 ∧ derivative b = 0 ∧ derivative c = 0) ∨
-      Nat.max₃ a.natDegree b.natDegree c.natDegree + 1 ≤ (radical (a * b * c)).natDegree :=
-  by
+      Nat.max₃ a.natDegree b.natDegree c.natDegree + 1 ≤ (radical (a * b * c)).natDegree := by
   -- Utility assertions
   have hbc : IsCoprime b c := rot3_isCoprime hsum hab
-  have hca : IsCoprime c a := rot3_isCoprime (by rw [←rot3_add]; exact hsum) hbc
+  have hca : IsCoprime c a := rot3_isCoprime (by rw [← rot3_add]; exact hsum) hbc
   have wbc := wronskian_eq_of_sum_zero hsum
   set w := wronskian a b with wab
   have wca : w = wronskian c a := by
     rw [rot3_add] at hsum
     have h := wronskian_eq_of_sum_zero hsum
     rw [← wbc] at h; exact h
-  have abc_dr_dvd_w : (a * b * c).divRadical ∣ w :=
-    by
-    have adr_dvd_w := a.divRadical_dvd_wronskian_left b
-    have bdr_dvd_w := a.divRadical_dvd_wronskian_right b
-    have cdr_dvd_w := b.divRadical_dvd_wronskian_right c
+  have abc_dr_dvd_w : Polynomial.divRadical (a * b * c) ∣ w := by
+    have adr_dvd_w := Polynomial.divRadical_dvd_wronskian_left a b
+    have bdr_dvd_w := Polynomial.divRadical_dvd_wronskian_right a b
+    have cdr_dvd_w := Polynomial.divRadical_dvd_wronskian_right b c
     rw [← wab] at adr_dvd_w bdr_dvd_w
     rw [← wbc] at cdr_dvd_w
-    have cop_ab_dr := hab.divRadical
-    have cop_bc_dr := hbc.divRadical
-    have cop_ca_dr := hca.divRadical
+    have cop_ab_dr := IsCoprime.divRadical hab
+    have cop_bc_dr := IsCoprime.divRadical hbc
+    have cop_ca_dr := IsCoprime.divRadical hca
     have cop_abc_dr := cop_ca_dr.symm.mul_left cop_bc_dr
     have abdr_dvd_w := cop_ab_dr.mul_dvd adr_dvd_w bdr_dvd_w
     have abcdr_dvd_w := cop_abc_dr.mul_dvd abdr_dvd_w cdr_dvd_w
@@ -153,12 +161,12 @@ theorem Polynomial.abc {a b c : k[X]}
   by_cases hw : w = 0
   · left
     rw [hw] at wab wbc
-    cases' hab.wronskian_eq_zero_iff.mp wab.symm with ga gb
-    cases' hbc.wronskian_eq_zero_iff.mp wbc.symm with _ gc
-    refine' ⟨ga, gb, gc⟩
+    obtain ⟨ga, gb⟩ := (IsCoprime.wronskian_eq_zero_iff hab).mp wab.symm
+    obtain ⟨_, gc⟩ := (IsCoprime.wronskian_eq_zero_iff hbc).mp wbc.symm
+    exact ⟨ga, gb, gc⟩
   · right
     rw [Nat.max₃_add_distrib_right, Nat.max₃_le]
-    refine' ⟨_, _, _⟩
+    refine ⟨?_, ?_, ?_⟩
     · rw [rot3_mul] at abc_dr_dvd_w ⊢
       apply abc_subcall wbc <;> assumption
     · rw [rot3_mul, rot3_mul] at abc_dr_dvd_w ⊢
@@ -170,23 +178,24 @@ theorem Polynomial.abc_char0 [CharZero k] {a b c : k[X]}
     (hab : IsCoprime a b) (hsum : a + b + c = 0) :
     (a.natDegree = 0 ∧ b.natDegree = 0 ∧ c.natDegree = 0) ∨
       Nat.max₃ a.natDegree b.natDegree c.natDegree + 1 ≤ (radical (a * b * c)).natDegree := by
-  rcases Polynomial.abc ha hb hc hab hsum with _ | h
-  . left
+  rcases LeanPolyABC.Polynomial.abc ha hb hc hab hsum with _ | h
+  · left
     repeat (any_goals constructor)
     all_goals (apply natDegree_eq_zero_of_derivative_eq_zero; tauto)
-  . tauto
+  · tauto
 
-lemma isUnit_iff_natDegree_eq_zero {a : k[X]} (ha : a ≠ 0) :
+omit [DecidableEq k] in
+theorem isUnit_iff_natDegree_eq_zero {a : k[X]} (ha : a ≠ 0) :
     IsUnit a ↔ a.natDegree = 0 := by
   rw [isUnit_iff_degree_eq_zero, degree_eq_natDegree ha]
   simp only [Nat.cast_eq_zero]
 
-lemma natDegree_radical_eq_zero_iff {a : k[X]} :
+theorem natDegree_radical_eq_zero_iff {a : k[X]} :
     (radical a).natDegree = 0 ↔ a.natDegree = 0 := by
   by_cases ha : a = 0
-  . rw [ha]
-    simp only [radical_zero_eq_one, natDegree_zero, natDegree_one, iff_true]
-  . rw [←isUnit_iff_natDegree_eq_zero ha, ←isUnit_iff_natDegree_eq_zero (radical_ne_zero _)]
+  · rw [ha]
+    simp only [radical_zero_eq_one, natDegree_zero, natDegree_one]
+  · rw [← isUnit_iff_natDegree_eq_zero ha, ← isUnit_iff_natDegree_eq_zero (radical_ne_zero _)]
     rw [radical_isUnit_iff ha]
 
 -- Variant of Mason--Stothers not requiring coprimality of `a` and `b`
@@ -198,7 +207,7 @@ theorem Polynomial.abc'_char0 [CharZero k]
   rcases gcd_dvd_left a b with ⟨a', eq_a'⟩
   rcases gcd_dvd_right a b with ⟨b', eq_b'⟩
   have hab : IsCoprime a' b' := by
-    rw [←gcd_isUnit_iff]
+    rw [← gcd_isUnit_iff]
     apply isUnit_gcd_of_eq_mul_gcd eq_a' eq_b'
     apply gcd_ne_zero_of_right
     assumption
@@ -210,53 +219,55 @@ theorem Polynomial.abc'_char0 [CharZero k]
   set c' := -(a' + b') with def_c'
   have eq_c' : c = d * c' := by
     rw [def_c', mul_neg, eq_neg_iff_add_eq_zero,
-        mul_add, add_comm c _, ←eq_a', ←eq_b']
+        mul_add, add_comm c _, ← eq_a', ← eq_b']
     exact hsum
   have hc' : c' ≠ 0 := by
     rw [eq_c', mul_ne_zero_iff] at hc; exact hc.right
   have hsum' : a' + b' + c' = 0 := by
-    rw [eq_a', eq_b', eq_c', ←mul_add, ←mul_add, mul_eq_zero] at hsum
+    rw [eq_a', eq_b', eq_c', ← mul_add, ← mul_add, mul_eq_zero] at hsum
     rcases hsum with dz | goal
-    . exfalso; exact hd dz
-    . exact goal
+    · exact absurd dz hd
+    · exact goal
   have hbc := rot3_isCoprime hsum' hab
-  have hca := rot3_isCoprime (by rw [←rot3_add]; exact hsum') hbc
-  rcases (Polynomial.abc_char0 ha' hb' hc' hab hsum') with heq | hineq
-  . by_cases hd' : (natDegree d) = 0
-    . left
+  have hca := rot3_isCoprime (by rw [← rot3_add]; exact hsum') hbc
+  rcases LeanPolyABC.Polynomial.abc_char0 ha' hb' hc' hab hsum' with heq | hineq
+  · by_cases hd' : (natDegree d) = 0
+    · left
       rw [eq_a', eq_b', eq_c']
       (repeat rw [Polynomial.natDegree_mul _ _]) <;> try assumption
       simp only [hd', zero_add]
       exact heq
-    . right
+    · right
       simp only [Polynomial.natDegree_eq_zero] at heq
       rcases heq with ⟨⟨ca', eq_ca'⟩, ⟨cb', eq_cb'⟩, ⟨cc', eq_cc'⟩⟩
       rw [eq_comm] at eq_ca' eq_cb' eq_cc'
       rw [eq_a', eq_b', eq_c']
       rw [natDegree_mul hd ha', natDegree_mul hd hb', natDegree_mul hd hc']
-      rw [←Nat.max₃_add_distrib_left _ _ _ _]
+      rw [← Nat.max₃_add_distrib_left _ _ _ _]
       simp_rw [eq_ca', eq_cb', eq_cc', C_ne_zero] at ha' hb' hc' ⊢
       simp only [Nat.max₃, natDegree_C, max_self, add_zero]
       rw [add_comm _ 1, add_le_add_iff_right]
-      rw [radical_mul_unit_right ha'.isUnit_C,
-          radical_mul_unit_right hb'.isUnit_C]
+      rw [radical_mul_unit_right (Ne.isUnit_C ha'),
+          radical_mul_unit_right (Ne.isUnit_C hb')]
       revert hd'
       rw [not_imp_comm]
       simp only [not_le, Nat.lt_one_iff, add_eq_zero, and_self]
       exact natDegree_radical_eq_zero_iff.mp
-  . right
+  · right
     rw [eq_a', eq_b', eq_c']
     (repeat rw [mul_comm d _, Polynomial.natDegree_mul _ hd]) <;> try assumption
-    rw [←Nat.max₃_add_distrib_right _ _ _ _]
-    rw [add_right_comm, ←add_assoc, Nat.add_le_add_iff_right]
+    rw [← Nat.max₃_add_distrib_right _ _ _ _]
+    rw [add_right_comm, ← add_assoc, Nat.add_le_add_iff_right]
     have habc := hca.symm.mul_left hbc
     rw [radical_hMul habc, natDegree_mul (radical_ne_zero _) (radical_ne_zero _)] at hineq
     rw [radical_hMul hab, natDegree_mul (radical_ne_zero _) (radical_ne_zero _)] at hineq
     apply le_trans hineq
     apply add_le_add_three <;> apply natDegree_le_of_dvd
-    . exact radical_dvd_radical_self_mul hd
-    . exact radical_ne_zero _
-    . exact radical_dvd_radical_self_mul hd
-    . exact radical_ne_zero _
-    . exact radical_dvd_self _
-    . exact hc'
+    · exact radical_dvd_radical_self_mul hd
+    · exact radical_ne_zero _
+    · exact radical_dvd_radical_self_mul hd
+    · exact radical_ne_zero _
+    · exact radical_dvd_self _
+    · exact hc'
+
+end LeanPolyABC

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -1266,14 +1266,14 @@ projects:
       github_repo: seewoo5/lean-poly-abc
     status: verified
     main_declarations:
-      - Polynomial.abc
-      - Polynomial.flt
+      - LeanPolyABC.Polynomial.abc
+      - LeanPolyABC.Polynomial.flt
     main_results:
-      - declaration: Polynomial.abc
+      - declaration: LeanPolyABC.Polynomial.abc
         informal: Mason–Stothers — for coprime non-constant polynomials with a+b=c, the max degree is below the degree of the radical of abc.
-      - declaration: Polynomial.flt
+      - declaration: LeanPolyABC.Polynomial.flt
         informal: The polynomial Fermat's Last Theorem — no nontrivial coprime polynomial solutions of aⁿ+bⁿ=cⁿ for n ≥ 3.
-      - declaration: Polynomial.flt_catalan
+      - declaration: LeanPolyABC.Polynomial.flt_catalan
         informal: The polynomial Fermat–Catalan inequality bounding solutions of aᵖ+bᵍ=cʳ.
     tags:
       - number-theory

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -1253,3 +1253,33 @@ projects:
     msc:
       - "68W15"
       - "05C15"
+  - slug: lean-poly-abc
+    title: Polynomial ABC (Mason–Stothers) and its corollaries
+    summary: Formalizes the Mason–Stothers theorem (the polynomial ABC theorem) and derives the polynomial Fermat's Last Theorem, the Fermat–Catalan inequality, Davenport's theorem, and a no-parametrization corollary.
+    branch: number theory
+    entry_module: LeanPool.LeanPolyABC
+    authors:
+      - Seewoo Lee
+    source:
+      title: "Formalization of Polynomial ABC and FLT"
+      url: https://github.com/seewoo5/lean-poly-abc
+      github_repo: seewoo5/lean-poly-abc
+    status: verified
+    main_declarations:
+      - Polynomial.abc
+      - Polynomial.flt
+    main_results:
+      - declaration: Polynomial.abc
+        informal: Mason–Stothers — for coprime non-constant polynomials with a+b=c, the max degree is below the degree of the radical of abc.
+      - declaration: Polynomial.flt
+        informal: The polynomial Fermat's Last Theorem — no nontrivial coprime polynomial solutions of aⁿ+bⁿ=cⁿ for n ≥ 3.
+      - declaration: Polynomial.flt_catalan
+        informal: The polynomial Fermat–Catalan inequality bounding solutions of aᵖ+bᵍ=cʳ.
+    tags:
+      - number-theory
+      - polynomials
+      - algebra
+      - mason-stothers
+    msc:
+      - "11C08"
+      - "12E05"


### PR DESCRIPTION
Vendor-only import of [seewoo5/lean-poly-abc](https://github.com/seewoo5/lean-poly-abc) — a formalization of the **Mason–Stothers theorem** (polynomial ABC) and its corollaries (polynomial FLT, Fermat–Catalan, Davenport). The author (Seewoo Lee) added the license at our request.

## What this PR does
- Vendors the upstream `LeanPolyABC` library (9 `.lean` files) into `LeanPool/LeanPolyABC/`.
- Adds entry module `LeanPool/LeanPolyABC.lean`, the `projects.yml` entry, and updates `LeanPool.lean`.
- Intra-project imports rewritten to `LeanPool.LeanPolyABC.*` (incl. the `«LeanPolyABC»` guillemet form); four-line header added. **Proof/declaration bodies unchanged** — not a port.

## Status — draft, CI red expected, awaiting port
- Upstream toolchain **Lean v4.9.0-rc2**; lean-pool is on v4.30.0-rc2. Not ported, so `lake build` will fail until bumped.
- Upstream license: **Apache-2.0** (verified) — redistributed directly, no NOTICE follow-up required.
- No active `sorry`/`admit` (the one `sorry` in `Lib/Wronskian.lean` is inside a comment block; the real lemma follows).
- **Porter / dedup note:** the core Mason–Stothers theorem and polynomial FLT were upstreamed into mathlib4 (PRs #15706, #18882) after this project was written, so the port should reconcile `Polynomial.abc` / `Polynomial.flt` with mathlib (reuse or rename) and keep the still-distinct corollaries (Fermat–Catalan, Davenport, no-parametrization) as the value-add.

Main results: `Polynomial.abc` (Mason–Stothers), `Polynomial.flt` (polynomial FLT), `Polynomial.flt_catalan` (Fermat–Catalan).