### PR TITLE
Import frucht formalization

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -518,6 +518,12 @@ import LeanPool.FriezePatterns
 import LeanPool.FriezePatterns.Chapter1
 import LeanPool.FriezePatterns.Chapter2
 import LeanPool.FriezePatterns.Chapter3
+import LeanPool.Frucht
+import LeanPool.Frucht.Classical
+import LeanPool.Frucht.ClassicalReplacements
+import LeanPool.Frucht.Frucht
+import LeanPool.Frucht.Graphs
+import LeanPool.Frucht.SetTheory
 import LeanPool.GrothendieckVanishing
 import LeanPool.GrothendieckVanishing.ClosedImmersion
 import LeanPool.GrothendieckVanishing.ClosedImmersionCohomology

--- a/LeanPool/Frucht.lean
+++ b/LeanPool/Frucht.lean
@@ -1,0 +1,17 @@
+/-
+Copyright (c) 2026 Shuhao Song. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Shuhao Song
+-/
+import LeanPool.Frucht.Frucht
+
+/-!
+# Frucht's theorem: every group is a graph automorphism group
+
+Source: url:https://github.com/znssong/Frucht
+Authors: Shuhao Song
+Status: verified
+Main declarations: `Frucht`, `choice_implies_frucht`, `foundation_implies_frucht`
+Tags: graph-theory, group-theory, automorphism-group, set-theory
+MSC: 05C25
+-/

