### PR TITLE
Speed up docs CI: reuse the doc cache on main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,12 +52,14 @@ jobs:
             .lake/build
             docbuild/.lake/build
           key: Docs-Lake-${{ runner.os }}-${{ hashFiles('lake-manifest.json', 'docbuild/lake-manifest.json', 'LeanPool.lean') }}-${{ github.sha }}
-          # PR doc builds never deploy (Pages steps are main-only), so they
-          # restore the latest main cache and build incrementally. main keeps
-          # the exact key incl. LeanPool.lean so a project-add fully rebuilds.
+          # The doc tree builds incrementally per module, so unchanged Mathlib
+          # modules are reused from cache and only changed/new modules re-render.
+          # Both PR and main fall back to the latest doc cache and build only the
+          # delta, so adding a project no longer triggers a full Mathlib re-render
+          # on main (the previous exact-key-only behaviour cost ~4h per merge).
           restore-keys: |
             Docs-Lake-${{ runner.os }}-${{ hashFiles('lake-manifest.json', 'docbuild/lake-manifest.json', 'LeanPool.lean') }}-
-            ${{ github.event_name == 'pull_request' && format('Docs-Lake-{0}-', runner.os) || 'Docs-Lake-main-uses-exact-key-only' }}
+            Docs-Lake-${{ runner.os }}-
 
       - name: Install Lean
         uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9


### PR DESCRIPTION
## Problem

The `main` doc build takes **2–4+ hours** (e.g. the v4.31 bump's doc build was 4h19m; the #145 merge 2h22m), while PR doc builds finish in ~17 min.

Cause: doc-gen4 renders the entire Mathlib import closure, and the cache key hashes `LeanPool.lean`. On `main` the restore-key fallback is a deliberate no-match (`Docs-Lake-main-uses-exact-key-only`), so **every merged import PR re-renders all of Mathlib's doc pages from scratch**, even though adding a project changes zero Mathlib pages. PR builds are fast only because they *do* restore the latest cache and build incrementally.

## Fix

Let `main` fall back to the latest doc cache (`Docs-Lake-${{ runner.os }}-`), exactly like PR builds already do. doc-gen4 + Lake build docs incrementally per module, so unchanged Mathlib modules are reused and only the new project's pages render. Expected: **~4h → ~20 min** on a project-add.

Trade-off: incremental doc-gen4 could leave a stale page if a declaration is ever *removed* (rare for an append-mostly pool); a periodic clean rebuild can be triggered via `workflow_dispatch` if needed.

Infra-only change (single workflow file); no content touched.