### PR TITLE
Audit and fix project source identifiers

### DIFF
--- a/LeanPool/Apportionment.lean
+++ b/LeanPool/Apportionment.lean
@@ -10,7 +10,7 @@ import LeanPool.Apportionment.PlausibleInstances
 /-!
 # Apportionmentlib
 
-Source: url:https://github.com/mdbrnowski/Apportionmentlib
+Source: url:https://archive.org/details/fairrepresentati00bali
 Authors: Michał Dobranowski
 Status: verified
 Main declarations: `Apportionment.balinski_young`

--- a/LeanPool/BrauerGroupNew.lean
+++ b/LeanPool/BrauerGroupNew.lean
@@ -39,7 +39,7 @@ import LeanPool.BrauerGroupNew.Subfield
 /-!
 # Brauer Group Core
 
-Source: url:https://doi.org/10.1017/9781107359419
+Source: url:https://doi.org/10.1017/9781316661277
 Authors: Yunzhou Xie, Yichen Feng, Jujian Zhang, Yael Dillies
 Status: verified
 Main declarations: `BrauerGroup.BruaerGroup`, `BrauerGroupHom.Br`, `WedderburnArtin`

--- a/LeanPool/DemazureOperatorsLean.lean
+++ b/LeanPool/DemazureOperatorsLean.lean
@@ -14,7 +14,7 @@ import LeanPool.DemazureOperatorsLean.Matsumoto
 /-!
 # Demazure Operators and Lean
 
-Source: doi:10.1070/RM1973v028n03ABEH001549
+Source: doi:10.1070/RM1973v028n03ABEH001557
 Authors: Óscar Álvarez Sánchez
 Status: verified
 Main declarations: `Demazure.Dem`, `CoxeterSystem.strongExchangeProperty`

--- a/LeanPool/Erdos1196.lean
+++ b/LeanPool/Erdos1196.lean
@@ -15,7 +15,7 @@ import LeanPool.Erdos1196.FormalConjecturesErdos1196
 /-!
 # Primitive Sets Above x (Erdos Problem 1196)
 
-Source: url:https://github.com/math-inc/Erdos1196
+Source: arxiv:2605.00301
 Authors: Math Inc.
 Status: verified
 Main declarations: `PrimitiveSetsAboveX.mainTheorem`, `Erdos1196.erdos_1196`

--- a/LeanPool/ErdosTuzaValtr.lean
+++ b/LeanPool/ErdosTuzaValtr.lean
@@ -9,7 +9,7 @@ import LeanPool.ErdosTuzaValtr.All
 /-!
 # The Erdős–Tuza–Valtr conjecture
 
-Source: arxiv:2206.04260
+Source: arxiv:2206.04260, doi:10.1016/j.ejc.2024.104085
 Authors: Jineon Baek
 Status: verified
 Main declarations: `ErdosTuzaValtr.main`, `Config.main_lemma`

--- a/LeanPool/Fineqs.lean
+++ b/LeanPool/Fineqs.lean
@@ -9,7 +9,7 @@ import LeanPool.Fineqs.Main
 /-!
 # FinEqs - reducing equations defining a subset of n-space over a finite field
 
-Source: arxiv:1906.11174
+Source: arxiv:1906.11174, doi:10.5802/afst.1766
 Authors: Stefan Barańczuk, Aristotle
 Status: verified
 Main declarations: `LeanPool.Fineqs.theorem_1`, `LeanPool.Fineqs.prop_1`

--- a/LeanPool/FriezePatterns.lean
+++ b/LeanPool/FriezePatterns.lean
@@ -11,7 +11,7 @@ import LeanPool.FriezePatterns.Chapter3
 /-!
 # Maxima of Coxeter frieze patterns are Fibonacci numbers
 
-Source: arxiv:2407.16717
+Source: arxiv:2407.16717, doi:10.1080/00150517.2024.2430958
 Authors: Antoine de Saint-Germain
 Status: verified
 Main declarations: `main3`, `FluteBounded`, `glideSymm`, `translationInvariance`

--- a/LeanPool/GrothendieckVanishing.lean
+++ b/LeanPool/GrothendieckVanishing.lean
@@ -9,7 +9,7 @@ import LeanPool.GrothendieckVanishing.GrothendieckVanishingOverview
 /-!
 # Grothendieck's Vanishing Theorem
 
-Source: url:https://github.com/Vilin97/Clawristotle/tree/grothendieck-vanishing
+Source: doi:10.1007/978-1-4757-3849-0, url:https://github.com/Vilin97/Clawristotle/tree/grothendieck-vanishing
 Authors: Vasily Ilin, Brian Nugent
 Status: verified
 Main declarations: `GrothendieckVanishing`

