### PR TITLE
Import leansieve formalization

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -696,6 +696,13 @@ import LeanPool.LeanPolyABC.Lib.Max3
 import LeanPool.LeanPolyABC.Lib.Radical
 import LeanPool.LeanPolyABC.Lib.Wronskian
 import LeanPool.LeanPolyABC.MasonStothers
+import LeanPool.Leansieve
+import LeanPool.Leansieve.ASeq.ASeq
+import LeanPool.Leansieve.PrimeGen.PrimeGen
+import LeanPool.Leansieve.PrimeSieve.PrimeSieve
+import LeanPool.Leansieve.Rake.Rake
+import LeanPool.Leansieve.RakeMap.RakeMap
+import LeanPool.Leansieve.RakeSieve.RakeSieve
 import LeanPool.LowDimSolvClassification
 import LeanPool.LowDimSolvClassification.Classification1
 import LeanPool.LowDimSolvClassification.Classification2

--- a/LeanPool/Leansieve.lean
+++ b/LeanPool/Leansieve.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2026 tangentstorm. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: tangentstorm
+-/
+import LeanPool.Leansieve.ASeq.ASeq
+import LeanPool.Leansieve.PrimeGen.PrimeGen
+import LeanPool.Leansieve.PrimeSieve.PrimeSieve
+import LeanPool.Leansieve.Rake.Rake
+import LeanPool.Leansieve.RakeMap.RakeMap
+import LeanPool.Leansieve.RakeSieve.RakeSieve
+
+/-!
+# leansieve: a formally verified prime number sieve
+
+A formalization of natural-number sieves in Lean 4, modeling the natural numbers
+as collections of arithmetic sequences. An `ASeq` is a single arithmetic sequence
+`k + d * n`; a `Rake` is a sorted collection of arithmetic sequences sharing the
+same delta; a `RakeMap` bijects a rake with a predicate-defined subset of the
+naturals. On top of these, `PrimeSieve` proves the generic correctness logic of a
+prime sieve (each step produces the next consecutive prime, skipping none), and
+`RakeSieve` instantiates that logic into a concrete, sieve-of-Eratosthenes-style
+prime generator.
+
+Source: url:https://github.com/tangentstorm/leansieve
+Authors: tangentstorm
+Status: verified
+Main declarations: `hs_suffice`, `c_prime`, `no_skipped_prime`, `RakeSieve.init`, `RakeSieve.next`
+Tags: prime-sieve, number-theory, arithmetic-sequences, eratosthenes
+MSC: 11A41
+-/

--- a/LeanPool/Leansieve.lean
+++ b/LeanPool/Leansieve.lean
@@ -11,7 +11,18 @@ import LeanPool.Leansieve.RakeMap.RakeMap
 import LeanPool.Leansieve.RakeSieve.RakeSieve
 
 /-!
-# leansieve: a formally verified prime number sieve
+# A formally verified prime number sieve
+
+Source: url:https://github.com/tangentstorm/leansieve
+Authors: tangentstorm
+Status: verified
+Main declarations: `Leansieve.hs_suffice`, `Leansieve.c_prime`, `Leansieve.no_skipped_prime`
+Tags: prime-sieve, number-theory, arithmetic-sequences, eratosthenes
+MSC: 11A41, 11N35
+-/
+
+/-!
+## Overview
 
 A formalization of natural-number sieves in Lean 4, modeling the natural numbers
 as collections of arithmetic sequences. An `ASeq` is a single arithmetic sequence
@@ -22,10 +33,5 @@ prime sieve (each step produces the next consecutive prime, skipping none), and
 `RakeSieve` instantiates that logic into a concrete, sieve-of-Eratosthenes-style
 prime generator.
 
-Source: url:https://github.com/tangentstorm/leansieve
-Authors: tangentstorm
-Status: verified
-Main declarations: `hs_suffice`, `c_prime`, `no_skipped_prime`, `RakeSieve.init`, `RakeSieve.next`
-Tags: prime-sieve, number-theory, arithmetic-sequences, eratosthenes
-MSC: 11A41
+All declarations live in the `Leansieve` namespace.
 -/

--- a/LeanPool/Leansieve/ASeq/ASeq.lean
+++ b/LeanPool/Leansieve/ASeq/ASeq.lean
@@ -7,14 +7,28 @@ Authors: tangentstorm
 import Mathlib.Tactic.Linarith
 import Batteries.Data.List.Lemmas
 
-structure ASeq where  -- arithmetic sequence (k + dn)
-  k : Nat  -- constant
-  d : Nat  -- delta (step size)
-deriving Repr
+/-!
+# Arithmetic sequences (`ASeq`)
 
-def ASeq.le (a b: ASeq) := if a.d = b.d then a.k≤b.k else a.d<b.d
+An `ASeq` is a single arithmetic sequence `k + d * n` of natural numbers. This
+module defines arithmetic sequences, their evaluation, composition, partition
+into residue classes, and the `gte` truncation that keeps only the terms at or
+above a given bound. These are the atoms out of which a `Rake` is built.
+-/
+
+namespace Leansieve
+
+/-- An arithmetic sequence `k + d * n` of natural numbers. -/
+structure ASeq where
+  /-- The constant term. -/
+  k : Nat
+  /-- The common difference (step size). -/
+  d : Nat
+
+/-- Lexicographic order on arithmetic sequences (by delta, then constant). -/
+def ASeq.le (a b : ASeq) := if a.d = b.d then a.k ≤ b.k else a.d < b.d
 instance : LE ASeq where le := ASeq.le
-instance : Std.Total (α := ASeq) (·≤·) where
+instance : Std.Total (α := ASeq) (· ≤ ·) where
   total a b := by
     change (if a.d = b.d then a.k ≤ b.k else a.d < b.d) ∨
       (if b.d = a.d then b.k ≤ a.k else b.d < a.d)
@@ -36,30 +50,31 @@ instance : Ord ASeq where
     | .eq => compare s1.d s2.d
     | ord => ord
 
-@[simp] def aseq (k:Nat) (d:Nat) := ASeq.mk k d
+/-- Build the arithmetic sequence `k + d * n`. -/
+@[simp] def aseq (k : Nat) (d : Nat) := ASeq.mk k d
 
 namespace ASeq
 
--- identity sequence
-def nats  := aseq 0 1
+/-- The sequence of all naturals (`0 + 1 * n`). -/
+def nats := aseq 0 1
+/-- The sequence of even naturals (`0 + 2 * n`). -/
 def evens := aseq 0 2
-def odds  := aseq 1 2
+/-- The sequence of odd naturals (`1 + 2 * n`). -/
+def odds := aseq 1 2
 
--- apply formula to n
+/-- The `n`-th term of the sequence, `s.k + s.d * n`. -/
 @[simp] def term (s : ASeq) (n : Nat) : Nat := s.k + s.d * n
 
 -- you can coerce an ASeq a function
 instance : CoeFun ASeq fun _ => Nat → Nat := ⟨term⟩
 
+/-- The first `n` terms of a sequence. -/
+def terms (s : ASeq) (n : Nat) : List Nat := List.range n |>.map fun i => term s i
 
--- generate n terms of a sequence
-def terms (s : ASeq) (n : Nat) : List Nat := List.range n |>.map λ i => term s i
+/-- Compose two sequences: `(s.compose t) n = s (t n)`. -/
+def compose (s t : ASeq) : ASeq := aseq (s.k + s.d * t.k) (s.d * t.d)
 
-
--- apply one formula to another: r(n) := s(t(n))
-def compose (s t: ASeq) : ASeq := aseq (s.k + s.d * t.k) (s.d * t.d)
-
-theorem compose_def (s t: ASeq) {n:Nat} : (s.compose t) n = s (t n) :=
+theorem compose_def (s t : ASeq) {n : Nat} : (s.compose t) n = s (t n) :=
   let y := (s.compose t) n
   calc
     y = s.k + (s.d * t.k) + (s.d * t.d * n) := by rfl
@@ -67,10 +82,11 @@ theorem compose_def (s t: ASeq) {n:Nat} : (s.compose t) n = s (t n) :=
     _ = s (t.k + t.d * n) := by rfl
     _ = s (t n) := by rfl
 
+/-- Partition a sequence into `n` sub-sequences by residue class of the input. -/
 def partition (s : ASeq) (n : Nat) : List ASeq :=
-  List.range n |>.map fun i => compose s $ .mk i n
+  List.range n |>.map fun i => compose s <| .mk i n
 
-theorem length_partition {s: ASeq} {n: Nat}
+theorem length_partition {s : ASeq} {n : Nat}
   : (s.partition n).length = n := by
     simp [partition]
 
@@ -83,7 +99,7 @@ instance : ToString ASeq where
     else if s.d == 1 then s!"{s.k} + n"
     else s!"{s.k} + {s.d}n"
 
--- limit results to those greater than or equal to n
+/-- Truncate the sequence to keep only terms `≥ n`. -/
 def gte (s : ASeq) (n : Nat) : ASeq :=
   if n ≤ s.k then s
   else if n ≤ s.d then .mk (s.k + s.d) s.d
@@ -91,10 +107,10 @@ def gte (s : ASeq) (n : Nat) : ASeq :=
     let t := n / s.d
     ASeq.mk (s.k + s.d * (t + 1)) s.d
 
-protected lemma self_lt_mul_div_add (n d : Nat) (hd: d > 0) : n ≤ d * (n/d + 1) := by
+protected lemma self_lt_mul_div_add (n d : Nat) (hd : d > 0) : n ≤ d * (n/d + 1) := by
   set r := n % d with hr
   set q := n / d with hq
-  simp
+  simp only [ge_iff_le]
   have : d * (n/d) + (n % d) = n := Nat.div_add_mod n d
   have : r + d * q = n := by rw[←hq, ←hr] at this; linarith
   have : r < d := Nat.mod_lt n hd
