### PR TITLE
Enrich project sources with verified secondary identifiers

### DIFF
--- a/LeanPool/ABCExceptions.lean
+++ b/LeanPool/ABCExceptions.lean
@@ -11,7 +11,7 @@ import LeanPool.ABCExceptions.Section4
 /-!
 # Exceptional Set in the abc Conjecture
 
-Source: url:https://arxiv.org/abs/2410.12234
+Source: arxiv:2410.12234
 Authors: Bhavik Mehta, Arend Mellendijk
 Status: verified
 Main declarations: `abcConjecture_iff_countTriples`, `thm_4_point_3`

--- a/LeanPool/AharoniKorman.lean
+++ b/LeanPool/AharoniKorman.lean
@@ -9,7 +9,7 @@ import LeanPool.AharoniKorman.Counterexample
 /-!
 # Disproof of the Aharoni-Korman Conjecture
 
-Source: url:https://github.com/b-mehta/AharoniKorman
+Source: arxiv:2411.16844, doi:10.1007/BF00383948
 Authors: Bhavik Mehta
 Status: verified
 Main declarations: `LeanPool.AharoniKorman.aharoni_korman_false`

--- a/LeanPool/AndersonConjecture.lean
+++ b/LeanPool/AndersonConjecture.lean
@@ -16,7 +16,7 @@ import LeanPool.AndersonConjecture.QuasiCompleteRing
 /-!
 # The Anderson Conjecture: A Weakly Quasi-Complete Ring Need Not Be Quasi-Complete
 
-Source: url:https://github.com/frenzymath/Anderson-Conjecture
+Source: doi:10.1007/978-1-4939-0925-4_2
 Authors: FrenzyMath
 Status: verified
 Main declarations: `anderson_main_theorem`

--- a/LeanPool/ArchonFirstProofResults.lean
+++ b/LeanPool/ArchonFirstProofResults.lean
@@ -10,7 +10,7 @@ import LeanPool.ArchonFirstProofResults.FirstProof6
 /-!
 # Archon-FirstProof-Results
 
-Source: url:https://github.com/frenzymath/Archon-FirstProof-Results
+Source: arxiv:2602.05192
 Authors: FrenzyMath
 Status: verified
 Main declarations: `Problem4.harmonic_mean_inequality_full`, `Problem6.exists_eps_light_subset`

--- a/LeanPool/ArtinWedderburn.lean
+++ b/LeanPool/ArtinWedderburn.lean
@@ -20,7 +20,7 @@ import LeanPool.ArtinWedderburn.ArtinWedderburnTheorem
 /-!
 # Artin-Wedderburn Theorem
 
-Source: url:https://doi.org/10.1007/978-1-4419-8616-0
+Source: arxiv:2405.04588, doi:10.1007/978-1-4419-8616-0
 Authors: Matevz Miščič, Maša Žaucer, Job Petrovčič
 Status: verified
 Main declarations: `LeanPool.ArtinWedderburn.ArtinWedderburnForPrime`

--- a/LeanPool/DirectedTopologyLean4.lean
+++ b/LeanPool/DirectedTopologyLean4.lean
@@ -35,7 +35,7 @@ import LeanPool.DirectedTopologyLean4.UnitIntervalAux
 /-!
 # Directed Topology in Lean 4
 
-Source: url:https://github.com/Dominique-Lawson/Directed-Topology-Lean-4
+Source: arxiv:2312.06506, doi:10.4230/LIPIcs.ITP.2024.8
 Authors: Dominique Lawson, Henning Basold, Peter Bruin
 Status: verified
 Main declarations: `DirectedSpace`, `Dipath`, `DirectedVanKampen.directed_van_kampen`

--- a/LeanPool/Duality.lean
+++ b/LeanPool/Duality.lean
@@ -15,7 +15,7 @@ import LeanPool.Duality.LinearProgrammingB
 /-!
 # Duality theory in linear optimization and its extensions
 
-Source: arxiv:2409.08119
+Source: arxiv:2409.08119, doi:10.46298/afm.14253
 Authors: Martin Dvorak
 Status: verified
 Main declarations: `extendedFarkas`, `StandardLP.strongDuality`