--- a/LeanPool/Isoperimetric.lean
+++ b/LeanPool/Isoperimetric.lean
@@ -12,7 +12,7 @@ import LeanPool.Isoperimetric.PrekopaLeindler
 /-!
 # Prekopa-Leindler, Brunn-Minkowski, and the isoperimetric inequality
 
-Source: url:https://github.com/hojonathanho/isoperimetric
+Source: url:https://terrytao.wordpress.com/2011/09/16/the-brunn-minkowski-inequality-for-nilpotent-groups/
 Authors: Jonathan Ho
 Status: verified
 Main declarations: `prekopa_leindler`, `brunn_minkowski`, `isoperimetric_inequality`

--- a/LeanPool/LeanBooleanfun.lean
+++ b/LeanPool/LeanBooleanfun.lean
@@ -13,7 +13,7 @@ import LeanPool.LeanBooleanfun.Arrow
 /-!
 # Analysis of Boolean functions in Lean
 
-Source: doi:10.1017/CBO9781139814782
+Source: arxiv:2105.10386, doi:10.1017/CBO9781139814782
 Authors: Joris Roos
 Status: verified
 Main declarations: `LeanPool.LeanBooleanfun.BooleanFun.BV.dictator_of_condorcet_and_unanimous`

--- a/LeanPool/LowDimSolvClassification.lean
+++ b/LeanPool/LowDimSolvClassification.lean
@@ -18,7 +18,7 @@ import LeanPool.LowDimSolvClassification.Tactics
 /-!
 # Classification of low-dimensional solvable Lie algebras
 
-Source: url:https://bookstore.ams.org/crmm-33
+Source: doi:10.1090/crmm/033, url:https://bookstore.ams.org/crmm-33
 Authors: Viviana del Barco, Gustavo Infanti, Exequiel Rivas, Paul Schwahn
 Status: verified
 Main declarations: `LieAlgebra.Dim3.classification`

--- a/LeanPool/PCFTheory.lean
+++ b/LeanPool/PCFTheory.lean
@@ -10,7 +10,7 @@ import LeanPool.PCFTheory.ClubGuessing
 /-!
 # PCF Theory
 
-Source: url:https://github.com/YnirPaz/PCF-Theory
+Source: doi:10.1007/978-1-4020-5764-9_15
 Authors: YnirPaz
 Status: verified
 Main declarations: `Ordinal.exists_isClubGuessing_of_cof_uncountable`

--- a/LeanPool/PartialCombinatoryAlgebras.lean
+++ b/LeanPool/PartialCombinatoryAlgebras.lean
@@ -14,7 +14,7 @@ import LeanPool.PartialCombinatoryAlgebras.GraphModel
 /-!
 # Partial Combinatory Algebras
 
-Source: url:https://doi.org/10.1016/S0049-237X(08)80044-6
+Source: url:https://doi.org/10.1016/S0049-237X(08)80003-1
 Authors: Andrej Bauer
 Status: verified
 Main declarations: `LeanPool.PartialCombinatoryAlgebras.PCA`

--- a/LeanPool/QuasiBorelSpaces.lean
+++ b/LeanPool/QuasiBorelSpaces.lean
@@ -40,7 +40,7 @@ import LeanPool.QuasiBorelSpaces.UnitInterval
 /-!
 # Quasi-Borel Spaces
 
-Source: arxiv:1701.02547
+Source: arxiv:1701.02547, doi:10.1109/LICS.2017.8005137
 Authors: Anthony Vandikas, Kiarash Sotoudeh
 Status: verified
 Main declarations: `QuasiBorelSpace`, `OmegaQuasiBorelSpace`, `QuasiBorelSpace.ProbabilityMeasure`

--- a/LeanPool/RiemannMappingTheorem.lean
+++ b/LeanPool/RiemannMappingTheorem.lean
@@ -9,7 +9,7 @@ import LeanPool.RiemannMappingTheorem.Main
 /-!
 # Riemann Mapping Theorem
 
-Source: url:https://github.com/vbeffara/rMT4
+Source: url:https://github.com/vbeffara/RMT4
 Authors: Vincent Beffara
 Status: verified
 Main declarations: `RMT`, `main`, `montel`, `hurwitz`
@@ -41,6 +41,6 @@ The headline theorems are:
 
 ## Provenance
 
-Imported from <https://github.com/vbeffara/rMT4>. Upstream contains no `sorry`s.
+Imported from <https://github.com/vbeffara/RMT4>. Upstream contains no `sorry`s.
 Ported from Lean v4.26.0 to Lean Pool's v4.30.0-rc2.
 -/