@@ -102,19 +118,20 @@ protected lemma self_lt_mul_div_add (n d : Nat) (hd: d > 0) : n ≤ d * (n/d + 1
 
 theorem gte_term (s : ASeq) (n : Nat) : s.d > 0 → n ≤ term (s.gte n) 0 := by
   intro hdz
-  simp[term, ASeq.gte]
+  simp only [term, gte, mul_zero, add_zero]
   if hsk : n ≤ s.k then simp [hsk]
   else if hsd : n ≤ s.d then simp [hsd, hsk]; linarith
   else
-    simp[hsk,hsd]
-    have hle: n ≤ s.d * (n/s.d + 1) := ASeq.self_lt_mul_div_add n s.d hdz
+    simp only [hsk, ↓reduceIte, hsd]
+    have hle : n ≤ s.d * (n/s.d + 1) := ASeq.self_lt_mul_div_add n s.d hdz
     linarith
 
 theorem gte_same_delta (s : ASeq) (n : Nat) : (s.gte n).d = s.d := by
-  simp[ASeq.gte]
+  simp only [gte]
   if hsk : n ≤ s.k then simp [hsk]
   else if hsd : n ≤ s.d then simp [hsd, hsk]
   else simp[hsk,hsd]
 
-
 end ASeq
+
+end Leansieve

--- a/LeanPool/Leansieve/ASeq/ASeq.lean
+++ b/LeanPool/Leansieve/ASeq/ASeq.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 tangentstorm. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: tangentstorm
+-/
+-- ASeq: Arithmetic Sequences
+import Mathlib.Tactic.Linarith
+import Batteries.Data.List.Lemmas
+
+structure ASeq where  -- arithmetic sequence (k + dn)
+  k : Nat  -- constant
+  d : Nat  -- delta (step size)
+deriving Repr
+
+def ASeq.le (a b: ASeq) := if a.d = b.d then a.k≤b.k else a.d<b.d
+instance : LE ASeq where le := ASeq.le
+instance : Std.Total (α := ASeq) (·≤·) where
+  total a b := by
+    change (if a.d = b.d then a.k ≤ b.k else a.d < b.d) ∨
+      (if b.d = a.d then b.k ≤ a.k else b.d < a.d)
+    by_cases h : a.d = b.d
+    · rw [if_pos h, if_pos h.symm]
+      exact Nat.le_total a.k b.k
+    · have h' : b.d ≠ a.d := by
+        intro hba
+        exact h hba.symm
+      rw [if_neg h, if_neg h']
+      exact lt_or_gt_of_ne h
+
+instance : Inhabited ASeq where
+  default := .mk 0 1
+
+instance : Ord ASeq where
+  compare s1 s2 :=
+    match compare s1.k s2.k with
+    | .eq => compare s1.d s2.d
+    | ord => ord
+
+@[simp] def aseq (k:Nat) (d:Nat) := ASeq.mk k d
+
+namespace ASeq
+
+-- identity sequence
+def nats  := aseq 0 1
+def evens := aseq 0 2
+def odds  := aseq 1 2
+
+-- apply formula to n
+@[simp] def term (s : ASeq) (n : Nat) : Nat := s.k + s.d * n
+
+-- you can coerce an ASeq a function
+instance : CoeFun ASeq fun _ => Nat → Nat := ⟨term⟩
+
+
+-- generate n terms of a sequence
+def terms (s : ASeq) (n : Nat) : List Nat := List.range n |>.map λ i => term s i
+
+
+-- apply one formula to another: r(n) := s(t(n))
+def compose (s t: ASeq) : ASeq := aseq (s.k + s.d * t.k) (s.d * t.d)
+
+theorem compose_def (s t: ASeq) {n:Nat} : (s.compose t) n = s (t n) :=
+  let y := (s.compose t) n
+  calc
+    y = s.k + (s.d * t.k) + (s.d * t.d * n) := by rfl
+    _ = s.k + s.d * (t.k + t.d * n) := by linarith
+    _ = s (t.k + t.d * n) := by rfl
+    _ = s (t n) := by rfl
+
+def partition (s : ASeq) (n : Nat) : List ASeq :=
+  List.range n |>.map fun i => compose s $ .mk i n
+
+theorem length_partition {s: ASeq} {n: Nat}
+  : (s.partition n).length = n := by
+    simp [partition]
+
+instance : ToString ASeq where
+  toString s :=
+    if s.k == 0 then
+      if s.d == 1 then "n"
+      else s!"{s.d}n"
+    else if s.d == 0 then s!"{s.k}"
+    else if s.d == 1 then s!"{s.k} + n"
+    else s!"{s.k} + {s.d}n"
+
+-- limit results to those greater than or equal to n
+def gte (s : ASeq) (n : Nat) : ASeq :=
+  if n ≤ s.k then s
+  else if n ≤ s.d then .mk (s.k + s.d) s.d
+  else
+    let t := n / s.d
+    ASeq.mk (s.k + s.d * (t + 1)) s.d
+
+protected lemma self_lt_mul_div_add (n d : Nat) (hd: d > 0) : n ≤ d * (n/d + 1) := by
+  set r := n % d with hr
+  set q := n / d with hq
+  simp
+  have : d * (n/d) + (n % d) = n := Nat.div_add_mod n d
+  have : r + d * q = n := by rw[←hq, ←hr] at this; linarith
+  have : r < d := Nat.mod_lt n hd
+  linarith
+
+theorem gte_term (s : ASeq) (n : Nat) : s.d > 0 → n ≤ term (s.gte n) 0 := by
+  intro hdz
+  simp[term, ASeq.gte]
+  if hsk : n ≤ s.k then simp [hsk]
+  else if hsd : n ≤ s.d then simp [hsd, hsk]; linarith
+  else
+    simp[hsk,hsd]
+    have hle: n ≤ s.d * (n/s.d + 1) := ASeq.self_lt_mul_div_add n s.d hdz
+    linarith
+
+theorem gte_same_delta (s : ASeq) (n : Nat) : (s.gte n).d = s.d := by
+  simp[ASeq.gte]
+  if hsk : n ≤ s.k then simp [hsk]
+  else if hsd : n ≤ s.d then simp [hsd, hsk]
+  else simp[hsk,hsd]
+
+
+end ASeq

--- a/LeanPool/Leansieve/PrimeGen/PrimeGen.lean
+++ b/LeanPool/Leansieve/PrimeGen/PrimeGen.lean
@@ -9,7 +9,20 @@ import Mathlib.Data.Nat.Prime.Infinite
 import Mathlib.Data.Nat.Find
 import Mathlib.Tactic.Linarith.Frontend
 
-def NPrime : Type := { n: Nat // Nat.Prime n } deriving Repr, Ord, LT, LE
+/-!
+# Prime generators (`PrimeGen`)
+
+This module specifies what it means for an algorithm to enumerate the primes in
+order. `NPrime` is the subtype of prime naturals; `PrimeGen` is the class of
+state machines that, starting from `init` and stepping with `next`, never skip a
+prime. `SimpleGen` is the trivial reference implementation, and `primes` reads a
+finite prefix of any generator's output.
+-/
+
+namespace Leansieve
+
+/-- The subtype of natural numbers that are prime. -/
+def NPrime : Type := { n : Nat // Nat.Prime n } deriving Repr, Ord, LT, LE
 
 @[simp] theorem NPrime.eq_iff (a b : NPrime) : a = b ↔ a.val = b.val := Subtype.ext_iff
 instance : ToString NPrime where toString s := s!"{s.val}"
@@ -18,69 +31,87 @@ instance : Coe NPrime Nat where coe n := n.val
 -- interestingly, the following seems to shadow normal Nat ∈ Set Nat operations.
 -- instance : Membership NPrime (Set Nat) where mem n s := n.val ∈ s
 
+/-- A `PrimeGen` is a state machine over `α` that enumerates the primes in
+order: starting from `init` and stepping with `next`, it never skips a prime. -/
 class PrimeGen (α : Type) where
+  /-- The prime currently held by a state. -/
   P : α → NPrime
+  /-- The initial state. -/
   init : α
+  /-- Step to the next state. -/
   next : α → α
-  hP' (g:α) : (¬∃ q, Nat.Prime q ∧ P g < q ∧  q < P (next g))
+  /-- Stepping skips no prime between the current and next primes. -/
+  hP' (g : α) : (¬∃ q, Nat.Prime q ∧ P g < q ∧ q < P (next g))
 open PrimeGen
 
-abbrev PrimeGt (n p:Nat) := Nat.Prime p ∧ n < p
+/-- `PrimeGt n p` holds when `p` is a prime strictly greater than `n`. -/
+abbrev PrimeGt (n p : Nat) := Nat.Prime p ∧ n < p
 
-structure MinPrimeGt (n:Nat) where
+/-- The least prime strictly greater than `n`, together with proofs that it is
+prime, exceeds `n`, and is minimal among such primes. -/
+structure MinPrimeGt (n : Nat) where
+  /-- The witnessing prime. -/
   p : Nat
+  /-- `p` is a prime greater than `n`. -/
   hpgt : PrimeGt n p
-  hmin : ∀q:Nat, q < p → (¬ PrimeGt n q)
-def MinPrimeGt.p' (m:MinPrimeGt n) := m.hpgt.left
+  /-- No smaller number is a prime greater than `n`. -/
+  hmin : ∀ q : Nat, q < p → (¬ PrimeGt n q)
 
-section simple_gen
+/-- The primality half of `MinPrimeGt.hpgt`: the witnessing prime is prime. -/
+lemma MinPrimeGt.p' (m : MinPrimeGt n) : Nat.Prime m.p := m.hpgt.left
 
-  theorem ex_prime_gt (c:Nat) : ∃ p, PrimeGt c p := by
-    let d := c + 1 -- because the line below has ≤ and we need <
-    let ⟨p, hcp, hprime⟩ : ∃ (p : ℕ), d ≤ p ∧ Nat.Prime p :=
-      Nat.exists_infinite_primes d
-    use p; constructor
-    · exact hprime
-    · omega
+section simpleGen
 
-  def min_prime_gt (n: Nat) : MinPrimeGt n :=
-    let e := ex_prime_gt n
-    { p:=Nat.find e,
-      hpgt:=Nat.find_spec e,
-      hmin:= by exact fun {q} a => Nat.find_min e a}
+theorem ex_prime_gt (c : Nat) : ∃ p, PrimeGt c p := by
+  let d := c + 1 -- because the line below has ≤ and we need <
+  let ⟨p, hcp, hprime⟩ : ∃ (p : ℕ), d ≤ p ∧ Nat.Prime p :=
+    Nat.exists_infinite_primes d
+  use p; constructor
+  · exact hprime
+  · omega
 
-  structure SimpleGen where
-    p : NPrime
-    c : MinPrimeGt p.val
+/-- The least prime greater than `n`, packaged as a `MinPrimeGt`. -/
+def minPrimeGt (n : Nat) : MinPrimeGt n :=
+  let e := ex_prime_gt n
+  { p := Nat.find e,
+    hpgt := Nat.find_spec e,
+    hmin := by exact fun {q} a => Nat.find_min e a }
 
-  def SimpleGen.next (g:SimpleGen) : SimpleGen :=
-    { p:=⟨g.c.p, g.c.hpgt.left⟩, c:=min_prime_gt g.c.p }
+/-- A reference prime generator carrying the current prime and the next one. -/
+structure SimpleGen where
+  /-- The current prime. -/
+  p : NPrime
+  /-- The least prime greater than the current one. -/
+  c : MinPrimeGt p.val
 
-  instance : PrimeGen SimpleGen where
-    P g := g.p
-    init := {p := ⟨2, Nat.prime_two⟩, c := min_prime_gt 2 }
-    next := .next
-    hP' g := by  -- goal: no prime q between g.p and (g.next.p = g.c.p)
-      -- why? that would imply prime_gt (g.p) q, but hmin contradicts this
-      intro h
-      rcases h with ⟨q, hq, hgt, hlt⟩
-      exact (g.c.hmin q hlt) ⟨hq, hgt⟩
+/-- Advance a `SimpleGen` to the next prime. -/
+def SimpleGen.next (g : SimpleGen) : SimpleGen :=
+  { p := ⟨g.c.p, g.c.hpgt.left⟩, c := minPrimeGt g.c.p }
 
-  open PrimeGen
+instance : PrimeGen SimpleGen where
+  P g := g.p
+  init := { p := ⟨2, Nat.prime_two⟩, c := minPrimeGt 2 }
+  next := .next
+  hP' g := by  -- goal: no prime q between g.p and (g.next.p = g.c.p)
+    -- why? that would imply prime_gt (g.p) q, but hmin contradicts this
+    intro h
+    rcases h with ⟨q, hq, hgt, hlt⟩
+    exact (g.c.hmin q hlt) ⟨hq, hgt⟩
 
-end simple_gen
+end simpleGen
 
-/- function power. apply f recursively n times to x₀ and collect the results.
-  (!! lean has `f^[n] x` but this doesn't collect intermediate results. maybe
-  another version exists?) -/
-def fpow (f : α → α) (n:Nat) (x₀ : α) : List α :=
-  let rec aux (n:Nat) (x:α) (acc:List α) :=
+/-- Function power: apply `f` recursively `n` times to `x₀`, collecting every
+intermediate result (`f^[n] x` only returns the last value). -/
+def fpow (f : α → α) (n : Nat) (x₀ : α) : List α :=
+  aux (n-1) x₀ [] |>.reverse
+where
+  /-- Accumulate `n` iterates of `f` starting from `x`, prepending each onto `acc`. -/
+  aux (n : Nat) (x : α) (acc : List α) :=
     if n = 0 then x::acc
     else aux (n-1) (f x) (x::acc)
-  aux (n-1) x₀ [] |>.reverse
 
-
-
-def primes (α : Type) [pg: PrimeGen α] (n : Nat) : List NPrime :=
+/-- Read the first `n` primes produced by a `PrimeGen`. -/
+def primes (α : Type) [pg : PrimeGen α] (n : Nat) : List NPrime :=
   fpow (fun g => pg.next g) n pg.init |>.map fun g => pg.P g
 
+end Leansieve

--- a/LeanPool/Leansieve/PrimeGen/PrimeGen.lean
+++ b/LeanPool/Leansieve/PrimeGen/PrimeGen.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2026 tangentstorm. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: tangentstorm
+-/
+-- PrimeGen: a specification for algorithms that generate prime numbers.
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Data.Nat.Prime.Infinite
+import Mathlib.Data.Nat.Find
+import Mathlib.Tactic.Linarith.Frontend
+
+def NPrime : Type := { n: Nat // Nat.Prime n } deriving Repr, Ord, LT, LE
+
+@[simp] theorem NPrime.eq_iff (a b : NPrime) : a = b ↔ a.val = b.val := Subtype.ext_iff
+instance : ToString NPrime where toString s := s!"{s.val}"
+instance : Dvd NPrime where dvd a b := a.val ∣ b.val
+instance : Coe NPrime Nat where coe n := n.val
+-- interestingly, the following seems to shadow normal Nat ∈ Set Nat operations.
+-- instance : Membership NPrime (Set Nat) where mem n s := n.val ∈ s
+
+class PrimeGen (α : Type) where
+  P : α → NPrime
+  init : α
+  next : α → α
+  hP' (g:α) : (¬∃ q, Nat.Prime q ∧ P g < q ∧  q < P (next g))
+open PrimeGen
+
+abbrev PrimeGt (n p:Nat) := Nat.Prime p ∧ n < p
+
+structure MinPrimeGt (n:Nat) where
+  p : Nat
+  hpgt : PrimeGt n p
+  hmin : ∀q:Nat, q < p → (¬ PrimeGt n q)
+def MinPrimeGt.p' (m:MinPrimeGt n) := m.hpgt.left
+
+section simple_gen
+
+  theorem ex_prime_gt (c:Nat) : ∃ p, PrimeGt c p := by
+    let d := c + 1 -- because the line below has ≤ and we need <
+    let ⟨p, hcp, hprime⟩ : ∃ (p : ℕ), d ≤ p ∧ Nat.Prime p :=
+      Nat.exists_infinite_primes d
+    use p; constructor
+    · exact hprime
+    · omega
+
+  def min_prime_gt (n: Nat) : MinPrimeGt n :=
+    let e := ex_prime_gt n
+    { p:=Nat.find e,
+      hpgt:=Nat.find_spec e,
+      hmin:= by exact fun {q} a => Nat.find_min e a}
+
+  structure SimpleGen where
+    p : NPrime
+    c : MinPrimeGt p.val
+
+  def SimpleGen.next (g:SimpleGen) : SimpleGen :=
+    { p:=⟨g.c.p, g.c.hpgt.left⟩, c:=min_prime_gt g.c.p }
+
+  instance : PrimeGen SimpleGen where
+    P g := g.p
+    init := {p := ⟨2, Nat.prime_two⟩, c := min_prime_gt 2 }
+    next := .next
+    hP' g := by  -- goal: no prime q between g.p and (g.next.p = g.c.p)
+      -- why? that would imply prime_gt (g.p) q, but hmin contradicts this
+      intro h
+      rcases h with ⟨q, hq, hgt, hlt⟩
+      exact (g.c.hmin q hlt) ⟨hq, hgt⟩
+
+  open PrimeGen
+
+end simple_gen
+
+/- function power. apply f recursively n times to x₀ and collect the results.
+  (!! lean has `f^[n] x` but this doesn't collect intermediate results. maybe
+  another version exists?) -/
+def fpow (f : α → α) (n:Nat) (x₀ : α) : List α :=
+  let rec aux (n:Nat) (x:α) (acc:List α) :=
+    if n = 0 then x::acc
+    else aux (n-1) (f x) (x::acc)
+  aux (n-1) x₀ [] |>.reverse
+
+
+
+def primes (α : Type) [pg: PrimeGen α] (n : Nat) : List NPrime :=
+  fpow (fun g => pg.next g) n pg.init |>.map fun g => pg.P g
+

--- a/LeanPool/Leansieve/PrimeSieve/PrimeSieve.lean
+++ b/LeanPool/Leansieve/PrimeSieve/PrimeSieve.lean
@@ -1,0 +1,198 @@
+/-
+Copyright (c) 2026 tangentstorm. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: tangentstorm
+-/
+import LeanPool.Leansieve.PrimeGen.PrimeGen
+
+
+abbrev nosk' P C := (¬∃ q:Nat, Nat.Prime q ∧ P < q ∧ q < C) -- no skipped prime
+class PrimeSieveState (α : Type) where
+  P     (s:α) : NPrime
+  C     (s:α) : Nat
+  next  (s:α) (hC: Nat.Prime (C s)) (hN: nosk' (P s) (C s)): α
+  hNext (s:α) (hC: Nat.Prime (C s)) (hN: nosk' (P s) (C s)) {s':α}
+    : (s'=(next s hC hN) → P s' = C s ∧ C s' > C s)
+open PrimeSieveState
+
+-- R: the "residue", or "remaining" nats coprime to all primes < p.
+-- In a sieve, these are the numbers that haven't yet been "sifted out."
+def R(P:Nat) : Set Nat := { n | n≥2 ∧ ∀q≤P, Nat.Prime q → ¬q∣n }
+
+/-- everything in R is greater than P. we use this to show C > P later. -/
+lemma r_gt_p (p:Nat) : (∀r∈R p, r > p) := by
+  -- argument: R and S together say ∀ p:prime ≤ P, ¬ p∣r
+  intro r hrr;  unfold R at hrr
+  -- if r is ≤ P, there is a contradiction.
+  by_contra h; simp at h
+  -- r (like all natural numbers) has a minimum prime factor f
+  have : r ≠ 1 := by aesop -- R say r ≥ 2
+  obtain ⟨f, hf', hfr⟩ : ∃ f, Nat.Prime f ∧ f ∣ r :=
+      Nat.exists_prime_and_dvd ‹r ≠ 1›
+  -- from a chain of relationships we can conclude that f≤P...
+  have : 0 < r := by exact Nat.zero_lt_of_lt hrr.left
+  have : f ≤ r := Nat.le_of_dvd this hfr
+  have : f ≤ p := by omega
+  aesop
+
+
+/- if p₁ is the next consecutive prime after p₀ then
+  R p₁ = { n:(R p₀) | ¬ p₁∣n }
+  This corresponds to the idea that each time you identify
+  the next prime in a sieve, you sift out all its multiples. -/
+theorem r_next (p₀: Nat) (m: MinPrimeGt p₀) {n:Nat}
+  : (n ∈ R p₀ ∧ ¬↑m.p ∣ n) ↔ (n ∈ R m.p) := by
+    let ⟨h₁,hinc⟩ := m.hpgt; let hmin := m.hmin; set p₁ := m.p
+    unfold R; simp; apply Iff.intro
+    all_goals intro hn; apply And.intro; simp_all
+    · show ∀ q ≤ p₁, Nat.Prime q → ¬q ∣ n
+      intro q hq hq2
+      by_cases hq₀: q≤p₀
+      case pos => simp_all
+      case neg =>
+        by_contra hqn
+        simp at hq₀
+        have : q ≠ 1 := by aesop
+        obtain ⟨f, hf', hfq⟩ := Nat.exists_prime_and_dvd ‹q ≠ 1›
+        have hmin := m.hmin
+        absurd hmin; simp; use f; split_ands
+        · show f < m.p
+          have : 0 < q := by omega
+          have : f ≤ q := by exact Nat.le_of_dvd this hfq
+          have : q ≠ p₁ := by aesop
+          omega
+        · exact hf'
+        · show p₀ < f
+          simp_all
+          by_contra h
+          have : f ≤ p₀ := by omega
+          have : 2 ≤ f := by exact Nat.Prime.two_le hf'
+          simp_all
+          have : ¬ f ∣ n := by aesop
+          have : f ∣ n := by exact Nat.dvd_trans hfq hqn
+          contradiction
+    · show ∀ q ≤ p₀, Nat.Prime q → ¬q ∣ n
+      intro q hq hq2
+      have : q ≤ p₁ := by omega
+      exact (hn.right q this) hq2
+    · show ¬p₁ ∣ n
+      simp_all
+
+/- A prime sieve implementation can model `R p` by providing
+a bijection between `R p` and its internal data structures.
+
+For RakeSieve, this is exposed to the type system by attaching
+a predicate to the internal data structure.
+
+Whatever the sieve does to "sift out" multiples of the next
+prime `p₁` is equivalent to the expression  `∧ ¬(p₁∣n)`.
+
+The following theorem allows us to construct a predicate for
+membership in `R pₙ` by induction using predicates of this
+form at each step. -/
+theorem r_next_prop {p₀ n:Nat} {h₀ h₁: Nat → Prop} {m : MinPrimeGt p₀}
+  (hh₀: h₀ n ↔ n ∈ R p₀) (hh₁: h₁ n ↔ h₀ n ∧ ¬(m.p ∣ n))
+  : (h₁ n ↔ n ∈ R m.p) := by
+  simp[hh₁, hh₀]
+  exact r_next p₀ m
+
+/--
+PrimeSieveDriver provides the generic proof that a
+A PrimeSieve is a PrimeGen that uses a SieveState to generate primes.
+In practice, this means that it somehow models the set of natural
+numbers greater than 1 that are coprime to a list of known primes,
+and then repeatedly:
+  - obtains the minimum of this set as the next prime
+  - eliminates multiples of the new prime. -/
+class PrimeSieveDriver (α : Type) [PrimeSieveState α] where
+  hCinR  (g:α) : C g ∈ R (P g)            -- C is an element of R
+  hRmin  (g:α) : ∀ n ∈ R (P g), C g ≤ n   -- C is min of R
+open PrimeSieveDriver
+
+theorem c_gt_p (α : Type) [PrimeSieveState α] [PrimeSieveDriver α] (g:α) : C g > P g := by
+  have := hCinR g
+  exact r_gt_p (↑(P g)) (C g) this
+
+theorem no_skipped_prime (α : Type) [PrimeSieveState α] [PrimeSieveDriver α] (g:α)
+  : ¬ ∃ q:Nat, Nat.Prime q ∧ P g < q ∧ q < C g := by
+    intro ⟨q, ⟨hQ', hPltQ, hQltC⟩⟩ -- `intro q` on a ¬∃ goal requires we find a contradiction.
+    -- hRmin tells us that that C is the min of the set R.
+    have hRmin: ∀n ∈ R (P g), C g ≤ n := hRmin <| g
+
+    -- demonstrating `q ∈ R` would show the contradiction since `q<P` and `P` is min of `R`
+    suffices hQinR: q ∈ R (P g) from by apply hRmin at hQinR; omega
+
+    -- so now we just show hQinR. q∈R means q≥2 ∧ (¬∃p∈ S g, p∣q)
+    -- both of these facts follow immediately from the fact that q is prime,
+    -- provided we can *also* show that q itself is not an element of s.
+    unfold R; constructor
+    · show q ≥ 2 ; exact Nat.Prime.two_le hQ'
+    · show ∀ p ≤ ↑(P g), Nat.Prime p → ¬(p ∣ q)
+      intro p hp hp' -- assume p exists and p|q. show a contradiction.
+      -- since that p|q and both are prime, it follows that p=q.
+      have := Nat.prime_dvd_prime_iff_eq hp' hQ'
+      omega
+
+lemma no_prime_factors_im_no_factors {c:Nat} -- c is a candidate prime
+  (h2lc: 2 ≤ c)                              -- c is at least 2
+  (hnpf: ∀ p < c, Nat.Prime p → ¬(p∣c))      -- c has no prime factors
+  : Nat.Prime c := by
+    have : ∀ m < c, m ∣ c → m=1 := by  -- c has no divisors but 1 and c
+      intro m hmc hmdc  -- give names to the above assumptions
+      by_contra         -- assume ¬(m=1) and show contradiction
+      obtain ⟨p, hp', hpm⟩ : ∃ p, Nat.Prime p ∧ p ∣ m :=
+        Nat.exists_prime_and_dvd ‹m ≠ 1›
+      have : p∣c := Nat.dvd_trans hpm hmdc
+      have : ¬(p∣c) := by
+        have : 0 < c := by omega
+        have : 0 < m := Nat.pos_of_dvd_of_pos hmdc this
+        have : p ≤ m := Nat.le_of_dvd this hpm
+        have : p < c := by omega
+        exact hnpf p this hp'
+      contradiction
+    exact Nat.prime_def_lt.mpr ⟨‹2 ≤ c› , this⟩
+
+
+theorem c_prime (α: Type) [PrimeSieveState α] [PrimeSieveDriver α] (g:α)
+  : Nat.Prime (C g) := by
+    set c := C g
+    have hfac: ∀ q < C g, Nat.Prime q → ¬ q ∣ c := by
+      intro q₀ hqc hPq
+      set q : NPrime := ⟨q₀,hPq⟩
+      by_cases hq: q ≤ (P g)
+      case pos => -- ¬p∣C because C∈R and that's how R is defined
+        have hCinR := hCinR g
+        unfold R at hCinR; simp at hCinR
+        aesop
+      case neg => -- we have P < q and q < C but this can't happen
+        have : (P g) < q := by exact Nat.gt_of_not_le hq
+        have := no_skipped_prime α g
+        absurd this; use q; aesop
+    have h2c: 2 ≤ C g := by
+      set p := P g
+      have : p.val ≥ 2 := by exact Nat.Prime.two_le p.prop
+      have : c > p.val := c_gt_p α g
+      omega
+    exact no_prime_factors_im_no_factors h2c hfac
+
+
+-- demonstrate that a sieve generates the next consecutive prime at each step.
+-- "we have a new, bigger prime, and there is no prime between them".
+theorem hs_suffice (α : Type) [PrimeSieveState α] [PrimeSieveDriver α] (g:α)
+  :  (Nat.Prime (C g)) ∧ (C g > P g) ∧ (¬∃ q, Nat.Prime q ∧ P g < q ∧  q < C g) := by
+    split_ands
+    · exact c_prime α g
+    · exact c_gt_p α g
+    · exact no_skipped_prime α g
+
+def nextState {α : Type} [PrimeSieveState α] [PrimeSieveDriver α] (s: α) : α :=
+  let c' := c_prime α s
+  let ns := no_skipped_prime α s
+  PrimeSieveState.next s c' ns
+
+variable (α : Type) [PrimeSieveState α] [PrimeSieveDriver α]
+structure PrimeSieve  where
+  state  : α
+
+def PrimeSieve.next (x:PrimeSieve α) : PrimeSieve α :=
+  { state := nextState x.state }

--- a/LeanPool/Leansieve/PrimeSieve/PrimeSieve.lean
+++ b/LeanPool/Leansieve/PrimeSieve/PrimeSieve.lean
@@ -5,22 +5,41 @@ Authors: tangentstorm
 -/
 import LeanPool.Leansieve.PrimeGen.PrimeGen
 
+/-!
+# Generic prime sieve correctness (`PrimeSieve`)
 
-abbrev nosk' P C := (¬∃ q:Nat, Nat.Prime q ∧ P < q ∧ q < C) -- no skipped prime
+This module proves, abstractly, that a sieve is correct. A `PrimeSieveState`
+exposes the current prime `P`, the next candidate `C`, and a `next` step; a
+`PrimeSieveDriver` asserts that `C` is the minimum of the residue set `R (P g)`.
+From these, `c_prime`, `no_skipped_prime`, and `hs_suffice` show each step yields
+the next consecutive prime, skipping none.
+-/
+
+namespace Leansieve
+
+/-- `nosk' P C`: there is no prime strictly between `P` and the candidate `C`. -/
+abbrev nosk' P C := (¬∃ q : Nat, Nat.Prime q ∧ P < q ∧ q < C) -- no skipped prime
+
+/-- The observable state of a prime sieve: the current prime, the next
+candidate, and a step taking proofs that the candidate is prime and skips none. -/
 class PrimeSieveState (α : Type) where
-  P     (s:α) : NPrime
-  C     (s:α) : Nat
-  next  (s:α) (hC: Nat.Prime (C s)) (hN: nosk' (P s) (C s)): α
-  hNext (s:α) (hC: Nat.Prime (C s)) (hN: nosk' (P s) (C s)) {s':α}
-    : (s'=(next s hC hN) → P s' = C s ∧ C s' > C s)
+  /-- The current prime. -/
+  P (s : α) : NPrime
+  /-- The candidate for the next prime. -/
+  C (s : α) : Nat
+  /-- Advance the sieve, given the candidate is prime and skips no prime. -/
+  next (s : α) (hC : Nat.Prime (C s)) (hN : nosk' (P s) (C s)) : α
+  /-- After stepping, the new prime is the old candidate and the candidate grows. -/
+  hNext (s : α) (hC : Nat.Prime (C s)) (hN : nosk' (P s) (C s)) {s' : α}
+    : (s' = (next s hC hN) → P s' = C s ∧ C s' > C s)
 open PrimeSieveState
 
--- R: the "residue", or "remaining" nats coprime to all primes < p.
--- In a sieve, these are the numbers that haven't yet been "sifted out."
-def R(P:Nat) : Set Nat := { n | n≥2 ∧ ∀q≤P, Nat.Prime q → ¬q∣n }
+/-- The "residue" set: naturals `≥ 2` that are coprime to every prime `≤ P`. In
+a sieve these are the numbers not yet sifted out at stage `P`. -/
+def R (P : Nat) : Set Nat := { n | n ≥ 2 ∧ ∀ q ≤ P, Nat.Prime q → ¬q ∣ n }
 
 /-- everything in R is greater than P. we use this to show C > P later. -/
-lemma r_gt_p (p:Nat) : (∀r∈R p, r > p) := by
+lemma r_gt_p (p : Nat) : (∀ r ∈ R p, r > p) := by
   -- argument: R and S together say ∀ p:prime ≤ P, ¬ p∣r
   intro r hrr;  unfold R at hrr
   -- if r is ≤ P, there is a contradiction.
@@ -35,39 +54,39 @@ lemma r_gt_p (p:Nat) : (∀r∈R p, r > p) := by
   have : f ≤ p := by omega
   aesop
 
-
 /- if p₁ is the next consecutive prime after p₀ then
   R p₁ = { n:(R p₀) | ¬ p₁∣n }
   This corresponds to the idea that each time you identify
   the next prime in a sieve, you sift out all its multiples. -/
-theorem r_next (p₀: Nat) (m: MinPrimeGt p₀) {n:Nat}
+theorem r_next (p₀ : Nat) (m : MinPrimeGt p₀) {n : Nat}
   : (n ∈ R p₀ ∧ ¬↑m.p ∣ n) ↔ (n ∈ R m.p) := by
-    let ⟨h₁,hinc⟩ := m.hpgt; let hmin := m.hmin; set p₁ := m.p
-    unfold R; simp; apply Iff.intro
-    all_goals intro hn; apply And.intro; simp_all
+    let ⟨h₁, hinc⟩ := m.hpgt; let hmin := m.hmin; set p₁ := m.p
+    unfold R; simp only [ge_iff_le, Set.mem_setOf_eq]; apply Iff.intro
+    all_goals intro hn; apply And.intro; simp_all only [not_and, not_lt, true_and]
     · show ∀ q ≤ p₁, Nat.Prime q → ¬q ∣ n
       intro q hq hq2
-      by_cases hq₀: q≤p₀
+      by_cases hq₀ : q ≤ p₀
       case pos => simp_all
       case neg =>
         by_contra hqn
-        simp at hq₀
+        simp only [not_le] at hq₀
         have : q ≠ 1 := by aesop
         obtain ⟨f, hf', hfq⟩ := Nat.exists_prime_and_dvd ‹q ≠ 1›
         have hmin := m.hmin
-        absurd hmin; simp; use f; split_ands
-        · show f < m.p
+        absurd hmin
+        simp only [not_and, not_lt, not_forall, not_le]
+        refine ⟨f, ?_, hf', ?_⟩
+        · -- goal: f < p₁
           have : 0 < q := by omega
           have : f ≤ q := by exact Nat.le_of_dvd this hfq
           have : q ≠ p₁ := by aesop
           omega
-        · exact hf'
-        · show p₀ < f
-          simp_all
+        · -- goal: p₀ < f
+          simp_all only [not_and, not_lt, ne_eq]
           by_contra h
           have : f ≤ p₀ := by omega
           have : 2 ≤ f := by exact Nat.Prime.two_le hf'
-          simp_all
+          simp_all only [not_lt]
           have : ¬ f ∣ n := by aesop
           have : f ∣ n := by exact Nat.dvd_trans hfq hqn
           contradiction
@@ -90,10 +109,10 @@ prime `p₁` is equivalent to the expression  `∧ ¬(p₁∣n)`.
 The following theorem allows us to construct a predicate for
 membership in `R pₙ` by induction using predicates of this
 form at each step. -/
-theorem r_next_prop {p₀ n:Nat} {h₀ h₁: Nat → Prop} {m : MinPrimeGt p₀}
-  (hh₀: h₀ n ↔ n ∈ R p₀) (hh₁: h₁ n ↔ h₀ n ∧ ¬(m.p ∣ n))
+theorem r_next_prop {p₀ n : Nat} {h₀ h₁ : Nat → Prop} {m : MinPrimeGt p₀}
+  (hh₀ : h₀ n ↔ n ∈ R p₀) (hh₁ : h₁ n ↔ h₀ n ∧ ¬(m.p ∣ n))
   : (h₁ n ↔ n ∈ R m.p) := by
-  simp[hh₁, hh₀]
+  simp only [hh₁, hh₀]
   exact r_next p₀ m
 
 /--
@@ -105,61 +124,60 @@ and then repeatedly:
   - obtains the minimum of this set as the next prime
   - eliminates multiples of the new prime. -/
 class PrimeSieveDriver (α : Type) [PrimeSieveState α] where
-  hCinR  (g:α) : C g ∈ R (P g)            -- C is an element of R
-  hRmin  (g:α) : ∀ n ∈ R (P g), C g ≤ n   -- C is min of R
+  /-- The candidate `C` lies in the residue set `R (P g)`. -/
+  hCinR (g : α) : C g ∈ R (P g)            -- C is an element of R
+  /-- The candidate `C` is the minimum of the residue set `R (P g)`. -/
+  hRmin (g : α) : ∀ n ∈ R (P g), C g ≤ n   -- C is min of R
 open PrimeSieveDriver
 
-theorem c_gt_p (α : Type) [PrimeSieveState α] [PrimeSieveDriver α] (g:α) : C g > P g := by
+theorem c_gt_p (α : Type) [PrimeSieveState α] [PrimeSieveDriver α] (g : α) : C g > P g := by
   have := hCinR g
   exact r_gt_p (↑(P g)) (C g) this
 
-theorem no_skipped_prime (α : Type) [PrimeSieveState α] [PrimeSieveDriver α] (g:α)
-  : ¬ ∃ q:Nat, Nat.Prime q ∧ P g < q ∧ q < C g := by
+theorem no_skipped_prime (α : Type) [PrimeSieveState α] [PrimeSieveDriver α] (g : α)
+  : ¬ ∃ q : Nat, Nat.Prime q ∧ P g < q ∧ q < C g := by
     intro ⟨q, ⟨hQ', hPltQ, hQltC⟩⟩ -- `intro q` on a ¬∃ goal requires we find a contradiction.
     -- hRmin tells us that that C is the min of the set R.
-    have hRmin: ∀n ∈ R (P g), C g ≤ n := hRmin <| g
-
+    have hRmin : ∀ n ∈ R (P g), C g ≤ n := hRmin <| g
     -- demonstrating `q ∈ R` would show the contradiction since `q<P` and `P` is min of `R`
-    suffices hQinR: q ∈ R (P g) from by apply hRmin at hQinR; omega
-
+    suffices hQinR : q ∈ R (P g) from by apply hRmin at hQinR; omega
     -- so now we just show hQinR. q∈R means q≥2 ∧ (¬∃p∈ S g, p∣q)
     -- both of these facts follow immediately from the fact that q is prime,
     -- provided we can *also* show that q itself is not an element of s.
     unfold R; constructor
-    · show q ≥ 2 ; exact Nat.Prime.two_le hQ'
+    · show q ≥ 2; exact Nat.Prime.two_le hQ'
     · show ∀ p ≤ ↑(P g), Nat.Prime p → ¬(p ∣ q)
       intro p hp hp' -- assume p exists and p|q. show a contradiction.
       -- since that p|q and both are prime, it follows that p=q.
       have := Nat.prime_dvd_prime_iff_eq hp' hQ'
       omega
 
-lemma no_prime_factors_im_no_factors {c:Nat} -- c is a candidate prime
-  (h2lc: 2 ≤ c)                              -- c is at least 2
-  (hnpf: ∀ p < c, Nat.Prime p → ¬(p∣c))      -- c has no prime factors
+lemma no_prime_factors_im_no_factors {c : Nat} -- c is a candidate prime
+  (h2lc : 2 ≤ c) -- c is at least 2
+  (hnpf : ∀ p < c, Nat.Prime p → ¬(p ∣ c)) -- c has no prime factors
   : Nat.Prime c := by
-    have : ∀ m < c, m ∣ c → m=1 := by  -- c has no divisors but 1 and c
+    have : ∀ m < c, m ∣ c → m = 1 := by  -- c has no divisors but 1 and c
       intro m hmc hmdc  -- give names to the above assumptions
       by_contra         -- assume ¬(m=1) and show contradiction
       obtain ⟨p, hp', hpm⟩ : ∃ p, Nat.Prime p ∧ p ∣ m :=
         Nat.exists_prime_and_dvd ‹m ≠ 1›
-      have : p∣c := Nat.dvd_trans hpm hmdc
-      have : ¬(p∣c) := by
+      have : p ∣ c := Nat.dvd_trans hpm hmdc
+      have : ¬(p ∣ c) := by
         have : 0 < c := by omega
         have : 0 < m := Nat.pos_of_dvd_of_pos hmdc this
         have : p ≤ m := Nat.le_of_dvd this hpm
         have : p < c := by omega
         exact hnpf p this hp'
       contradiction
-    exact Nat.prime_def_lt.mpr ⟨‹2 ≤ c› , this⟩
+    exact Nat.prime_def_lt.mpr ⟨‹2 ≤ c›, this⟩
 
-
-theorem c_prime (α: Type) [PrimeSieveState α] [PrimeSieveDriver α] (g:α)
+theorem c_prime (α : Type) [PrimeSieveState α] [PrimeSieveDriver α] (g : α)
   : Nat.Prime (C g) := by
     set c := C g
-    have hfac: ∀ q < C g, Nat.Prime q → ¬ q ∣ c := by
+    have hfac : ∀ q < C g, Nat.Prime q → ¬ q ∣ c := by
       intro q₀ hqc hPq
-      set q : NPrime := ⟨q₀,hPq⟩
-      by_cases hq: q ≤ (P g)
+      set q : NPrime := ⟨q₀, hPq⟩
+      by_cases hq : q ≤ (P g)
       case pos => -- ¬p∣C because C∈R and that's how R is defined
         have hCinR := hCinR g
         unfold R at hCinR; simp at hCinR
@@ -168,31 +186,38 @@ theorem c_prime (α: Type) [PrimeSieveState α] [PrimeSieveDriver α] (g:α)
         have : (P g) < q := by exact Nat.gt_of_not_le hq
         have := no_skipped_prime α g
         absurd this; use q; aesop
-    have h2c: 2 ≤ C g := by
+    have h2c : 2 ≤ C g := by
       set p := P g
       have : p.val ≥ 2 := by exact Nat.Prime.two_le p.prop
       have : c > p.val := c_gt_p α g
       omega
     exact no_prime_factors_im_no_factors h2c hfac
 
-
 -- demonstrate that a sieve generates the next consecutive prime at each step.
 -- "we have a new, bigger prime, and there is no prime between them".
-theorem hs_suffice (α : Type) [PrimeSieveState α] [PrimeSieveDriver α] (g:α)
-  :  (Nat.Prime (C g)) ∧ (C g > P g) ∧ (¬∃ q, Nat.Prime q ∧ P g < q ∧  q < C g) := by
+theorem hs_suffice (α : Type) [PrimeSieveState α] [PrimeSieveDriver α] (g : α)
+  : (Nat.Prime (C g)) ∧ (C g > P g) ∧ (¬∃ q, Nat.Prime q ∧ P g < q ∧ q < C g) := by
     split_ands
     · exact c_prime α g
     · exact c_gt_p α g
     · exact no_skipped_prime α g
 
-def nextState {α : Type} [PrimeSieveState α] [PrimeSieveDriver α] (s: α) : α :=
+/-- Advance a sieve state by one step, discharging the primality and
+no-skipped-prime obligations from the generic proofs above. -/
+def nextState {α : Type} [PrimeSieveState α] [PrimeSieveDriver α] (s : α) : α :=
   let c' := c_prime α s
   let ns := no_skipped_prime α s
   PrimeSieveState.next s c' ns
 
 variable (α : Type) [PrimeSieveState α] [PrimeSieveDriver α]
-structure PrimeSieve  where
-  state  : α
 
-def PrimeSieve.next (x:PrimeSieve α) : PrimeSieve α :=
+/-- A prime sieve: a wrapper carrying a single sieve state. -/
+structure PrimeSieve where
+  /-- The underlying sieve state. -/
+  state : α
+
+/-- Advance a `PrimeSieve` by one step. -/
+def PrimeSieve.next (x : PrimeSieve α) : PrimeSieve α :=
   { state := nextState x.state }
+
+end Leansieve

--- a/LeanPool/Leansieve/Rake/Rake.lean
+++ b/LeanPool/Leansieve/Rake/Rake.lean
@@ -1,0 +1,485 @@
+/-
+Copyright (c) 2026 tangentstorm. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: tangentstorm
+-/
+-- For the purposes of this library, a "Rake" is a sorted
+-- list of arithmetic sequences that share the same delta.
+import LeanPool.Leansieve.ASeq.ASeq
+import Mathlib.Data.List.Sort
+import Mathlib.Data.List.Dedup
+import Mathlib.Data.List.Basic
+import Mathlib.Data.List.Perm.Basic
+
+namespace List
+
+abbrev Sorted {α : Type _} (r : α → α → Prop) (l : List α) : Prop := l.Pairwise r
+
+end List
+
+structure Rake : Type where
+  d     : Nat
+  ks    : List Nat
+  size : Nat := ks.length
+  sorted: Bool := true
+  hsort : sorted → List.Sorted (·<·) ks := by simp
+  huniq : sorted → ks.Nodup := by simp
+  hsize : 0 < ks.length := by simp
+
+namespace Rake
+
+def zer : Rake := { d := 0, ks := [0] }
+def nat : Rake := { d := 1, ks := [0] }
+def ge2 : Rake := { d := 1, ks := [2] }
+
+section « terms » -- generating output terms from the rake
+
+def term (r: Rake) (n : Nat) : Nat :=
+  let q := r.ks.length
+  have : n%q < r.ks.length := Nat.mod_lt _ r.hsize
+  aseq r.ks[n%q] r.d |>.term (n/q)
+
+def terms (r: Rake) (n: Nat) : List Nat :=
+  List.range n |>.map r.term
+
+theorem term_simp (r:Rake) (n:Nat)
+: (∃k, (r.term n = k + r.d * (n/r.ks.length)) ∧ ∃i: Fin r.ks.length, i=n%r.ks.length ∧ k=r.ks[i]) := by
+  let i: Fin r.ks.length := ⟨n%r.ks.length, Nat.mod_lt n r.hsize⟩
+  use r.ks[i]
+  apply And.intro
+  · dsimp[term, i]
+  · use i
+
+theorem term_iff (r:Rake)
+  : ∀m, (∃n, r.term n = m) ↔ (∃ k∈r.ks,  ∃x:Nat, k+x*r.d = m) := by
+  intro m; apply Iff.intro
+  · show (∃ n, r.term n = m) → ∃ k ∈ r.ks, ∃ x, k + x * r.d = m
+    -- this is just grunt work, but it follows from the definition of term
+    intro ⟨n,hn⟩; obtain ⟨k, hk, i, hi, hki⟩ := r.term_simp n
+    use k; apply And.intro
+    · simp[List.mem_iff_get]; use i; exact hki.symm
+    · use (n/r.ks.length); subst hki hn; simp_all;
+      exact Nat.mul_comm (n / r.ks.length) r.d
+
+  · show (∃ k ∈ r.ks, ∃ x, k + x * r.d = m) → ∃ n, r.term n = m
+    -- in other words, given some k in our list and an arbitrary x
+    -- the rake ought to produce m = k + x * r.d at some point. we prove
+    -- this by working backwards to calculate what n we have to plug
+    -- into (r.term n) in order to get n back out.
+    intro ⟨k, hk, hx₀⟩
+
+    -- k is a member of ks so it must have an index in ks: k=r.ks.get i
+    rw[List.mem_iff_get] at hk
+    obtain ⟨i: Fin r.ks.length, hi₀ : r.ks.get i = k⟩ := hk
+
+    -- k uniquely identifies a particular arithmetic sequence within
+    -- the rake, and there's some x that we can feed into this sequence
+    -- to get the result m. we can obtain it:
+    obtain ⟨x, hx: k + x * r.d = m⟩ := hx₀
+
+    -- now we can choose n so that r.term n picks k=ks[ i ] as the constant.
+    -- this happens ∀ n, i = n % r.ks.length ∧ x = n / r.ks.length
+    have hi₁ : i.val % r.ks.length = i.val := Nat.mod_eq_of_lt i.prop
+    let n := (i.val % r.ks.length) + (x * r.ks.length)
+
+    -- now we run this definition of `n` through `r.term n` and
+    -- once we deal with annoying divmod issues, out comes the result.
+    use n
+    have hmod : (n % r.ks.length) = i.val := by
+      dsimp [n]
+      calc
+        (i.val % r.ks.length + x * r.ks.length) % r.ks.length = (i.val % r.ks.length) % r.ks.length := by
+          rw [Nat.add_mul_mod_self_right]
+        _ = i.val % r.ks.length := Nat.mod_mod _ _
+        _ = i.val := Nat.mod_eq_of_lt i.prop
+    have hdiv : (n / r.ks.length) = x := by
+      dsimp [n]
+      rw [Nat.add_mul_div_right _ _ r.hsize, Nat.div_eq_of_lt (Nat.mod_lt _ r.hsize)]
+      simp
+    calc
+      r.term n = r.ks[i] + x * r.d := by
+        dsimp [term]
+        simp [hmod, hdiv, Nat.mul_comm]
+      _ = k + x * r.d := by simpa using congrArg (fun t => t + x * r.d) hi₀
+      _ = m := hx
+
+end « terms »
+
+section « sequences » -- arithmetic sequences for each k ∈ ks
+
+def seq (r:Rake) (n:Nat) {hn:n<r.ks.length} : ASeq :=
+  aseq (r.ks[n]'hn) r.d
+
+def seqs (r: Rake) : List ASeq :=
+  r.ks.map (λ k => aseq k r.d)
+
+/--
+  this is slightly more specific than `term_iff`, in that
+  it gives you a specific k and its index -/
+theorem k_of_term (r: Rake) (hmn: r.term m = n)
+: ∃k ∈ r.ks, ∃i : (Fin r.ks.length),
+    i = m%r.ks.length
+    ∧ k = r.ks[i]
+    ∧ n = k + r.d * (m/r.ks.length) := by
+  set q := r.ks.length with hq
+  have hmq: m%q < r.ks.length := Nat.mod_lt _ r.hsize
+  set k := r.ks[m%q] with hk; use k
+  split_ands
+  · show k ∈ r.ks
+    exact List.get_mem r.ks ⟨m % q, hmq⟩
+  · set i : Fin _ := ⟨m%q, Nat.mod_lt m r.hsize⟩ with hi
+    use i
+    split_ands
+    · rw[hi]
+    · rw[hi,hk]; simp
+    · simp[←hmn,term, ← hq, hk]
+
+end « sequences »
+
+section « sort and dedup »
+
+def sort_nodup (xs:List Nat) (hxs₀ : List.Nodup xs)
+: { xs':List Nat // List.Sorted (·<·) xs' ∧ xs'.Perm xs
+    ∧ xs.length = xs'.length ∧ xs'.Nodup } :=
+  let xs' := xs.mergeSort (·≤·)
+  have hnodup : xs'.Nodup := (List.mergeSort_perm xs (·≤·)).nodup_iff.mpr hxs₀
+  have hsorted : xs'.SortedLE := List.sortedLE_mergeSort (l := xs)
+  have hlength := by simp_all only [List.length_mergeSort, xs']
+  have hperm : xs'.Perm xs := List.mergeSort_perm xs (·≤·)
+  ⟨xs', And.intro (List.SortedLE.sortedLT_of_nodup hsorted hnodup |>.pairwise)
+    (And.intro hperm (And.intro hlength hnodup))⟩
+
+def sort (r: Rake) : {r':Rake // r'.d=r.d ∧ r'.sorted ∧ r'.ks.Perm r.ks.dedup } :=
+  if hs: r.sorted then
+    have hp: r.ks.Perm r.ks.dedup := by
+      have := r.huniq hs
+      rw[←r.ks.dedup_eq_self] at this
+      rw[this]
+    ⟨r, And.intro rfl <| And.intro hs hp⟩
+  else
+    let ks₀ := r.ks
+    let ks₁ := ks₀.dedup
+    let ks₂ := sort_nodup ks₁ ks₀.nodup_dedup
+  have ⟨hsort, hperm, hlength, hnodup⟩  := ks₂.prop
+  have hlen₁ : ks₁.length ≠ 0 := by have:=r.hsize; aesop
+  have hsize := Nat.lt_of_lt_of_eq (Nat.zero_lt_of_ne_zero hlen₁) hlength
+  ⟨{ d:=r.d, ks:=ks₂, hsort:=λ_=>hsort, huniq:=λ_=>hnodup, hsize:=hsize}, by
+    refine ⟨rfl, ?_, hperm⟩
+    show true = true
+    rfl⟩
+
+lemma length_pos_of_dedup {l:List Nat} (hlen: 0 < l.length) : 0 < l.dedup.length := by
+  obtain ⟨hd, tl, hcons⟩ := List.exists_cons_of_length_pos hlen
+  have : hd ∈ l := by rw [hcons]; simp
+  rw[←List.mem_dedup] at this
+  exact List.length_pos_of_mem this
+
+def zero_le_cases (n:Nat) (zeq: 0=n → P) (zlt: 0<n → P) : P :=
+  if h:0=n then zeq h else zlt <| Nat.zero_lt_of_ne_zero λa=>h a.symm
+
+lemma sorted_get (xs:List Nat) (hxs: List.Sorted (·<·) xs) (i j:Fin xs.length) (hij: i<j)
+  : (xs[i] < xs[j]) := by
+  conv at hxs => dsimp[List.Sorted]; rw[List.pairwise_iff_get]
+  simp_all
+
+/--
+As currently defined, the terms of a sorted rake can be non-ascending in one of two ways:
+- ascending sawtooth pattern if ∃k∈r.ks, k>r.d
+- cyclic (and possibly constant) if r.d=0
+But in all cases, if the rake is sorted, term 0 is the minimum. -/
+theorem sorted_min_term_zero (r: Rake) (hr: r.sorted) : ∀ n, (r.term 0 ≤ r.term n) := by
+  intro n
+  obtain ⟨k₀, hk₀, i₀, hi₀⟩ := r.term_simp 0
+  obtain ⟨k₁, hk₁, i₁, hi₁⟩ := r.term_simp n
+  simp[hk₀, hk₁]
+  suffices k₀ ≤ k₁ by exact le_add_right this
+  rw[hi₀.right, hi₁.right]
+  apply zero_le_cases i₁.val; all_goals intro hi
+  case zeq => simp_all
+  case zlt =>
+    have : i₀.val < i₁.val := by aesop
+    exact Nat.le_of_succ_le <| sorted_get r.ks (r.hsort hr) i₀ i₁ this
+
+theorem sort_term_iff_term  (r:Rake) (n:Nat)
+  : (∃m, r.term m = n) ↔ (∃m', r.sort.val.term m' = n) := by
+  if h: r.sorted then
+    constructor <;> intro hm <;> simpa [sort, h] using hm
+  else
+    let ⟨rs, ⟨hd, hsort, hperm⟩⟩ := r.sort; simp
+    have : ∀k, k∈rs.ks ↔ k∈r.ks.dedup := fun k => List.Perm.mem_iff hperm
+    have hmem : ∀k, k∈r.ks ↔ k∈rs.ks := by aesop
+    apply Iff.intro
+    all_goals
+      intro h; rw[term_iff] at h; obtain ⟨k, hk₀, hk₁⟩ := h
+      specialize hmem k
+      rw[term_iff]
+      use k
+      apply And.intro
+    · rwa[←hmem]
+    · rwa[hd]
+    · rwa[hmem]
+    · rwa[←hd]
+
+end « sort and dedup »
+
+section « rake operations »
+
+section « partition »
+
+lemma List.mod_length {α : Type} (l:List α) (i:Nat) (hl: 0 < l.length)
+  : (i % l.length) < l.length := by exact Nat.mod_lt (↑i) hl
+
+/--
+Partition each sequence in the rake by partitioning their *inputs*
+into equivalance classes mod n. This multiplies the number of sequences
+by n. We can't allow n to be zero because then we'd have no sequences left,
+and this would break the guarantee that term (n) < term n+1. -/
+def partition (r:Rake) (j: Nat) (hj:0<j:=by simp): Rake :=
+  let ks' := List.range (j*r.ks.length) |>.map λi =>
+    r.ks[i%r.ks.length]'(List.mod_length r.ks i r.hsize) + (i/r.ks.length) * r.d
+  have : ks'.length = j*r.ks.length := by simp [ks']
+  have := r.hsize
+  { d:= r.d*j, ks := ks', sorted:=false, hsize:=by aesop }
+
+@[simp]
+theorem length_partition (r:Rake) (j: Nat) (hj:0<j)
+  : (r.partition j hj).ks.length = j * r.ks.length := by simp[partition]
+
+theorem partition_def (r:Rake) (j: Nat) (hj:0<j) (i') (hi')
+  : (r.partition j hj).ks[i'] =
+    r.ks[i'%r.ks.length]'(List.mod_length r.ks i' r.hsize) + (i'/r.ks.length) * r.d
+  := by simp[partition]
+
+theorem partition_term_same (r:Rake) (j:Nat) (hj: 0 < j) (r':Rake) (hr':r' = r.partition j hj)
+  : ∀n, (∃m', r'.term m' = n) → (∃m, r.term m = n) := by
+  -- `partition` changes `d` and `ks` but keeps a permutation of the terms.
+  -- we use term_iff so we can argue in terms of `.ks` before and after.
+  intro n; repeat rw[term_iff]
+
+  -- note that r'.d := r.d*j by the definition of `partition`
+  (have : r'.d = r.d*j := by simp[hr', partition]); simp only[this]; clear this
+
+  -- we can now write the goal like so:
+  show (∃ k' ∈ r'.ks, ∃ x', k' + x' * (r.d * j) = n) → ∃ k ∈ r.ks, ∃ x, k + x * r.d = n
+  -- introduce variables for the left side such that
+  -- hik: (r'[i']=k)   and   hx': k' + x' + r.d * j= n
+  intro ⟨k', hk', x', hx'⟩
+  obtain ⟨i', hik'⟩ : ∃(i': Fin r'.ks.length), _:= by
+    rw[List.mem_iff_get] at hk'; exact hk'
+
+  show ∃ k, k ∈ r.ks ∧ ∃ x, k + x * r.d = n
+  -- we already have a theorem that relates the indices of k and k'
+  -- derived from the definition of `partition`.
+  have hdef := partition_def r j hj
+  specialize hdef i' (by rw[←hr']; exact i'.prop)
+  set i  := i' % r.ks.length with hi
+  set k  := r.ks[i]'(List.mod_length r.ks i' r.hsize) with hk
+  set x  := i' / r.ks.length with hx
+  use k
+  apply And.intro
+  · exact List.get_mem r.ks ⟨i, by simpa [i] using List.mod_length r.ks i' r.hsize⟩
+  · replace hdef : k' = k + x * r.d := by simp_all
+    open Nat in rw[mul_comm,hdef,mul_comm,add_assoc,mul_assoc,←mul_add,mul_comm] at hx'
+    use x + j * x'
+
+theorem partition_term_keep (r:Rake) (j:Nat) (hj: 0 < j) (r':Rake) (hr':r' = r.partition j hj)
+  : ∀t, (∃n, r.term n = t) → (∃n, r'.term n = t) := by
+  /- In this direction, each sequence `ksᵢ + d` gets partitioned into
+    *multiple* sequences. There are exactly `j` new sequences, arranged like so:
+
+    `  r.ks  = [ks₀, ks₁, ..., ksₖ₋₁]`
+    `  r'.ks = [ks₀, ks₁, ..., ks₀+d, ks₁+d, ..., ks[z]₋₁+d×(j-1)]`
+
+    Since `r.term n = r.ks[(i := n % z)] + d * (n /z)`, and
+    `r'.ks.length` is a multiple of `r.ks.length`, the terms come out
+    in the exact same order.
+
+    To prove this, we first use `k_of_term` to expand the formula for `r.term n`: -/
+  intro t ⟨n, hn⟩; simp[term_iff]
+
+  set z := r.ks.length
+  set z':= r'.ks.length with hz'
+  have hz'z: z' = (z * j) := by rw[hz',hr',length_partition,Nat.mul_comm]
+
+  obtain ⟨k, _, i, hi, hki, ht⟩ := r.k_of_term (hn: r.term n = t)
+  set i' : Fin z':= ⟨n%z', Nat.mod_lt n r'.hsize⟩ with hi'
+  set k' := r'.ks[i'] with hk'
+  have hi'_val : (i' : Nat) = n % z' := by simp [hi']
+
+  -- map the new constant to the old one
+  have hdef: k' = k + i'/z * r.d := by
+    have hpart := partition_def r j hj i' (by simpa [hr', length_partition, hz', z] using i'.prop)
+    have hidx : (↑i' % r.ks.length) = n % r.ks.length := by
+      rw [hi'_val, hz'z, Nat.mod_mul_right_mod]
+    have hkidx : r.ks[↑i' % r.ks.length] = k := by
+      simpa [hidx, hi] using hki.symm
+    calc
+      k' = r.ks[↑i' % r.ks.length] + (↑i' / r.ks.length) * r.d := by
+        simpa [hr', hk'] using hpart
+      _ = k + (↑i' / z) * r.d := by
+        simpa [z] using congrArg (fun t => t + (↑i' / z) * r.d) hkidx
+
+  show ∃ k' ∈ r'.ks, ∃ x', k' + x' * r'.d = t
+  use k'
+  apply And.intro
+  · show k' ∈ r'.ks
+    exact List.get_mem r'.ks i'
+  · use n/z'; subst ht; rw[Nat.mul_comm]
+    set  t':= k' + r'.d * (n/z') with ht'
+    show t' = k  + r.d  * (n/z)  -- we need to remove the `'` on `r'.d` and `z'`
+    calc t' = k + i'/z * r.d + (r.d * j) * (n/(z *j))  := by simp_all [partition]
+      _= k + r.d * (i'/z + j * (n/(z *j)))             :=
+         by rw[Nat.mul_assoc, Nat.add_assoc, Nat.mul_comm, Nat.mul_add]
+      _= k + r.d * ((n%(z*j)/z) + j * (n/(z *j)))      := by
+         have hiDiv : ↑i' / z = n % (z * j) / z := by rw [hi'_val, hz'z]
+         rw [hiDiv]
+      _= k + r.d * (((n/z)%j) + j * (n/(z *j)))        := by rw[Nat.mod_mul_right_div_self]
+      _= k + r.d * ((n/z)%j + j * ((n/z)/j))           :=
+         by
+           simp [z]
+           left
+           left
+           exact Eq.symm (Nat.div_div_eq_div_mul n z j)
+      _= k + r.d * (n / z)                             := by rw[Nat.mod_add_div (n/z) j]
+
+theorem partition_term_iff (r:Rake) (j:Nat) (hj: 0 < j)
+  : ∀n, (∃m, (r.partition j hj).term m = n) ↔ (∃m, r.term m = n) :=
+  λn => Iff.intro
+    (partition_term_same r j hj (r.partition j hj) rfl n)
+    (partition_term_keep r j hj (r.partition j hj) rfl n)
+
+end « partition »
+
+section « rem (remove multiples) »
+
+variable (r: Rake) {j: Nat} (hj: 0<j)
+
+/-- remove all multiples of `j`. -/
+def rem : Rake :=
+  -- !! I was going to have be a bit smarter in the general case but
+  --    this makes no difference in RakeSieve because j is always prime
+  -- let gcd := r.d.gcd j
+  -- have hz : 0 < (j/gcd) := Nat.div_gcd_pos_of_pos_right r.d hj
+  -- let r' := if j∣r.d then r else r.partition (j/gcd) hz
+  let r' := r.partition j hj
+  let ks := r'.ks.filter (λk => ¬j∣k)
+  if hlen: ks.length = 0 then zer
+  else { d := r'.d, ks:=ks, sorted := false, hsize := Nat.zero_lt_of_ne_zero hlen }
+
+abbrev HasNonMultiple (j:Nat): Prop := ∃n, ¬j∣n ∧ ∃m, r.term m=n
+lemma rem_def' (r:Rake) {j: Nat} (hj: 0<j) (r': Rake) (hr': r' = r.rem hj)
+  : r'=zer
+  ∨ (r'.d=r.d*j ∧ r'.ks=(r.partition j hj).ks.filter (λk => ¬j∣k) ∧ 0<r'.ks.length) := by
+    simp[hr',rem,partition]; split <;> simp_all[Nat.zero_lt_of_ne_zero]
+
+theorem rem_def (r:Rake) {j: Nat} (hj: 0<j) (r': Rake) (hr': r' = r.rem hj) (hnm: HasNonMultiple r j)
+  : r'.d=r.d*j ∧ r'.ks=(r.partition j hj).ks.filter (λk => ¬j∣k) ∧ 0<r'.ks.length := by
+  obtain hzer | ⟨hd', hks', hlen'⟩ := rem_def' r hj r' hr'
+  · -- show hzer case cannot happen thanks to h₁
+    -- r produces terms that don't divide k, and r.partition produces the same terms.
+
+    -- from h1 we can obtain a k∈r.k coprime to p
+    obtain ⟨n, hn, hex⟩ := hnm
+    obtain ⟨k, hk, x, hx⟩ := by rwa[←r.partition_term_iff j hj n, term_iff] at hex
+    have hjk : ¬j ∣ k := by
+      by_contra h
+      have :  j ∣     r.d * j * x := by
+        have := Nat.dvd_mul_right j (r.d*x); rwa[Nat.mul_left_comm,←Nat.mul_assoc] at this
+      have :  j ∣ k + r.d * j * x := by exact (Nat.dvd_add_iff_right h).mp this
+      have : ¬j ∣ k + r.d * j * x := by
+        have : (r.partition j hj).d = r.d * j := by aesop
+        rwa[←hx, this,Nat.mul_comm] at hn
+      contradiction
+
+    -- now show that k survives the filter operation:
+    set r'k := (r.partition j hj).ks.filter (λk => ¬j∣k)
+    have rk: k ∈ r'k := by simp[hk, r'k, hjk, List.mem_filter]
+
+    -- k ≠ 0 because ¬p∣k and ∀n,n∣0
+    have : k ≠ 0 := by by_contra h; have := Nat.dvd_zero j; rw[h] at hjk; contradiction
+    -- but that contradicts the notion that r'=hzer
+    have : k = 0 := by
+      set rpk := (r.partition j hj).ks.filter (λk => ¬j∣k)
+      have rk: k ∈ rpk := by simp[hk, hjk, rpk, List.mem_filter]
+      have hlen : rpk.length ≠ 0 := Nat.ne_of_gt (List.length_pos_of_mem rk)
+      have hnot : ¬ ∀ a ∈ (r.partition j hj).ks, j ∣ a := by
+        intro hall
+        exact hjk (hall k hk)
+      have : r'.ks = rpk := by simp [hr', rem, rpk, hnot]
+      have : r'.ks = [0] := by simp[hzer, zer]
+      simp_all
+    contradiction
+
+  · -- the non-zer case just passes through
+    exact ⟨hd', hks', hlen'⟩
+
+theorem rem_drop (r:Rake) {j: Nat} (hj: 0<j) (r': Rake) (hr': r' = r.rem hj) (hnm: HasNonMultiple r j)
+  : ∀n, j∣n → ¬(∃m, r'.term m = n) := by
+  -- general idea:
+  --   the only way term m = n is if ∃x, ∃k∈r.ks, k + x*d = n
+  --   x would have to be be n/ks.length, but i'm not sure we need that fact
+  --   term_iff supplies this fact.
+  intro n hjn; rw[term_iff]
+  -- we will show no such k exists
+  push_neg; intro k hk x
+  set d' := r'.d
+  -- either rem returns zer, or we can extract the formulas for d and ks
+  obtain ⟨hd', hks', hlen'⟩ := rem_def r hj r' hr' hnm
+  -- we only have to show ¬j∣k, because `j∣d` so `x*d` cancels out mod j
+  suffices ¬j∣k from by
+    by_contra h
+    have h₀: j ∣ k + x * d' := by rwa[h.symm] at hjn
+    have h₁: j ∣ x * d' := Dvd.dvd.mul_left (Dvd.intro_left r.d hd'.symm) x
+    have : j ∣ k := (Nat.dvd_add_iff_left h₁).mpr h₀
+    contradiction
+  show ¬j∣k
+  simp_all[List.mem_filter]
+
+theorem rem_keep (r:Rake) {j: Nat} (hj: 0<j) (r': Rake) (hr': r' = r.rem hj)
+  : ∀n, ¬j∣n → (∃m, r.term m = n) → (∃m', r'.term m' = n) := by
+  -- this follows from partition_term_iff and the nature of filter
+  intro n hjn ht
+  have ht' := ht
+  -- r produces terms that don't divide k, and r.partition produces the same terms.
+  rw[←r.partition_term_iff j hj n, term_iff] at ht'
+  -- since r.partition produces n, we can show ¬j∣k for the corresponding k
+  obtain ⟨k, hk, x, hx⟩ := ht'
+  have hnm: HasNonMultiple r j := by use n
+  obtain ⟨hd', hks'⟩ := rem_def r hj r' hr' hnm
+  -- !! this duplicates some work from rem_def' ... consolidate?
+  have hjk : ¬ j ∣ k := by
+    by_contra h
+    have : j ∣  r.d * j * x := by
+      have : j ∣  j * (r.d * x) := Nat.dvd_mul_right j _
+      rwa[Nat.mul_left_comm,←Nat.mul_assoc] at this
+    have :  j ∣ k + r.d * j * x := by exact (Nat.dvd_add_iff_right h).mp this
+    have : ¬j ∣ k + r.d * j * x := by
+      have : (r.partition j hj).d = r.d * j := by aesop
+      rwa[←hx, this,Nat.mul_comm] at hjn
+    contradiction
+  have : k ∈ r'.ks := by simp[hk, hks', hjk, List.mem_filter]
+  rw[term_iff]
+  use k; aesop
+
+theorem rem_same (r:Rake) {j: Nat} (hj: 0<j) (r': Rake) (hr': r' = r.rem hj) (hnm: HasNonMultiple r j)
+  : ∀n, (∃m', r'.term m' = n) → (∃m, r.term m = n) := by
+  -- this follows from partition_term_iff and the nature of filter.
+  intro n h; rw[term_iff] at h; obtain ⟨k, hk, x, hx⟩ := h
+  obtain ⟨hd', hks'⟩ := rem_def r hj r' hr' hnm
+  have := r.partition_term_iff j hj n
+  rw[term_iff] at this; rw[←this]
+  have : k ∈ (r.partition j hj).ks := by simp_all
+  use k; aesop
+
+end « rem (remove multiples) »
+
+section « gte (greater than or equal to) »
+
+def gte (r: Rake) (n: Nat) : Rake  :=
+  let f : ℕ → ℕ := (λk => let s := aseq k r.d; (ASeq.gte s n).k)
+  { d := r.d, ks := r.ks.map f, sorted := false,
+    hsize := Nat.lt_of_lt_of_eq r.hsize (r.ks.length_map _).symm }
+
+end « gte (greater than or equal to) »
+
+end « rake operations »

--- a/LeanPool/Leansieve/Rake/Rake.lean
+++ b/LeanPool/Leansieve/Rake/Rake.lean
@@ -11,84 +11,110 @@ import Mathlib.Data.List.Dedup
 import Mathlib.Data.List.Basic
 import Mathlib.Data.List.Perm.Basic
 
+/-!
+# Rakes (`Rake`)
+
+A `Rake` is a sorted collection of arithmetic sequences sharing a common delta.
+This module defines rakes, their `term`/`terms` enumeration, the `term_iff`
+characterization of the produced set, sorting and deduplication, the
+`partition` that refines each sequence modulo `j`, the `rem` operation that
+removes all multiples of `j`, and `gte` truncation.
+-/
+
+namespace Leansieve
+
 namespace List
 
+/-- A list is `Sorted` for `r` when consecutive elements are pairwise related. -/
 abbrev Sorted {α : Type _} (r : α → α → Prop) (l : List α) : Prop := l.Pairwise r
 
 end List
 
+/-- A `Rake` is a (by default sorted, deduplicated) list of constants `ks`
+sharing a common delta `d`, representing the union of arithmetic sequences
+`ks[i] + d * n`. -/
 structure Rake : Type where
-  d     : Nat
-  ks    : List Nat
+  /-- The common delta shared by every sequence. -/
+  d : Nat
+  /-- The list of constants, one per arithmetic sequence. -/
+  ks : List Nat
+  /-- The number of constants (defaults to `ks.length`). -/
   size : Nat := ks.length
-  sorted: Bool := true
+  /-- Whether `ks` is maintained sorted and deduplicated. -/
+  sorted : Bool := true
+  /-- When sorted, `ks` is strictly increasing. -/
   hsort : sorted → List.Sorted (·<·) ks := by simp
+  /-- When sorted, `ks` has no duplicates. -/
   huniq : sorted → ks.Nodup := by simp
+  /-- `ks` is nonempty. -/
   hsize : 0 < ks.length := by simp
 
 namespace Rake
 
+/-- The empty/zero rake `{0}` with delta `0`. -/
 def zer : Rake := { d := 0, ks := [0] }
+/-- The rake enumerating all naturals (`0 + 1 * n`). -/
 def nat : Rake := { d := 1, ks := [0] }
+/-- The rake enumerating naturals `≥ 2` (`2 + 1 * n`). -/
 def ge2 : Rake := { d := 1, ks := [2] }
 
 section « terms » -- generating output terms from the rake
 
-def term (r: Rake) (n : Nat) : Nat :=
+/-- The `n`-th term produced by the rake (interleaving its sequences). -/
+def term (r : Rake) (n : Nat) : Nat :=
   let q := r.ks.length
   have : n%q < r.ks.length := Nat.mod_lt _ r.hsize
   aseq r.ks[n%q] r.d |>.term (n/q)
 
-def terms (r: Rake) (n: Nat) : List Nat :=
+/-- The first `n` terms produced by the rake. -/
+def terms (r : Rake) (n : Nat) : List Nat :=
   List.range n |>.map r.term
 
-theorem term_simp (r:Rake) (n:Nat)
-: (∃k, (r.term n = k + r.d * (n/r.ks.length)) ∧ ∃i: Fin r.ks.length, i=n%r.ks.length ∧ k=r.ks[i]) := by
-  let i: Fin r.ks.length := ⟨n%r.ks.length, Nat.mod_lt n r.hsize⟩
+theorem term_simp (r : Rake) (n : Nat)
+: (∃ k, (r.term n = k + r.d * (n/r.ks.length)) ∧
+    ∃ i : Fin r.ks.length, i = n%r.ks.length ∧ k = r.ks[i]) := by
+  let i : Fin r.ks.length := ⟨n%r.ks.length, Nat.mod_lt n r.hsize⟩
   use r.ks[i]
   apply And.intro
   · dsimp[term, i]
   · use i
 
-theorem term_iff (r:Rake)
-  : ∀m, (∃n, r.term n = m) ↔ (∃ k∈r.ks,  ∃x:Nat, k+x*r.d = m) := by
+theorem term_iff (r : Rake)
+  : ∀ m, (∃ n, r.term n = m) ↔ (∃ k ∈ r.ks, ∃ x : Nat, k + x*r.d = m) := by
   intro m; apply Iff.intro
   · show (∃ n, r.term n = m) → ∃ k ∈ r.ks, ∃ x, k + x * r.d = m
     -- this is just grunt work, but it follows from the definition of term
-    intro ⟨n,hn⟩; obtain ⟨k, hk, i, hi, hki⟩ := r.term_simp n
+    intro ⟨n, hn⟩; obtain ⟨k, hk, i, hi, hki⟩ := r.term_simp n
     use k; apply And.intro
-    · simp[List.mem_iff_get]; use i; exact hki.symm
-    · use (n/r.ks.length); subst hki hn; simp_all;
+    · simp only [List.mem_iff_get, List.get_eq_getElem]; use i; exact hki.symm
+    · use (n/r.ks.length); subst hki hn
+      simp_all only [Fin.getElem_fin, Nat.add_left_cancel_iff]
       exact Nat.mul_comm (n / r.ks.length) r.d
-
   · show (∃ k ∈ r.ks, ∃ x, k + x * r.d = m) → ∃ n, r.term n = m
     -- in other words, given some k in our list and an arbitrary x
     -- the rake ought to produce m = k + x * r.d at some point. we prove
     -- this by working backwards to calculate what n we have to plug
     -- into (r.term n) in order to get n back out.
     intro ⟨k, hk, hx₀⟩
-
     -- k is a member of ks so it must have an index in ks: k=r.ks.get i
     rw[List.mem_iff_get] at hk
-    obtain ⟨i: Fin r.ks.length, hi₀ : r.ks.get i = k⟩ := hk
-
+    obtain ⟨i : Fin r.ks.length, hi₀ : r.ks.get i = k⟩ := hk
     -- k uniquely identifies a particular arithmetic sequence within
     -- the rake, and there's some x that we can feed into this sequence
     -- to get the result m. we can obtain it:
-    obtain ⟨x, hx: k + x * r.d = m⟩ := hx₀
-
+    obtain ⟨x, hx : k + x * r.d = m⟩ := hx₀
     -- now we can choose n so that r.term n picks k=ks[ i ] as the constant.
     -- this happens ∀ n, i = n % r.ks.length ∧ x = n / r.ks.length
     have hi₁ : i.val % r.ks.length = i.val := Nat.mod_eq_of_lt i.prop
     let n := (i.val % r.ks.length) + (x * r.ks.length)
-
     -- now we run this definition of `n` through `r.term n` and
     -- once we deal with annoying divmod issues, out comes the result.
     use n
     have hmod : (n % r.ks.length) = i.val := by
       dsimp [n]
       calc
-        (i.val % r.ks.length + x * r.ks.length) % r.ks.length = (i.val % r.ks.length) % r.ks.length := by
+        (i.val % r.ks.length + x * r.ks.length) % r.ks.length
+            = (i.val % r.ks.length) % r.ks.length := by
           rw [Nat.add_mul_mod_self_right]
         _ = i.val % r.ks.length := Nat.mod_mod _ _
         _ = i.val := Nat.mod_eq_of_lt i.prop
@@ -107,22 +133,23 @@ end « terms »
 
 section « sequences » -- arithmetic sequences for each k ∈ ks
 
-def seq (r:Rake) (n:Nat) {hn:n<r.ks.length} : ASeq :=
+/-- The `n`-th arithmetic sequence of the rake (constant `ks[n]`, delta `d`). -/
+def seq (r : Rake) (n : Nat) {hn : n < r.ks.length} : ASeq :=
   aseq (r.ks[n]'hn) r.d
 
-def seqs (r: Rake) : List ASeq :=
-  r.ks.map (λ k => aseq k r.d)
+/-- The list of arithmetic sequences making up the rake. -/
+def seqs (r : Rake) : List ASeq :=
+  r.ks.map (fun k => aseq k r.d)
 
-/--
-  this is slightly more specific than `term_iff`, in that
-  it gives you a specific k and its index -/
-theorem k_of_term (r: Rake) (hmn: r.term m = n)
-: ∃k ∈ r.ks, ∃i : (Fin r.ks.length),
+/-- this is slightly more specific than `term_iff`, in that
+it gives you a specific k and its index -/
+theorem k_of_term (r : Rake) (hmn : r.term m = n)
+: ∃ k ∈ r.ks, ∃ i : (Fin r.ks.length),
     i = m%r.ks.length
     ∧ k = r.ks[i]
     ∧ n = k + r.d * (m/r.ks.length) := by
   set q := r.ks.length with hq
-  have hmq: m%q < r.ks.length := Nat.mod_lt _ r.hsize
+  have hmq : m%q < r.ks.length := Nat.mod_lt _ r.hsize
   set k := r.ks[m%q] with hk; use k
   split_ands
   · show k ∈ r.ks
@@ -131,15 +158,17 @@ theorem k_of_term (r: Rake) (hmn: r.term m = n)
     use i
     split_ands
     · rw[hi]
-    · rw[hi,hk]; simp
-    · simp[←hmn,term, ← hq, hk]
+    · rw[hi, hk]; simp
+    · simp[←hmn, term, ← hq, hk]
 
 end « sequences »
 
 section « sort and dedup »
 
-def sort_nodup (xs:List Nat) (hxs₀ : List.Nodup xs)
-: { xs':List Nat // List.Sorted (·<·) xs' ∧ xs'.Perm xs
+/-- Sort a duplicate-free list of naturals, with proofs that the result is
+strictly sorted, a permutation of the input, of equal length, and duplicate-free. -/
+def sortNodup (xs : List Nat) (hxs₀ : List.Nodup xs)
+: { xs' : List Nat // List.Sorted (·<·) xs' ∧ xs'.Perm xs
     ∧ xs.length = xs'.length ∧ xs'.Nodup } :=
   let xs' := xs.mergeSort (·≤·)
   have hnodup : xs'.Nodup := (List.mergeSort_perm xs (·≤·)).nodup_iff.mpr hxs₀
@@ -149,9 +178,10 @@ def sort_nodup (xs:List Nat) (hxs₀ : List.Nodup xs)
   ⟨xs', And.intro (List.SortedLE.sortedLT_of_nodup hsorted hnodup |>.pairwise)
     (And.intro hperm (And.intro hlength hnodup))⟩
 
-def sort (r: Rake) : {r':Rake // r'.d=r.d ∧ r'.sorted ∧ r'.ks.Perm r.ks.dedup } :=
-  if hs: r.sorted then
-    have hp: r.ks.Perm r.ks.dedup := by
+/-- Sort and deduplicate a rake's constants, returning an equivalent sorted rake. -/
+def sort (r : Rake) : {r' : Rake // r'.d = r.d ∧ r'.sorted ∧ r'.ks.Perm r.ks.dedup } :=
+  if hs : r.sorted then
+    have hp : r.ks.Perm r.ks.dedup := by
       have := r.huniq hs
       rw[←r.ks.dedup_eq_self] at this
       rw[this]
@@ -159,25 +189,26 @@ def sort (r: Rake) : {r':Rake // r'.d=r.d ∧ r'.sorted ∧ r'.ks.Perm r.ks.dedu
   else
     let ks₀ := r.ks
     let ks₁ := ks₀.dedup
-    let ks₂ := sort_nodup ks₁ ks₀.nodup_dedup
-  have ⟨hsort, hperm, hlength, hnodup⟩  := ks₂.prop
-  have hlen₁ : ks₁.length ≠ 0 := by have:=r.hsize; aesop
+    let ks₂ := sortNodup ks₁ ks₀.nodup_dedup
+  have ⟨hsort, hperm, hlength, hnodup⟩ := ks₂.prop
+  have hlen₁ : ks₁.length ≠ 0 := by have := r.hsize; aesop
   have hsize := Nat.lt_of_lt_of_eq (Nat.zero_lt_of_ne_zero hlen₁) hlength
-  ⟨{ d:=r.d, ks:=ks₂, hsort:=λ_=>hsort, huniq:=λ_=>hnodup, hsize:=hsize}, by
+  ⟨{ d := r.d, ks := ks₂, hsort := fun _ => hsort, huniq := fun _ => hnodup, hsize := hsize}, by
     refine ⟨rfl, ?_, hperm⟩
-    show true = true
     rfl⟩
 
-lemma length_pos_of_dedup {l:List Nat} (hlen: 0 < l.length) : 0 < l.dedup.length := by
+lemma length_pos_of_dedup {l : List Nat} (hlen : 0 < l.length) : 0 < l.dedup.length := by
   obtain ⟨hd, tl, hcons⟩ := List.exists_cons_of_length_pos hlen
   have : hd ∈ l := by rw [hcons]; simp
   rw[←List.mem_dedup] at this
   exact List.length_pos_of_mem this
 
-def zero_le_cases (n:Nat) (zeq: 0=n → P) (zlt: 0<n → P) : P :=
-  if h:0=n then zeq h else zlt <| Nat.zero_lt_of_ne_zero λa=>h a.symm
+/-- Case split on whether `n` is zero or positive, choosing the matching branch. -/
+def zeroLeCases (n : Nat) (zeq : 0 = n → P) (zlt : 0 < n → P) : P :=
+  if h : 0 = n then zeq h else zlt <| Nat.zero_lt_of_ne_zero fun a => h a.symm
 
-lemma sorted_get (xs:List Nat) (hxs: List.Sorted (·<·) xs) (i j:Fin xs.length) (hij: i<j)
+lemma sorted_get (xs : List Nat) (hxs : List.Sorted (· < ·) xs) (i j : Fin xs.length)
+    (hij : i < j)
   : (xs[i] < xs[j]) := by
   conv at hxs => dsimp[List.Sorted]; rw[List.pairwise_iff_get]
   simp_all
@@ -187,27 +218,27 @@ As currently defined, the terms of a sorted rake can be non-ascending in one of 
 - ascending sawtooth pattern if ∃k∈r.ks, k>r.d
 - cyclic (and possibly constant) if r.d=0
 But in all cases, if the rake is sorted, term 0 is the minimum. -/
-theorem sorted_min_term_zero (r: Rake) (hr: r.sorted) : ∀ n, (r.term 0 ≤ r.term n) := by
+theorem sorted_min_term_zero (r : Rake) (hr : r.sorted) : ∀ n, (r.term 0 ≤ r.term n) := by
   intro n
   obtain ⟨k₀, hk₀, i₀, hi₀⟩ := r.term_simp 0
   obtain ⟨k₁, hk₁, i₁, hi₁⟩ := r.term_simp n
-  simp[hk₀, hk₁]
+  simp only [hk₀, Nat.zero_div, mul_zero, add_zero, hk₁]
   suffices k₀ ≤ k₁ by exact le_add_right this
   rw[hi₀.right, hi₁.right]
-  apply zero_le_cases i₁.val; all_goals intro hi
+  apply zeroLeCases i₁.val; all_goals intro hi
   case zeq => simp_all
   case zlt =>
     have : i₀.val < i₁.val := by aesop
     exact Nat.le_of_succ_le <| sorted_get r.ks (r.hsort hr) i₀ i₁ this
 
-theorem sort_term_iff_term  (r:Rake) (n:Nat)
-  : (∃m, r.term m = n) ↔ (∃m', r.sort.val.term m' = n) := by
-  if h: r.sorted then
+theorem sort_term_iff_term (r : Rake) (n : Nat)
+  : (∃ m, r.term m = n) ↔ (∃ m', r.sort.val.term m' = n) := by
+  if h : r.sorted then
     constructor <;> intro hm <;> simpa [sort, h] using hm
   else
-    let ⟨rs, ⟨hd, hsort, hperm⟩⟩ := r.sort; simp
-    have : ∀k, k∈rs.ks ↔ k∈r.ks.dedup := fun k => List.Perm.mem_iff hperm
-    have hmem : ∀k, k∈r.ks ↔ k∈rs.ks := by aesop
+    let ⟨rs, ⟨hd, hsort, hperm⟩⟩ := r.sort; simp only
+    have : ∀ k, k ∈ rs.ks ↔ k ∈ r.ks.dedup := fun k => List.Perm.mem_iff hperm
+    have hmem : ∀ k, k ∈ r.ks ↔ k ∈ rs.ks := by aesop
     apply Iff.intro
     all_goals
       intro h; rw[term_iff] at h; obtain ⟨k, hk₀, hk₁⟩ := h
@@ -226,7 +257,7 @@ section « rake operations »
 
 section « partition »
 
-lemma List.mod_length {α : Type} (l:List α) (i:Nat) (hl: 0 < l.length)
+lemma List.mod_length {α : Type} (l : List α) (i : Nat) (hl : 0 < l.length)
   : (i % l.length) < l.length := by exact Nat.mod_lt (↑i) hl
 
 /--
@@ -234,56 +265,55 @@ Partition each sequence in the rake by partitioning their *inputs*
 into equivalance classes mod n. This multiplies the number of sequences
 by n. We can't allow n to be zero because then we'd have no sequences left,
 and this would break the guarantee that term (n) < term n+1. -/
-def partition (r:Rake) (j: Nat) (hj:0<j:=by simp): Rake :=
-  let ks' := List.range (j*r.ks.length) |>.map λi =>
+def partition (r : Rake) (j : Nat) (hj : 0 < j := by simp) : Rake :=
+  let ks' := List.range (j*r.ks.length) |>.map fun i =>
     r.ks[i%r.ks.length]'(List.mod_length r.ks i r.hsize) + (i/r.ks.length) * r.d
   have : ks'.length = j*r.ks.length := by simp [ks']
   have := r.hsize
-  { d:= r.d*j, ks := ks', sorted:=false, hsize:=by aesop }
+  { d := r.d*j, ks := ks', sorted := false, hsize := by aesop }
 
 @[simp]
-theorem length_partition (r:Rake) (j: Nat) (hj:0<j)
+theorem length_partition (r : Rake) (j : Nat) (hj : 0 < j)
   : (r.partition j hj).ks.length = j * r.ks.length := by simp[partition]
 
-theorem partition_def (r:Rake) (j: Nat) (hj:0<j) (i') (hi')
+theorem partition_def (r : Rake) (j : Nat) (hj : 0 < j) (i') (hi')
   : (r.partition j hj).ks[i'] =
     r.ks[i'%r.ks.length]'(List.mod_length r.ks i' r.hsize) + (i'/r.ks.length) * r.d
   := by simp[partition]
 
-theorem partition_term_same (r:Rake) (j:Nat) (hj: 0 < j) (r':Rake) (hr':r' = r.partition j hj)
-  : ∀n, (∃m', r'.term m' = n) → (∃m, r.term m = n) := by
+theorem partition_term_same (r : Rake) (j : Nat) (hj : 0 < j) (r' : Rake)
+    (hr' : r' = r.partition j hj)
+  : ∀ n, (∃ m', r'.term m' = n) → (∃ m, r.term m = n) := by
   -- `partition` changes `d` and `ks` but keeps a permutation of the terms.
   -- we use term_iff so we can argue in terms of `.ks` before and after.
   intro n; repeat rw[term_iff]
-
   -- note that r'.d := r.d*j by the definition of `partition`
   (have : r'.d = r.d*j := by simp[hr', partition]); simp only[this]; clear this
-
   -- we can now write the goal like so:
-  show (∃ k' ∈ r'.ks, ∃ x', k' + x' * (r.d * j) = n) → ∃ k ∈ r.ks, ∃ x, k + x * r.d = n
+  -- `(∃ k' ∈ r'.ks, ∃ x', k' + x' * (r.d * j) = n) → ∃ k ∈ r.ks, ∃ x, k + x * r.d = n`
   -- introduce variables for the left side such that
   -- hik: (r'[i']=k)   and   hx': k' + x' + r.d * j= n
   intro ⟨k', hk', x', hx'⟩
-  obtain ⟨i', hik'⟩ : ∃(i': Fin r'.ks.length), _:= by
+  obtain ⟨i', hik'⟩ : ∃ (i' : Fin r'.ks.length), _ := by
     rw[List.mem_iff_get] at hk'; exact hk'
-
-  show ∃ k, k ∈ r.ks ∧ ∃ x, k + x * r.d = n
+  -- goal: `∃ k, k ∈ r.ks ∧ ∃ x, k + x * r.d = n`
   -- we already have a theorem that relates the indices of k and k'
   -- derived from the definition of `partition`.
   have hdef := partition_def r j hj
   specialize hdef i' (by rw[←hr']; exact i'.prop)
-  set i  := i' % r.ks.length with hi
-  set k  := r.ks[i]'(List.mod_length r.ks i' r.hsize) with hk
-  set x  := i' / r.ks.length with hx
+  set i := i' % r.ks.length with hi
+  set k := r.ks[i]'(List.mod_length r.ks i' r.hsize) with hk
+  set x := i' / r.ks.length with hx
   use k
   apply And.intro
   · exact List.get_mem r.ks ⟨i, by simpa [i] using List.mod_length r.ks i' r.hsize⟩
   · replace hdef : k' = k + x * r.d := by simp_all
-    open Nat in rw[mul_comm,hdef,mul_comm,add_assoc,mul_assoc,←mul_add,mul_comm] at hx'
+    open Nat in rw[mul_comm, hdef, mul_comm, add_assoc, mul_assoc, ←mul_add, mul_comm] at hx'
     use x + j * x'
 
-theorem partition_term_keep (r:Rake) (j:Nat) (hj: 0 < j) (r':Rake) (hr':r' = r.partition j hj)
-  : ∀t, (∃n, r.term n = t) → (∃n, r'.term n = t) := by
+theorem partition_term_keep (r : Rake) (j : Nat) (hj : 0 < j) (r' : Rake)
+    (hr' : r' = r.partition j hj)
+  : ∀ t, (∃ n, r.term n = t) → (∃ n, r'.term n = t) := by
   /- In this direction, each sequence `ksᵢ + d` gets partitioned into
     *multiple* sequences. There are exactly `j` new sequences, arranged like so:
 
@@ -295,19 +325,16 @@ theorem partition_term_keep (r:Rake) (j:Nat) (hj: 0 < j) (r':Rake) (hr':r' = r.p
     in the exact same order.
 
     To prove this, we first use `k_of_term` to expand the formula for `r.term n`: -/
-  intro t ⟨n, hn⟩; simp[term_iff]
-
+  intro t ⟨n, hn⟩; simp only [term_iff]
   set z := r.ks.length
-  set z':= r'.ks.length with hz'
-  have hz'z: z' = (z * j) := by rw[hz',hr',length_partition,Nat.mul_comm]
-
-  obtain ⟨k, _, i, hi, hki, ht⟩ := r.k_of_term (hn: r.term n = t)
-  set i' : Fin z':= ⟨n%z', Nat.mod_lt n r'.hsize⟩ with hi'
+  set z' := r'.ks.length with hz'
+  have hz'z : z' = (z * j) := by rw[hz', hr', length_partition, Nat.mul_comm]
+  obtain ⟨k, _, i, hi, hki, ht⟩ := r.k_of_term (hn : r.term n = t)
+  set i' : Fin z' := ⟨n%z', Nat.mod_lt n r'.hsize⟩ with hi'
   set k' := r'.ks[i'] with hk'
   have hi'_val : (i' : Nat) = n % z' := by simp [hi']
-
   -- map the new constant to the old one
-  have hdef: k' = k + i'/z * r.d := by
+  have hdef : k' = k + i'/z * r.d := by
     have hpart := partition_def r j hj i' (by simpa [hr', length_partition, hz', z] using i'.prop)
     have hidx : (↑i' % r.ks.length) = n % r.ks.length := by
       rw [hi'_val, hz'z, Nat.mod_mul_right_mod]
@@ -318,33 +345,32 @@ theorem partition_term_keep (r:Rake) (j:Nat) (hj: 0 < j) (r':Rake) (hr':r' = r.p
         simpa [hr', hk'] using hpart
       _ = k + (↑i' / z) * r.d := by
         simpa [z] using congrArg (fun t => t + (↑i' / z) * r.d) hkidx
-
-  show ∃ k' ∈ r'.ks, ∃ x', k' + x' * r'.d = t
+  -- goal: `∃ k' ∈ r'.ks, ∃ x', k' + x' * r'.d = t`
   use k'
   apply And.intro
   · show k' ∈ r'.ks
     exact List.get_mem r'.ks i'
   · use n/z'; subst ht; rw[Nat.mul_comm]
-    set  t':= k' + r'.d * (n/z') with ht'
-    show t' = k  + r.d  * (n/z)  -- we need to remove the `'` on `r'.d` and `z'`
-    calc t' = k + i'/z * r.d + (r.d * j) * (n/(z *j))  := by simp_all [partition]
-      _= k + r.d * (i'/z + j * (n/(z *j)))             :=
+    set t' := k' + r'.d * (n/z') with ht'
+    -- goal: `t' = k + r.d * (n/z)`; we need to remove the `'` on `r'.d` and `z'`
+    calc t' = k + i'/z * r.d + (r.d * j) * (n/(z *j)) := by simp_all [partition]
+      _= k + r.d * (i'/z + j * (n/(z *j))) :=
          by rw[Nat.mul_assoc, Nat.add_assoc, Nat.mul_comm, Nat.mul_add]
-      _= k + r.d * ((n%(z*j)/z) + j * (n/(z *j)))      := by
+      _= k + r.d * ((n%(z*j)/z) + j * (n/(z *j))) := by
          have hiDiv : ↑i' / z = n % (z * j) / z := by rw [hi'_val, hz'z]
          rw [hiDiv]
-      _= k + r.d * (((n/z)%j) + j * (n/(z *j)))        := by rw[Nat.mod_mul_right_div_self]
-      _= k + r.d * ((n/z)%j + j * ((n/z)/j))           :=
+      _= k + r.d * (((n/z)%j) + j * (n/(z *j))) := by rw[Nat.mod_mul_right_div_self]
+      _= k + r.d * ((n/z)%j + j * ((n/z)/j)) :=
          by
-           simp [z]
+           simp only [Nat.add_left_cancel_iff, mul_eq_mul_left_iff, z]
            left
            left
            exact Eq.symm (Nat.div_div_eq_div_mul n z j)
-      _= k + r.d * (n / z)                             := by rw[Nat.mod_add_div (n/z) j]
+      _= k + r.d * (n / z) := by rw[Nat.mod_add_div (n/z) j]
 
-theorem partition_term_iff (r:Rake) (j:Nat) (hj: 0 < j)
-  : ∀n, (∃m, (r.partition j hj).term m = n) ↔ (∃m, r.term m = n) :=
-  λn => Iff.intro
+theorem partition_term_iff (r : Rake) (j : Nat) (hj : 0 < j)
+  : ∀ n, (∃ m, (r.partition j hj).term m = n) ↔ (∃ m, r.term m = n) :=
+  fun n => Iff.intro
     (partition_term_same r j hj (r.partition j hj) rfl n)
     (partition_term_keep r j hj (r.partition j hj) rfl n)
 
@@ -352,7 +378,7 @@ end « partition »
 
 section « rem (remove multiples) »
 
-variable (r: Rake) {j: Nat} (hj: 0<j)
+variable (r : Rake) {j : Nat} (hj : 0 < j)
 
 /-- remove all multiples of `j`. -/
 def rem : Rake :=
@@ -362,45 +388,45 @@ def rem : Rake :=
   -- have hz : 0 < (j/gcd) := Nat.div_gcd_pos_of_pos_right r.d hj
   -- let r' := if j∣r.d then r else r.partition (j/gcd) hz
   let r' := r.partition j hj
-  let ks := r'.ks.filter (λk => ¬j∣k)
-  if hlen: ks.length = 0 then zer
-  else { d := r'.d, ks:=ks, sorted := false, hsize := Nat.zero_lt_of_ne_zero hlen }
+  let ks := r'.ks.filter (fun k => ¬j ∣ k)
+  if hlen : ks.length = 0 then zer
+  else { d := r'.d, ks := ks, sorted := false, hsize := Nat.zero_lt_of_ne_zero hlen }
 
-abbrev HasNonMultiple (j:Nat): Prop := ∃n, ¬j∣n ∧ ∃m, r.term m=n
-lemma rem_def' (r:Rake) {j: Nat} (hj: 0<j) (r': Rake) (hr': r' = r.rem hj)
-  : r'=zer
-  ∨ (r'.d=r.d*j ∧ r'.ks=(r.partition j hj).ks.filter (λk => ¬j∣k) ∧ 0<r'.ks.length) := by
-    simp[hr',rem,partition]; split <;> simp_all[Nat.zero_lt_of_ne_zero]
+/-- The rake has a term that is not a multiple of `j`. -/
+abbrev HasNonMultiple (j : Nat) : Prop := ∃ n, ¬j ∣ n ∧ ∃ m, r.term m = n
 
-theorem rem_def (r:Rake) {j: Nat} (hj: 0<j) (r': Rake) (hr': r' = r.rem hj) (hnm: HasNonMultiple r j)
-  : r'.d=r.d*j ∧ r'.ks=(r.partition j hj).ks.filter (λk => ¬j∣k) ∧ 0<r'.ks.length := by
+lemma rem_def' (r : Rake) {j : Nat} (hj : 0 < j) (r' : Rake) (hr' : r' = r.rem hj)
+  : r' = zer
+  ∨ (r'.d = r.d*j ∧ r'.ks = (r.partition j hj).ks.filter (fun k => ¬j ∣ k) ∧ 0 < r'.ks.length) := by
+    simp[hr', rem, partition]; split <;> simp_all[Nat.zero_lt_of_ne_zero]
+
+theorem rem_def (r : Rake) {j : Nat} (hj : 0 < j) (r' : Rake) (hr' : r' = r.rem hj)
+    (hnm : HasNonMultiple r j)
+  : r'.d = r.d*j ∧ r'.ks = (r.partition j hj).ks.filter (fun k => ¬j ∣ k) ∧ 0 < r'.ks.length := by
   obtain hzer | ⟨hd', hks', hlen'⟩ := rem_def' r hj r' hr'
   · -- show hzer case cannot happen thanks to h₁
     -- r produces terms that don't divide k, and r.partition produces the same terms.
-
     -- from h1 we can obtain a k∈r.k coprime to p
     obtain ⟨n, hn, hex⟩ := hnm
     obtain ⟨k, hk, x, hx⟩ := by rwa[←r.partition_term_iff j hj n, term_iff] at hex
     have hjk : ¬j ∣ k := by
       by_contra h
-      have :  j ∣     r.d * j * x := by
-        have := Nat.dvd_mul_right j (r.d*x); rwa[Nat.mul_left_comm,←Nat.mul_assoc] at this
-      have :  j ∣ k + r.d * j * x := by exact (Nat.dvd_add_iff_right h).mp this
+      have : j ∣ r.d * j * x := by
+        have := Nat.dvd_mul_right j (r.d*x); rwa[Nat.mul_left_comm, ←Nat.mul_assoc] at this
+      have : j ∣ k + r.d * j * x := by exact (Nat.dvd_add_iff_right h).mp this
       have : ¬j ∣ k + r.d * j * x := by
         have : (r.partition j hj).d = r.d * j := by aesop
-        rwa[←hx, this,Nat.mul_comm] at hn
+        rwa[←hx, this, Nat.mul_comm] at hn
       contradiction
-
     -- now show that k survives the filter operation:
-    set r'k := (r.partition j hj).ks.filter (λk => ¬j∣k)
-    have rk: k ∈ r'k := by simp[hk, r'k, hjk, List.mem_filter]
-
+    set r'k := (r.partition j hj).ks.filter (fun k => ¬j ∣ k)
+    have rk : k ∈ r'k := by simp[hk, r'k, hjk, List.mem_filter]
     -- k ≠ 0 because ¬p∣k and ∀n,n∣0
     have : k ≠ 0 := by by_contra h; have := Nat.dvd_zero j; rw[h] at hjk; contradiction
     -- but that contradicts the notion that r'=hzer
     have : k = 0 := by
-      set rpk := (r.partition j hj).ks.filter (λk => ¬j∣k)
-      have rk: k ∈ rpk := by simp[hk, hjk, rpk, List.mem_filter]
+      set rpk := (r.partition j hj).ks.filter (fun k => ¬j ∣ k)
+      have rk : k ∈ rpk := by simp[hk, hjk, rpk, List.mem_filter]
       have hlen : rpk.length ≠ 0 := Nat.ne_of_gt (List.length_pos_of_mem rk)
       have hnot : ¬ ∀ a ∈ (r.partition j hj).ks, j ∣ a := by
         intro hall
@@ -409,34 +435,34 @@ theorem rem_def (r:Rake) {j: Nat} (hj: 0<j) (r': Rake) (hr': r' = r.rem hj) (hnm
       have : r'.ks = [0] := by simp[hzer, zer]
       simp_all
     contradiction
-
   · -- the non-zer case just passes through
     exact ⟨hd', hks', hlen'⟩
 
-theorem rem_drop (r:Rake) {j: Nat} (hj: 0<j) (r': Rake) (hr': r' = r.rem hj) (hnm: HasNonMultiple r j)
-  : ∀n, j∣n → ¬(∃m, r'.term m = n) := by
+theorem rem_drop (r : Rake) {j : Nat} (hj : 0 < j) (r' : Rake) (hr' : r' = r.rem hj)
+    (hnm : HasNonMultiple r j)
+  : ∀ n, j ∣ n → ¬(∃ m, r'.term m = n) := by
   -- general idea:
   --   the only way term m = n is if ∃x, ∃k∈r.ks, k + x*d = n
   --   x would have to be be n/ks.length, but i'm not sure we need that fact
   --   term_iff supplies this fact.
   intro n hjn; rw[term_iff]
   -- we will show no such k exists
-  push_neg; intro k hk x
+  push Not; intro k hk x
   set d' := r'.d
   -- either rem returns zer, or we can extract the formulas for d and ks
   obtain ⟨hd', hks', hlen'⟩ := rem_def r hj r' hr' hnm
   -- we only have to show ¬j∣k, because `j∣d` so `x*d` cancels out mod j
-  suffices ¬j∣k from by
+  suffices ¬j ∣ k from by
     by_contra h
-    have h₀: j ∣ k + x * d' := by rwa[h.symm] at hjn
-    have h₁: j ∣ x * d' := Dvd.dvd.mul_left (Dvd.intro_left r.d hd'.symm) x
+    have h₀ : j ∣ k + x * d' := by rwa[h.symm] at hjn
+    have h₁ : j ∣ x * d' := Dvd.dvd.mul_left (Dvd.intro_left r.d hd'.symm) x
     have : j ∣ k := (Nat.dvd_add_iff_left h₁).mpr h₀
     contradiction
-  show ¬j∣k
+  show ¬j ∣ k
   simp_all[List.mem_filter]
 
-theorem rem_keep (r:Rake) {j: Nat} (hj: 0<j) (r': Rake) (hr': r' = r.rem hj)
-  : ∀n, ¬j∣n → (∃m, r.term m = n) → (∃m', r'.term m' = n) := by
+theorem rem_keep (r : Rake) {j : Nat} (hj : 0 < j) (r' : Rake) (hr' : r' = r.rem hj)
+  : ∀ n, ¬j ∣ n → (∃ m, r.term m = n) → (∃ m', r'.term m' = n) := by
   -- this follows from partition_term_iff and the nature of filter
   intro n hjn ht
   have ht' := ht
@@ -444,25 +470,26 @@ theorem rem_keep (r:Rake) {j: Nat} (hj: 0<j) (r': Rake) (hr': r' = r.rem hj)
   rw[←r.partition_term_iff j hj n, term_iff] at ht'
   -- since r.partition produces n, we can show ¬j∣k for the corresponding k
   obtain ⟨k, hk, x, hx⟩ := ht'
-  have hnm: HasNonMultiple r j := by use n
+  have hnm : HasNonMultiple r j := by use n
   obtain ⟨hd', hks'⟩ := rem_def r hj r' hr' hnm
   -- !! this duplicates some work from rem_def' ... consolidate?
   have hjk : ¬ j ∣ k := by
     by_contra h
-    have : j ∣  r.d * j * x := by
-      have : j ∣  j * (r.d * x) := Nat.dvd_mul_right j _
-      rwa[Nat.mul_left_comm,←Nat.mul_assoc] at this
-    have :  j ∣ k + r.d * j * x := by exact (Nat.dvd_add_iff_right h).mp this
+    have : j ∣ r.d * j * x := by
+      have : j ∣ j * (r.d * x) := Nat.dvd_mul_right j _
+      rwa[Nat.mul_left_comm, ←Nat.mul_assoc] at this
+    have : j ∣ k + r.d * j * x := by exact (Nat.dvd_add_iff_right h).mp this
     have : ¬j ∣ k + r.d * j * x := by
       have : (r.partition j hj).d = r.d * j := by aesop
-      rwa[←hx, this,Nat.mul_comm] at hjn
+      rwa[←hx, this, Nat.mul_comm] at hjn
     contradiction
   have : k ∈ r'.ks := by simp[hk, hks', hjk, List.mem_filter]
   rw[term_iff]
   use k; aesop
 
-theorem rem_same (r:Rake) {j: Nat} (hj: 0<j) (r': Rake) (hr': r' = r.rem hj) (hnm: HasNonMultiple r j)
-  : ∀n, (∃m', r'.term m' = n) → (∃m, r.term m = n) := by
+theorem rem_same (r : Rake) {j : Nat} (hj : 0 < j) (r' : Rake) (hr' : r' = r.rem hj)
+    (hnm : HasNonMultiple r j)
+  : ∀ n, (∃ m', r'.term m' = n) → (∃ m, r.term m = n) := by
   -- this follows from partition_term_iff and the nature of filter.
   intro n h; rw[term_iff] at h; obtain ⟨k, hk, x, hx⟩ := h
   obtain ⟨hd', hks'⟩ := rem_def r hj r' hr' hnm
@@ -475,11 +502,16 @@ end « rem (remove multiples) »
 
 section « gte (greater than or equal to) »
 
-def gte (r: Rake) (n: Nat) : Rake  :=
-  let f : ℕ → ℕ := (λk => let s := aseq k r.d; (ASeq.gte s n).k)
+/-- Truncate every sequence of the rake to keep only terms `≥ n`. -/
+def gte (r : Rake) (n : Nat) : Rake :=
+  let f : ℕ → ℕ := (fun k => let s := aseq k r.d; (ASeq.gte s n).k)
   { d := r.d, ks := r.ks.map f, sorted := false,
     hsize := Nat.lt_of_lt_of_eq r.hsize (r.ks.length_map _).symm }
 
 end « gte (greater than or equal to) »
 
 end « rake operations »
+
+end Rake
+
+end Leansieve

--- a/LeanPool/Leansieve/RakeMap/RakeMap.lean
+++ b/LeanPool/Leansieve/RakeMap/RakeMap.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 tangentstorm. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: tangentstorm
+-/
+import LeanPool.Leansieve.Rake.Rake
+
+/--
+A RakeMap provides a 1-to-1 mapping between its rake
+and a set of numbers with some property. -/
+structure RakeMap (pred: Nat → Prop) where
+  rake : Rake
+  hbij : ∀ n, pred n ↔ ∃ m, rake.term m = n
+  hord : rake.sorted := by rfl
+
+namespace RakeMap
+
+open Rake
+
+def pred {p:Nat → Prop} (_:RakeMap p) : Nat → Prop := p
+@[simp] def term (rm: RakeMap p) (n:Nat) := rm.rake.term n
+
+theorem min_term_zero (rm:RakeMap p)  : ∀ n, (rm.term 0 ≤ rm.term n) :=
+  @Rake.sorted_min_term_zero rm.rake rm.hord
+
+/-- proof that rm_nat.term provides a bijection from Nat → Nat
+ (it happens to be an identity map, but this is not necessary for proofs) -/
+def rm_nat : RakeMap (λ _ => True) := {
+  rake := nat
+  hbij := by intro n; simp[Rake.term, nat, aseq, ASeq.term]}
+
+def rm_ge2 : RakeMap (λn => 2≤n) := {
+  rake := ge2
+  hbij := by
+    intro n; simp[Rake.term, ge2, aseq, ASeq.term]; apply Iff.intro
+    · show 2 ≤ n → ∃ m, 2 + m = n
+      intro n2; use n-2; simp_all
+    · show (∃ m, 2 + m = n) → 2 ≤ n
+      intro hm; obtain ⟨m,hm⟩ := hm; rw[←hm]; simp }
+
+-- operations on RakeMap -------------------------------------------------------
+
+/-
+This removes all multiples of a number from the rake.
+- `hx: 0 < x` is necessary because we multiply the delta
+  by x in the partition step, and delta=0 gives you a cyclic rake.
+- `hnmr` is a proof that the rake contains at least one non-multiple of j.
+  This is a number that won't be removed. If all numbers were
+  removed, `term` would become meaningless.
+
+In the future, it may make sense to also provide a version of
+`rem` that requires no such proof but returns `Option Rake`. -/
+def rem (rm : RakeMap prop) (j: Nat) (hj: 0<j) (hnmr: ∃n m, ¬j∣n ∧ rm.term m = n)
+  : RakeMap (λ n => prop n ∧ ¬j∣n) :=
+  let r₀ := rm.rake
+  let r₁ := r₀.rem hj;
+  have hbij₀ := rm.hbij
+  have hbij₁ : ∀n, prop n ∧ ¬j∣n ↔ ∃ m, r₁.term m = n := by
+    intro n
+    have hnm: r₀.HasNonMultiple j := by
+      obtain ⟨n, m, hjn, ht⟩ := hnmr
+      dsimp[HasNonMultiple, r₀]
+      use n; aesop
+    have hd := r₀.rem_drop hj
+    have hk := r₀.rem_keep hj
+    have hs := r₀.rem_same hj
+    repeat aesop
+  let r₂ := r₁.sort
+  let hbij₂ : ∀ n, prop n ∧ ¬j∣n ↔ ∃ m, r₂.val.term m = n := by
+    intro n
+    have hs := r₁.sort_term_iff_term n
+    apply Iff.intro; all_goals aesop
+  { rake := r₂, hbij := hbij₂, hord := by simp[r₂.prop] }

--- a/LeanPool/Leansieve/RakeMap/RakeMap.lean
+++ b/LeanPool/Leansieve/RakeMap/RakeMap.lean
@@ -5,59 +5,81 @@ Authors: tangentstorm
 -/
 import LeanPool.Leansieve.Rake.Rake
 
+/-!
+# Rake maps (`RakeMap`)
+
+A `RakeMap` bundles a `Rake` together with a proof that its terms biject with the
+set of naturals satisfying a given predicate. This module provides the base maps
+`rmNat` and `rmGe2` and the `rem` operation that removes all multiples of `j`,
+refining the predicate accordingly.
+-/
+
+namespace Leansieve
+
 /--
 A RakeMap provides a 1-to-1 mapping between its rake
 and a set of numbers with some property. -/
-structure RakeMap (pred: Nat → Prop) where
+structure RakeMap (pred : Nat → Prop) where
+  /-- The underlying rake. -/
   rake : Rake
+  /-- The rake's terms biject with the naturals satisfying `pred`. -/
   hbij : ∀ n, pred n ↔ ∃ m, rake.term m = n
+  /-- The rake is sorted. -/
   hord : rake.sorted := by rfl
 
 namespace RakeMap
 
 open Rake
 
-def pred {p:Nat → Prop} (_:RakeMap p) : Nat → Prop := p
-@[simp] def term (rm: RakeMap p) (n:Nat) := rm.rake.term n
+/-- The predicate that the rake map enumerates. -/
+def pred {p : Nat → Prop} (rm : RakeMap p) : Nat → Prop := match rm with | _ => p
 
-theorem min_term_zero (rm:RakeMap p)  : ∀ n, (rm.term 0 ≤ rm.term n) :=
+/-- The `n`-th term of the rake map. -/
+@[simp] def term (rm : RakeMap p) (n : Nat) := rm.rake.term n
+
+theorem min_term_zero (rm : RakeMap p) : ∀ n, (rm.term 0 ≤ rm.term n) :=
   @Rake.sorted_min_term_zero rm.rake rm.hord
 
-/-- proof that rm_nat.term provides a bijection from Nat → Nat
- (it happens to be an identity map, but this is not necessary for proofs) -/
-def rm_nat : RakeMap (λ _ => True) := {
+/-- The rake map over all naturals (`rmNat.term` is a bijection `Nat → Nat`;
+it happens to be the identity map, though that is not needed for the proofs). -/
+def rmNat : RakeMap (fun _ => True) := {
   rake := nat
   hbij := by intro n; simp[Rake.term, nat, aseq, ASeq.term]}
 
-def rm_ge2 : RakeMap (λn => 2≤n) := {
+/-- The rake map over the naturals `≥ 2`. -/
+def rmGe2 : RakeMap (fun n => 2 ≤ n) := {
   rake := ge2
   hbij := by
-    intro n; simp[Rake.term, ge2, aseq, ASeq.term]; apply Iff.intro
+    intro n
+    simp only [Rake.term, ASeq.term, aseq, ge2, List.length_cons, List.length_nil, zero_add,
+      List.getElem_singleton, Nat.div_one, one_mul]
+    apply Iff.intro
     · show 2 ≤ n → ∃ m, 2 + m = n
       intro n2; use n-2; simp_all
     · show (∃ m, 2 + m = n) → 2 ≤ n
-      intro hm; obtain ⟨m,hm⟩ := hm; rw[←hm]; simp }
+      intro hm; obtain ⟨m, hm⟩ := hm; rw[←hm]; simp }
 
 -- operations on RakeMap -------------------------------------------------------
 
-/-
+/--
 This removes all multiples of a number from the rake.
-- `hx: 0 < x` is necessary because we multiply the delta
-  by x in the partition step, and delta=0 gives you a cyclic rake.
+- `hj : 0 < j` is necessary because we multiply the delta
+  by j in the partition step, and delta=0 gives you a cyclic rake.
 - `hnmr` is a proof that the rake contains at least one non-multiple of j.
   This is a number that won't be removed. If all numbers were
   removed, `term` would become meaningless.
 
 In the future, it may make sense to also provide a version of
 `rem` that requires no such proof but returns `Option Rake`. -/
-def rem (rm : RakeMap prop) (j: Nat) (hj: 0<j) (hnmr: ∃n m, ¬j∣n ∧ rm.term m = n)
-  : RakeMap (λ n => prop n ∧ ¬j∣n) :=
+def rem {prop : Nat → Prop} (rm : RakeMap prop) (j : Nat) (hj : 0 < j)
+    (hnmr : ∃ n m, ¬j ∣ n ∧ rm.term m = n)
+  : RakeMap (fun n => prop n ∧ ¬j ∣ n) :=
   let r₀ := rm.rake
-  let r₁ := r₀.rem hj;
+  let r₁ := r₀.rem hj
   have hbij₀ := rm.hbij
-  have hbij₁ : ∀n, prop n ∧ ¬j∣n ↔ ∃ m, r₁.term m = n := by
+  have hbij₁ : ∀ n, prop n ∧ ¬j ∣ n ↔ ∃ m, r₁.term m = n := by
     intro n
-    have hnm: r₀.HasNonMultiple j := by
+    have hnm : r₀.HasNonMultiple j := by
       obtain ⟨n, m, hjn, ht⟩ := hnmr
       dsimp[HasNonMultiple, r₀]
       use n; aesop
@@ -66,8 +88,12 @@ def rem (rm : RakeMap prop) (j: Nat) (hj: 0<j) (hnmr: ∃n m, ¬j∣n ∧ rm.ter
     have hs := r₀.rem_same hj
     repeat aesop
   let r₂ := r₁.sort
-  let hbij₂ : ∀ n, prop n ∧ ¬j∣n ↔ ∃ m, r₂.val.term m = n := by
+  let hbij₂ : ∀ n, prop n ∧ ¬j ∣ n ↔ ∃ m, r₂.val.term m = n := by
     intro n
     have hs := r₁.sort_term_iff_term n
     apply Iff.intro; all_goals aesop
   { rake := r₂, hbij := hbij₂, hord := by simp[r₂.prop] }
+
+end RakeMap
+
+end Leansieve

--- a/LeanPool/Leansieve/RakeSieve/RakeSieve.lean
+++ b/LeanPool/Leansieve/RakeSieve/RakeSieve.lean
@@ -7,13 +7,34 @@ Authors: tangentstorm
 import LeanPool.Leansieve.RakeMap.RakeMap
 import LeanPool.Leansieve.PrimeSieve.PrimeSieve
 
+/-!
+# A concrete prime sieve (`RakeSieve`)
+
+`RakeSieve` instantiates the generic `PrimeSieve` correctness logic with a
+concrete rake-based representation of the residue set. `init` builds the state
+for the numbers coprime to `2`; `next` sifts out multiples of the current prime;
+and the `PrimeSieveState`/`PrimeSieveDriver` instances tie these to the abstract
+correctness proofs, yielding a sieve-of-Eratosthenes-style prime generator.
+-/
+
+namespace Leansieve
+
+/-- A concrete sieve state: a rake map enumerating the residue set `R p`,
+together with the current prime `p` and the next candidate `c`. -/
 structure RakeSieve where
-  prop : Nat -> Prop
-  rm: RakeMap prop
+  /-- The predicate characterizing the residue set. -/
+  prop : Nat → Prop
+  /-- The rake map enumerating `prop`. -/
+  rm : RakeMap prop
+  /-- The current prime. -/
   p : NPrime               -- the current prime
+  /-- The candidate for the next prime. -/
   c : Nat                  -- the candidate for next prime
-  hprop : ∀ n:Nat, prop n ↔ n ∈ R p
+  /-- `prop` agrees with membership in the residue set `R p`. -/
+  hprop : ∀ n : Nat, prop n ↔ n ∈ R p
+  /-- The candidate lies in the residue set. -/
   hCinR : c ∈ R p
+  /-- The candidate is the minimum of the residue set. -/
   hRmin : ∀ r ∈ R p, c ≤ r
   -- Q : Array RakeMap     -- queue of found primes
 
@@ -21,38 +42,41 @@ namespace RakeSieve
 
 open RakeMap
 
+/-- The initial sieve state: the numbers coprime to `2`, current prime `2`,
+candidate `3`. -/
 def init : RakeSieve :=
-  let rm : RakeMap (λn => n≥2 ∧ ¬2∣n) := rm_ge2 |>.rem 2 (by simp) (by
-    use 3; use 1; simp[rm_ge2, Rake.ge2, Rake.term])
+  let rm : RakeMap (fun n => n ≥ 2 ∧ ¬2 ∣ n) := rmGe2 |>.rem 2 (by simp) (by
+    use 3; use 1; simp[rmGe2, Rake.ge2, Rake.term])
   let p := ⟨2, Nat.prime_two⟩
   { prop := rm.pred, rm := rm, p := p, c := 3,
     hprop := by
-      have hrm : rm.pred = λn => n ≥ 2 ∧ ¬ 2∣n := by simp[RakeMap.pred]
-      show ∀ n, rm.pred n ↔ n ∈ R p
+      have hrm : rm.pred = fun n => n ≥ 2 ∧ ¬ 2 ∣ n := by simp[RakeMap.pred]
+      -- goal: `∀ n, rm.pred n ↔ n ∈ R p`
       have hbij := rm.hbij
-      unfold R; simp_all; intro n
+      unfold R; simp_all only [ge_iff_le, Nat.two_dvd_ne_zero, Set.mem_setOf_eq]; intro n
       apply Iff.intro
       case mp =>
         intro hn
         apply And.intro
         · rw[← hbij] at hn; exact hn.left
         · intro q hq hq'
-          simp[←hbij] at hn
+          simp only [← hbij] at hn
           have hp2 : (p : Nat) = 2 := rfl
           have hq2 : 2 ≤ q := Nat.Prime.two_le hq'
           have : 2 = q := by omega
           rw[this] at hn
           omega
       case mpr =>
-        simp; intro hn hn2; rw[←hbij]; simp_all
-        have hp2: p.val = 2 := by rfl
+        simp only [and_imp]; intro hn hn2; rw[←hbij]; simp_all only [true_and]
+        have hp2 : p.val = 2 := by rfl
         have hn2' := hn2
         set p' := p.val
-        specialize hn2' p';  simp[hp2] at hn2'
+        specialize hn2' p'; simp only [hp2, Std.le_refl, Nat.two_dvd_ne_zero, forall_const] at hn2'
         exact hn2' Nat.prime_two
     hCinR := by
       -- clearly 3 isn't divisible by 2, so is in r
-      unfold R; simp; intro q hqle hq'
+      unfold R; simp only [ge_iff_le, Set.mem_setOf_eq, Nat.reduceLeDiff, true_and]
+      intro q hqle hq'
       have hp2 : (p : Nat) = 2 := rfl
       have hq2 : 2 ≤ q := Nat.Prime.two_le hq'
       have : q = 2 := by omega
@@ -67,23 +91,25 @@ def init : RakeSieve :=
       -- now we can use hrr to prove ¬2∣2, which is absurd
       have := Nat.prime_two; aesop }
 
-def next (rs₀ : RakeSieve) (hC₀: Nat.Prime rs₀.c) (hNS: nosk' rs₀.p rs₀.c): RakeSieve :=
+/-- Advance the sieve: sift out multiples of the current prime, yielding the
+next sieve state with the old candidate as the new prime. -/
+def next (rs₀ : RakeSieve) (hC₀ : Nat.Prime rs₀.c) (hNS : nosk' rs₀.p rs₀.c) : RakeSieve :=
   let h₀ := rs₀.prop
-  have hh₀ : ∀n, h₀ n ↔ n ∈ R rs₀.p := rs₀.hprop
+  have hh₀ : ∀ n, h₀ n ↔ n ∈ R rs₀.p := rs₀.hprop
   have hCR₀ := rs₀.hCinR
-  have hpgt:PrimeGt rs₀.p rs₀.c := by
+  have hpgt : PrimeGt rs₀.p rs₀.c := by
     constructor
     · exact hC₀
     · exact r_gt_p (↑rs₀.p) rs₀.c hCR₀
-  have hmin: ∀ q < rs₀.c, ¬PrimeGt (↑rs₀.p) q := by
-    simp_all; intro q hq hq'; apply hNS at hq'; omega
-  let c' : MinPrimeGt rs₀.p := { p:=rs₀.c, hpgt:=hpgt, hmin:=hmin}
-
+  have hmin : ∀ q < rs₀.c, ¬PrimeGt (↑rs₀.p) q := by
+    simp_all only [not_exists, not_and, not_lt]; intro q hq hq'; apply hNS at hq'; omega
+  let c' : MinPrimeGt rs₀.p := { p := rs₀.c, hpgt := hpgt, hmin := hmin}
   -- to call `rem`, we have to prove that it won't remove everything.
   -- so we must produce a proof that another prime besides c exists.
-  have : ∃n m, ¬c'.p ∣ n ∧ rs₀.rm.term m = n := by
+  have : ∃ n m, ¬c'.p ∣ n ∧ rs₀.rm.term m = n := by
     have hC₀' : Nat.Prime rs₀.c := hC₀
-    obtain ⟨q, hqgt, hq⟩ : ∃ q, rs₀.c.succ ≤ q ∧ Nat.Prime q := Nat.exists_infinite_primes rs₀.c.succ
+    obtain ⟨q, hqgt, hq⟩ : ∃ q, rs₀.c.succ ≤ q ∧ Nat.Prime q :=
+      Nat.exists_infinite_primes rs₀.c.succ
     have hqR : q ∈ R rs₀.p := by
       unfold R
       constructor
@@ -97,29 +123,28 @@ def next (rs₀ : RakeSieve) (hC₀: Nat.Prime rs₀.c) (hNS: nosk' rs₀.p rs�
     intro hdiv
     have : rs₀.c = q := Nat.prime_dvd_prime_iff_eq hC₀' hq |>.mp hdiv
     omega
-
   -- now we can use this fact to remove multiples of c
   let rs := rs₀.rm.rem c'.p (Nat.Prime.pos hC₀) this
   let c₁ := rs.rake.term 0
-  have hc₁: ∃ i, rs.rake.term i = c₁ := by
+  have hc₁ : ∃ i, rs.rake.term i = c₁ := by
     exact exists_apply_eq_apply (fun a => rs.rake.term a) 0
   let h₁ := rs.pred
-  have hh₁ : ∀n, h₁ n ↔ h₀ n ∧ ¬(c'.p∣n) := by
+  have hh₁ : ∀ n, h₁ n ↔ h₀ n ∧ ¬(c'.p ∣ n) := by
     intro n
     rfl
-  have hprop : ∀n, h₁ n ↔ n ∈ R c'.p := by
+  have hprop : ∀ n, h₁ n ↔ n ∈ R c'.p := by
     intro n; exact r_next_prop (hh₀ n) (hh₁ n)
   { prop := rs.pred, rm := rs, p := ⟨c'.p, hC₀⟩, c := c₁,
     hprop := hprop
     hCinR := by
-      show c₁ ∈ R c'.p
-      · have : h₁ c₁ := by rw[← rs.hbij] at hc₁; exact hc₁
-        specialize hprop c₁
-        exact hprop.mp this
+      -- goal: `c₁ ∈ R c'.p`
+      have : h₁ c₁ := by rw[← rs.hbij] at hc₁; exact hc₁
+      specialize hprop c₁
+      exact hprop.mp this
     hRmin := by
-      dsimp[c₁,p,h₁] at *
+      dsimp[c₁, p, h₁] at *
       intro r hr
-      have : ∃k, rs.rake.term k = r := by
+      have : ∃ k, rs.rake.term k = r := by
         exact (rs.hbij r).mp ((hprop r).mpr hr)
       obtain ⟨k, hk⟩ := this
       rw[←hk]
@@ -130,12 +155,12 @@ instance : PrimeSieveState RakeSieve where
   C x := x.c
   next := .next
   hNext := by
-    intro s hC hNS s' hs'; simp_all; rw[←hs']
+    intro s hC hNS s' hs'; simp_all only [gt_iff_lt]; rw[←hs']
     unfold next at hs'; simp at hs'
-    have hpc: s'.p = s.c := by simp_all
+    have hpc : s'.p = s.c := by simp_all
     apply And.intro
     · exact hpc
-    · show s'.c > s.c
+    · -- goal: `s'.c > s.c`
       have := s'.hCinR
       have := r_gt_p
       aesop
@@ -145,3 +170,7 @@ open PrimeSieveState
 instance : PrimeSieveDriver RakeSieve where
   hCinR x := by dsimp[C]; dsimp[P]; exact x.hCinR
   hRmin x := by dsimp[C]; dsimp[P]; exact x.hRmin
+
+end RakeSieve
+
+end Leansieve

--- a/LeanPool/Leansieve/RakeSieve/RakeSieve.lean
+++ b/LeanPool/Leansieve/RakeSieve/RakeSieve.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2026 tangentstorm. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: tangentstorm
+-/
+-- RakeSieve uses a rake to implement a prime sieve.
+import LeanPool.Leansieve.RakeMap.RakeMap
+import LeanPool.Leansieve.PrimeSieve.PrimeSieve
+
+structure RakeSieve where
+  prop : Nat -> Prop
+  rm: RakeMap prop
+  p : NPrime               -- the current prime
+  c : Nat                  -- the candidate for next prime
+  hprop : ∀ n:Nat, prop n ↔ n ∈ R p
+  hCinR : c ∈ R p
+  hRmin : ∀ r ∈ R p, c ≤ r
+  -- Q : Array RakeMap     -- queue of found primes
+
+namespace RakeSieve
+
+open RakeMap
+
+def init : RakeSieve :=
+  let rm : RakeMap (λn => n≥2 ∧ ¬2∣n) := rm_ge2 |>.rem 2 (by simp) (by
+    use 3; use 1; simp[rm_ge2, Rake.ge2, Rake.term])
+  let p := ⟨2, Nat.prime_two⟩
+  { prop := rm.pred, rm := rm, p := p, c := 3,
+    hprop := by
+      have hrm : rm.pred = λn => n ≥ 2 ∧ ¬ 2∣n := by simp[RakeMap.pred]
+      show ∀ n, rm.pred n ↔ n ∈ R p
+      have hbij := rm.hbij
+      unfold R; simp_all; intro n
+      apply Iff.intro
+      case mp =>
+        intro hn
+        apply And.intro
+        · rw[← hbij] at hn; exact hn.left
+        · intro q hq hq'
+          simp[←hbij] at hn
+          have hp2 : (p : Nat) = 2 := rfl
+          have hq2 : 2 ≤ q := Nat.Prime.two_le hq'
+          have : 2 = q := by omega
+          rw[this] at hn
+          omega
+      case mpr =>
+        simp; intro hn hn2; rw[←hbij]; simp_all
+        have hp2: p.val = 2 := by rfl
+        have hn2' := hn2
+        set p' := p.val
+        specialize hn2' p';  simp[hp2] at hn2'
+        exact hn2' Nat.prime_two
+    hCinR := by
+      -- clearly 3 isn't divisible by 2, so is in r
+      unfold R; simp; intro q hqle hq'
+      have hp2 : (p : Nat) = 2 := rfl
+      have hq2 : 2 ≤ q := Nat.Prime.two_le hq'
+      have : q = 2 := by omega
+      aesop
+    hRmin := by
+      -- to show that every number in R 2 is ≥ 3,
+      -- show that an r∈R 2 where r<3 leads to a contradiction.
+      dsimp[R]; intro r ⟨hr, hrr⟩; by_contra h; simp_all
+      -- r ≥ 2 and r < 3, so r must be 2
+      have r2 : r = 2 := by omega
+      -- but R 2 means not divisible by primes ≤ 2
+      -- now we can use hrr to prove ¬2∣2, which is absurd
+      have := Nat.prime_two; aesop }
+
+def next (rs₀ : RakeSieve) (hC₀: Nat.Prime rs₀.c) (hNS: nosk' rs₀.p rs₀.c): RakeSieve :=
+  let h₀ := rs₀.prop
+  have hh₀ : ∀n, h₀ n ↔ n ∈ R rs₀.p := rs₀.hprop
+  have hCR₀ := rs₀.hCinR
+  have hpgt:PrimeGt rs₀.p rs₀.c := by
+    constructor
+    · exact hC₀
+    · exact r_gt_p (↑rs₀.p) rs₀.c hCR₀
+  have hmin: ∀ q < rs₀.c, ¬PrimeGt (↑rs₀.p) q := by
+    simp_all; intro q hq hq'; apply hNS at hq'; omega
+  let c' : MinPrimeGt rs₀.p := { p:=rs₀.c, hpgt:=hpgt, hmin:=hmin}
+
+  -- to call `rem`, we have to prove that it won't remove everything.
+  -- so we must produce a proof that another prime besides c exists.
+  have : ∃n m, ¬c'.p ∣ n ∧ rs₀.rm.term m = n := by
+    have hC₀' : Nat.Prime rs₀.c := hC₀
+    obtain ⟨q, hqgt, hq⟩ : ∃ q, rs₀.c.succ ≤ q ∧ Nat.Prime q := Nat.exists_infinite_primes rs₀.c.succ
+    have hqR : q ∈ R rs₀.p := by
+      unfold R
+      constructor
+      · exact Nat.Prime.two_le hq
+      · intro q' hq'le hq' hdiv
+        have : q' = q := Nat.prime_dvd_prime_iff_eq hq' hq |>.mp hdiv
+        omega
+    have hqprop : rs₀.prop q := (hh₀ q).mpr hqR
+    obtain ⟨m, hm⟩ := (rs₀.rm.hbij q).mp hqprop
+    refine ⟨q, m, ?_, hm⟩
+    intro hdiv
+    have : rs₀.c = q := Nat.prime_dvd_prime_iff_eq hC₀' hq |>.mp hdiv
+    omega
+
+  -- now we can use this fact to remove multiples of c
+  let rs := rs₀.rm.rem c'.p (Nat.Prime.pos hC₀) this
+  let c₁ := rs.rake.term 0
+  have hc₁: ∃ i, rs.rake.term i = c₁ := by
+    exact exists_apply_eq_apply (fun a => rs.rake.term a) 0
+  let h₁ := rs.pred
+  have hh₁ : ∀n, h₁ n ↔ h₀ n ∧ ¬(c'.p∣n) := by
+    intro n
+    rfl
+  have hprop : ∀n, h₁ n ↔ n ∈ R c'.p := by
+    intro n; exact r_next_prop (hh₀ n) (hh₁ n)
+  { prop := rs.pred, rm := rs, p := ⟨c'.p, hC₀⟩, c := c₁,
+    hprop := hprop
+    hCinR := by
+      show c₁ ∈ R c'.p
+      · have : h₁ c₁ := by rw[← rs.hbij] at hc₁; exact hc₁
+        specialize hprop c₁
+        exact hprop.mp this
+    hRmin := by
+      dsimp[c₁,p,h₁] at *
+      intro r hr
+      have : ∃k, rs.rake.term k = r := by
+        exact (rs.hbij r).mp ((hprop r).mpr hr)
+      obtain ⟨k, hk⟩ := this
+      rw[←hk]
+      exact rs.min_term_zero k }
+
+instance : PrimeSieveState RakeSieve where
+  P x := x.p
+  C x := x.c
+  next := .next
+  hNext := by
+    intro s hC hNS s' hs'; simp_all; rw[←hs']
+    unfold next at hs'; simp at hs'
+    have hpc: s'.p = s.c := by simp_all
+    apply And.intro
+    · exact hpc
+    · show s'.c > s.c
+      have := s'.hCinR
+      have := r_gt_p
+      aesop
+
+open PrimeSieveState
+
+instance : PrimeSieveDriver RakeSieve where
+  hCinR x := by dsimp[C]; dsimp[P]; exact x.hCinR
+  hRmin x := by dsimp[C]; dsimp[P]; exact x.hRmin

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -1873,3 +1873,39 @@ projects:
     msc:
       - "11F11"
       - "30E20"
+  - slug: leansieve
+    title: A formally verified prime number sieve
+    summary: Formalizes natural-number sieves as collections of arithmetic sequences and proves the generic correctness of a prime sieve, instantiated as a concrete sieve-of-Eratosthenes-style prime generator.
+    branch: number theory
+    entry_module: LeanPool.Leansieve
+    authors:
+      - tangentstorm
+    source:
+      url: "https://github.com/tangentstorm/leansieve"
+      github_repo: tangentstorm/leansieve
+    status: verified
+    main_declarations:
+      - hs_suffice
+      - c_prime
+      - no_skipped_prime
+      - RakeSieve.init
+      - RakeSieve.next
+    main_results:
+      - declaration: hs_suffice
+        informal: Proves that each step of a generic prime sieve produces a prime strictly greater than the previous one with no prime skipped in between, i.e. the next consecutive prime.
+      - declaration: c_prime
+        informal: Proves that the candidate value produced at each sieve step is prime.
+      - declaration: no_skipped_prime
+        informal: Proves that no prime lies strictly between the current prime and the next candidate produced by the sieve.
+      - declaration: RakeSieve.init
+        informal: Constructs the initial RakeSieve state representing the numbers coprime to 2 with current prime 2 and candidate 3.
+      - declaration: RakeSieve.next
+        informal: Advances a RakeSieve by sifting out multiples of the current prime, yielding the next sieve state.
+    tags:
+      - prime-sieve
+      - number-theory
+      - arithmetic-sequences
+      - eratosthenes
+    msc:
+      - "11A41"
+      - "11N35"

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -1885,21 +1885,19 @@ projects:
       github_repo: tangentstorm/leansieve
     status: verified
     main_declarations:
-      - hs_suffice
-      - c_prime
-      - no_skipped_prime
-      - RakeSieve.init
-      - RakeSieve.next
+      - Leansieve.hs_suffice
+      - Leansieve.c_prime
+      - Leansieve.no_skipped_prime
     main_results:
-      - declaration: hs_suffice
+      - declaration: Leansieve.hs_suffice
         informal: Proves that each step of a generic prime sieve produces a prime strictly greater than the previous one with no prime skipped in between, i.e. the next consecutive prime.
-      - declaration: c_prime
+      - declaration: Leansieve.c_prime
         informal: Proves that the candidate value produced at each sieve step is prime.
-      - declaration: no_skipped_prime
+      - declaration: Leansieve.no_skipped_prime
         informal: Proves that no prime lies strictly between the current prime and the next candidate produced by the sieve.
-      - declaration: RakeSieve.init
+      - declaration: Leansieve.RakeSieve.init
         informal: Constructs the initial RakeSieve state representing the numbers coprime to 2 with current prime 2 and candidate 3.
-      - declaration: RakeSieve.next
+      - declaration: Leansieve.RakeSieve.next
         informal: Advances a RakeSieve by sifting out multiples of the current prime, yielding the next sieve state.
     tags:
       - prime-sieve


### PR DESCRIPTION
Imports the tangentstorm/leansieve formalization (A formally verified prime number sieve) into Lean Pool.

- Upstream: https://github.com/tangentstorm/leansieve (MIT)
- Vendored under `LeanPool/Leansieve/`, registered in `projects.yml`.
- **Draft / Phase 1: vendored only, not yet bumped to v4.31-rc1 — CI is expected red.**

Excluded files and notes:
- `Rake_gte.lean` — the only file containing `sorry` (3 sorries); explicitly unverified per its own header comment, not a `lean_lib`, and not imported by any of the six root libraries. Dropped in full (its `RakeMap.gte` declaration depends on the sorried lemmas).
- `Main.lean`, `OldMain.lean` — executable/scratch drivers (`#eval`-based), not part of the formalization and not `lean_lib`s.

The source has six root libraries (`ASeq`, `PrimeGen`, `PrimeSieve`, `Rake`, `RakeMap`, `RakeSieve`), each vendored under its own subdirectory per the multi-root rule. Upstream is MIT (sublicensed); copyright line: `Copyright (c) 2024 tangentstorm` — a NOTICE entry should be added later.