--- a/LeanPool/ErdosTuzaValtr.lean
+++ b/LeanPool/ErdosTuzaValtr.lean
@@ -9,7 +9,7 @@ import LeanPool.ErdosTuzaValtr.All
 /-!
 # The Erdős–Tuza–Valtr conjecture
 
-Source: url:https://github.com/jcpaik/erdos-tuza-valtr
+Source: arxiv:2206.04260
 Authors: Jineon Baek
 Status: verified
 Main declarations: `ErdosTuzaValtr.main`, `Config.main_lemma`

--- a/LeanPool/LeanBooleanfun.lean
+++ b/LeanPool/LeanBooleanfun.lean
@@ -13,7 +13,7 @@ import LeanPool.LeanBooleanfun.Arrow
 /-!
 # Analysis of Boolean functions in Lean
 
-Source: url:https://github.com/roos-j/lean-booleanfun
+Source: doi:10.1017/CBO9781139814782
 Authors: Joris Roos
 Status: verified
 Main declarations: `LeanPool.LeanBooleanfun.BooleanFun.BV.dictator_of_condorcet_and_unanimous`

--- a/LeanPool/LeanModularForms.lean
+++ b/LeanPool/LeanModularForms.lean
@@ -187,7 +187,7 @@ import LeanPool.LeanModularForms.ValenceFormula.WindingWeights.RhoPlusOne
 /-!
 # Modular forms and the generalized residue theorem
 
-Source: arxiv:1808.00997
+Source: arxiv:1808.00997, doi:10.1155/2019/6130464
 Authors: Chris Birkbeck
 Status: verified
 Main declarations: `generalizedResidueTheorem`, `valence_formula_textbook_orbit_finsum`

--- a/LeanPool/LeanPolyABC.lean
+++ b/LeanPool/LeanPolyABC.lean
@@ -9,7 +9,7 @@ import LeanPool.LeanPolyABC.All
 /-!
 # Polynomial ABC (Mason–Stothers) and its corollaries
 
-Source: url:https://github.com/seewoo5/lean-poly-abc
+Source: arxiv:2408.15180
 Authors: Seewoo Lee
 Status: verified
 Main declarations: `LeanPolyABC.Polynomial.abc`, `LeanPolyABC.Polynomial.flt`

--- a/LeanPool/Monlib4.lean
+++ b/LeanPool/Monlib4.lean
@@ -9,7 +9,7 @@ import LeanPool.Monlib4.Monlib
 /-!
 # Monlib4 Operator-Algebra and Quantum-Set Core
 
-Source: doi:10.4169/amer.math.monthly.124.10.966
+Source: arxiv:1810.08368, doi:10.4169/amer.math.monthly.124.10.966
 Authors: Monica Omar
 Status: verified
 Main declarations: `Matrix.aut_mat_inner`, `QuantumSet`, `schurMul`, `QuantumGraph`

--- a/LeanPool/Monsky.lean
+++ b/LeanPool/Monsky.lean
@@ -19,7 +19,7 @@ import LeanPool.Monsky.Square
 /-!
 # Monsky's Theorem
 
-Source: doi:10.2307/2316270
+Source: doi:10.2307/2317329
 Authors: Dhyan Aranha, contributors
 Status: verified
 Main declarations: `LeanPool.Monsky.monsky_theorem`

--- a/LeanPool/Neukirch.lean
+++ b/LeanPool/Neukirch.lean
@@ -10,7 +10,7 @@ import LeanPool.Neukirch.HilbertRamificationTheory
 /-!
 # Neukirch's Algebraic Number Theory: Hilbert ramification theory
 
-Source: url:https://github.com/jjdishere/neukirch
+Source: doi:10.1007/978-3-662-03983-0
 Authors: Hu Yongle
 Status: verified
 Main declarations: `NumberField.ramificationIdx_mul_inertiaDegOfIsGalois`