--- a/LeanPool/Sensitivity.lean
+++ b/LeanPool/Sensitivity.lean
@@ -16,7 +16,7 @@ import LeanPool.Sensitivity.Consequences
 /-!
 # Sensitivity Conjecture: sqrt(deg) <= sensitivity
 
-Source: arxiv:1907.00847
+Source: arxiv:1907.00847, doi:10.4007/annals.2019.190.3.6
 Authors: Samuel Schlesinger
 Status: verified
 Main declarations: `LeanPoolSensitivity.sensitivity_ge_sqrt_degree`

--- a/LeanPool/Shannon1948Formalization.lean
+++ b/LeanPool/Shannon1948Formalization.lean
@@ -9,7 +9,7 @@ import LeanPool.Shannon1948Formalization.Entropy
 /-!
 # Shannon Entropy Characterization
 
-Source: url:https://github.com/SamuelSchlesinger/shannon-1948-formalization
+Source: doi:10.1002/j.1538-7305.1948.tb01338.x
 Authors: Samuel Schlesinger
 Status: verified
 Main declarations: `LeanPool.Shannon1948Formalization.entropyNat_unique`

--- a/LeanPool/SumsThreeSquares.lean
+++ b/LeanPool/SumsThreeSquares.lean
@@ -10,7 +10,7 @@ import LeanPool.SumsThreeSquares.SumThreeSquares
 /-!
 # Sums of Three Squares
 
-Source: doi:10.2307/2033731
+Source: doi:10.1090/S0002-9939-1957-0085275-8
 Authors: Bhavik Mehta, Pietro Monticone, Abel Donate Munoz
 Status: verified
 Main declarations: `LeanPool.SumsThreeSquares.blueprint_case_mod8_eq3`

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -12,7 +12,7 @@ projects:
         - I. N. Bernstein
         - I. M. Gelfand
         - S. I. Gelfand
-      doi: "10.1070/RM1973v028n03ABEH001549"
+      doi: "10.1070/RM1973v028n03ABEH001557"
       github_repo: bolito2/DemazureOperatorsLean
     status: verified
     main_declarations:
@@ -158,7 +158,7 @@ projects:
       - Jujian Zhang
     source:
       arxiv: "2602.03716"
-      github_repo: axiommath/fel-polynomial
+      github_repo: AxiomMath/fel-polynomial
     status: verified
     main_declarations:
       - fels_conjecture
@@ -350,8 +350,8 @@ projects:
     authors:
       - Vincent Beffara
     source:
-      url: https://github.com/vbeffara/rMT4
-      github_repo: vbeffara/rmt4
+      url: https://github.com/vbeffara/RMT4
+      github_repo: vbeffara/RMT4
     status: verified
     main_declarations:
       - RMT
@@ -411,7 +411,7 @@ projects:
     authors:
       - Math Inc.
     source:
-      url: "https://github.com/math-inc/Erdos1196"
+      arxiv: "2605.00301"
       github_repo: math-inc/Erdos1196
     status: verified
     main_declarations:
@@ -463,6 +463,7 @@ projects:
       - Vasily Ilin
       - Brian Nugent
     source:
+      doi: "10.1007/978-1-4757-3849-0"
       url: https://github.com/Vilin97/Clawristotle/tree/grothendieck-vanishing
       github_repo: Vilin97/Clawristotle
     status: verified
@@ -487,6 +488,7 @@ projects:
       - Samuel Schlesinger
     source:
       arxiv: "1907.00847"
+      doi: "10.4007/annals.2019.190.3.6"
       github_repo: SamuelSchlesinger/sensitivity-conjecture
     status: verified
     main_declarations:
@@ -511,7 +513,7 @@ projects:
     authors:
       - Jonathan Ho
     source:
-      url: https://github.com/hojonathanho/isoperimetric
+      url: https://terrytao.wordpress.com/2011/09/16/the-brunn-minkowski-inequality-for-nilpotent-groups/
       github_repo: hojonathanho/isoperimetric
     status: verified
     main_declarations:
@@ -575,7 +577,7 @@ projects:
       title: "Realizability: An Introduction to its Categorical Side"
       authors:
         - Jaap van Oosten
-      url: https://doi.org/10.1016/S0049-237X(08)80044-6
+      url: https://doi.org/10.1016/S0049-237X(08)80003-1
       github_repo: andrejbauer/partial-combinatory-algebras
     status: verified
     main_declarations:
@@ -639,7 +641,7 @@ projects:
       - Pietro Monticone
       - Abel Donate Munoz
     source:
-      doi: "10.2307/2033731"
+      doi: "10.1090/S0002-9939-1957-0085275-8"
       github_repo: pitmonticone/SumsThreeSquares
     status: verified
     main_declarations:
@@ -647,6 +649,7 @@ projects:
     main_results:
       - declaration: LeanPool.SumsThreeSquares.blueprint_case_mod8_eq3
         informal: Proves the mod-8-equals-3 blueprint case for the three-squares theorem.
+        source_ref: "H. Davenport, The geometry of numbers, The Mathematical Gazette 31 (1947), 206-210, doi:10.2307/3608159."
     tags:
       - number-theory
       - quadratic-forms
@@ -776,7 +779,7 @@ projects:
         - Heini Halberstam
         - Hans-Egon Richert
       url: https://archive.org/details/sievemethods0000halb
-      github_repo: FLDutchmann/selberg-sieve4
+      github_repo: amellendijk/selberg-sieve4
     status: verified
     main_declarations:
       - fundamental_theorem_simple
@@ -842,6 +845,7 @@ projects:
     authors:
       - Joris Roos
     source:
+      arxiv: "2105.10386"
       doi: "10.1017/CBO9781139814782"
       github_repo: roos-j/lean-booleanfun
     status: verified
@@ -891,6 +895,7 @@ projects:
       - Aristotle
     source:
       arxiv: "1906.11174"
+      doi: "10.5802/afst.1766"
       github_repo: nasqret/fineqs
     status: verified
     main_declarations:
@@ -961,6 +966,7 @@ projects:
       authors:
         - Pavel Winternitz
         - Libor Šnobl
+      doi: "10.1090/crmm/033"
       url: https://bookstore.ams.org/crmm-33
       github_repo: LieLean/LowDimSolvClassification
     status: verified
@@ -1073,7 +1079,7 @@ projects:
     authors:
       - Samuel Schlesinger
     source:
-      url: https://github.com/SamuelSchlesinger/shannon-1948-formalization
+      doi: "10.1002/j.1538-7305.1948.tb01338.x"
       github_repo: SamuelSchlesinger/shannon-1948-formalization
     status: verified
     main_declarations:
@@ -1128,7 +1134,7 @@ projects:
     authors:
       - YnirPaz
     source:
-      url: https://github.com/YnirPaz/PCF-Theory
+      doi: "10.1007/978-1-4020-5764-9_15"
       github_repo: YnirPaz/PCF-Theory
     status: verified
     main_declarations:
@@ -1299,6 +1305,7 @@ projects:
     source:
       title: "On the Erdős–Tuza–Valtr Conjecture"
       arxiv: "2206.04260"
+      doi: "10.1016/j.ejc.2024.104085"
       github_repo: jcpaik/erdos-tuza-valtr
     status: verified
     main_declarations:
@@ -1354,6 +1361,7 @@ projects:
       authors:
         - Antoine de Saint-Germain
       arxiv: "2407.16717"
+      doi: "10.1080/00150517.2024.2430958"
       github_repo: Antoine-dSG/frieze_patterns
     status: verified
     main_declarations:
@@ -1692,8 +1700,8 @@ projects:
       authors:
         - Philippe Gille
         - Tamás Szamuely
-      url: https://doi.org/10.1017/9781107359419
-      github_repo: Whysoserioushah/BrauerGroup_new
+      url: https://doi.org/10.1017/9781316661277
+      github_repo: Whysoserioushah/BrauerGroup
     status: verified
     main_declarations:
       - BrauerGroup.BruaerGroup
@@ -1760,7 +1768,7 @@ projects:
     authors:
       - Michał Dobranowski
     source:
-      url: https://github.com/mdbrnowski/Apportionmentlib
+      url: https://archive.org/details/fairrepresentati00bali
       github_repo: mdbrnowski/apportionmentlib
     status: verified
     main_declarations:
@@ -1806,6 +1814,7 @@ projects:
       - Kiarash Sotoudeh
     source:
       arxiv: "1701.02547"
+      doi: "10.1109/LICS.2017.8005137"
       github_repo: YellPika/quasi-borel-spaces
     status: verified
     main_declarations:


### PR DESCRIPTION
Audited the `source` block of every project in `LeanPool/projects.yml`, resolving each `doi` / `arxiv` / `url` / `github_repo` against Crossref, the DataCite & arXiv APIs, and GitHub, and confirming it points to the work the project actually formalizes. Each project was investigated and every *proposed change was then independently re-resolved* before applying, to avoid writing a wrong/hallucinated identifier into the registry.