--- a/LeanPool/Frucht/Classical.lean
+++ b/LeanPool/Frucht/Classical.lean
@@ -1,0 +1,483 @@
+/-
+Copyright (c) 2026 Shuhao Song. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Shuhao Song
+-/
+import Mathlib.Data.Set.Basic
+
+/-!
+# Choice-free metaprogramming infrastructure
+
+This file sets up the `ChoiceFree` framework used throughout the Frucht development:
+the abstract `collect`/`elements` axioms modelling sets as types, the `@[classical]`,
+`@[replace]`, and `@[restrict]` attributes that audit a declaration against the
+trusted axioms and register choice-free surrogates, and the `elim_choice` tactic
+that mechanically rewrites a proof term to use those surrogates.
+-/
+
+universe u
+
+axiom collect : ∀ {α : Type u}, (α → Type u) → Type u
+@[coe] axiom elements : ∀ {α : Type u}, α → Type u
+axiom elements_inj : ∀ {α : Type u}, Function.Injective (elements (α := α))
+axiom collect_ext : ∀ {α β} (f : α → Type u) (g : β → Type u),
+  collect f = collect g ↔ Set.range f = Set.range g
+axiom collect_elements : ∀ {α : Type u}, collect (elements (α := α)) = α
+
+noncomputable def Classical.uniqueChoice {α : Sort u}
+  (hα : Nonempty α) (_ : Subsingleton α) : α := Classical.choice hα
+
+namespace ChoiceFree
+
+open Lean Meta Parser Std Elab Tactic
+
+abbrev Graph (V : Type*) [BEq V] [Hashable V] := HashMap V (HashSet V)
+
+namespace Graph
+variable {V : Type*} [BEq V] [Hashable V] [Inhabited V]
+
+def insert' (G : Graph V) (u v : V) := G.insert u <|
+  match G[u]? with
+  | some x => x.insert v
+  | none => {v}
+
+def reverse (G : Graph V) : Graph V := Id.run do
+  let mut H : Graph V := {}
+  for (u, V) in G do
+    for v in V do H ← H.insert' v u
+  return H
+
+def Reachable (G : Graph V) (S : HashSet V) : HashSet V := Id.run do
+  let mut visited : HashSet V := {}
+  let mut stack := S.toArray
+  while !stack.isEmpty do
+    let u := stack.back!
+    stack ← stack.pop
+    visited ← visited.insert u
+    if u ∈ G then
+      for v in G[u]! do
+        if v ∉ visited then stack ← stack.push v
+  return visited
+
+def reverseReachable (G : Graph V) (S : HashSet V) : HashSet V := Id.run do
+  Reachable (reverse G) S
+
+def derived (G : Graph V) (S : HashSet V) := Id.run do
+  let mut H : Graph V := {}
+  for (u, V) in G do
+    for v in V do
+      if u ∈ S ∧ v ∈ S then H ← H.insert' u v
+  return H
+
+def reverseReachableDerived (G : Graph V) (S : HashSet V) :=
+  G.reverse.derived (G.reverseReachable S)
+
+def inDegrees (G : Graph V) := Id.run do
+  G.reverse.fold (fun deg k v => deg.insert k v.size) (G.map fun _ _ => 0)
+
+def topologicalOrder (G : Graph V) [Repr V] : Array V := Id.run do
+  let mut sorted := #[]
+  let mut indeg := G.inDegrees
+  let mut q : Queue V := .empty
+  for (v, deg) in indeg do
+    if deg == 0 then q := q.enqueue v
+  while !q.isEmpty do
+    let (v, q') := q.dequeue?.get!
+    q := q'
+    if indeg[v]! == 0 then sorted := sorted.push v
+    if let some ws := G[v]? then
+      for w in ws do
+        indeg := indeg.insert w (indeg[w]! - 1)
+        if indeg[w]! == 0 then q := q.enqueue w
+  return sorted
+
+end Graph
+
+structure ReplaceItem where
+  name : Name
+  levelPerm : Option (Array Nat)
+deriving Inhabited
+
+abbrev ChoiceFreeReplacementExtension :=
+  SimpleScopedEnvExtension (Name × ReplaceItem) (HashMap Name ReplaceItem)
+
+abbrev CachedChoiceFreeExtension :=
+  SimpleScopedEnvExtension Name (HashSet Name)
+
+initialize choiceFreeReplacementExtension : ChoiceFreeReplacementExtension ←
+  registerSimpleScopedEnvExtension {
+    initial := {}
+    addEntry := fun s (k, v) => s.insert k v
+  }
+
+initialize cachedChoiceFreeExtension : CachedChoiceFreeExtension ←
+  registerSimpleScopedEnvExtension {
+    initial := {}
+    addEntry := fun s k => s.insert k
+  }
+
+def choiceFreeAlternative (name : Name) : CoreM ReplaceItem := do
+  let map := choiceFreeReplacementExtension.getState (← getEnv)
+  match map[name]? with
+  | some replacement => return replacement
+  | none => return ⟨name, none⟩
+
+initialize
+  registerBuiltinAttribute {
+    name            := `replace
+    descr           := s!"Replace a definition with its choice-free version"
+    applicationTime := .afterCompilation
+    add             := fun decl stx kind => do
+      let ⟨decl, _⟩ ← choiceFreeAlternative decl
+      let ident ← Attribute.Builtin.getIdent stx
+      let name ← resolveGlobalConstNoOverload ident
+      let old := ((← getEnv).find? name).get!
+      let new := ((← getEnv).find? decl).get!
+      if old.levelParams.length != new.levelParams.length then
+        throwError "The replaced theorem must have the same number of universe parameters \
+          as the original"
+      let check : MetaM (Array Nat) := do
+        let levelMVars ← mkFreshLevelMVarsFor old
+        let oldType := old.type
+        let newType := new.type.instantiateLevelParams new.levelParams levelMVars
+        if !(← isDefEq oldType newType) then
+          throwError "The replaced theorem must have the same type as the original."
+        let perm ← levelMVars.toArray.mapM fun mvar => do
+          let some lvl ← getLevelMVarAssignment? mvar.mvarId!
+            | throwError "Not all universe metavariables were filled."
+          let .param name := lvl
+            | throwError "Filled metavariable {lvl} is not a level parameter."
+          return old.levelParams.findIdx (· == name)
+        return perm
+      let perm ← check.run'
+      choiceFreeReplacementExtension.add (name, ⟨decl, some perm⟩)
+  }
+
+def mkChoiceFreeName (name : Name) := `_choiceFree ++ name
+def originalName := (Name.replacePrefix · `_choiceFree .anonymous)
+
+def replaceExpr (e : Expr) : CoreM Expr :=
+  Core.transform e fun e => do
+    match e with
+    | .const name us =>
+      let ⟨name, perm⟩ ← choiceFreeAlternative name
+      match perm with
+      | none => return .done (.const name us)
+      | some perm => return .done <| .const name <|
+        (List.range perm.size).map fun i => us[perm[i]!]!
+    | _ => return .continue
+
+def replaceDeclaration (e : Name) (replaceType : Bool := true) : CoreM Unit := do
+  if (choiceFreeReplacementExtension.getState (← getEnv)).contains e then return
+  let replaceExpr' (e : Expr) : CoreM Expr :=
+    if replaceType then replaceExpr e else return e
+  let modified : Bool ← (do
+    try
+      match (← getEnv).find? e with
+      | ConstantInfo.defnInfo v =>
+        addDecl <| .defnDecl { v with
+          name := mkChoiceFreeName v.name,
+          type := ← replaceExpr' v.type, value := ← replaceExpr v.value }
+        return true
+      | ConstantInfo.thmInfo v =>
+        addDecl <| .thmDecl { v with
+          name := mkChoiceFreeName v.name,
+          type := ← replaceExpr' v.type, value := ← replaceExpr v.value }
+        return true
+      | ConstantInfo.opaqueInfo v =>
+        addDecl <| .opaqueDecl { v with
+          name := mkChoiceFreeName v.name,
+          type := ← replaceExpr' v.type, value := ← replaceExpr v.value }
+        return true
+      | _ => return false
+    catch ex =>
+      throwError m!"Error when replacing definition {e}:\n{ex.toMessageData}")
+  if modified then
+    choiceFreeReplacementExtension.add (e, ⟨mkChoiceFreeName e, none⟩)
+
+namespace CollectAxioms
+
+structure State where
+  visited : HashSet Name := {}
+  axioms : HashSet Name := {}
+  dependencies : Graph Name := {}
+
+abbrev M := StateT State CoreM
+
+partial def collect (c : Name) (stopSet : HashSet Name) : M Unit := do
+  let collectExpr (e : Expr) : M Unit := e.getUsedConstants.forM fun ident => do
+    modify fun s => { s with dependencies := s.dependencies.insert' c ident }
+    collect ident stopSet
+  let s ← get
+  unless s.visited.contains c do
+    modify fun s => { s with visited := s.visited.insert c }
+    if stopSet.contains c then
+      modify fun s => { s with axioms := s.axioms.insert c }
+    else
+      match (← getEnv).checked.get.find? c with
+      | some (ConstantInfo.axiomInfo v)  =>
+        collectExpr v.type
+        modify fun s => { s with axioms := s.axioms.insert c }
+      | some (ConstantInfo.defnInfo v)   => collectExpr v.type *> collectExpr v.value
+      | some (ConstantInfo.thmInfo v)    => collectExpr v.type *> collectExpr v.value
+      | some (ConstantInfo.opaqueInfo v) => collectExpr v.type *> collectExpr v.value
+      | some (ConstantInfo.quotInfo _)   => pure ()
+      | some (ConstantInfo.ctorInfo v)   => collectExpr v.type
+      | some (ConstantInfo.recInfo v)    => collectExpr v.type
+      | some (ConstantInfo.inductInfo v) =>
+        collectExpr v.type *> v.ctors.forM fun ctor => do
+          modify fun s => { s with dependencies := s.dependencies.insert' c ctor }
+          collect ctor stopSet
+      | none                             => pure ()
+
+def collectAxioms (constName : Name) (stopSet : HashSet Name) :
+    CoreM (HashSet Name × Graph Name) := do
+  let (_, s) ← (CollectAxioms.collect constName stopSet).run {}
+  pure (s.axioms, s.dependencies)
+
+end CollectAxioms
+
+def allowedAxioms : HashSet Name := {
+  ``sorryAx, ``propext, ``Quot.sound,
+  ``Classical.em, ``Classical.uniqueChoice,
+  ``collect, ``elements, ``elements_inj, ``collect_ext, ``collect_elements
+}
+
+def showDependencyGraph (dependencies : Graph Name) : Format :=
+  let showName (name : Name) : Format :=
+    .text (originalName name).toString
+  let showNameSet (key : Name) (set : HashSet Name) : Format := .nest 2 (
+    f!"{showName key} is used by:" ++ .line ++
+    .nest 1 ("[" ++ Format.join ((set.toList.map showName).intersperse ("," ++ .line)) ++ "]")
+  )
+  let order := dependencies.topologicalOrder
+  Format.join <| List.intersperse .line <|
+    (order.toList.filterMap fun name => dependencies[name]?.map (showNameSet name))
+
+def registerClassical (strict : Bool) (decl : Name) (stx : Syntax) (kind : AttributeKind) :
+    AttrM Unit := do
+  Attribute.Builtin.ensureNoArgs stx
+  unless kind == AttributeKind.global do
+    throwError "invalid attribute 'classical', must be global"
+  let replaced := (choiceFreeReplacementExtension.getState (← getEnv)).keys.foldl
+    Std.HashSet.insert {}
+  let cached := cachedChoiceFreeExtension.getState (← getEnv)
+  let (_, dependencies) ← CollectAxioms.collectAxioms decl
+    (allowedAxioms ∪ replaced ∪ cached ∪ HashSet.ofArray (cached.toArray.map originalName))
+  let dependencyOrder := dependencies.reverseReachableDerived replaced |>.topologicalOrder
+  for defn in dependencyOrder do
+    replaceDeclaration defn (!strict || defn != decl)
+  let ⟨decl, _⟩ ← choiceFreeAlternative decl
+  let (usedAxioms, dependencies) ←
+    CollectAxioms.collectAxioms decl <|
+    if strict then allowedAxioms else allowedAxioms ∪ cached
+  let unallowedAxioms := usedAxioms.filter
+    fun x => !(allowedAxioms.contains x || cached.contains x)
+  if strict && usedAxioms.contains ``sorryAx then
+    throwError f!"Strict mode doesn't allow `sorry`"
+  if !unallowedAxioms.isEmpty then
+    throwError (
+      f!"invalid attribute 'classical', the definition used axioms {unallowedAxioms.toList}\n" ++
+      showDependencyGraph dependencies
+    )
+  for (name, depends) in dependencies do
+    cachedChoiceFreeExtension.add name
+    for name' in depends do
+      cachedChoiceFreeExtension.add name'
+
+initialize
+  registerBuiltinAttribute {
+    name            := `classical
+    descr           := s!"Ensure that the definition is in the classical ZF set theory"
+    applicationTime := .afterCompilation
+    add             := registerClassical false
+  }
+
+initialize
+  registerBuiltinAttribute {
+    name            := `classical!
+    descr           := s!"Ensure that the definition is in the classical ZF set theory, \
+      but not replacing the type of the theorem"
+    applicationTime := .afterCompilation
+    add             := registerClassical true
+  }
+
+section ElimChoiceTactic
+
+abbrev ClassicalRestrictExtension :=
+  SimpleScopedEnvExtension
+    (Name × Name × Array Int)
+    (HashMap Name (Array (Name × Array Int)))
+
+def intLit := optional "-" >> numLit
+@[attr_parser] def restrict :=
+  leading_parser "restrict" >> ppSpace >> ident >> many (ppSpace >> intLit)
+
+initialize classicalRestrictExtension : ClassicalRestrictExtension ←
+  registerSimpleScopedEnvExtension {
+    initial := {}
+    addEntry := fun s (k, v, pos) => s.insert k ((s.getD k #[]).push (v, pos))
+  }
+
+initialize
+  registerBuiltinAttribute {
+    name            := `restrict
+    descr           := s!"Adding some restriction to get the theorem free of choice"
+    applicationTime := .afterCompilation
+    add             := fun decl stx kind => do
+      let name ← resolveGlobalConstNoOverload stx[1]
+      let pos := stx[2].getArgs.map <| fun x =>
+        match x[0].getOptional? with
+        | some _ => -x[1].toNat - 1
+        | none => x[1].toNat
+      classicalRestrictExtension.add (name, (decl, pos))
+  }
+
+def expandApp : Expr → Expr × Array Expr
+  | .app f x => let (f, args) := expandApp f; (f, args.push x)
+  | e => (e, #[])
+
+def expandArgs' : Expr → Expr × Array Expr
+  | .forallE _ type body _ => let (body, args) := expandArgs' body; (body, args.push type)
+  | e => (e, #[])
+
+def expandArgs (e : Expr) : Expr × Array Expr :=
+  let (body, args) := expandArgs' e
+  (body, args.reverse)
+
+inductive Binder where
+  | forallE (name : Name) (type : Expr) (info : BinderInfo)
+  | letE (name : Name) (type : Expr) (value : Expr)
+deriving Repr, Inhabited, BEq, Hashable
+
+abbrev Binders := Array Binder
+
+def dsimp' (e : Expr) : MetaM Expr := do
+  let ctx ← Simp.mkContext (config := {dsimp := true})
+  return (← Meta.dsimp e ctx).1
+
+def reverts : Binders × Expr → Expr :=
+  fun (xs, e) => reverts' (xs.toList, e)
+where
+  reverts' : (xs : List Binder × Expr) → Expr
+    | (.forallE name type info :: xs, e) => .forallE name type (reverts' (xs, e)) info
+    | (.letE name type value :: xs, e) => .letE name type value (reverts' (xs, e)) false
+    | ([], e) => e
+
+def appBVars (e : Expr) (ctx : Binders) :=
+  (Array.range ctx.size).foldr (fun i e =>
+    match ctx[i]! with
+    | .forallE .. => mkApp e (.bvar i)
+    | _ => e) e
+
+def introsP (mvarId : MVarId) (maxVars : Nat) : MetaM (Array FVarId × MVarId) := do
+  let type ← mvarId.getType
+  let type ← instantiateMVars type
+  let n := getIntrosSize type
+  if n == 0 then
+    return (#[], mvarId)
+  else
+    mvarId.introNP (min n maxVars)
+
+structure ElimChoiceState where
+  goals : Array MVarId := #[]
+  mvars : HashMap Expr Expr := {}
+  usings : Array Name := #[]
+
+abbrev M := StateT ElimChoiceState MetaM
+
+partial def elimChoice (ctx : Binders) (e : Expr) : M Expr :=
+  let f := elimChoice ctx
+  match e with
+  | .app _ _ => do
+    let (fn, args) := expandApp e
+    let args ← args.mapM f
+    match fn with
+    | .const name us =>
+      let map := classicalRestrictExtension.getState (← getEnv)
+      match map[name]? with
+      | some candidates => do
+        let intersection := candidates.filter (·.1 ∈ (← get).usings)
+        let (newfn, pos) :=
+          if !intersection.isEmpty then intersection[0]!
+          else candidates[0]!
+        let expr : M (Option Expr) := do
+          let newFnConstant := ((← getEnv).find? newfn).get!
+          let (_, newArgs) := expandArgs newFnConstant.type
+          let mut args := args
+          let getMVar (i : Nat) : M Expr := do
+            let holeType := newArgs[i]!
+              |>.instantiateLevelParams newFnConstant.levelParams us
+              |>.instantiateRevRange 0 i args
+            let holeType ← dsimp' (reverts (ctx, holeType))
+            for (type, mvar) in (← get).mvars do
+              if ← isDefEq type holeType then return appBVars mvar ctx
+            let mvar ← mkFreshExprMVar holeType
+            let (_, newMVar) ← introsP mvar.mvarId! ctx.size
+            modify fun s => { s with
+              mvars := s.mvars.insert holeType mvar
+              goals := s.goals.push newMVar
+            }
+            return appBVars mvar ctx
+          for i in pos do
+            if -args.size ≤ i ∧ i < 0 then args := args.eraseIdx! (i.natAbs - 1)
+            else if i ≤ args.size then args := args.insertIdx! i.natAbs (← getMVar i.natAbs)
+            else return none
+          trace[ElimChoice.verbose] "Choice-free replacement used: {newfn}"
+          return some (mkAppN (mkConst newfn us) args)
+        match ← expr with
+        | some e => return e
+        | none => return mkAppN (← f fn) args
+      | none => return mkAppN (← f fn) args
+    | _ => return mkAppN (← f fn) args
+  | .lam name type body info =>
+    return .lam name (← f type)
+      (← elimChoice (ctx.push (.forallE name type info)) body) info
+  | .forallE name type body info =>
+    return .forallE name (← f type)
+      (← elimChoice (ctx.push (.forallE name type info)) body) info
+  | .letE name type value body nondep =>
+    return .letE name (← f type) (← f value)
+      (← elimChoice (ctx.push (.letE name type value)) body) nondep
+  | .mdata data expr =>
+    return .mdata data (← f expr)
+  | .proj name idx expr =>
+    return .proj name idx (← f expr)
+  | e => return e
+
+def mkPrivateName' (module : Name) (name : Name) : Name :=
+  Name.mkNum (privateHeader ++ module) 0 ++ name
+
+syntax "elim_choice" term ("unfolding" (colGt ident)*)?
+  ("private" ((colGt ident)+ "in" ident)+)? ("using" (colGt ident)+)? : tactic
+
+elab_rules : tactic
+| `(tactic| elim_choice $e $[unfolding $ids*]?
+    $[private $[$[$privs]* in $modules]*]? $[using $usings*]?) =>
+  withMainContext do
+    let old ← Term.elabTermAndSynthesize e none
+    let constNames :=
+      match expandApp old with
+      | (.const name _, _) => #[name]
+      | (_, _) => #[]
+    let mut ids := constNames ++ (← (ids.getD #[]).mapM resolveGlobalConstNoOverload)
+    if privs.isSome then
+      for (module, priv_of_ns) in modules.get!.zip privs.get! do
+        for priv in priv_of_ns do
+          ids := ids.push (mkPrivateName' module.getId priv.getId)
+    let old ← whnf old
+    let old ← deltaExpand (allowOpaque := true) old
+      fun name => ids.any (fun id => id.isPrefixOf (privateToUserName name))
+    let old ← dsimp' old
+    let (new, result) ← (elimChoice {} old).run {
+      usings := ← (usings.getD #[]).mapM resolveGlobalConstNoOverload
+    }
+    (← getMainGoal).assign new
+    replaceMainGoal result.goals.toList
+
+end ElimChoiceTactic
+
+initialize
+  registerTraceClass `ElimChoice.verbose
+
+end ChoiceFree

--- a/LeanPool/Frucht/ClassicalReplacements.lean
+++ b/LeanPool/Frucht/ClassicalReplacements.lean
@@ -1,0 +1,386 @@
+/-
+Copyright (c) 2026 Shuhao Song. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Shuhao Song
+-/
+import Mathlib.Data.List.Intervals
+import Mathlib.Logic.Equiv.Set
+import Mathlib.Logic.Small.Basic
+import Mathlib.Data.Setoid.Basic
+import Mathlib.SetTheory.Cardinal.Basic
+import Mathlib.SetTheory.Cardinal.SchroederBernstein
+import Mathlib.Order.ConditionallyCompleteLattice.Basic
+import Mathlib.Order.CompleteBooleanAlgebra
+import LeanPool.Frucht.Classical
+
+/-!
+# Choice-free replacements for Mathlib declarations
+
+This file builds choice-free (`@[classical]`) versions of a range of Mathlib
+declarations -- `Classical.choice`/`Classical.indefiniteDescription` surrogates,
+`Equiv` constructors, well-founded `min`, cardinal arithmetic, Schröder-Bernstein,
+`Small` lemmas, and lattice instances -- so that downstream constructions in the
+Frucht development can be checked against the trusted axioms only.
+-/
+
+noncomputable section
+
+universe u v w
+
+open Setoid Function
+
+attribute [restrict Classical.choice 2] Classical.uniqueChoice
+
+@[classical, replace Classical.propDecidable]
+def propDecidable' (a : Prop) : Decidable a :=
+  Classical.uniqueChoice
+    (match em a with
+    | Or.inl h => ⟨isTrue h⟩
+    | Or.inr h => ⟨isFalse h⟩)
+    inferInstance
+
+@[classical, restrict Classical.indefiniteDescription 3]
+def definiteDescription
+    {α} {p : α → Prop} (h : ∃ x, p x) (h' : ∀ {x y}, p x → p y → x = y) : {x // p x} :=
+  Classical.uniqueChoice
+    (let ⟨x, px⟩ := h; ⟨⟨x, px⟩⟩)
+    ⟨fun ⟨x, hx⟩ ⟨y, hy⟩ => by simp only [Subtype.mk.injEq]; exact h' hx hy⟩
+
+@[classical, restrict Classical.choose 3]
+def Exists.chooseUnique
+    {α} {p : α → Prop} (ex : ∃ a, p a) (unique : ∀ {x y}, p x → p y → x = y) :=
+  (definiteDescription ex unique).val
+
+@[classical, restrict Classical.choose_spec 3]
+lemma Exists.chooseUnique_spec
+    {α} {p : α → Prop} (ex : ∃ a, p a) (unique : ∀ {x y}, p x → p y → x = y) :
+    p (ex.chooseUnique unique) :=
+  (definiteDescription ex unique).property
+
+namespace Equiv
+
+@[classical, replace ofBijective]
+def ofBijective' {α β} (f : α → β) (hf : Bijective f) : α ≃ β where
+  toFun := f
+  invFun := fun b =>
+    (show ∃ a, f a = b by apply hf.surjective).chooseUnique
+    (fun {x y} hx hy => by rw [← hy] at hx; exact hf.injective hx)
+  left_inv := by
+    intro x
+    simp only
+    generalize_proofs h h'
+    exact hf.injective (h.chooseUnique_spec h')
+  right_inv := by
+    intro x
+    simp only
+    generalize_proofs h h'
+    exact h.chooseUnique_spec h'
+
+@[classical, replace ofInjective]
+def ofInjective' {α β} (f : α → β) (hf : Injective f) : α ≃ Set.range f :=
+  ofBijective' (fun x => ⟨f x, by simp⟩) (by
+    constructor
+    · intro x y eq
+      simp only [Subtype.mk.injEq] at eq
+      simpa using hf eq
+    · intro x
+      obtain ⟨y, hy⟩ := x.2
+      simpa [Subtype.ext_iff] using ⟨y, hy⟩)
+
+@[classical, replace punitOfNonemptyOfSubsingleton]
+def punitOfNonemptyOfSubsingleton' {α} [h : Nonempty α] [Subsingleton α] :
+    α ≃ PUnit.{v} := by
+  elim_choice Equiv.punitOfNonemptyOfSubsingleton.{u, v} (α := α) unfolding Nonempty.some
+  infer_instance
+
+end Equiv
+
+namespace List
+
+@[classical, replace pairwise_lt_range']
+lemma pairwise_lt_range'' {s n} (step := 1) (pos : 0 < step := by simp) :
+    List.Pairwise (· < ·) (range' s n step) := by
+  induction n generalizing s with
+  | zero => exact List.Pairwise.nil
+  | succ n ih =>
+    rw [range'_succ]
+    refine List.pairwise_cons.mpr ⟨?_, ih⟩
+    intro a ha
+    rw [mem_range'] at ha
+    obtain ⟨i, _, rfl⟩ := ha
+    calc s < s + step := Nat.lt_add_of_pos_right pos
+      _ ≤ s + step + step * i := Nat.le_add_right _ _
+
+end List
+
+namespace WellFounded
+
+variable {α} {r : α → α → Prop} [wo : IsWellOrder α r]
+    (H : WellFounded r) (s : Set α) (h : s.Nonempty)
+
+@[classical] lemma min_aux
+    {x y : α} (hx : x ∈ s ∧ ∀ x_1 ∈ s, ¬r x_1 x) (hy : y ∈ s ∧ ∀ x ∈ s, ¬r x y) : x = y := by
+  have := hx.2 y hy.1
+  have := hy.2 x hx.1
+  have := trichotomous (r := r) x y
+  tauto
+
+@[classical, restrict WellFounded.min 2]
+def min' : α := by
+  elim_choice H.min s h
+  apply WellFounded.min_aux
+
+@[classical, restrict min_mem 2]
+lemma min_mem' : H.min' s h ∈ s :=
+  (definiteDescription (has_min H s h) (@min_aux α r wo s)).property.1
+
+@[classical, restrict not_lt_min 2]
+lemma not_lt_min' {x} (hx : x ∈ s) : ¬r x (H.min' s ⟨x, hx⟩) :=
+  (definiteDescription (has_min H s ⟨x, hx⟩) (@min_aux α r wo s)).property.2 x hx
+
+end WellFounded
+
+namespace CompletelyDistribLattice
+
+@[classical, restrict toCompleteLattice -1 1]
+instance toCompleteLattice' {α} [self : CompleteLattice α] :
+    CompleteLattice α := self
+
+@[classical, restrict toCompleteDistribLattice -1 1]
+instance toCompleteDistribLattice' {α} [self : CompleteDistribLattice α] :
+    CompleteDistribLattice α := self
+
+end CompletelyDistribLattice
+
+namespace Fintype
+
+@[classical, replace Fintype.finite]
+theorem finite' {α} (_inst : Fintype α) : Finite α := by
+  letI := Classical.decEq α
+  obtain ⟨e⟩ := truncEquivFin α
+  exact ⟨e⟩
+
+@[classical] theorem equivOfCardEq' {α β} [Fintype α] [Fintype β] (h : card α = card β) :
+    Nonempty (α ≃ β) := by
+  letI := Classical.decEq α
+  letI := Classical.decEq β
+  obtain ⟨e⟩ := truncEquivOfCardEq h
+  exact ⟨e⟩
+
+end Fintype
+
+attribute [-instance] CompleteLinearOrder.toCompletelyDistribLattice
+
+namespace CompleteLinearOrder
+
+@[classical] instance toCompleteDistribLattice
+    {α} [h : CompleteLinearOrder α] : CompleteDistribLattice α := {
+    __ := ‹CompleteLinearOrder α›
+}
+
+@[classical, replace toConditionallyCompleteLinearOrderBot]
+instance toConditionallyCompleteLinearOrderBot'
+    {α} [h : CompleteLinearOrder α] : ConditionallyCompleteLinearOrderBot α where
+  csSup_empty := sSup_empty
+  csSup_of_not_bddAbove := fun s H => (H (OrderTop.bddAbove s)).elim
+  csInf_of_not_bddBelow := fun s H => (H (OrderBot.bddBelow s)).elim
+  __ := CompleteLattice.toConditionallyCompleteLattice
+  __ := h
+
+end CompleteLinearOrder
+
+attribute [-instance] Set.instCompleteAtomicBooleanAlgebra
+
+namespace CompleteAtomicBooleanAlgebra
+
+@[classical, restrict toCompleteBooleanAlgebra -1 1]
+instance toCompleteBooleanAlgebra' {α} [self : CompleteBooleanAlgebra α] :
+    CompleteBooleanAlgebra α := self
+
+end CompleteAtomicBooleanAlgebra
+
+@[classical] instance Set.instCompleteBooleanAlgebra {α} : CompleteBooleanAlgebra (Set α) where
+  le := (· ⊆ ·)
+  lt := (· ⊂ ·)
+  le_refl := fun _ _ h => h
+  le_trans := fun _ _ _ hab hbc _ hx => hbc (hab hx)
+  le_antisymm := fun _ _ hab hba => Set.ext fun x => ⟨fun h => hab h, fun h => hba h⟩
+  sup := (· ∪ ·)
+  le_sup_left := fun _ _ _ h => Or.inl h
+  le_sup_right := fun _ _ _ h => Or.inr h
+  sup_le := fun _ _ _ hac hbc _ h => h.elim (fun h => hac h) (fun h => hbc h)
+  inf := (· ∩ ·)
+  inf_le_left := fun _ _ _ h => h.1
+  inf_le_right := fun _ _ _ h => h.2
+  le_inf := fun _ _ _ hab hac _ h => ⟨hab h, hac h⟩
+  sSup := fun S => {x | ∃ t ∈ S, x ∈ t}
+  isLUB_sSup := fun S => ⟨fun t t_in a a_in => ⟨t, t_in, a_in⟩,
+    fun b hb a ⟨t, t_in, a_in⟩ => hb t_in a_in⟩
+  sInf := fun S => {x | ∀ t ∈ S, x ∈ t}
+  isGLB_sInf := fun S => ⟨fun t t_in a h => h t t_in,
+    fun b hb a a_in t t_in => hb t_in a_in⟩
+  top := univ
+  le_top := fun _ _ _ => trivial
+  bot := ∅
+  bot_le := fun _ _ h => h.elim
+  le_sup_inf := fun _ _ _ _ h =>
+    h.1.elim Or.inl fun hy => h.2.elim Or.inl fun hz => Or.inr ⟨hy, hz⟩
+  compl := fun s => {a | a ∉ s}
+  sdiff := fun x y => {a | a ∈ x ∧ a ∉ y}
+  himp := fun x y => {a | a ∈ x → a ∈ y}
+  inf_compl_le_bot := fun _ _ h => h.2 h.1
+  top_le_sup_compl := fun x a _ => em (a ∈ x)
+  sdiff_eq := fun _ _ => rfl
+  himp_eq := fun x _ => Set.ext fun a => ⟨fun h => (em (a ∈ x)).elim (fun hx => Or.inl (h hx))
+      (fun hx => Or.inr hx), fun h hx => h.elim id (fun hnx => absurd hx hnx)⟩
+
+namespace Function
+
+open Classical in
+@[classical, restrict invFun -2 2 4]
+def invFun' {α β : Sort*} [Inhabited α] (f : α → β) (hf : Injective f) : β → α :=
+  fun b => if h : ∃ x, f x = b then h.chooseUnique (fun h h' => hf (h' ▸ h)) else default
+
+@[classical, restrict leftInverse_invFun -2 2]
+lemma leftInverse_invFun' {α β : Sort*} [Inhabited α] {f : α → β}
+    (hf : Injective f) : LeftInverse (invFun' f hf) f := by
+  intro x
+  simp only [invFun', exists_apply_eq_apply, ↓reduceDIte]
+  generalize_proofs h h'
+  exact hf (h.chooseUnique_spec h')
+
+@[classical, restrict invFun_eq -2 2 5]
+lemma invFun_eq' {α β : Sort*} [Inhabited α] {f : α → β} {b : β}
+    (hf : Injective f) (hb : ∃ a, f a = b) : f (invFun' f hf b) = b := by
+  simp only [invFun', hb, ↓reduceDIte]
+  obtain ⟨a, ha⟩ := hb
+  generalize_proofs hb eq
+  rw [hb.chooseUnique_spec eq]
+
+@[classical, replace Embedding.setValue]
+def Embedding.setValue' {α β : Sort*} (f : α ↪ β) (a : α) (b : β)
+    [∀ a', Decidable (a' = a)] [∀ a', Decidable (f a' = b)] : α ↪ β :=
+  ⟨fun a' => if a' = a then b else if f a' = b then f a else f a', by
+    intro x y h
+    simp only at h
+    split_ifs at h <;>
+      try simp_all only [not_false_eq_true, not_true_eq_false, EmbeddingLike.apply_eq_iff_eq]
+    · rename_i h₁ h₂ h₃
+      rw [← h, f.apply_eq_iff_eq] at h₂
+      exact h₁ h₂
+    · rename_i h₁ h₂ h₃
+      rwa [← h₃, f.apply_eq_iff_eq] at h₁⟩
+
+@[classical, replace Embedding.setValue_eq]
+def Embedding.setValue_eq' {α β : Sort*} (f : α ↪ β) (a : α) (b : β)
+    [∀ a', Decidable (a' = a)] [∀ a', Decidable (f a' = b)] : (f.setValue' a b) a = b := by
+  simp [setValue']
+
+@[classical, replace Embedding.schroeder_bernstein_of_rel]
+theorem Embedding.schroeder_bernstein_of_rel'
+    {α β : Type*} {f : α → β} {g : β → α} (hf : Function.Injective f)
+    (hg : Function.Injective g) (R : α → β → Prop) (hp₁ : ∀ a : α, R a (f a))
+    (hp₂ : ∀ b : β, R (g b) b) :
+    ∃ h : α → β, Bijective h ∧ ∀ a : α, R a (h a) := by
+  by_cases em : IsEmpty β
+  · have : IsEmpty α := f.isEmpty
+    exact ⟨_, ((Equiv.equivEmpty α).trans (Equiv.equivEmpty β).symm).bijective, by simp⟩
+  · simp only [not_isEmpty_iff] at em
+    obtain ⟨x⟩ := em
+    letI : Inhabited β := ⟨x⟩
+    elim_choice Embedding.schroeder_bernstein_of_rel hf hg R hp₁ hp₂ <;>
+      first | infer_instance | assumption
+
+end Function
+
+namespace Cardinal
+
+private lemma mem_not_both {α} {S T : Set α} (H : Disjoint S T) {a : α}
+    (hS : a ∈ S) (hT : a ∈ T) : False := by
+  have h1 : ({a} : Set α) ≤ S := by intro b hb; cases hb; exact hS
+  have h2 : ({a} : Set α) ≤ T := by intro b hb; cases hb; exact hT
+  exact H h1 h2 (rfl : a ∈ ({a} : Set α))
+
+@[classical, replace mk_union_of_disjoint]
+lemma mk_union_of_disjoint' {α} {S T : Set α} (H : Disjoint S T) :
+    #(S ∪ T : Set α) = #S + #T := by
+  classical
+  apply Cardinal.mk_congr
+  refine ⟨fun x => if h : (x : α) ∈ S then Sum.inl ⟨x, h⟩ else Sum.inr ⟨x, x.2.resolve_left h⟩,
+    Sum.elim (fun a => ⟨a, Or.inl a.2⟩) (fun b => ⟨b, Or.inr b.2⟩), ?_, ?_⟩
+  · intro x
+    simp only []
+    by_cases h : (x : α) ∈ S
+    · rw [dif_pos h]; rfl
+    · rw [dif_neg h]; rfl
+  · rintro (a | b)
+    · simp only [Sum.elim_inl]; rw [dif_pos a.2]
+    · simp only [Sum.elim_inr]; rw [dif_neg (fun h => mem_not_both H h b.2)]
+
+@[classical, replace nonempty_unique]
+lemma nonempty_unique' {α} [hα : Subsingleton α] [ne : Nonempty α] : Nonempty (Unique α) := by
+  obtain ⟨x⟩ := ne
+  refine ⟨⟨⟨x⟩, fun y => hα.elim y x⟩⟩
+
+private theorem mk_singleton' {α : Type v} (a : α) : #({a} : Set α) = 1 := by
+  have hp : #(PUnit.{v + 1}) = 1 := by
+    have h : (1 : Cardinal.{v}) = lift.{v, 0} #(Fin 1) := rfl
+    rw [h, Cardinal.lift_mk_fin]
+    exact Cardinal.mk_congr ⟨fun _ => ⟨0, Nat.zero_lt_one⟩, fun _ => PUnit.unit,
+      fun _ => rfl, fun _ => by ext; omega⟩
+  rw [← hp]
+  exact Cardinal.mk_congr ⟨fun _ => PUnit.unit, fun _ => ⟨a, rfl⟩,
+    fun ⟨_, hx⟩ => Subtype.ext hx.symm, fun _ => rfl⟩
+
+open Fintype in
+@[classical, replace mk_fintype]
+theorem mk_fintype' (α : Type u) [h : Fintype α] : #α = Fintype.card α := by
+  obtain ⟨e⟩ := equivOfCardEq' (show card α = card (ULift.{u, 0} (Fin (Fintype.card α))) by simp)
+  exact mk_congr e
+
+@[classical, replace mk_insert]
+theorem mk_insert' {α} {s : Set α} {a : α} (h : a ∉ s) :
+    #(insert a s : Set α) = #s + 1 := by
+  have hdis : Disjoint ({a} : Set α) s := by
+    intro u hu1 hu2 b hb
+    have hbS : b ∈ ({a} : Set α) := hu1 hb
+    have hbs : b ∈ s := hu2 hb
+    cases hbS
+    exact absurd hbs h
+  rw [Set.insert_eq, mk_union_of_disjoint' hdis, mk_singleton', add_comm]
+
+end Cardinal
+
+@[classical, replace quotientKerEquivOfSurjective]
+def quotientKerEquivOfSurjective' {α β} (f : α → β) (hf : Surjective f) :
+    Quotient (ker f) ≃ β :=
+  (Setoid.quotientKerEquivRange f).trans (Surjective.range_eq hf ▸ Equiv.Set.univ _)
+
+@[reducible, classical, replace small_subtype]
+def small_subtype' (α) [hα : Small.{u} α] (P : α → Prop) : Small.{u} { x // P x } := by
+  obtain ⟨S, ⟨e⟩⟩ := hα
+  exact ⟨_, ⟨Equiv.subtypeEquivOfSubtype e.symm (p := P) |>.symm⟩⟩
+
+@[classical, replace small_of_surjective]
+theorem small_of_surjective' {α β} [hα : Small.{u} α] {f : α → β} (hf : Surjective f) :
+    Small.{u} β := by
+  obtain ⟨S, ⟨e⟩⟩ := hα
+  refine ⟨_, ⟨quotientKerEquivOfSurjective' (f ∘ e.symm) ?_ |>.symm⟩⟩
+  simpa
+
+@[classical, replace small_sum]
+instance small_sum' {α β} [hα : Small.{w} α] [hβ : Small.{w} β] : Small.{w} (α ⊕ β) := by
+  obtain ⟨S, ⟨e⟩⟩ := hα
+  obtain ⟨S', ⟨e'⟩⟩ := hβ
+  exact ⟨_, ⟨Equiv.sumCongr e e'⟩⟩
+
+@[classical, replace isLeast_csInf]
+theorem isLeast_csInf'
+    {α} [ConditionallyCompleteLinearOrder α] {s : Set α} [WellFoundedLT α] (hs : s.Nonempty) :
+    IsLeast s (sInf s) := by
+  have : IsWellOrder α (InvImage (· < ·) id) := by
+    have heq : (InvImage (· < ·) (id : α → α)) = (· < ·) := by funext a b; rfl
+    rw [heq]; infer_instance
+  elim_choice isLeast_csInf hs
+    unfolding sInf_eq_argmin_on argminOn argminOn_mem not_lt_argminOn argminOn_le <;>
+    assumption

--- a/LeanPool/Frucht/Frucht.lean
+++ b/LeanPool/Frucht/Frucht.lean
@@ -1,0 +1,1010 @@
+/-
+Copyright (c) 2026 Shuhao Song. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Shuhao Song
+-/
+import Mathlib.SetTheory.Ordinal.Basic
+import Mathlib.Tactic.NormNum
+import LeanPool.Frucht.SetTheory
+import LeanPool.Frucht.Graphs
+
+/-!
+# Frucht's theorem, choice-free
+
+Assembles the canonical pointed graphs and Cayley colored graphs into the main
+results: a strong form of Frucht's theorem that every group is isomorphic to the
+automorphism group of a simple graph, derived from the axiom of choice and, more
+finely, from foundation and the `FAFA₂` set-theoretic rigidity hypothesis.
+-/
+
+noncomputable section
+universe u v
+
+open Function Relation Cardinal
+
+@[classical] def top (x : Type u) := castMem (trcl_singleton_contains_self (x := x))
+
+@[classical] def canonicalGraph (α : Type u) : PointedGraph (trcl {α}) where
+  p := top α
+  r := fun x y => (y : Type u) ∈ (x : Type u)
+
+@[classical] def FAFA₂On (M : Set (Type u)) :=
+  ∀ α ∈ M, ∀ β ∈ M, canonicalGraph α ≃· canonicalGraph β → α = β
+
+namespace canonicalGraph
+
+open PointedGraph
+
+variable {x y : Type u} (f : canonicalGraph x ≃· canonicalGraph y) (a b : trcl {x})
+
+@[classical] lemma p_eq : (canonicalGraph x).p = top x := rfl
+
+@[classical] lemma reachable_iff :
+    ReflTransGen (canonicalGraph x).r a b ↔ ↑b ∈ trcl {↑a} := by
+  rw [mem_trcl_singleton_iff]
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · apply ReflTransGen.swap
+    refine ReflTransGen.lift _ ?_ h
+    simp [canonicalGraph]
+  · replace h := h.swap
+    refine ReflTransGen.liftInjective elements_inj ?_ ?_ h
+    · simp [canonicalGraph]
+    · simpa only [← mem_def, swap] using fun _ _ => trcl_singleton_trans_of_mem
+
+@[classical] def isoInduce (hy : y ∈ trcl {x}) :
+    canonicalGraph y ≃· (canonicalGraph x).induce (castMem hy) where
+  toFun := fun z => ⟨
+    castMem (trcl_singleton_trans (elements_mem z) hy),
+    by simpa [reachable_iff] using elements_mem _
+  ⟩
+  invFun := fun ⟨z, hz⟩ => by
+    simp only [reachable_iff, elements_cast] at hz
+    exact castMem hz
+  map_point' := by simp +instances [induce, p_eq, top]
+  left_inv := by simp [LeftInverse]
+  right_inv := by simp [RightInverse, LeftInverse]
+  map_rel_iff' := by simp +instances [induce, canonicalGraph]
+
+@[classical] def isoInduceElement : canonicalGraph ↑a ≃· (canonicalGraph x).induce a := by
+  convert isoInduce (elements_mem a) <;> simp
+
+@[classical] def move (a : x) : y := by
+  let a' := moveSub sub_trcl_singleton a
+  have : ↑(f a') ∈ y := by
+    suffices (canonicalGraph y).r (top y) (f a') by
+      simpa [canonicalGraph, top] using this
+    rw [← p_eq, ← f.map_point, f.map_rel_iff, p_eq]
+    simp [canonicalGraph, top, a', moveSub, elements_mem]
+  exact castMem this
+
+@[classical] def moveIso (a : x) : canonicalGraph ↑a ≃· canonicalGraph ↑(move f a) :=
+  let a' := moveSub sub_trcl_singleton a
+  calc
+    _ ≃· canonicalGraph ↑a' := by
+      convert PointedGraphIso.refl (G := canonicalGraph ↑a)
+      · simp [a']
+      · congr 1; simp [a']
+    _ ≃· (canonicalGraph x).induce a' := by
+      convert isoInduce (elements_mem _) <;> simp
+    _ ≃· (canonicalGraph y).induce (f a') := by
+      apply induceIso
+    _ ≃· canonicalGraph ↑(f a') := by
+      convert isoInduce (elements_mem _) |>.symm <;> simp
+    _ ≃· _ := by
+      convert PointedGraphIso.refl (G := canonicalGraph ↑(f a'))
+      · simp [move, a']
+      · congr 1; simp [move, a']
+
+@[classical] lemma is_rigid
+    {M : Set (Type u)} (hfafa : FAFA₂On M) (htrans : TransitiveClass M) (hx : x ∈ M) :
+    (canonicalGraph x).Rigid := by
+  refine @Unique.instSubsingleton _ ⟨⟨.refl⟩, ?_⟩
+  intro f
+  ext a
+  change f a = a
+  have := calc
+    _ ≃· _ := isoInduceElement a
+    _ ≃· _ := induceIso f a
+    _ ≃· _ := isoInduceElement (f a) |>.symm
+  exact (elements_inj <| hfafa
+    _ (mem_transitive htrans hx (elements_mem a))
+    _ (mem_transitive htrans hx (elements_mem (f a))) this) |>.symm
+
+end canonicalGraph
+
+open canonicalGraph in
+@[classical] theorem fafa₂_on_wf : FAFA₂On WF := by
+  intro x hx y hy f
+  clear hy
+  induction hx generalizing y with
+  | @intro x hx ih =>
+    ext z
+    refine ⟨fun hz => ?_, fun hz => ?_⟩
+    · have := ih _ hz _ (elements_cast _ ▸ moveIso f (castMem hz))
+      exact this ▸ elements_mem _
+    · have := ih _ (elements_mem _) _ (moveIso f.symm (castMem hz)).symm
+      simp only [elements_cast] at this
+      exact this ▸ elements_mem _
+
+@[classical] class HasEnoughPointedGraph (α : Type u) where
+  S : Set (Sigma PointedGraph.{u})
+  equiv : α ≃ S
+  all_rigid : S ⊆ {G | G.2.Rigid}
+  not_isomorphic : S.Pairwise fun G H => IsEmpty (G.2 ≃· H.2)
+
+@[classical, reducible] def instHasEnoughPointedGraph
+    {M : Set (Type u)} (hfafa : FAFA₂On M) (htrans : TransitiveClass M) {α} (hα : α ∈ M) :
+    HasEnoughPointedGraph α := by
+  let f (x : α) := Sigma.mk _ (canonicalGraph (x : Type u))
+  refine ⟨_, Equiv.ofInjective' f ?_, ?_, ?_⟩
+  · intro x y eq
+    simp only [Sigma.mk.injEq, f] at eq
+    let φ {α : Type u} (G : PointedGraph α) : Type u := G.p
+    have : φ (canonicalGraph x) = φ (canonicalGraph y) := by
+      congr 1 <;> simp [eq]
+    simp only [canonicalGraph, top, elements_cast, φ] at this
+    exact elements_inj this
+  · intro G hG
+    obtain ⟨x, hx⟩ := hG
+    rw [← hx]
+    exact canonicalGraph.is_rigid hfafa htrans (htrans _ hα _ (elements_mem _))
+  · refine fun x hx y hy ne => ⟨fun iso => ?_⟩
+    obtain ⟨x', hx'⟩ := hx
+    obtain ⟨y', hy'⟩ := hy
+    rw [← hx', ← hy'] at iso
+    absurd ne
+    suffices x' = y' by ext1 <;> rw [← hx', ← hy', this]
+    refine elements_inj (hfafa _ ?_ _ ?_ iso)
+    · refine htrans _ hα _ (elements_mem _)
+    · refine htrans _ hα _ (elements_mem _)
+
+@[classical, reducible] def instHasEnoughPointedGraphFromEquiv
+    {α β} [A : HasEnoughPointedGraph α] (f : α ≃ β) : HasEnoughPointedGraph β where
+  S := A.S
+  equiv := f.symm.trans A.equiv
+  all_rigid := A.all_rigid
+  not_isomorphic := A.not_isomorphic
+
+@[classical] class HasEnoughRCPG (α : Type u) where
+  S : Set (Sigma RCPG.{u})
+  equiv : α ≃ S
+  nontrivial : ∀ G ∈ S, Nontrivial G.1
+  not_isomorphic : S.Pairwise fun G H => IsEmpty (G.2 ≃p H.2)
+
+namespace RCPG
+
+open SimpleGraph
+
+variable (m n : ℕ) [NeZero m] [NeZero n]
+
+@[classical] def path : RCPG (Fin n) :=
+  { pathGraph n with
+    p := 0
+    is_rigid' := @Unique.instSubsingleton _
+      ⟨⟨⟨.refl, rfl⟩⟩, fun | ⟨f, hf⟩ => Subtype.val_inj.mp (pathGraph_rigid f hf)⟩
+    is_connected := by
+      obtain ⟨m, ⟨_⟩⟩ := Nat.exists_eq_add_one_of_ne_zero (NeZero.ne n)
+      exact pathGraph_connected _ }
+
+@[classical] lemma path_not_isomorphic (ne : m ≠ n) : IsEmpty (path m ≃p path n) :=
+  ⟨fun e => ne (Fin.equiv_iff_eq.mp ⟨e.toEquiv⟩)⟩
+
+instance : HasEnoughRCPG Bool where
+  S := _
+  equiv := Equiv.ofInjective'
+    (fun | false => ⟨_, path 2⟩ | true => ⟨_, path 3⟩)
+    (by simpa using fun h => absurd (Fin.equiv_iff_eq.mp ⟨Equiv.cast h⟩) (by simp))
+  nontrivial := by
+    simp only [Bool.range_eq, Set.mem_insert_iff, Set.mem_singleton_iff, forall_eq_or_imp,
+      forall_eq]
+    constructor <;> infer_instance
+  not_isomorphic := by simp [Set.Pairwise, path_not_isomorphic]
+
+end RCPG
+
+namespace HasEnoughRCPG
+
+variable {C} [HasEnoughRCPG C] (u v : C)
+
+@[classical] def type : Type u := (equiv u).1.1
+@[classical] def rcpgOfColor : RCPG (type u) := (equiv u).1.2
+@[classical] def graph : SimpleGraph (type u) := (rcpgOfColor u).toSimpleGraph
+@[classical] def point : type u := (rcpgOfColor u).p
+@[classical] lemma graph_connected : (graph u).Connected := (rcpgOfColor u).is_connected
+@[classical] instance : Nontrivial (type u) := nontrivial (equiv u).1 (equiv u).2
+
+variable {u v}
+
+@[classical] lemma color_eq_of_iso (f : rcpgOfColor u ≃p rcpgOfColor v) : u = v := by
+  by_contra ne
+  exact not_isomorphic (equiv u).2 (equiv v).2
+    (Subtype.val_inj.not.mpr (equiv.injective.ne ne)) |>.false f
+
+end HasEnoughRCPG
+
+open HasEnoughRCPG
+
+namespace ColoredGraph
+
+variable {α : Type u} {C : Type v} [HasEnoughRCPG C] (G : ColoredGraph α C)
+
+@[classical] inductive RCPGPoints : Type _
+  | o (x : α)
+  | a (x y : α)
+  | b (x y : α)
+  | c (x y : α) (u : type (G x y))
+  | l (x y : α) (u : type (G x y))
+
+section ImplicitArgument
+
+variable {G} (q : RCPGPoints G)
+
+namespace RCPGPoints
+
+@[classical] abbrev p (x y : α) := c x y (point (G x y))
+@[classical] instance instNontrivial [ne : Nonempty α] : Nontrivial G.RCPGPoints := by
+  obtain ⟨x⟩ := ne
+  refine ⟨a x x, .b x x, by simp⟩
+
+@[classical] def Is_o := ∃ x, o x = q
+@[classical] def Is_a := ∃ x y, a x y = q
+@[classical] def Is_b := ∃ x y, b x y = q
+@[classical] def Is_c := ∃ x y u, c x y u = q
+@[classical] def Is_l := ∃ x y u, l x y u = q
+@[classical] def Is_p := ∃ x y, p x y = q
+
+end RCPGPoints
+
+@[classical] inductive RCPGRelation : G.RCPGPoints → G.RCPGPoints → Prop
+  | roa (x y) : RCPGRelation (.o x) (.a x y)
+  | rao (x y) : RCPGRelation (.a x y) (.o x)
+  | rab (x y) : RCPGRelation (.a x y) (.b x y)
+  | rba (x y) : RCPGRelation (.b x y) (.a x y)
+  | rap (x y) : RCPGRelation (.a x y) (.p x y)
+  | rpa (x y) : RCPGRelation (.p x y) (.a x y)
+  | rpo (x y) : RCPGRelation (.p x y) (.o y)
+  | rop (x y) : RCPGRelation (.o y) (.p x y)
+  | rcl (x y u) : RCPGRelation (.c x y u) (.l x y u)
+  | rlc (x y u) : RCPGRelation (.l x y u) (.c x y u)
+  | rcc (x y u v) (hzw : (graph (G x y)).Adj u v) : RCPGRelation (.c x y u) (.c x y v)
+
+end ImplicitArgument
+
+@[classical] def elimColor : SimpleGraph G.RCPGPoints where
+  Adj := RCPGRelation
+  symm := by
+    intro x y r
+    cases r <;> constructor
+    rename_i x y a b hab
+    exact hab.symm
+  loopless := by
+    refine ⟨fun x hx => ?_⟩
+    cases hx
+    rename_i x y a ha
+    exact (graph (G _ _)).loopless.irrefl _ ha
+
+end ColoredGraph
+
+namespace ColoredGraphIso
+
+open ColoredGraph
+
+variable {α β C} [HasEnoughRCPG C] {G : ColoredGraph α C} {H : ColoredGraph β C} (f : G ≃c H)
+
+@[classical] def toElimColorMap : G.RCPGPoints → H.RCPGPoints
+  | .o x => .o (f x)
+  | .a x y => .a (f x) (f y)
+  | .b x y => .b (f x) (f y)
+  | .c x y u => .c (f x) (f y) (congr_arg type f.map_color ▸ u)
+  | .l x y u => .l (f x) (f y) (congr_arg type f.map_color ▸ u)
+
+@[classical] def toElimColorEquiv : G.RCPGPoints ≃ H.RCPGPoints where
+  toFun := toElimColorMap f
+  invFun := toElimColorMap f.symm
+  left_inv := by rintro ⟨_⟩ <;> simp [toElimColorMap]
+  right_inv := by rintro ⟨_⟩ <;> simp [toElimColorMap, apply_symm_apply]
+
+@[classical] lemma toElimColorMap_adj_iff {p q : G.RCPGPoints} (adj : G.elimColor.Adj p q) :
+    H.elimColor.Adj (f.toElimColorMap p) (f.toElimColorMap q) := by
+  simp only [ColoredGraph.elimColor]
+  cases adj with
+  | roa x y => constructor
+  | rao x y => constructor
+  | rab x y => constructor
+  | rba x y => constructor
+  | rap x y =>
+    simp only [toElimColorMap]
+    convert RCPGRelation.rap (f x) (f y) using 2
+    rw [eqRec_eq_cast, cast_eq_iff_heq, ← f.map_color]
+  | rpa x y =>
+    simp only [toElimColorMap]
+    convert RCPGRelation.rpa (f x) (f y) using 2
+    rw [eqRec_eq_cast, cast_eq_iff_heq, ← f.map_color]
+  | rpo x y =>
+    simp only [toElimColorMap]
+    convert RCPGRelation.rpo (f x) (f y) using 2
+    rw [eqRec_eq_cast, cast_eq_iff_heq, ← f.map_color]
+  | rop x y =>
+    simp only [toElimColorMap]
+    convert RCPGRelation.rop (f x) (f y) using 2
+    rw [eqRec_eq_cast, cast_eq_iff_heq, ← f.map_color]
+  | rcl x y u => constructor
+  | rlc x y u => constructor
+  | rcc x y u v adj =>
+    constructor
+    convert adj
+    rw [← propext_iff]
+    congr 1 <;> first | rw [← f.map_color] | simp
+
+@[classical] def toElimColorIso : G.elimColor ≃g H.elimColor :=
+  { toElimColorEquiv f with
+    map_rel_iff' := by
+      refine fun {a b} => ⟨fun h => ?_, fun h => ?_⟩
+      · convert f.symm.toElimColorMap_adj_iff h
+        · exact (f.toElimColorEquiv.left_inv a).symm
+        · exact (f.toElimColorEquiv.left_inv b).symm
+      · exact f.toElimColorMap_adj_iff h }
+
+end ColoredGraphIso
+
+namespace ColoredGraph
+
+open SimpleGraph
+
+variable {α β γ : Type u} {C : Type v} [HasEnoughRCPG C]
+    {G : ColoredGraph α C} {H : ColoredGraph β C} {I : ColoredGraph γ C}
+    (f : G.elimColor ≃g H.elimColor) (g : H.elimColor ≃g I.elimColor)
+    {p : G.RCPGPoints} (x₀ x y : α) (u : type (G x y))
+
+@[classical] lemma is_leaf_iff : G.elimColor.IsLeaf p ↔ p.Is_b ∨ p.Is_l := by
+  refine ⟨fun hp => ?_, fun hp => ?_⟩
+  · cases p with
+    | o x => exact False.elim ((by simp : ¬_)
+        (hp.unique (y₁ := .a x x) (y₂ := .p x x) (by constructor) (by constructor)))
+    | a x y => exact False.elim ((by simp : ¬_)
+        (hp.unique (y₁ := .b x y) (y₂ := .o x) (by constructor) (by constructor)))
+    | b x y => repeat constructor
+    | c x y u =>
+      obtain ⟨v, hv⟩ := (graph (G x y)).connected_exists_edge (graph_connected _) u
+      exact False.elim ((by simp : ¬_)
+        (hp.unique (y₁ := .c x y v) (y₂ := .l x y u) (by constructor; exact hv) (by constructor)))
+    | l x y u => right; repeat constructor
+  · rcases hp with ⟨x, y, hp⟩ | ⟨x, y, u, hp⟩
+    · cases hp
+      refine ⟨.a x y, by constructor, fun q hq => ?_⟩
+      cases hq
+      rfl
+    · cases hp
+      refine ⟨.c x y u, by constructor, fun q hq => ?_⟩
+      cases hq
+      rfl
+
+@[classical] lemma is_o_iff :
+    p.Is_o ↔ ¬G.elimColor.IsLeaf p ∧ ¬∃ x ∈ G.elimColor.neighborSet p, G.elimColor.IsLeaf x := by
+  simp only [is_leaf_iff]
+  refine ⟨fun hp => ⟨?_, ?_⟩, fun | ⟨hp, hp'⟩ => ?_⟩
+  · obtain ⟨x, ⟨_⟩⟩ := hp
+    rintro (⟨y, z, ⟨_⟩⟩ | ⟨y, z, u, ⟨_⟩⟩)
+  · obtain ⟨x, ⟨_⟩⟩ := hp
+    rintro ⟨p, ⟨_⟩, ⟨y, z, ⟨_⟩⟩ | ⟨y, z, u, ⟨_⟩⟩⟩
+  · cases p with
+    | o x => repeat constructor
+    | a x y => exact (hp' ⟨.b x y, by constructor, by repeat constructor⟩).elim
+    | b x y => refine (hp (by repeat constructor)).elim
+    | c x y u => exact (hp' ⟨.l x y u, by constructor, by right; repeat constructor⟩).elim
+    | l x y u => exact (hp (by right; repeat constructor)).elim
+
+@[classical] lemma is_neighbor_original_iff :
+    (∃ q ∈ G.elimColor.neighborSet p, q.Is_o) ↔ p.Is_a ∨ p.Is_p := by
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · rcases h with ⟨_, ⟨_⟩, ⟨_, ⟨_⟩⟩⟩
+    · repeat constructor
+    · right; repeat constructor
+  · rcases h with ⟨x, y, ⟨_⟩⟩ | ⟨x, y, ⟨_⟩⟩
+    · use .o x; repeat constructor
+    · use .o y; repeat constructor
+
+@[classical] lemma card_neighborSet_a (hp : p.Is_a) : #(G.elimColor.neighborSet p) = 3 := by
+  obtain ⟨x, y, hxy⟩ := hp
+  transitivity #({.o x, .b x y, .p x y} : Set G.RCPGPoints)
+  · congr 2
+    ext q
+    subst hxy
+    refine ⟨fun h => ?_, fun h => ?_⟩
+    · cases h <;> simp
+    · rcases h with ⟨⟨_⟩⟩ | ⟨⟨_⟩⟩ | ⟨⟨_⟩⟩ <;> constructor
+  · repeat rw [mk_insert]
+    · rw [mk_singleton]
+      norm_num
+    · simp
+    · simp
+
+@[classical] lemma card_neighborSet_p (hp : p.Is_p) : 4 ≤ #(G.elimColor.neighborSet p) := by
+  obtain ⟨x, y, hxy⟩ := hp
+  obtain ⟨u, hu⟩ := (graph (G x y)).connected_exists_edge (graph_connected _) (point (G x y))
+  transitivity #({.a x y, .o y, .l x y (point (G x y)), .c x y u} : Set G.RCPGPoints)
+  · repeat rw [mk_insert]
+    · rw [mk_singleton]
+      norm_num
+    · simp
+    · simp
+    · simp
+  · apply mk_le_mk_of_subset
+    intro q hq
+    simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hq
+    cases hxy
+    rcases hq with ⟨⟨_⟩⟩ | ⟨⟨_⟩⟩ | ⟨⟨_⟩⟩ | ⟨⟨_⟩⟩ <;> constructor
+    exact hu
+
+@[classical] lemma is_a_iff :
+    p.Is_a ↔ (∃ q ∈ G.elimColor.neighborSet p, q.Is_o) ∧ #(G.elimColor.neighborSet p) = 3 := by
+  rw [is_neighbor_original_iff]
+  refine ⟨fun h => ⟨.inl h, ?_⟩, fun | ⟨or, h⟩ => or.resolve_right ?_⟩
+  · exact card_neighborSet_a h
+  · intro hp
+    have := h ▸ card_neighborSet_p hp
+    norm_num at this
+
+@[classical] lemma is_p_iff :
+    p.Is_p ↔ (∃ q ∈ G.elimColor.neighborSet p, q.Is_o) ∧ #(G.elimColor.neighborSet p) ≠ 3 := by
+  rw [is_neighbor_original_iff]
+  refine ⟨fun h => ⟨.inr h, ?_⟩, fun | ⟨or, h⟩ => or.resolve_left ?_⟩
+  · intro hp
+    have := is_a_iff.mpr ⟨is_neighbor_original_iff.mpr (.inr h), hp⟩
+    rcases h with ⟨x, y, ⟨_⟩⟩
+    rcases this with ⟨x, y, ⟨_⟩⟩
+  · contrapose! h
+    exact card_neighborSet_a h
+
+@[classical] lemma iso_o : p.Is_o ↔ (f p).Is_o := by
+  rw [is_o_iff, is_o_iff, ← propext_iff]
+  congr 2
+  · rw [f.map_leaf]
+  · rw [eq_comm, propext_iff, Set.BijOn.exists (f.map_neighborSet p)]
+    congr! 3 with q
+    simp [f.map_leaf]
+
+@[classical] lemma iso_a : p.Is_a ↔ (f p).Is_a := by
+  rw [is_a_iff, is_a_iff, ← propext_iff]
+  congr 1
+  · rw [Set.BijOn.exists (f.map_neighborSet p)]
+    congr! 3 with q
+    rw [iso_o]
+  · congr 1
+    rw [(f.mapNeighborSet _).cardinal_eq]
+
+@[classical] lemma iso_p : p.Is_p ↔ (f p).Is_p := by
+  rw [is_p_iff, is_p_iff, ← propext_iff]
+  congr 1
+  · rw [Set.BijOn.exists (f.map_neighborSet p)]
+    congr! 3 with q
+    rw [iso_o]
+  · congr 1
+    rw [(f.mapNeighborSet _).cardinal_eq]
+
+@[classical] lemma is_b_iff :
+    p.Is_b ↔ G.elimColor.IsLeaf p ∧ ∃ q ∈ G.elimColor.neighborSet p, q.Is_a := by
+  rw [is_leaf_iff]
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · refine ⟨.inl h, ?_⟩
+    rcases h with ⟨x, y, ⟨_⟩⟩
+    refine ⟨.a x y, ?_⟩
+    repeat constructor
+  · refine h.1.resolve_right ?_
+    rintro ⟨x, y, u, ⟨_⟩⟩
+    rcases h with ⟨-, q, ⟨_⟩, ⟨x, y, ⟨_⟩⟩⟩
+
+@[classical] lemma iso_b : p.Is_b ↔ (f p).Is_b := by
+  rw [is_b_iff, is_b_iff, ← propext_iff]
+  congr 1
+  · rw [f.map_leaf]
+  · rw [Set.BijOn.exists (f.map_neighborSet p)]
+    congr! 3 with q
+    rw [iso_a]
+
+@[classical] lemma is_cl_iff : p.Is_c ∨ p.Is_l ↔ ¬p.Is_o ∧ ¬p.Is_a ∧ ¬p.Is_b := by
+  cases p <;>
+    simp [RCPGPoints.Is_o, RCPGPoints.Is_a, RCPGPoints.Is_b, RCPGPoints.Is_c, RCPGPoints.Is_l]
+
+@[classical] lemma is_c_iff : p.Is_c ↔ ¬G.elimColor.IsLeaf p ∧ ¬p.Is_o ∧ ¬p.Is_a ∧ ¬p.Is_b := by
+  rw [← is_cl_iff, is_leaf_iff]
+  cases p <;> simp [RCPGPoints.Is_b, RCPGPoints.Is_c, RCPGPoints.Is_l]
+
+@[classical] lemma is_l_iff : p.Is_l ↔ G.elimColor.IsLeaf p ∧ ¬p.Is_o ∧ ¬p.Is_a ∧ ¬p.Is_b := by
+  rw [← is_cl_iff, is_leaf_iff]
+  cases p <;> simp [RCPGPoints.Is_b, RCPGPoints.Is_c, RCPGPoints.Is_l]
+
+@[classical] lemma iso_c : p.Is_c ↔ (f p).Is_c := by
+  rw [is_c_iff, is_c_iff]
+  congr! 3
+  · rw [f.map_leaf]
+  · rw [iso_o]
+  · rw [iso_a]
+  · rw [iso_b]
+
+@[classical] lemma iso_l : p.Is_l ↔ (f p).Is_l := by
+  rw [is_l_iff, is_l_iff]
+  congr! 3
+  · rw [f.map_leaf]
+  · rw [iso_o]
+  · rw [iso_a]
+  · rw [iso_b]
+
+@[classical] def colorSet : Set G.RCPGPoints :=
+  {q | ∃ w : G.elimColor.Walk q (.p x y), ∀ r ∈ w.support, r.Is_c}
+
+@[classical] def colorSet_p : G.colorSet x y := ⟨.p x y, .nil, by simp [RCPGPoints.Is_c]⟩
+
+@[classical] lemma colorSet_eq : G.colorSet x y = Set.range (.c x y) := by
+  ext p
+  refine ⟨?_, fun | ⟨u, hu⟩ => ?_⟩
+  · simp only [colorSet, Set.mem_setOf_eq, forall_exists_index]
+    set q := (.p x y : G.RCPGPoints) with hq
+    clear_value q
+    intro w hw
+    induction w with
+    | @nil u => simp [hq]
+    | @cons r s t adj w ih =>
+      cases hq
+      simp only [Walk.support_cons, List.mem_cons, forall_eq_or_imp] at hw
+      specialize ih rfl hw.2
+      replace hw := hw.1
+      rcases ih with ⟨u, ⟨_⟩⟩
+      rcases hw with ⟨x', y', u', ⟨_⟩⟩
+      cases adj
+      simp
+  · subst hu
+    obtain ⟨w, -⟩ := (graph_connected (G x y)).exists_walk_length_eq_edist (point (G x y)) u
+    replace w := w.reverse
+    revert u
+    set p := point (G x y) with hp
+    clear_value p
+    intro u w
+    induction w with
+    | @nil p =>
+      cases hp
+      exact (G.colorSet_p x y).2
+    | @cons u v p adj w ih =>
+      cases hp
+      specialize ih rfl
+      obtain ⟨w', hw'⟩ := ih
+      use .cons (.rcc _ _ _ _ adj) w'
+      simp only [Walk.support_cons, List.mem_cons, forall_eq_or_imp]
+      refine ⟨by simp [RCPGPoints.Is_c], hw'⟩
+
+@[classical] def typeEquivColorSet : type (G x y) ≃ G.colorSet x y :=
+  Equiv.ofBijective'
+    (fun u => ⟨.c x y u, by simp [colorSet_eq]⟩)
+    ⟨by simp [Injective], by simp [Surjective, colorSet_eq]⟩
+
+@[classical] def graphIso : graph (G x y) ≃g G.elimColor.induce (G.colorSet x y) where
+  __ := G.typeEquivColorSet x y
+  map_rel_iff' := by
+    intro u v
+    refine ⟨fun h => ?_, fun h => ?_⟩
+    · cases h; assumption
+    · constructor; assumption
+
+@[classical] lemma graphIso_map_point : G.graphIso x y (point (G x y)) = G.colorSet_p x y := rfl
+
+@[classical] def colorRCPG : RCPG (G.colorSet x y) :=
+  { G.elimColor.induce (G.colorSet x y) with
+    p := G.colorSet_p x y
+    is_rigid' := by
+      refine ⟨fun | ⟨f, hf⟩, ⟨g, hg⟩ => ?_⟩
+      let φ := G.graphIso x y
+      let f' := φ |>.trans f |>.trans φ.symm
+      let g' := φ |>.trans g |>.trans φ.symm
+      have := (rcpgOfColor (G x y)).is_rigid.allEq ⟨f', ?_⟩ ⟨g', ?_⟩
+      on_goal 2 =>
+        rw [← point]
+        apply_fun φ
+        erw [RelIso.apply_symm_apply]
+        simp [hf, φ, graphIso_map_point]
+      on_goal 2 =>
+        rw [← point]
+        apply_fun φ
+        erw [RelIso.apply_symm_apply]
+        simp [hg, φ, graphIso_map_point]
+      replace this := congr_arg (fun e => φ.symm |>.trans e.toRelIso |>.trans φ) this
+      simp only [f', g', RelIso.ext_iff, RelIso.trans_apply, RelIso.apply_symm_apply] at this
+      ext p : 2
+      exact this p
+    is_connected := (G.graphIso x y).connected_iff.mp (graph_connected _) }
+
+@[classical] def rcpgOfColorIso : rcpgOfColor (G x y) ≃p G.colorRCPG x y :=
+  { G.graphIso x y with
+    map_point' := by
+      erw [← point, graphIso_map_point]
+      rfl }
+
+@[classical] lemma reachable_x : G.elimColor.Reachable (.o x₀) (.o x) := ⟨
+  .cons (v := .a x₀ x) (by constructor) <|
+  .cons (v := .p x₀ x) (by constructor) <|
+  .cons (v := .o x) (by constructor) .nil
+⟩
+
+@[classical] lemma reachable_a : G.elimColor.Reachable (.o x₀) (.a x y) :=
+  .trans (reachable_x x₀ x) ⟨.cons (v := .a x y) (by constructor) .nil⟩
+
+@[classical] lemma reachable_b : G.elimColor.Reachable (.o x₀) (.b x y) :=
+  .trans (reachable_a x₀ x y) ⟨.cons (v := .b x y) (by constructor) .nil⟩
+
+@[classical] lemma reachable_p : G.elimColor.Reachable (.o x₀) (.p x y) :=
+  .trans (reachable_a x₀ x y) ⟨.cons (v := .p x y) (by constructor) .nil⟩
+
+@[classical] lemma reachable_c : G.elimColor.Reachable (.o x₀) (.c x y u) :=
+  .trans (reachable_p x₀ x y) <| by
+    let p : G.colorSet x y := ⟨.p x y, by simp [colorSet_eq]⟩
+    let q : G.colorSet x y := ⟨.c x y u, by simp [colorSet_eq]⟩
+    obtain ⟨w⟩ := (G.colorRCPG x y).is_connected p q
+    exact ⟨w.map (Hom.comap _ _)⟩
+
+@[classical] lemma reachable_l : G.elimColor.Reachable (.o x₀) (.l x y u) :=
+  .trans (reachable_c x₀ x y u) ⟨.cons (v := .l x y u) (by constructor) .nil⟩
+
+@[classical] lemma elimColor_connected [ne : Nonempty α] : G.elimColor.Connected := by
+  rw [connected_iff_exists_forall_reachable]
+  obtain ⟨x₀⟩ := ne
+  refine ⟨.o x₀, fun p => ?_⟩
+  cases p with
+  | o x => exact reachable_x x₀ x
+  | a x y => exact reachable_a x₀ x y
+  | b x y => exact reachable_b x₀ x y
+  | c x y u => exact reachable_c x₀ x y u
+  | l x y u => exact reachable_l x₀ x y u
+
+@[classical] def extractOriginal {p : G.RCPGPoints} (hp : p.Is_o) :=
+  hp.chooseUnique <| by rintro x y ⟨_⟩ ⟨_⟩; rfl
+
+@[classical] def mapOriginal := extractOriginal ((iso_o f (p := .o x)).mp ⟨_, rfl⟩)
+
+@[classical] lemma mapOriginal_spec : f (.o x) = .o (mapOriginal f x) := by
+  simp only [mapOriginal, extractOriginal]
+  generalize_proofs h h'
+  exact (h.chooseUnique_spec h').symm
+
+@[classical] lemma mapOriginal_refl : mapOriginal (G := G) .refl x = x := by
+  have h := mapOriginal_spec (G := G) .refl x
+  simpa only [eq_comm, RelIso.refl_apply, RCPGPoints.o.injEq] using h
+
+@[classical] lemma mapOriginal_trans :
+    mapOriginal (f.trans g) x = mapOriginal g (mapOriginal f x) := by
+  have h₁ := mapOriginal_spec f x
+  have h₂ := mapOriginal_spec g (mapOriginal f x)
+  have h₃ := mapOriginal_spec (f.trans g) x
+  simpa only [eq_comm, RelIso.trans_apply, h₁, h₂, RCPGPoints.o.injEq] using h₃
+
+@[classical] lemma eq_p_iff : p = .p x y ↔
+    ∃ a, a.Is_a ∧ G.elimColor.Adj (.o x) a ∧ G.elimColor.Adj a p ∧ G.elimColor.Adj p (.o y) := by
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · cases h
+    use .a x y
+    repeat constructor
+  · rcases h with ⟨a, ⟨_, _, ⟨_⟩⟩, ⟨_⟩, ⟨_⟩, ⟨_⟩⟩
+    rfl
+
+@[classical] lemma eq_a_iff : p = .a x y ↔ p.Is_a ∧ G.elimColor.Adj p (.p x y) := by
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · cases h
+    repeat constructor
+  · rcases h with ⟨⟨_, _, ⟨_⟩⟩, ⟨_⟩⟩
+    rfl
+
+@[classical] lemma eq_b_iff : p = .b x y ↔ p.Is_b ∧ G.elimColor.Adj p (.a x y) := by
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · cases h
+    repeat constructor
+  · rcases h with ⟨⟨_, _, ⟨_⟩⟩, ⟨_⟩⟩
+    rfl
+
+@[classical] lemma map_p : f (.p x y) = .p (mapOriginal f x) (mapOriginal f y) := by
+  rw [eq_p_iff, ← mapOriginal_spec, ← mapOriginal_spec, ← f.exists_congr_right,
+    RelIso.coe_fn_toEquiv]
+  conv => enter [1, a]; simp only [f.map_adj_iff, ← iso_a]
+  rw [← eq_p_iff]
+
+@[classical] lemma map_a : f (.a x y) = .a (mapOriginal f x) (mapOriginal f y) := by
+  rw [eq_a_iff, ← iso_a, ← map_p, f.map_adj_iff, ← eq_a_iff]
+
+@[classical] lemma map_b : f (.b x y) = .b (mapOriginal f x) (mapOriginal f y) := by
+  rw [eq_b_iff, ← iso_b, ← map_a, f.map_adj_iff, ← eq_b_iff]
+
+@[classical] lemma mapOriginal_colorSet :
+    Set.BijOn f (G.colorSet x y) (H.colorSet (mapOriginal f x) (mapOriginal f y)) := by
+  rw [← RelIso.coe_fn_toEquiv, ← Equiv.image_eq_iff_bijOn,
+    ColoredGraph.colorSet, ColoredGraph.colorSet, ← Equiv.setOf_apply_symm_eq_image_setOf,
+    show ⇑f.toEquiv.symm = ⇑f.symm from rfl]
+  ext p
+  rw [Set.mem_setOf_eq, Set.mem_setOf_eq, ← map_p f x y]
+  conv_lhs => rw [show .p x y = f.symm (f (.p x y)) by simp]
+  rw [← f.symm.map_walk.exists_congr_right]
+  congr! 2 with w
+  simp only [Iso.map_walk, RelIso.symm_symm, RelEmbedding.coe_toRelHom,
+    RelIso.coe_toRelEmbedding, Equiv.coe_fn_mk]
+  erw [Walk.support_map]
+  simp only [RelEmbedding.coe_toRelHom, RelIso.coe_toRelEmbedding, List.mem_map,
+    forall_exists_index, and_imp, forall_apply_eq_imp_iff₂]
+  congr! 2 with q
+  rw [← iso_c]
+
+@[classical] def mapOriginal_colorRCPG :
+    G.colorRCPG x y ≃p H.colorRCPG (mapOriginal f x) (mapOriginal f y) where
+  __ := (mapOriginal_colorSet f x y).equiv
+  map_rel_iff' := f.map_adj_iff
+  map_point' := Subtype.ext (map_p f x y)
+
+@[classical] theorem mapOriginal_preserve_color :
+    G x y = H (mapOriginal f x) (mapOriginal f y) := by
+  apply color_eq_of_iso
+  calc
+    _ ≃p _ := G.rcpgOfColorIso x y
+    _ ≃p _ := mapOriginal_colorRCPG f x y
+    _ ≃p _ := H.rcpgOfColorIso (mapOriginal f x) (mapOriginal f y) |>.symm
+
+@[classical] def mapOriginalEquiv : α ≃ β := {
+  toFun := mapOriginal f
+  invFun := mapOriginal f.symm
+  left_inv := by simp [LeftInverse, mapOriginal_refl, ← mapOriginal_trans]
+  right_inv := by simp [LeftInverse, RightInverse, mapOriginal_refl, ← mapOriginal_trans]
+}
+
+@[classical] def toColoredGraphIso : G ≃c H :=
+  { mapOriginalEquiv f with
+    map_color' := (mapOriginal_preserve_color _ _ _).symm }
+
+@[classical] lemma toColoredGraphIso_apply : toColoredGraphIso f x = mapOriginal f x := rfl
+
+@[classical] lemma map_c : f (.c x y u) =
+    .c (mapOriginal f x) (mapOriginal f y) ((toColoredGraphIso f).map_color ▸ u) := by
+  have hmap : mapOriginal (toColoredGraphIso f).toElimColorIso = mapOriginal f := by
+    ext x
+    rw [← RCPGPoints.o.injEq (C := C), ← mapOriginal_spec]
+    rfl
+  have := RCPGIso.is_subsingleton.allEq
+    (mapOriginal_colorRCPG f x y)
+    (hmap ▸ mapOriginal_colorRCPG (toColoredGraphIso f).toElimColorIso x y)
+  let p : G.colorSet x y := ⟨.c x y u, by rw [G.colorSet_eq]; repeat constructor⟩
+  apply_fun (fun f => (f p).1) at this
+  convert this using 1
+  simp only [eqRec_eq_cast]
+  apply eq_of_heq
+  apply HEq.trans (b := (mapOriginal_colorRCPG (toColoredGraphIso f).toElimColorIso x y p).1) .rfl
+  congr 2 <;> try simp [hmap]
+  all_goals rw [hmap]
+
+@[classical] lemma eq_l_iff : p = .l x y u ↔ p.Is_l ∧ G.elimColor.Adj p (.c x y u) := by
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · cases h
+    repeat constructor
+  · rcases h with ⟨⟨_, _, _, ⟨_⟩⟩, ⟨_⟩⟩
+    rfl
+
+@[classical] lemma map_l : f (.l x y u) =
+    .l (mapOriginal f x) (mapOriginal f y) ((toColoredGraphIso f).map_color ▸ u) := by
+  rw [eq_l_iff, ← iso_l, ← map_c, f.map_adj_iff, ← eq_l_iff]
+
+@[classical] lemma toColoredGraphIso_injective :
+    Injective (toColoredGraphIso (G := G) (H := H)) := by
+  intro f g eq
+  ext p
+  simp only [toColoredGraphIso, mapOriginalEquiv, ColoredGraphIso.mk.injEq, Equiv.mk.injEq] at eq
+  replace eq := eq.1
+  cases p with
+  | o x => simp only [mapOriginal_spec, eq]
+  | a x y => simp only [map_a, eq]
+  | b x y => simp only [map_b, eq]
+  | c x y u =>
+    simp only [map_c]
+    congr 1 <;> try simp [eq]
+    erw [heq_eqRec_iff_heq, eqRec_heq_iff_heq]
+  | l x y u =>
+    simp only [map_l]
+    congr 1 <;> try simp [eq]
+    erw [heq_eqRec_iff_heq, eqRec_heq_iff_heq]
+
+@[classical] lemma toColoredGraphIso_surjective :
+    Surjective (toColoredGraphIso (G := G) (H := H)) := by
+  refine fun f => ⟨f.toElimColorIso, ?_⟩
+  ext x
+  rw [toColoredGraphIso_apply, ← RCPGPoints.o.injEq (C := C), ← mapOriginal_spec]
+  rfl
+
+@[classical] def toColoredGraphIsoEquiv : (G.elimColor ≃g H.elimColor) ≃ (G ≃c H) :=
+  .ofBijective'
+    (fun _ => toColoredGraphIso _)
+    ⟨toColoredGraphIso_injective, toColoredGraphIso_surjective⟩
+
+@[classical] lemma toColoredGraphIsoEquiv_apply {x} :
+    toColoredGraphIsoEquiv f x = mapOriginal f x := rfl
+
+@[classical] def toColoredGraphIsoIso : (G.elimColor ≃g G.elimColor) ≃* (G ≃c G) :=
+  { toColoredGraphIsoEquiv with
+    map_mul' := by
+      intro f g
+      ext x
+      conv in f * g => change g.trans f
+      simp [toColoredGraphIsoEquiv_apply, mapOriginal_trans] }
+
+end ColoredGraph
+
+namespace PointedGraph
+
+open ColoredGraph
+
+variable {α β} {G : PointedGraph α} {H : PointedGraph β}
+
+open Classical in
+@[classical] def toColoredGraph {α} (G : PointedGraph α) : ColoredGraph α Bool :=
+  fun x y => (G.r x y : Bool)
+
+@[classical] def coloredGraphToPointedGraphIso :
+    {f : G.toColoredGraph ≃c H.toColoredGraph // f G.p = H.p} ↪ G ≃· H where
+  toFun := fun ⟨f, hf⟩ =>
+    { f with
+      map_rel_iff' := @fun x y => by
+        have hc := f.map_color (x := x) (y := y)
+        simp only [PointedGraph.toColoredGraph, decide_eq_decide] at hc
+        exact hc
+      map_point' := hf }
+  inj' := by
+    intro ⟨f, hf⟩ ⟨g, hg⟩ eq
+    rw [Subtype.mk.injEq]
+    rw [DFunLike.ext_iff] at eq ⊢
+    intro x
+    exact eq x
+
+@[classical] def elimColorToPointedGraphIso :
+    {f : G.toColoredGraph.elimColor ≃g H.toColoredGraph.elimColor // f (.o G.p) = .o H.p} ↪
+    G ≃· H where
+  toFun := fun ⟨f, hf⟩ =>
+    coloredGraphToPointedGraphIso
+    ⟨toColoredGraphIso f, by rwa [mapOriginal_spec, RCPGPoints.o.injEq] at hf⟩
+  inj' := by
+    intro ⟨f, hf⟩ ⟨g, hg⟩ eq
+    simpa [toColoredGraphIso_injective.eq_iff] using eq
+
+@[classical] def toRCPG (hG : G.Rigid) : RCPG G.toColoredGraph.RCPGPoints :=
+  { G.toColoredGraph.elimColor with
+    p := .o G.p
+    is_rigid' := Injective.subsingleton elimColorToPointedGraphIso.injective
+    is_connected := (toColoredGraph G).elimColor_connected (ne := ⟨G.p⟩) }
+
+@[classical] def rcpgToPointedGraphIso
+    (hG : G.Rigid) (hH : H.Rigid) (f : G.toRCPG hG ≃p H.toRCPG hH) : G ≃· H :=
+  elimColorToPointedGraphIso ⟨f.toRelIso, f.map_point'⟩
+
+@[classical] instance {α} [A : HasEnoughPointedGraph α] : HasEnoughRCPG α :=
+  let f := fun (⟨G, hG⟩ : A.S) => ⟨_, G.2.toRCPG (A.all_rigid hG)⟩
+  have f_inj : Injective f := by
+    rintro ⟨⟨β, G⟩, hG⟩ ⟨⟨γ, H⟩, hH⟩ eq
+    simp only [f, Sigma.mk.injEq] at eq
+    simp only [Subtype.mk.injEq]
+    generalize_proofs rigid_G rigid_H at eq
+    have iso : G.toRCPG rigid_G ≃p H.toRCPG rigid_H := by
+      convert RCPGIso.refl (G := toRCPG rigid_G) using 1
+      congr 1
+      · exact eq.1.symm
+      · exact eq.2.symm
+    by_contra ne
+    exact (A.not_isomorphic hG hH ne).false (rcpgToPointedGraphIso rigid_G rigid_H iso)
+  {
+    S := _
+    equiv := A.equiv.trans <| Equiv.ofInjective' f f_inj
+    nontrivial := by
+      rintro ⟨_, _⟩ ⟨⟨⟨β, G⟩, _⟩, ⟨_⟩⟩
+      have : Nonempty β := ⟨G.p⟩
+      infer_instance
+    not_isomorphic := by
+      rintro ⟨_, _⟩ ⟨⟨x, hx⟩, ⟨_⟩⟩ ⟨_, _⟩ ⟨⟨y, hy⟩, ⟨_⟩⟩ ne
+      replace ne := (f_inj.ne_iff (x := ⟨x, hx⟩) (y := ⟨y, hy⟩)).mp ne
+      simp only [ne_eq, Subtype.mk.injEq] at ne
+      refine ⟨fun iso => ?_⟩
+      dsimp only at iso
+      exact (A.not_isomorphic hx hy ne).false (rcpgToPointedGraphIso _ _ iso)
+  }
+
+end PointedGraph
+
+@[classical] theorem frucht_from_all_cardinals_fafa₂
+    {M : Set (Type u)} (hfafa : FAFA₂On M) (htrans : TransitiveClass M)
+    (all_cardinals_fafa : ∀ α : Type u, ∃ β ∈ M, Nonempty (α ≃ β)) :
+    Frucht.{u} := by
+  intro Γ _
+  obtain ⟨Δ, hΔ, ⟨iso⟩⟩ := all_cardinals_fafa Γ
+  haveI := instHasEnoughPointedGraph hfafa htrans hΔ
+  haveI := instHasEnoughPointedGraphFromEquiv iso.symm
+  refine ⟨_, (cayley Γ).elimColor, ⟨?_⟩⟩
+  exact ColoredGraph.toColoredGraphIsoIso.trans (cayleyIso Γ)
+
+@[classical] lemma fafa₂_iff : FAFA₂.{u} ↔ FAFA₂On.{u} Set.univ := by
+  simp only [FAFA₂, FAFA₂On]
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · rintro α - β - f
+    refine h α β (trcl {α}) (trcl {β}) ?_ ?_ ⟨f.toEquiv, ?_⟩
+      (top α) (by simp [top]) (top β) (by simp [top]) ?_
+    · rw [isTransitiveClosure_iff]
+    · rw [isTransitiveClosure_iff]
+    · simp only [InvImage, RelIso.coe_fn_toEquiv, PointedGraphIso.coe_fn_toEquiv]
+      exact f.map_rel_iff
+    · exact f.map_point
+  · intro α β X Y hX hY f x' hx' y' hy' hpoint
+    rw [isTransitiveClosure_iff] at hX hY
+    cases hX
+    cases hY
+    refine h _ (by simp) _ (by simp) ⟨⟨f.toEquiv, f.map_rel_iff⟩, ?_⟩
+    convert hpoint using 1
+    · have : x' = (canonicalGraph α).p := by
+        apply elements_inj
+        simp [hx', canonicalGraph, top]
+      apply elements_inj
+      simp [hpoint, hy', ← this]
+    · apply elements_inj
+      simp [hy', canonicalGraph, top]
+
+def constructOrdinal (α : Ordinal.{u}) : WF.{u} := by
+  refine Ordinal.lt_wf.fix (C := fun _ => WF.{u}) (fun β f =>
+    ⟨ collect fun (x : β.ToType) =>
+        match Ordinal.ToType.mk.symm x with
+        | ⟨x, hx⟩ => (f x hx).1,
+      ?_ ⟩) α
+  refine Acc.intro _ ?_
+  simp only [mem_collect, forall_exists_index, forall_apply_eq_imp_iff]
+  exact fun _ => (f _ _).2
+
+lemma constructOrdinal_mem_of_lt {α β : Ordinal.{u}} (lt : α < β) :
+    constructOrdinal α ∈ constructOrdinal β := by
+  conv_lhs => simp [constructOrdinal]
+  rw [WellFounded.fix_eq _ _]
+  simp only [mem_class_iff, mem_collect]
+  refine ⟨Ordinal.ToType.mk ⟨α, lt⟩, ?_⟩
+  rw [OrderIso.symm_apply_apply]
+  rfl
+
+lemma constructOrdinal_inj : Injective constructOrdinal := by
+  intro α β ne
+  contrapose! ne
+  have : α < β ∨ β < α := lt_or_gt_of_ne ne
+  obtain this | this := this
+  · exact fun h => not_mem_self_wf (h ▸ constructOrdinal_mem_of_lt this)
+  · exact fun h => not_mem_self_wf (h ▸ constructOrdinal_mem_of_lt this)
+
+def constructOrdinal_iso (α : Ordinal.{u}) : constructOrdinal α ≃ α.ToType := by
+  simp only [constructOrdinal]
+  rw [WellFounded.fix_eq]
+  conv => enter [1, 1, 1, 1, x, 1, 0, y, x]; change constructOrdinal y
+  refine (collectEquivRange _).trans (Equiv.ofInjective' _ ?_).symm
+  apply Injective.comp Subtype.val_injective
+  apply Injective.comp constructOrdinal_inj
+  apply Injective.comp Subtype.val_injective
+  exact OrderIso.injective _
+
+@[classical!] theorem fafa₂_implies_frucht : FAFA₂.{u} → Frucht.{u} :=
+  fun h => frucht_from_all_cardinals_fafa₂
+    (M := Set.univ)
+    (by rwa [← fafa₂_iff])
+    (by simp [TransitiveClass])
+    (fun α => ⟨α, by simp, ⟨.refl _⟩⟩)
+
+@[classical!] theorem foundation_implies_frucht : Foundation.{u} → Frucht.{u} := by
+  refine fun h => fafa₂_implies_frucht ?_
+  rw [fafa₂_iff]
+  convert fafa₂_on_wf
+  ext α
+  simp only [Set.mem_univ, true_iff]
+  by_contra hx
+  obtain ⟨x, hx⟩ := h (separate (trcl {α}) (· ∉ WF))
+    (by simpa [mem_separate] using ⟨α, trcl_singleton_contains_self, hx⟩)
+  simp only [mem_separate, and_imp] at hx
+  refine hx.1.2 (.intro _ ?_)
+  intro y hy
+  by_contra y_not_wf
+  exact hx.2 y (trcl_singleton_trans_of_mem hy hx.1.1) y_not_wf hy
+
+theorem choice_implies_frucht : Frucht.{u} :=
+  frucht_from_all_cardinals_fafa₂ fafa₂_on_wf transitive_wf <| by
+    intro α
+    obtain ⟨e⟩ : Nonempty ((#α).ord.ToType ≃ α) := by
+      rw [← Cardinal.eq]
+      apply mk_ord_toType
+    exact ⟨constructOrdinal (#α).ord, by simp, ⟨((constructOrdinal_iso _).trans e).symm⟩⟩

--- a/LeanPool/Frucht/Graphs.lean
+++ b/LeanPool/Frucht/Graphs.lean
@@ -1,0 +1,334 @@
+/-
+Copyright (c) 2026 Shuhao Song. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Shuhao Song
+-/
+import Mathlib.Combinatorics.SimpleGraph.Hasse
+import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
+import Mathlib.Tactic.Cases
+import LeanPool.Frucht.ClassicalReplacements
+
+/-!
+# Choice-free graph lemmas
+
+Reflexive-transitive-closure transport lemmas and the basic graph notions
+(pointed graphs, graph isomorphisms) used to build the Cayley colored graphs
+in the choice-free proof of Frucht's theorem.
+-/
+
+universe u v
+
+open Function Relation
+
+namespace ReflTransGen
+
+variable {α β} {r : α → α → Prop} {p : β → β → Prop} {a b : α}
+
+@[classical] lemma liftInjective
+    {f : α → β} (inj : Injective f) (h : ∀ a b, p (f a) (f b) → r a b)
+    (hrange : ∀ a b, p a b → a ∈ Set.range f → b ∈ Set.range f) (hab : ReflTransGen p (f a) (f b)) :
+    ReflTransGen r a b := by
+  set f_a := f a with hf_a
+  set f_b := f b with hf_b
+  clear_value f_a f_b
+  induction hab using ReflTransGen.head_induction_on generalizing a with
+  | refl =>
+    rw [hf_a] at hf_b
+    rw [inj hf_b]
+  | @head f_a f_c hac hcb ih =>
+    obtain ⟨c, hc⟩ := hrange _ _ hac ⟨a, hf_a.symm⟩
+    rw [hf_a, ← hc] at hac
+    exact .head (h _ _ hac) (ih hc.symm)
+
+@[classical] lemma liftHom
+    {s F} [FunLike F α β] [RelHomClass F r s] (f : F) (hab : ReflTransGen r a b) :
+    ReflTransGen s (f a) (f b) :=
+  ReflTransGen.lift f (fun _ _ => map_rel _) hab
+
+end ReflTransGen
+
+namespace SimpleGraph
+
+@[classical] theorem pathGraph_rigid
+    {n : ℕ} [NeZero n] (f : pathGraph n ≃g pathGraph n) (hf : f 0 = 0) : f = .refl := by
+  ext ⟨i, hi⟩
+  simp only [RelIso.refl_apply]
+  revert hi
+  induction i using Nat.strongRec with
+  | _ i ih =>
+    intro hi
+    by_cases i_zero : i = 0
+    · cases i_zero
+      rw [Fin.ext_iff] at hf
+      exact hf
+    · obtain ⟨j, ⟨_⟩⟩ := Nat.exists_eq_add_one_of_ne_zero i_zero
+      clear i_zero
+      set p : Fin n := ⟨j, by omega⟩
+      set q : Fin n := ⟨j + 1, hi⟩
+      have adj : (pathGraph n).Adj p q := by simp [pathGraph_adj, p, q]
+      replace adj := f.map_rel_iff.mpr adj
+      simp only [pathGraph_adj] at adj
+      obtain adj | adj := adj
+      · rw [← adj, ih j (by simp)]
+      · rw [ih j (by simp) (by omega)] at adj
+        have := ih (f q) (by omega) (by omega)
+        rw [← Fin.ext_iff, f.injective.eq_iff, Fin.ext_iff] at this
+        conv_rhs at this => simp only [q]
+        simp only at this
+        omega
+
+@[classical] def IsLeaf {α} (G : SimpleGraph α) (x : α) := ∃! y, G.Adj x y
+
+variable {α : Type u} {β : Type v} {G : SimpleGraph α} {H : SimpleGraph β} (f : G ≃g H)
+
+@[classical] lemma connected_exists_edge [Nontrivial α] (hconn : G.Connected) :
+    ∀ x, ∃ y, G.Adj x y := by
+  by_contra h
+  simp only [not_forall, not_exists] at h
+  obtain ⟨x, hx⟩ := h
+  obtain ⟨y, ne⟩ := exists_ne x
+  obtain ⟨p, hp⟩ := hconn.exists_walk_length_eq_edist x y
+  cases p with
+  | nil => simp at ne
+  | @cons _ _ _ hz => exact hx _ hz
+
+@[classical] lemma Iso.map_leaf (u : α) : G.IsLeaf u ↔ H.IsLeaf (f u) := by
+  simp only [IsLeaf]
+  apply Equiv.existsUnique_congr f.toEquiv
+  simp [Iso.map_adj_iff]
+
+@[classical] def Iso.map_walk {u v : α} : G.Walk u v ≃ H.Walk (f u) (f v) where
+  toFun := fun p => p.map f.toHom
+  invFun := fun p => (p.map f.symm.toHom).copy (by simp) (by simp)
+  left_inv := by
+    simp only [LeftInverse, RelHom.coeFn_mk, Embedding.toFun_eq_coe, Embedding.coeFn_mk,
+      RelIso.coe_fn_toEquiv, Walk.map_map]
+    intro x
+    convert_to (Walk.map Hom.id x).copy rfl rfl = x using 2 <;> (try congr 1; simp)
+  right_inv := by
+    simp only [RightInverse, LeftInverse, RelHom.coeFn_mk, Embedding.toFun_eq_coe,
+      Embedding.coeFn_mk, RelIso.coe_fn_toEquiv, Walk.map_copy, Walk.map_map]
+    intro x
+    convert_to (Walk.map Hom.id x).copy rfl rfl = x using 2 <;> (try congr 1; simp)
+
+@[classical] lemma Iso.map_neighborSet (u : α) :
+    Set.BijOn f (G.neighborSet u) (H.neighborSet (f u)) := by
+  rw [← RelIso.coe_fn_toEquiv, ← Equiv.image_eq_iff_bijOn,
+    neighborSet, neighborSet, ← Equiv.setOf_apply_symm_eq_image_setOf,
+    show (f.toEquiv.symm : _ → _) = f.symm from rfl, RelIso.coe_fn_toEquiv]
+  congr 1 with y'
+  conv_lhs => rw [show u = f.symm (f u) by simp, map_adj_iff]
+
+end SimpleGraph
+
+@[classical] structure PointedGraph (α : Type u) where
+  p : α
+  r : α → α → Prop
+
+@[classical] structure PointedGraphIso {α β : Type*} (G : PointedGraph α) (H : PointedGraph β)
+    extends RelIso G.r H.r where
+  map_point' : toRelIso G.p = H.p
+
+infix:25 " ≃· " => PointedGraphIso
+
+namespace PointedGraphIso
+
+variable {α β γ : Type*} {G : PointedGraph α} {H : PointedGraph β} {I : PointedGraph γ}
+
+@[classical] instance : EquivLike (G ≃· H) α β where
+  coe x := x.toRelIso
+  inv x := x.toRelIso.symm
+  left_inv := by simp [Function.LeftInverse]
+  right_inv := by simp [Function.RightInverse, Function.LeftInverse]
+  coe_injective' := fun
+    | ⟨e₁, _⟩, ⟨e₂, _⟩, h, _ => by simpa using h
+
+instance : RelHomClass (G ≃· H) G.r H.r where
+  map_rel f _ _ := Iff.mpr f.map_rel_iff'
+
+@[simp] lemma coe_fn_toEquiv (f : G ≃· H) : (f.toRelIso : α → β) = f :=
+  rfl
+
+@[classical] lemma map_point (f : G ≃· H) : f G.p = H.p := f.map_point'
+@[classical] lemma map_rel_iff (f : G ≃· H) {a b} :
+    H.r (f a) (f b) ↔ G.r a b := f.toRelIso.map_rel_iff
+
+@[classical, ext] lemma ext ⦃f g : G ≃· H⦄ (h : ∀ x, f x = g x) : f = g :=
+  DFunLike.ext f g h
+
+@[classical, refl] def refl : G ≃· G := ⟨.refl G.r, by simp⟩
+@[classical, symm] def symm (f : G ≃· H) : H ≃· G :=
+  ⟨f.toRelIso.symm, by apply_fun f.toRelIso; simpa using f.map_point'.symm⟩
+@[classical, trans] def trans (f : G ≃· H) (g : H ≃· I) : G ≃· I :=
+  ⟨f.toRelIso.trans g.toRelIso, by simp [f.map_point', g.map_point']⟩
+
+instance : Trans (@PointedGraphIso α β) (@PointedGraphIso β γ) PointedGraphIso where
+  trans := trans
+
+@[simp] lemma apply_symm_apply (f : G ≃· H) (x : β) : f (f.symm x) = x :=
+  f.toEquiv.apply_symm_apply x
+
+@[simp] lemma symm_apply_apply (f : G ≃· H) (x : α) : f.symm (f x) = x :=
+  f.toEquiv.symm_apply_apply x
+
+end PointedGraphIso
+
+namespace PointedGraph
+
+variable {α : Type u} {β : Type u} {G : PointedGraph α} {H : PointedGraph β} (f : G ≃· H)
+
+@[classical] abbrev Rigid := Subsingleton (G ≃· G)
+
+@[classical] def induce (x : α) : PointedGraph {y // ReflTransGen G.r x y} where
+  p := ⟨x, .refl⟩
+  r := fun x y => G.r x.val y.val
+
+@[classical] def induceIso (x : α) : G.induce x ≃· H.induce (f x) where
+  toFun := fun ⟨y, hy⟩ => ⟨f y, ReflTransGen.liftHom f hy⟩
+  invFun := fun ⟨y, hy⟩ => ⟨f.symm y, by simpa using ReflTransGen.liftHom f.symm hy⟩
+  left_inv := by simp [LeftInverse]
+  right_inv := by simp [RightInverse, LeftInverse]
+  map_rel_iff' := by
+    simp only [PointedGraph.induce, Equiv.coe_fn_mk, Subtype.forall]
+    intro y hy z hz
+    apply RelIso.map_rel_iff
+  map_point' := by simp [PointedGraph.induce]; congr 1
+
+end PointedGraph
+
+@[classical] structure RCPG (α : Type*) extends SimpleGraph α where
+  p : α
+  is_rigid' : Subsingleton {f : toSimpleGraph ≃g toSimpleGraph // f p = p}
+  is_connected : toSimpleGraph.Connected
+
+
+@[classical] structure RCPGIso {α β : Type*} (G : RCPG α) (H : RCPG β)
+    extends G.toSimpleGraph ≃g H.toSimpleGraph where
+  map_point' : toRelIso G.p = H.p
+
+infix:25 " ≃p " => RCPGIso
+
+@[classical] lemma RCPG.is_rigid {α} (G : RCPG α) : Subsingleton (G ≃p G) := by
+  refine ⟨fun f g => ?_⟩
+  have := G.is_rigid'.allEq ⟨f.toRelIso, f.map_point'⟩ ⟨g.toRelIso, g.map_point'⟩
+  simp only [Subtype.ext_iff] at this
+  cases f
+  cases g
+  simpa using this
+
+namespace RCPGIso
+
+variable {α β γ : Type*} {G : RCPG α} {H : RCPG β} {I : RCPG γ}
+
+@[classical] instance : EquivLike (G ≃p H) α β where
+  coe f := f.toRelIso
+  inv f := f.toRelIso.symm
+  left_inv := by simp [Function.LeftInverse]
+  right_inv := by simp [Function.RightInverse, Function.LeftInverse]
+  coe_injective' := fun
+    | ⟨e₁, _⟩, ⟨e₂, _⟩, h, _ => by simpa using h
+
+@[simp] lemma coe_fn_toEquiv (f : G ≃p H) : (f.toRelIso : α → β) = f := rfl
+
+def Simps.apply (h : G ≃p H) : α → β := h
+initialize_simps_projections RCPGIso (toFun → apply)
+
+@[classical, refl, simps! apply] def refl : G ≃p G := ⟨.refl _, by simp⟩
+@[classical, symm] def symm (f : G ≃p H) : H ≃p G :=
+  ⟨f.toRelIso.symm, by apply_fun f.toRelIso; simpa using f.map_point'.symm⟩
+
+@[classical, trans, simps! apply] def trans (f : G ≃p H) (g : H ≃p I) : G ≃p I :=
+  ⟨f.toRelIso.trans g.toRelIso, by simp [f.map_point', g.map_point']⟩
+
+instance : Trans (@RCPGIso α β) (@RCPGIso β γ) RCPGIso where
+  trans := trans
+
+@[classical] lemma map_point (f : G ≃p H) : f G.p = H.p := f.map_point'
+@[classical, ext] lemma ext ⦃f g : G ≃p H⦄ (h : ∀ x, f x = g x) : f = g :=
+  DFunLike.ext f g h
+
+@[classical, simp] lemma symm_apply_apply (f : G ≃p H) (x : α) : f.symm (f x) = x :=
+  f.toEquiv.symm_apply_apply x
+
+@[classical, simp] lemma apply_symm_apply (f : G ≃p H) (x : β) : f (f.symm x) = x :=
+  f.toEquiv.apply_symm_apply x
+
+@[classical] lemma is_subsingleton : Subsingleton (G ≃p H) := by
+  refine ⟨fun f g => ?_⟩
+  have := congr_arg (trans · g) (G.is_rigid.allEq (f.trans g.symm) refl)
+  simpa [RCPGIso.ext_iff] using this
+
+end RCPGIso
+
+def ColoredGraph α C := α → α → C
+
+@[classical] structure ColoredGraphIso {α β C : Type*} (G : ColoredGraph α C) (H : ColoredGraph β C)
+    extends α ≃ β where
+  map_color' : ∀ {a b}, H (toEquiv a) (toEquiv b) = G a b
+infix:25 " ≃c " => ColoredGraphIso
+
+namespace ColoredGraphIso
+
+variable {α β γ C : Type*} {G : ColoredGraph α C} {H : ColoredGraph β C} {I : ColoredGraph γ C}
+
+@[classical] instance : EquivLike (G ≃c H) α β where
+  coe x := x.toEquiv
+  inv x := x.toEquiv.symm
+  left_inv := by simp [Function.LeftInverse]
+  right_inv := by simp [Function.RightInverse, Function.LeftInverse]
+  coe_injective' := fun
+    | ⟨e₁, _⟩, ⟨e₂, _⟩, h, _ => by simpa using h
+
+@[classical, refl] def refl : G ≃c G := ⟨.refl α, by simp⟩
+@[classical, symm] def symm (f : G ≃c H) : H ≃c G :=
+  ⟨f.toEquiv.symm, fun {a b} => by
+    simpa using f.map_color' (a := f.toEquiv.symm a) (b := f.toEquiv.symm b) |>.symm⟩
+@[classical, trans] def trans (f : G ≃c H) (g : H ≃c I) : G ≃c I :=
+  ⟨f.toEquiv.trans g.toEquiv, by simp [f.map_color', g.map_color']⟩
+
+@[classical] lemma map_color (f : G ≃c H) : ∀ {x y}, H (f x) (f y) = G x y :=
+  f.map_color'
+
+@[classical, ext] lemma ext ⦃f g : G ≃c H⦄ (h : ∀ x, f x = g x) : f = g :=
+  DFunLike.ext f g h
+
+@[classical, simp] lemma symm_apply_apply (f : G ≃c H) (x : α) : f.symm (f x) = x :=
+  f.toEquiv.symm_apply_apply x
+
+@[classical, simp] lemma apply_symm_apply (f : G ≃c H) (x : β) : f (f.symm x) = x :=
+  f.toEquiv.apply_symm_apply x
+
+instance : Group (G ≃c G) where
+  one := refl
+  mul f₁ f₂ := f₂.trans f₁
+  inv := symm
+  mul_assoc _ _ _ := rfl
+  one_mul _ := rfl
+  mul_one _ := rfl
+  inv_mul_cancel f := ext f.symm_apply_apply
+
+@[simp] lemma mul_apply (f g : G ≃c G) (x : α) : (f * g) x = f (g x) := rfl
+
+end ColoredGraphIso
+
+def cayley (Γ : Type*) [Group Γ] : ColoredGraph Γ Γ := fun a b => a⁻¹ * b
+def cayleyIso (Γ : Type*) [Group Γ] : (cayley Γ ≃c cayley Γ) ≃* Γ where
+  toFun := fun x => x 1
+  invFun := fun x => {
+    toFun := fun y => x * y
+    invFun := fun y => x⁻¹ * y
+    left_inv := by simp [LeftInverse]
+    right_inv := by simp [Function.RightInverse, LeftInverse]
+    map_color' := by intro a b; simp [cayley]
+  }
+  left_inv := by
+    intro f
+    ext x
+    have := f.map_color (x := 1) (y := x)
+    simp [cayley, inv_mul_eq_iff_eq_mul] at this
+    exact this.symm
+  right_inv := mul_one
+  map_mul' := by
+    intro x y
+    have := x.map_color (x := 1) (y := y 1)
+    simpa [cayley, inv_mul_eq_iff_eq_mul] using this

--- a/LeanPool/Frucht/SetTheory.lean
+++ b/LeanPool/Frucht/SetTheory.lean
@@ -1,0 +1,380 @@
+/-
+Copyright (c) 2026 Shuhao Song. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Shuhao Song
+-/
+import Mathlib.Algebra.Order.Group.End
+import Mathlib.Combinatorics.SimpleGraph.Maps
+import LeanPool.Frucht.ClassicalReplacements
+
+/-!
+# Choice-free set theory on types
+
+Develops the ZF-style membership, subset, transitive closure, and well-foundedness
+structure on `Type u` (via the `collect`/`elements` axioms), together with the
+`ConditionallyCompleteLattice` instance, providing the set-theoretic substrate for
+the canonical pointed graphs used in the proof of Frucht's theorem.
+-/
+
+noncomputable section
+universe u
+open Relation
+
+variable {x y z : Type u} {M : Set (Type u)}
+
+@[classical] instance (priority := low) : CoeSort x (Type u) := ⟨elements (α := x)⟩
+
+@[classical] instance : Membership (Type u) (Type u) where
+  mem := fun y x => x ∈ Set.range ((↑) : y → Type u)
+
+@[classical] instance : HasSubset (Type u) where
+  Subset := fun x y => ∀ z ∈ x, z ∈ y
+
+@[classical] instance : Membership M M where
+  mem := fun y x => x.1 ∈ y.1
+
+@[classical] lemma mem_class_iff {x y : M} : x ∈ y ↔ x.1 ∈ y.1 := Iff.rfl
+
+section Definitions
+
+variable (x y z M)
+
+@[classical] def equivElements : x ≃ {y : Type u // y ∈ x} :=
+  Equiv.ofInjective' (elements (α := x)) (elements_inj (α := x))
+
+@[classical] def pairSet := collect <| fun
+  | ULift.up false => x
+  | ULift.up true => y
+
+@[classical] def bigUnion := collect fun y : Sigma ((↑) : x → _) => elements y.2
+@[classical] def powerset := collect fun y : Set x => collect fun z : y => (z : x)
+@[classical] def separate (p : Type u → Prop) := collect fun y : {y : x | p y} => (y : x)
+@[classical] def TransitiveClass := ∀ x ∈ M, ∀ y ∈ x, y ∈ M
+@[classical] def IsTransitive := ∀ y ∈ x, ∀ z ∈ y, z ∈ x
+@[classical] def IsTransitiveClosure :=
+  x ∈ y ∧ IsTransitive y ∧ ∀ z, x ∈ z → IsTransitive z → y ⊆ z
+
+end Definitions
+
+@[classical] lemma mem_def : x ∈ y ↔ x ∈ Set.range ((↑) : y → Type u) := Iff.rfl
+@[classical] lemma mem_iff : x ∈ y ↔ ∃ z : y, ↑z = x := Iff.rfl
+@[classical] lemma subset_iff : x ⊆ y ↔ ∀ z ∈ x, z ∈ y := Iff.rfl
+
+@[classical] lemma elements_mem (a : x) : ↑a ∈ x := by
+  simp [mem_iff]
+
+@[classical, simp]
+lemma mem_collect {α} {f : α → Type u} : x ∈ collect f ↔ ∃ y : α, f y = x := by
+  simp only [mem_iff]
+  have := collect_elements (α := collect f)
+  rw [collect_ext, Set.ext_iff] at this
+  simpa using this x
+
+@[classical] def castMem (h : x ∈ y) : y := (equivElements y).symm ⟨x, h⟩
+
+@[classical] lemma range_elements_collect {α : Type u} (f : α → _) :
+    Set.range ((↑) : collect f → _) = Set.range f := by
+  rw [← collect_ext, collect_elements]
+
+@[classical] def collectEquivRange {α : Type u} (f : α → _) : collect f ≃ Set.range f :=
+  range_elements_collect f ▸ equivElements _
+
+@[classical, simp] lemma elements_cast (h : x ∈ y) : ((castMem h : y) : Type u) = x := by
+  simp only [castMem, equivElements, Equiv.ofInjective', Equiv.ofBijective', Equiv.symm_mk,
+    Equiv.coe_fn_mk, Subtype.mk.injEq]
+  generalize_proofs ex unique
+  exact Exists.chooseUnique_spec ex unique
+
+@[classical, simp] lemma cast_elements (a : x) : castMem (elements_mem a) = a := by
+  apply elements_inj
+  simp only [castMem, equivElements, Equiv.ofInjective', Equiv.ofBijective', Equiv.symm_mk,
+    Equiv.coe_fn_mk, Subtype.mk.injEq]
+  generalize_proofs ex unique
+  exact Exists.chooseUnique_spec ex unique
+
+@[classical] def moveSub (hy : y ⊆ x) (z : y) : x := castMem (hy _ (elements_mem z))
+
+@[classical, simp]
+lemma elements_moveSub (hy : y ⊆ x) (z : y) : ((moveSub hy z : x) : Type u) = z := by
+  simp [moveSub]
+
+@[classical] lemma ext_iff : x = y ↔ (∀ z, z ∈ x ↔ z ∈ y) := by
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · simp [h]
+  · simp only [← collect_elements (α := x), ← collect_elements (α := y),
+      collect_ext, mem_collect] at h ⊢
+    ext z
+    exact h z
+
+@[classical, ext] lemma ext : (∀ z, z ∈ x ↔ z ∈ y) → x = y := by
+  simp [ext_iff]
+
+@[classical] lemma mem_pair : z ∈ pairSet x y ↔ z = x ∨ z = y := by
+  simp [pairSet]; tauto
+
+@[classical, simp] lemma mem_bigUnion : y ∈ bigUnion x ↔ ∃ z ∈ x, y ∈ z := by
+  simp only [bigUnion, mem_collect, Sigma.exists]
+  refine ⟨fun ⟨a, b, h⟩ => ?_, fun ⟨z, hz, hz'⟩ => ?_⟩
+  · use a
+    simp [← h, elements_mem]
+  · simp only [mem_iff] at hz hz'
+    obtain ⟨a, ha⟩ := hz
+    obtain ⟨b, hb⟩ := hz'
+    cases ha
+    cases hb
+    use a, b
+
+@[classical] lemma mem_powerset : y ∈ powerset x ↔ y ⊆ x := by
+  simp only [powerset, mem_collect, subset_iff]
+  refine ⟨fun ⟨z, hz⟩ w hw => ?_, fun w => ?_⟩
+  · rw [← hz, mem_collect] at hw
+    rw [mem_iff]
+    obtain ⟨t, ht⟩ := hw
+    use t.1
+  · use {z : x | (z : Type u) ∈ y}
+    ext z
+    simp only [Set.coe_setOf, Set.mem_setOf_eq, mem_collect, Subtype.exists, exists_prop]
+    refine ⟨fun ⟨a, ha, ha'⟩ => ?_, fun h => ?_⟩
+    · rwa [← ha']
+    · have h' := w _ h
+      simp only [mem_iff] at h'
+      obtain ⟨a, ha⟩ := h'
+      exact ⟨a, by simpa [ha]⟩
+
+@[classical] lemma mem_separate {p : Type u → Prop} : y ∈ separate x p ↔ y ∈ x ∧ p y := by
+  simp only [separate, Set.coe_setOf, Set.mem_setOf_eq, mem_collect,
+    Subtype.exists, exists_prop]
+  refine ⟨fun ⟨a, ha, ha'⟩ => ?_, fun ⟨h, h'⟩ => ?_⟩
+  · simp [← ha', ha, elements_mem]
+  · rw [mem_iff] at h
+    obtain ⟨a, ha⟩ := h
+    exact ⟨a, by simpa [ha]⟩
+
+@[classical] instance : EmptyCollection (Type u) where
+  emptyCollection := collect PEmpty.elim
+@[classical] instance : Singleton (Type u) (Type u) := ⟨fun x => pairSet x x⟩
+@[classical] instance : Union (Type u) := ⟨fun x y => bigUnion (pairSet x y)⟩
+@[classical] instance : Inter (Type u) := ⟨fun x y => separate x (fun z => z ∈ y)⟩
+
+@[classical, simp] lemma mem_empty : x ∈ (∅ : Type u) ↔ False := by
+  simp [EmptyCollection.emptyCollection]
+@[classical, simp] lemma mem_singleton : y ∈ ({x} : Type u) ↔ y = x := by
+  simp [Singleton.singleton, mem_pair]
+@[classical] lemma union_eq_big_union : x ∪ y = bigUnion (pairSet x y) := rfl
+@[classical] lemma inter_eq_separate : x ∩ y = separate x (fun z => z ∈ y) := rfl
+@[classical, simp] lemma mem_union : z ∈ x ∪ y ↔ z ∈ x ∨ z ∈ y := by
+  simp [union_eq_big_union, mem_bigUnion, mem_pair]
+@[classical, simp] lemma mem_inter : z ∈ x ∩ y ↔ z ∈ x ∧ z ∈ y := by
+  simp [inter_eq_separate, mem_separate]
+
+@[classical] instance : IsPartialOrder (Type u) (· ⊆ ·) where
+  refl := fun _ _ => by simp
+  trans := fun a b c ha hb x hx => hb _ (ha _ hx)
+  antisymm := by
+    intro a b h h'
+    ext x
+    refine ⟨fun hx => h _ hx, fun hx => h' _ hx⟩
+
+@[classical] instance : PartialOrder (Type u) where
+  le := (· ⊆ ·)
+  le_refl := subset_refl
+  le_trans := fun a b c => subset_trans
+  le_antisymm := fun a b => subset_antisymm
+
+@[classical] lemma le_iff_subset : x ≤ y ↔ x ⊆ y := Iff.rfl
+
+section collectSet
+
+variable (S : Set (Type u)) [hS : Small.{u} S]
+
+@[classical] def collectSet : Type u :=
+  Exists.chooseUnique
+    (show ∃ x, ∀ y, y ∈ x ↔ y ∈ S by
+      obtain ⟨α, ⟨eq⟩⟩ := hS
+      refine ⟨collect fun x : α => (eq.invFun x).1, fun y => ?_⟩
+      simp only [Equiv.invFun_as_coe, mem_collect]
+      refine ⟨fun ⟨a, ha⟩ => ?_, fun hy => ?_⟩
+      · simp [← ha]
+      · exact ⟨eq ⟨y, hy⟩, by simp⟩)
+    (fun {a b} ha hb => by simp only [← hb] at ha; exact ext ha)
+
+@[classical, simp] lemma mem_collectSet : x ∈ collectSet S ↔ x ∈ S := by
+  simp only [collectSet]
+  generalize_proofs h h'
+  exact h.chooseUnique_spec h' x
+
+open Classical in
+@[classical] instance : SupSet (Type u) where
+  sSup := fun S => if _ : Small.{u} S then bigUnion (collectSet S) else ∅
+
+@[classical] lemma sSup_of_small : sSup S = bigUnion (collectSet S) := by
+  simp [sSup, hS]
+
+@[classical] lemma mem_sSup : x ∈ sSup S ↔ ∃ y ∈ S, x ∈ y := by
+  simp [sSup_of_small, mem_collectSet]
+
+@[classical] lemma sSup_mem_upperBounds' : sSup S ∈ upperBounds S := by
+  intro α hα x hx
+  simp only [mem_sSup]
+  use α
+
+end collectSet
+
+@[classical] lemma bddAbove_iff {S : Set (Type u)} : BddAbove S ↔ Small.{u} S := by
+  refine ⟨fun hS => ?_, fun hS => ?_⟩
+  · obtain ⟨α, hα⟩ := hS
+    simp only [upperBounds, le_iff_subset, ← mem_powerset, Set.mem_setOf_eq] at hα
+    apply small_subset hα
+  · refine ⟨sSup S, sSup_mem_upperBounds' S⟩
+
+@[classical] lemma bddBelow_iff {S : Set (Type u)} : BddBelow S := by
+  use ∅
+  simp [lowerBounds, le_iff_subset, subset_iff, mem_empty]
+
+@[classical] instance : ConditionallyCompleteLattice (Type u) :=
+  conditionallyCompleteLatticeOfsSup (Type u)
+    (by intro a b; rw [bddAbove_iff]; apply small_pair)
+    (by intro a b; apply bddBelow_iff)
+    (fun S hS ne => by
+      rw [bddAbove_iff] at hS
+      refine ⟨sSup_mem_upperBounds' S, ?_⟩
+      intro x hx y hy
+      simp only [sSup_of_small S, mem_bigUnion, mem_collectSet] at hy
+      obtain ⟨z, hz, hy⟩ := hy
+      exact hx hz _ hy)
+
+@[classical] lemma mem_iSup {α : Type*} [Small.{u} α] (f : α → Type u) (x : Type u) :
+    x ∈ iSup f ↔ ∃ i : α, x ∈ f i := by
+  simp [iSup, sSup_of_small]
+
+@[classical] lemma sup_eq : x ⊔ y = x ∪ y := by
+  change sSup {x, y} = x ∪ y
+  haveI : Small ({x, y} : Set _) := by apply small_pair
+  rw [sSup_of_small]
+  ext z
+  simp
+
+@[classical] lemma inf_eq : x ⊓ y = x ∩ y := by
+  change sSup (lowerBounds {x, y}) = x ∩ y
+  ext z
+  haveI : Small (lowerBounds {x, y}) := by
+    apply small_subset (s := Set.range ((↑) : powerset x → _))
+    intro w hw
+    simp only [lowerBounds_insert, lowerBounds_singleton] at hw
+    change w ∈ powerset x
+    rw [mem_powerset]
+    exact hw.1
+  rw [sSup_of_small]
+  simp only [lowerBounds_insert, lowerBounds_singleton, mem_bigUnion, mem_collectSet, mem_inter]
+  refine ⟨fun ⟨w, ⟨hx, hy⟩, hz⟩ => ?_, fun ⟨hx, hy⟩ => ?_⟩
+  · exact ⟨hx _ hz, hy _ hz⟩
+  · refine ⟨x ∩ y, ?_⟩
+    simpa [le_iff_subset, subset_iff] using ⟨fun _ h _ => h, hx, hy⟩
+
+@[classical] def trcl_step (x : Type u) : ℕ → Type u
+  | 0 => x
+  | n + 1 => bigUnion (trcl_step x n)
+
+@[classical] def trcl (x : Type u) := ⨆ i : ℕ, trcl_step x i
+
+@[classical] lemma mem_trcl_singleton_iff : y ∈ trcl {x} ↔ ReflTransGen (· ∈ ·) y x := by
+  simp only [trcl, mem_iSup]
+  refine ⟨fun ⟨i, hy⟩ => ?_, fun h => ?_⟩
+  · induction i generalizing y with
+    | zero =>
+      simp only [trcl_step, mem_singleton] at hy
+      simpa [hy] using .refl
+    | succ i ih =>
+      simp only [forall_exists_index] at ih
+      simp only [trcl_step, mem_bigUnion] at hy
+      obtain ⟨z, hz, hz'⟩ := hy
+      exact .trans (.single hz') (ih _ hz hz)
+  · induction h using ReflTransGen.head_induction_on with
+    | refl => use 0; simp [trcl_step]
+    | @head z w hz hw ih =>
+      obtain ⟨i, ih⟩ := ih
+      use i + 1
+      simp only [trcl_step, mem_bigUnion]
+      use w
+
+@[classical] lemma sub_trcl_singleton : x ⊆ trcl {x} := by
+  intro y hy
+  rw [mem_trcl_singleton_iff]
+  exact .single hy
+
+@[classical] lemma sub_trcl : x ⊆ trcl x := by
+  change trcl_step x 0 ≤ trcl x
+  apply le_ciSup
+  erw [bddAbove_iff]
+  apply small_range
+
+@[classical] lemma trcl_singleton_contains_self : x ∈ trcl {x} :=
+  sub_trcl _ (by simp)
+
+@[classical] lemma trcl_singleton_trans_of_mem (hxy : x ∈ y) (hax : y ∈ trcl {z}) :
+    x ∈ trcl {z} := by
+  rw [mem_trcl_singleton_iff] at hax ⊢
+  exact .head hxy hax
+
+@[classical] lemma trcl_singleton_trans (hxy : x ∈ trcl {y}) (hyz : y ∈ trcl {z}) :
+    x ∈ trcl {z} := by
+  rw [mem_trcl_singleton_iff] at hxy hyz ⊢
+  exact .trans hxy hyz
+
+@[classical] lemma isTransitiveClosure_trcl : IsTransitiveClosure x (trcl {x}) := by
+  refine ⟨trcl_singleton_contains_self, ?_, ?_⟩
+  · intro y hy z hz
+    rw [mem_trcl_singleton_iff] at hy ⊢
+    exact .head hz hy
+  · intro y hy htrans z hz
+    rw [mem_trcl_singleton_iff] at hz
+    induction hz using ReflTransGen.head_induction_on with
+    | refl => exact hy
+    | @head z w hw _ hy => exact htrans _ hy _ hw
+
+@[classical] lemma isTransitiveClosure_iff : IsTransitiveClosure x y ↔ y = trcl {x} := by
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · have h' := isTransitiveClosure_trcl (x := x)
+    exact le_antisymm (h.2.2 _ trcl_singleton_contains_self h'.2.1) (h'.2.2 _ h.1 h.2.1)
+  · rw [h]
+    apply isTransitiveClosure_trcl
+
+@[classical] lemma mem_transitive
+    {M : Set (Type u)} (htrans : TransitiveClass M) (hx : x ∈ M) (hy : y ∈ trcl {x}) :
+    y ∈ M := by
+  rw [mem_trcl_singleton_iff] at hy
+  induction hy with
+  | refl => assumption
+  | @tail z x _ hz ih => exact ih (htrans _ hx _ hz)
+
+@[classical] def WF : Set (Type u) := Acc (· ∈ ·)
+@[classical] lemma well_founded_wf : IsWellFounded WF.{u} (· ∈ ·) :=
+  ⟨Acc.wfRel.2⟩
+
+@[classical] lemma transitive_wf : TransitiveClass WF := by
+  intro x hx y hy
+  induction hx with
+  | @intro α hα _ => exact hα _ hy
+
+lemma not_mem_self_wf {x : WF.{u}} : x ∉ x := by
+  intro hx
+  obtain ⟨y, hy, hmin⟩ := well_founded_wf.wf.has_min {x | x ∈ x} ⟨x, hx⟩
+  exact hmin _ hy hy
+
+@[classical] lemma heq_iff {α β} {a : α} {b : β} : HEq a b ↔ α = β ∧ (a : Type _) = b := by
+  refine ⟨fun h => ?_, fun ⟨eq, h⟩ => ?_⟩
+  · cases h
+    simp
+  · cases eq
+    simpa using elements_inj h
+
+@[classical] def FAFA₂ := ∀ (x y X Y : Type u),
+  (hX : IsTransitiveClosure x X) → (hY : IsTransitiveClosure y Y) →
+  (f : InvImage (· ∈ ·) ((↑) : X → Type u) ≃r InvImage (· ∈ ·) ((↑) : Y → Type u)) →
+  (x' : X) → (hx : ↑x' = x) → (y' : Y) → (hx : ↑y' = y) →
+  f x' = y' → x = y
+
+@[classical] def Foundation := ∀ x : Type u, (∃ y, y ∈ x) → ∃ y, y ∈ x ∧ ∀ z ∈ x, z ∉ y
+
+@[classical] def Frucht :=
+  ∀ (Γ : Type u) [Group Γ], ∃ V : Type u, ∃ G : SimpleGraph V, Nonempty ((G ≃g G) ≃* Γ)

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -2144,3 +2144,36 @@ projects:
     msc:
       - "11A41"
       - "11Y11"
+  - slug: frucht
+    title: "Frucht's theorem: every group is a graph automorphism group"
+    summary: Proves a strong form of Frucht's theorem that every group is isomorphic to the automorphism group of some simple graph, deriving it from the axiom of choice and, more finely, from foundation and a set-theoretic rigidity hypothesis, via canonical pointed graphs and Cayley colored graphs.
+    branch: graph theory
+    entry_module: LeanPool.Frucht
+    authors:
+      - Shuhao Song
+    source:
+      url: "https://github.com/znssong/Frucht"
+      github_repo: znssong/Frucht
+    status: verified
+    main_declarations:
+      - Frucht
+      - choice_implies_frucht
+      - foundation_implies_frucht
+    main_results:
+      - declaration: Frucht
+        informal: States Frucht's theorem, that every group is isomorphic to the automorphism group of some simple graph.
+      - declaration: choice_implies_frucht
+        informal: Proves Frucht's theorem assuming the axiom of choice.
+      - declaration: foundation_implies_frucht
+        informal: Proves Frucht's theorem from the axiom of foundation alone.
+      - declaration: fafa₂_implies_frucht
+        informal: Derives Frucht's theorem from the FAFA₂ rigidity hypothesis on canonical pointed graphs.
+      - declaration: frucht_from_all_cardinals_fafa₂
+        informal: Proves Frucht's theorem from a transitive class of canonical-graph-rigid representatives covering every cardinal.
+    tags:
+      - graph-theory
+      - group-theory
+      - automorphism-group
+      - set-theory
+    msc:
+      - "05C25"


### PR DESCRIPTION
Imports the znssong/Frucht formalization (Frucht's theorem: every group is a graph automorphism group) into Lean Pool.

- Upstream: https://github.com/znssong/Frucht (Apache-2.0)
- Vendored under `LeanPool/Frucht/`, registered in `projects.yml`.
- **Draft / Phase 1: vendored only, not yet bumped to v4.31-rc1 — CI is expected red.**

Excluded files (if any) and notes: No files excluded — all 5 upstream `.lean` files vendored. The single source root lib is `Frucht`. The only `sorry`-word occurrences are `` `sorryAx `` name literals and a `throwError` string inside an axiom-checking meta tool (`Classical.lean`); there are no `sorry`/`admit` proof stubs, so nothing was dropped. Bare `import Mathlib` in `ClassicalReplacements.lean` replaced with `import Mathlib.Tactic` (Phase 1 placeholder). Declarations live at the root namespace (no `namespace Frucht` wrapper upstream), so `main_declarations` are unqualified (`Frucht`, `choice_implies_frucht`, …).