--- a/LeanPool/Polylean.lean
+++ b/LeanPool/Polylean.lean
@@ -18,7 +18,7 @@ import LeanPool.Polylean.ConjInvLength.WordTree
 /-!
 # Polylean Unit Conjecture Counterexample
 
-Source: url:https://github.com/siddhartha-gadgil/Polylean
+Source: arxiv:2102.11818, doi:10.4007/annals.2021.194.3.9
 Authors: Siddhartha Gadgil, Anand Rao
 Status: verified
 Main declarations: `LeanPool.Polylean.P.torsionFree`, `LeanPool.Polylean.Gardam.GardamTheorem`

--- a/LeanPool/QuasiBorelSpaces.lean
+++ b/LeanPool/QuasiBorelSpaces.lean
@@ -40,7 +40,7 @@ import LeanPool.QuasiBorelSpaces.UnitInterval
 /-!
 # Quasi-Borel Spaces
 
-Source: url:https://github.com/YellPika/quasi-borel-spaces
+Source: arxiv:1701.02547
 Authors: Anthony Vandikas, Kiarash Sotoudeh
 Status: verified
 Main declarations: `QuasiBorelSpace`, `OmegaQuasiBorelSpace`, `QuasiBorelSpace.ProbabilityMeasure`

--- a/LeanPool/SardMoreira.lean
+++ b/LeanPool/SardMoreira.lean
@@ -29,7 +29,7 @@ import LeanPool.SardMoreira.WithRPowDist
 /-!
 # Moreira's version of Sard's theorem
 
-Source: url:https://github.com/urkud/SardMoreira
+Source: doi:10.5565/PUBLMAT_45101_06
 Authors: Yury G. Kudryashov
 Status: verified
 Main declarations: `dimH_image_le_sardMoreiraBound_of_finrank_le`

--- a/LeanPool/Sensitivity.lean
+++ b/LeanPool/Sensitivity.lean
@@ -16,7 +16,7 @@ import LeanPool.Sensitivity.Consequences
 /-!
 # Sensitivity Conjecture: sqrt(deg) <= sensitivity
 
-Source: url:https://github.com/SamuelSchlesinger/sensitivity-conjecture
+Source: arxiv:1907.00847
 Authors: Samuel Schlesinger
 Status: verified
 Main declarations: `LeanPoolSensitivity.sensitivity_ge_sqrt_degree`

--- a/LeanPool/Zeta3Irrational.lean
+++ b/LeanPool/Zeta3Irrational.lean
@@ -15,7 +15,7 @@ import LeanPool.Zeta3Irrational.D
 /-!
 # Beukers integral estimates for ζ(3)
 
-Source: doi:10.1112/blms/11.3.268
+Source: arxiv:2503.07625, doi:10.1112/blms/11.3.268
 Authors: Junqi Liu, Jujian Zhang
 Status: verified
 Main declarations: `LeanPool.Zeta3Irrational.linear_int`, `LeanPool.Zeta3Irrational.JJ_upper`

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -57,6 +57,7 @@ projects:
       authors:
         - Frits Beukers
       doi: "10.1112/blms/11.3.268"
+      arxiv: "2503.07625"
       github_repo: ahhwuhu/zeta_3_irrational
     status: verified
     main_declarations:
@@ -381,7 +382,7 @@ projects:
     authors:
       - FrenzyMath
     source:
-      url: https://github.com/frenzymath/Archon-FirstProof-Results
+      arxiv: "2602.05192"
       github_repo: frenzymath/Archon-FirstProof-Results
     status: verified
     main_declarations:
@@ -485,7 +486,7 @@ projects:
     authors:
       - Samuel Schlesinger
     source:
-      url: https://github.com/SamuelSchlesinger/sensitivity-conjecture
+      arxiv: "1907.00847"
       github_repo: SamuelSchlesinger/sensitivity-conjecture
     status: verified
     main_declarations:
@@ -604,6 +605,7 @@ projects:
       - Martin Dvorak
     source:
       arxiv: "2409.08119"
+      doi: "10.46298/afm.14253"
       github_repo: madvorak/duality
     status: verified
     main_declarations:
