### PR TITLE
[codex] Handle empty files in partial port audit

### DIFF
--- a/python/lean_pool/partial_port_audit.py
+++ b/python/lean_pool/partial_port_audit.py
@@ -334,6 +334,8 @@ def evaluate_stats(
         imported_by_path.setdefault(normalize_relative_path(file.path), []).append(file)
     truncated_files = []
     for file in sorted(upstream.files, key=lambda item: item.loc, reverse=True):
+        if file.loc == 0:
+            continue
         matching_imports = imported_by_path.get(normalize_relative_path(file.path), [])
         if not matching_imports:
             continue

--- a/python/tests/test_partial_port_audit.py
+++ b/python/tests/test_partial_port_audit.py
@@ -184,6 +184,24 @@ def test_evaluate_stats_flags_truncated_matched_file() -> None:
     )
 
 
+def test_evaluate_stats_ignores_zero_loc_files_for_truncation() -> None:
+    """Empty upstream files do not cause a divide-by-zero during comparison."""
+    imported = LeanStats(
+        (
+            LeanFile("LeanPool/Foo/Empty.lean", 0, "empty"),
+            LeanFile("LeanPool/Foo/Main.lean", 1000, "main"),
+        )
+    )
+    upstream = LeanStats(
+        (
+            LeanFile("Foo/Empty.lean", 0, "empty"),
+            LeanFile("Foo/Main.lean", 1000, "main"),
+        )
+    )
+
+    assert evaluate_stats("LeanPool.Foo", "owner/foo", imported, upstream) is None
+
+
 def test_evaluate_stats_accepts_close_import() -> None:
     """A near-complete import passes the tolerance check."""
     imported = LeanStats((LeanFile("LeanPool/Foo/Main.lean", 920, "main"),))


### PR DESCRIPTION
## What changed

- Skips zero-LOC upstream files when computing matched-file truncation ratios in the partial-port audit.
- Adds a regression test covering empty matched upstream files.

## Why

Running the audit against `import/hopfieldnet` exposed a `ZeroDivisionError` when an upstream file had zero non-comment LOC. That made the advisory audit crash instead of reporting the actual partial-port signal.

## Validation

- `cd python && uv run --group test pytest tests/test_partial_port_audit.py`
- `cd python && uv run ruff check lean_pool/partial_port_audit.py tests/test_partial_port_audit.py`
- `cd python && uv run python -m lean_pool.partial_port_audit --repo .. --base-ref origin/main --head-ref import/hopfieldnet --json`