Result: **21 source-block corrections across 21 projects.** Project cards were regenerated with `lean_pool.quality --write-project-cards`; this is a content-only PR (`projects.yml` + auto cards + one provenance line).

### Corrected — resolved to the wrong work or 404'd
| Project | Field | Before | After | Why |
|---|---|---|---|---|
| demazureoperatorslean | doi | `…ABEH001549` | `…ABEH001557` | old DOI 404s everywhere; 1557 is BGG 1973 "Schubert cells…" |
| brauergroup_new | url(doi) | `10.1017/9781107359419` | `10.1017/9781316661277` | old 404s; new = Gille–Szamuely, *CSA & Galois Cohomology*, 2nd ed. |
| brauergroup_new | github_repo | `Whysoserioushah/BrauerGroup_new` | `Whysoserioushah/BrauerGroup` | repo renamed (GitHub redirect) |
| sumsthreesquares | doi | `10.2307/2033731` | `10.1090/S0002-9939-1957-0085275-8` | old points to Warncke–Supnick; new = Ankeny, "Sums of three squares" |
| partial-combinatory-algebras | url(doi) | `…(08)80044-6` | `…(08)80003-1` | old chapter DOI 404s; new = van Oosten "PCAs" chapter |
| selberg-sieve4 | github_repo | `FLDutchmann/selberg-sieve4` | `amellendijk/selberg-sieve4` | owner account renamed |
| fel-conjecture | github_repo | `axiommath/fel-polynomial` | `AxiomMath/fel-polynomial` | canonical casing |
| riemann-mapping-theorem | url + repo | `vbeffara/rMT4`, `vbeffara/rmt4` | `vbeffara/RMT4` | canonical casing |
| apportionment | url | `…/Apportionmentlib` (repo dup) | archive.org *Fair Representation* | repo-dup → the actual Balinski–Young source |
| isoperimetric | url | `…/isoperimetric` (repo dup) | Tao's Brunn–Minkowski blog post | repo-dup → the source the README follows |

### Added — missing published identifier
| Project | Added | Note |
|---|---|---|
| erdos-tuza-valtr | doi `10.1016/j.ejc.2024.104085` | published EJC version of the arXiv preprint |
| fineqs | doi `10.5802/afst.1766` | published Ann. Toulouse version |
| quasi-borel-spaces | doi `10.1109/LICS.2017.8005137` | published LICS 2017 version |
| sensitivity | doi `10.4007/annals.2019.190.3.6` | Huang's Annals 2019 paper (published arXiv 1907.00847) |
| lean-booleanfun | arxiv `2105.10386` | O'Donnell's *Analysis of Boolean Functions* |
| frieze-patterns | doi `10.1080/00150517.2024.2430958` | published Fibonacci Quarterly version |
| lowdimsolvclassification | doi `10.1090/crmm/033` | AMS DOI for the Šnobl–Winternitz book |
| grothendieck-vanishing | doi `10.1007/978-1-4757-3849-0` | Hartshorne, *Algebraic Geometry* (the cited source; branch `url` kept) |
| shannon-1948-formalization | doi `10.1002/j.1538-7305.1948.tb01338.x` | Shannon 1948 (replaces repo-dup `url`) |
| pcf-theory | doi `10.1007/978-1-4020-5764-9_15` | Handbook of Set Theory chapter (replaces repo-dup `url`) |
| erdos1196 | arxiv `2605.00301` | the Math Inc. source paper (replaces repo-dup `url`) |
| sumsthreesquares | `source_ref` Davenport | the geometry-of-numbers proof method, previously unlisted |

### Notes / left for maintainer judgment
- **lean-bourgain** has the same repo-dup `url`; its fix (`url` → `doi:10.1142/S1793042105000108`, Bourgain 2005) is staged on the `import/lean-bourgain` branch since that project isn't on `main` yet.
- **aharonikorman** keeps `doi:10.1007/BF00383948` — it resolves to the *original 1992 conjecture* paper (not Hollom's disproof); it's a real, relevant reference, so left as-is rather than removed.
- **artin-wedderburn**: `source.title`/`authors` describe Lam's book while `arxiv:2405.04588` is Brešar's proof paper — both resolve; flagged but not changed (metadata, not an identifier).
- The `brauergroup_new` DOI differs from the tentative example in the request (`10.1007/978-3-031-64529-7_9`, a Springer item); the Cambridge 2nd-edition DOI above was verified to match the formalized book.

🤖 Generated with [Claude Code](https://claude.com/claude-code)