@@ -706,7 +708,8 @@ projects:
       - Siddhartha Gadgil
       - Anand Rao
     source:
-      url: https://github.com/siddhartha-gadgil/Polylean
+      arxiv: "2102.11818"
+      doi: "10.4007/annals.2021.194.3.9"
       github_repo: siddhartha-gadgil/Polylean
     status: verified
     main_declarations:
@@ -735,7 +738,8 @@ projects:
       - Henning Basold
       - Peter Bruin
     source:
-      url: https://github.com/Dominique-Lawson/Directed-Topology-Lean-4
+      arxiv: "2312.06506"
+      doi: "10.4230/LIPIcs.ITP.2024.8"
       github_repo: Dominique-Lawson/Directed-Topology-Lean-4
     status: verified
     main_declarations:
@@ -805,12 +809,12 @@ projects:
       - Bhavik Mehta
       - Arend Mellendijk
     source:
-      url: https://arxiv.org/abs/2410.12234
       title: Bounds on the exceptional set in the abc conjecture
       authors:
         - Tim Browning
         - Jared Duker Lichtman
         - Joni Teräväinen
+      arxiv: "2410.12234"
       github_repo: b-mehta/ABC-Exceptions
     status: verified
     main_declarations:
@@ -838,7 +842,7 @@ projects:
     authors:
       - Joris Roos
     source:
-      url: https://github.com/roos-j/lean-booleanfun
+      doi: "10.1017/CBO9781139814782"
       github_repo: roos-j/lean-booleanfun
     status: verified
     main_declarations:
@@ -984,7 +988,8 @@ projects:
       title: A First Course in Noncommutative Rings
       authors:
         - T. Y. Lam
-      url: https://doi.org/10.1007/978-1-4419-8616-0
+      arxiv: "2405.04588"
+      doi: "10.1007/978-1-4419-8616-0"
       github_repo: JobPetrovcic/ArtinWedderburn
     status: verified
     main_declarations:
@@ -1099,7 +1104,8 @@ projects:
     authors:
       - Bhavik Mehta
     source:
-      url: https://github.com/b-mehta/AharoniKorman
+      arxiv: "2411.16844"
+      doi: "10.1007/BF00383948"
       github_repo: b-mehta/AharoniKorman
     status: verified
     main_declarations:
@@ -1205,7 +1211,7 @@ projects:
     authors:
       - Yury G. Kudryashov
     source:
-      url: https://github.com/urkud/SardMoreira
+      doi: "10.5565/PUBLMAT_45101_06"
       github_repo: urkud/SardMoreira
       paper: http://dmle.icmat.es/pdf/PUBLICACIONSMATEMATIQUES_2001_45_01_06.pdf
     status: verified
@@ -1262,7 +1268,7 @@ projects:
       - Seewoo Lee
     source:
       title: "Formalization of Polynomial ABC and FLT"
-      url: https://github.com/seewoo5/lean-poly-abc
+      arxiv: "2408.15180"
       github_repo: seewoo5/lean-poly-abc
     status: verified
     main_declarations:
@@ -1292,7 +1298,7 @@ projects:
       - Jineon Baek
     source:
       title: "On the Erdős–Tuza–Valtr Conjecture"
-      url: https://github.com/jcpaik/erdos-tuza-valtr
+      arxiv: "2206.04260"
       github_repo: jcpaik/erdos-tuza-valtr
     status: verified
     main_declarations:
@@ -1412,7 +1418,7 @@ projects:
     authors:
       - Hu Yongle
     source:
-      url: https://github.com/jjdishere/neukirch
+      doi: "10.1007/978-3-662-03983-0"
       github_repo: jjdishere/neukirch
     status: verified
     main_declarations:
@@ -1501,7 +1507,7 @@ projects:
       title: On dividing a square into triangles
       authors:
         - Paul Monsky
-      doi: "10.2307/2316270"
+      doi: "10.2307/2317329"
       github_repo: dhyan-aranha/Monsky
     status: verified
     main_declarations:
@@ -1621,6 +1627,7 @@ projects:
       - Monica Omar
     source:
       doi: 10.4169/amer.math.monthly.124.10.966
+      arxiv: "1810.08368"
       github_repo: themathqueen/monlib4
     status: verified
     main_declarations:
@@ -1775,7 +1782,7 @@ projects:
     authors:
       - FrenzyMath
     source:
-      url: "https://github.com/frenzymath/Anderson-Conjecture"
+      doi: "10.1007/978-1-4939-0925-4_2"
       github_repo: frenzymath/Anderson-Conjecture
     status: verified
     main_declarations:
@@ -1798,7 +1805,7 @@ projects:
       - Anthony Vandikas
       - Kiarash Sotoudeh
     source:
-      url: https://github.com/YellPika/quasi-borel-spaces
+      arxiv: "1701.02547"
       github_repo: YellPika/quasi-borel-spaces
     status: verified
     main_declarations:
@@ -1832,6 +1839,7 @@ projects:
       - Chris Birkbeck
     source:
       arxiv: "1808.00997"
+      doi: "10.1155/2019/6130464"
       github_repo: CBirkbeck/LeanModularForms
     status: verified
     main_declarations:


### PR DESCRIPTION
Now that `projects.yml` allows multiple source identifiers, this adds the additional arxiv/doi each project's work actually has — verified from arXiv abstract pages, CrossRef/publisher records, or the upstream README — and regenerates the project cards to list them all.

## Additions (18 projects)

| project | added |
|---|---|
| duality | `doi` 10.46298/afm.14253 (AFM published version) |
| leanmodularforms | `doi` 10.1155/2019/6130464 (J. Math published version) |
| monlib4 | `arxiv` 1810.08368 (preprint of the AMM paper) |
| polylean | `arxiv` 2102.11818 + `doi` 10.4007/annals.2021.194.3.9 (Gardam, Annals 2021) |
| directed-topology-lean-4 | `arxiv` 2312.06506 + `doi` 10.4230/LIPIcs.ITP.2024.8 (ITP 2024) |
| aharonikorman | `arxiv` 2411.16844 (Hollom) + `doi` 10.1007/BF00383948 (Aharoni–Korman 1992) |
| artin-wedderburn | `arxiv` 2405.04588 (Brešar) + `doi` 10.1007/978-1-4419-8616-0 (Lam) |
| sensitivity | `arxiv` 1907.00847 (Huang, sensitivity conjecture) |
| archon-firstproof-results | `arxiv` 2602.05192 |
| lean-poly-abc | `arxiv` 2408.15180 |
| erdos-tuza-valtr | `arxiv` 2206.04260 |
| quasi-borel-spaces | `arxiv` 1701.02547 |
| neukirch | `doi` 10.1007/978-3-662-03983-0 (Neukirch, ANT) |
| lean-booleanfun | `doi` 10.1017/CBO9781139814782 (O'Donnell) |
| anderson-conjecture | `doi` 10.1007/978-1-4939-0925-4_2 |
| sardmoreira | `doi` 10.5565/PUBLMAT_45101_06 (Moreira) |
| abc-exceptions | `arxiv` 2410.12234 (was carried as a url) |
| zeta_3_irrational | `arxiv` 2503.07625 (the formalization's own paper) |

For github-only sources, the redundant repo `url` (already in `github_repo`) was replaced by the typed identifier.

## Fix

- **monsky**: the listed `doi` `10.2307/2316270` resolves to Wilansky's *"How Separable is a Space?"*, not Monsky's paper. Corrected to `10.2307/2317329` (verified via CrossRef against the entry's own title/author).

## Judgment calls worth a look

- **quasi-borel-spaces** cites two foundational papers (arXiv 1701.02547 and 1811.04196); the single `arxiv` key holds only the primary.
- **zeta_3_irrational**: added the formalization's *own* arXiv paper alongside the original Beukers `doi` — drop it if you'd rather keep only the mathematical source.
- Projects with no verifiable second identifier (future-dated AxiomMath preprints, textbook-only sources, original formalizations) were left unchanged.
- All `.lean` changes are regenerated `Source:` card lines only.
