### PR TITLE
Import lean-subst formalization

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -696,6 +696,15 @@ import LeanPool.LeanPolyABC.Lib.Max3
 import LeanPool.LeanPolyABC.Lib.Radical
 import LeanPool.LeanPolyABC.Lib.Wronskian
 import LeanPool.LeanPolyABC.MasonStothers
+import LeanPool.LeanSubst
+import LeanPool.LeanSubst.HetRen
+import LeanPool.LeanSubst.Laws
+import LeanPool.LeanSubst.List
+import LeanPool.LeanSubst.Normal
+import LeanPool.LeanSubst.Option
+import LeanPool.LeanSubst.Reduction
+import LeanPool.LeanSubst.Ren
+import LeanPool.LeanSubst.Subst
 import LeanPool.LowDimSolvClassification
 import LeanPool.LowDimSolvClassification.Classification1
 import LeanPool.LowDimSolvClassification.Classification2

--- a/LeanPool/LeanSubst.lean
+++ b/LeanPool/LeanSubst.lean
@@ -15,17 +15,21 @@ import LeanPool.LeanSubst.Normal
 /-!
 # De Bruijn substitution framework (lean-subst)
 
-An Autosubst-style framework for De Bruijn substitution over non-indexed syntax.
-Substitutions are modelled as sequences of substitution actions (`Subst.Action`),
-so renamings embed into substitutions and variable-annotated data is preserved.
-The development establishes the convergent rewriting laws of the substitution
-calculus and uses them to prove abstract metatheory: confluence of reduction
-relations and strong normalization.
-
 Source: url:https://github.com/amarmaduke/lean-subst
 Authors: Andrew Marmaduke
 Status: verified
 Main declarations: `LeanSubst.Subst.compose`, `LeanSubst.Ren.apply_compose`, `LeanSubst.Star.confluence`, `LeanSubst.Conv.star_equiv`, `LeanSubst.SN.wellfounded`
 Tags: type-theory, de-bruijn, substitution, autosubst, rewriting
 MSC: 03B40, 68N18
+-/
+
+/-!
+## Overview
+
+An Autosubst-style framework for De Bruijn substitution over non-indexed syntax.
+Substitutions are modelled as sequences of substitution actions (`Subst.Action`),
+so renamings embed into substitutions and variable-annotated data is preserved.
+The development establishes the convergent rewriting laws of the substitution
+calculus and uses them to prove abstract metatheory: confluence of reduction
+relations and strong normalization.
 -/

--- a/LeanPool/LeanSubst.lean
+++ b/LeanPool/LeanSubst.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2026 Andrew Marmaduke. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Marmaduke
+-/
+import LeanPool.LeanSubst.Ren
+import LeanPool.LeanSubst.HetRen
+import LeanPool.LeanSubst.Subst
+import LeanPool.LeanSubst.Laws
+import LeanPool.LeanSubst.Option
+import LeanPool.LeanSubst.List
+import LeanPool.LeanSubst.Reduction
+import LeanPool.LeanSubst.Normal
+
+/-!
+# De Bruijn substitution framework (lean-subst)
+
+An Autosubst-style framework for De Bruijn substitution over non-indexed syntax.
+Substitutions are modelled as sequences of substitution actions (`Subst.Action`),
+so renamings embed into substitutions and variable-annotated data is preserved.
+The development establishes the convergent rewriting laws of the substitution
+calculus and uses them to prove abstract metatheory: confluence of reduction
+relations and strong normalization.
+
+Source: url:https://github.com/amarmaduke/lean-subst
+Authors: Andrew Marmaduke
+Status: verified
+Main declarations: `LeanSubst.Subst.compose`, `LeanSubst.Ren.apply_compose`, `LeanSubst.Star.confluence`, `LeanSubst.Conv.star_equiv`, `LeanSubst.SN.wellfounded`
+Tags: type-theory, de-bruijn, substitution, autosubst, rewriting
+MSC: 03B40, 68N18
+-/

--- a/LeanPool/LeanSubst/HetRen.lean
+++ b/LeanPool/LeanSubst/HetRen.lean
@@ -61,9 +61,9 @@ namespace LeanSubst
   /-- Notation `t⟨r⟩` for applying heterogeneous renaming `r` to `t`. -/
   macro:max t:term noWs "⟨" r:term "⟩" : term => `(hrmap $r $t)
   /-- Notation `a :: r` for `HetRen.cons`. -/
-  infixr:67 (name := HetRen.cons_notation) " :: " => HetRen.cons
+  infixr:67 (name := HetRen.consNotation) " :: " => HetRen.cons
   /-- Notation `r1 ∘ r2` for `HetRen.compose`. -/
-  infixr:85 (name := HetRen.compose_notation) " ∘ " => HetRen.compose
+  infixr:85 (name := HetRen.composeNotation) " ∘ " => HetRen.compose
 
   /-- Pretty-printer that displays `hrmap r t` as `t⟨r⟩`. -/
   @[app_unexpander hrmap]

--- a/LeanPool/LeanSubst/HetRen.lean
+++ b/LeanPool/LeanSubst/HetRen.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 Andrew Marmaduke. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Marmaduke
+-/
+import LeanPool.LeanSubst.Ren
+
+namespace LeanSubst
+  universe u
+  variable {S T : Type}
+
+  structure HetRen (T : Type) where
+    act : Nat -> Nat
+
+  def HetRen.id T : HetRen T := ⟨λ x => x⟩
+
+  def HetRen.add T (k : Nat) : HetRen T := ⟨(· + k)⟩
+
+  def HetRen.sub T (k : Nat) : HetRen T := ⟨(· - k)⟩
+
+  def HetRen.lift (r : HetRen T) (k : Nat := 1) : HetRen T := .mk λ n =>
+    if n < k then n else r.act (n - k) + k
+
+  def HetRen.cons (a : Nat) (r : HetRen T) : HetRen T := .mk λ n =>
+    match n with
+    | 0 => a
+    | n + 1 => r.act n
+
+  def HetRen.append : List Nat -> HetRen T -> HetRen T
+  | .nil, r => r
+  | .cons hd tl, r => append tl (r.cons hd)
+
+  instance : HAppend (List Nat) (HetRen T) (HetRen T) where
+    hAppend := HetRen.append
+
+  def HetRen.compose : HetRen T -> HetRen T -> HetRen T
+  | r1, r2 => .mk λ n => r2.act (r1.act n)
+
+  def Ren.het T (r : Ren) : HetRen T := ⟨r.act⟩
+
+  @[simp]
+  theorem Ren.het_action {T i} {r : Ren} : (r.het T).act i = r.act i := by simp [Ren.het]
+
+  class HetRenMap (S T : Type) where
+    hrmap : HetRen T -> S -> S
+
+  export HetRenMap (hrmap)
+
+  macro:max t:term noWs "⟨" r:term "⟩" : term => `(hrmap $r $t)
+  infixr:67 (name := HetRen.cons_notation) " :: " => HetRen.cons
+  infixr:85 (name := HetRen.compose_notation) " ∘ " => HetRen.compose
+
+  @[app_unexpander hrmap]
+  def unexpandHetRenApply : Lean.PrettyPrinter.Unexpander
+  | `($_ $r $t) => `($t⟨$r⟩)
+  | _ => throw ()
+
+  @[simp, grind =]
+  theorem HetRen.lift_zero {r : HetRen T} : r.lift 0 = r := by
+    unfold HetRen.lift; congr
+
+  @[grind =]
+  theorem HetRen.lift_succ {r : HetRen T} {k} : r.lift (k + 1) = (r.lift k).lift := by
+    induction k; simp
+    case _ n ih =>
+      unfold HetRen.lift; congr; funext; case _ i =>
+      simp; unfold HetRen.lift at ih; simp at ih
+      grind
+
+  @[simp]
+  theorem HetRen.id_action {x} : (HetRen.id T).act x = x := by simp [HetRen.id]
+
+  @[simp]
+  theorem HetRen.lift_id {k} : HetRen.lift (HetRen.id T) k = HetRen.id T := by
+    simp [HetRen.id, HetRen.lift]; congr; funext; case _ x =>
+    cases x <;> simp; omega
+
+  @[simp]
+  theorem HetRen.cons_head_action {n} {r : HetRen T} : (n::r).act 0 = n := by simp [HetRen.cons]
+
+  @[simp]
+  theorem HetRen.cons_tail_action {n i} {r : HetRen T} : (n::r).act (i + 1) = r.act i := by simp [HetRen.cons]
+
+  @[simp]
+  theorem HetRen.compose_id_left {r : HetRen T} : (id T) ∘ r = r := by
+    simp [HetRen.compose, HetRen.id]
+
+  @[simp]
+  theorem HetRen.compose_id_right {r : HetRen T} : r ∘ (id T) = r := by
+    simp [HetRen.compose, HetRen.id]
+
+  @[simp]
+  theorem HetRen.compose_assoc {r1 r2 r3 : HetRen T} : (r1 ∘ r2) ∘ r3 = r1 ∘ r2 ∘ r3 := by
+    simp [HetRen.compose]
+
+  @[simp]
+  theorem HetRen.compose_action {r1 r2 : HetRen T} {x} : (r1 ∘ r2).act x = r2.act (r1.act x) := by
+    simp [HetRen.compose]
+
+  theorem HetRen.compose_lift_k1 {r1 r2 : HetRen T} : (r1 ∘ r2).lift = r1.lift ∘ r2.lift := by
+    simp [HetRen.compose, HetRen.lift]
+    funext; case _ x =>
+    cases x <;> simp
+
+  @[simp]
+  theorem HetRen.compose_lift {k} {r1 r2 : HetRen T} : (r1 ∘ r2).lift k = r1.lift k ∘ r2.lift k := by
+    induction k generalizing r1 r2; simp
+    case _ k ih =>
+      rw [lift_succ, ih]
+      rw [lift_succ (r := r1)]
+      rw [lift_succ (r := r2)]
+      rw [compose_lift_k1]
+
+  class HetRenMapId (S T : Type) [HetRenMap S T] where
+    apply_id {t : S} : t⟨HetRen.id T⟩ = t
+
+  class HetRenMapCompose (S T : Type) [HetRenMap S T] where
+    apply_compose {s : S} {r1 r2 : HetRen T} : s⟨r1⟩⟨r2⟩ = s⟨r1 ∘ r2⟩
+
+  @[simp, grind =]
+  theorem HetRen.apply_id [HetRenMap S T] [HetRenMapId S T] {t : S} : t⟨id T⟩ = t := HetRenMapId.apply_id
+
+  @[simp, grind =]
+  theorem HetRen.apply_compose [HetRenMap S T] [HetRenMapCompose S T] {t : S} {r1 r2 : HetRen T}
+    : t⟨r1⟩⟨r2⟩ = t⟨r1 ∘ r2⟩
+  := HetRenMapCompose.apply_compose
+
+end LeanSubst

--- a/LeanPool/LeanSubst/HetRen.lean
+++ b/LeanPool/LeanSubst/HetRen.lean
@@ -9,23 +9,31 @@ namespace LeanSubst
   universe u
   variable {S T : Type}
 
+  /-- A renaming tagged by a target type `T`, represented by its action on indices. -/
   structure HetRen (T : Type) where
+    /-- The underlying function on De Bruijn indices. -/
     act : Nat -> Nat
 
+  /-- The identity heterogeneous renaming at type `T`. -/
   def HetRen.id T : HetRen T := ⟨λ x => x⟩
 
+  /-- The heterogeneous renaming that shifts every index up by `k`. -/
   def HetRen.add T (k : Nat) : HetRen T := ⟨(· + k)⟩
 
+  /-- The heterogeneous renaming that shifts every index down by `k`. -/
   def HetRen.sub T (k : Nat) : HetRen T := ⟨(· - k)⟩
 
+  /-- Lift a heterogeneous renaming under `k` binders, fixing the first `k` indices. -/
   def HetRen.lift (r : HetRen T) (k : Nat := 1) : HetRen T := .mk λ n =>
     if n < k then n else r.act (n - k) + k
 
+  /-- Extend a heterogeneous renaming by mapping index `0` to `a` and shifting the rest. -/
   def HetRen.cons (a : Nat) (r : HetRen T) : HetRen T := .mk λ n =>
     match n with
     | 0 => a
     | n + 1 => r.act n
 
+  /-- Prepend a list of indices to a heterogeneous renaming via repeated `HetRen.cons`. -/
   def HetRen.append : List Nat -> HetRen T -> HetRen T
   | .nil, r => r
   | .cons hd tl, r => append tl (r.cons hd)
@@ -33,23 +41,31 @@ namespace LeanSubst
   instance : HAppend (List Nat) (HetRen T) (HetRen T) where
     hAppend := HetRen.append
 
+  /-- Sequential composition of heterogeneous renamings: apply `r1` then `r2`. -/
   def HetRen.compose : HetRen T -> HetRen T -> HetRen T
   | r1, r2 => .mk λ n => r2.act (r1.act n)
 
+  /-- View a plain renaming as a heterogeneous renaming at type `T`. -/
   def Ren.het T (r : Ren) : HetRen T := ⟨r.act⟩
 
   @[simp]
   theorem Ren.het_action {T i} {r : Ren} : (r.het T).act i = r.act i := by simp [Ren.het]
 
+  /-- A type `S` whose values support being acted on by a heterogeneous renaming over `T`. -/
   class HetRenMap (S T : Type) where
+    /-- Apply a heterogeneous renaming to a value. -/
     hrmap : HetRen T -> S -> S
 
   export HetRenMap (hrmap)
 
+  /-- Notation `t⟨r⟩` for applying heterogeneous renaming `r` to `t`. -/
   macro:max t:term noWs "⟨" r:term "⟩" : term => `(hrmap $r $t)
+  /-- Notation `a :: r` for `HetRen.cons`. -/
   infixr:67 (name := HetRen.cons_notation) " :: " => HetRen.cons
+  /-- Notation `r1 ∘ r2` for `HetRen.compose`. -/
   infixr:85 (name := HetRen.compose_notation) " ∘ " => HetRen.compose
 
+  /-- Pretty-printer that displays `hrmap r t` as `t⟨r⟩`. -/
   @[app_unexpander hrmap]
   def unexpandHetRenApply : Lean.PrettyPrinter.Unexpander
   | `($_ $r $t) => `($t⟨$r⟩)
@@ -111,10 +127,14 @@ namespace LeanSubst
       rw [lift_succ (r := r2)]
       rw [compose_lift_k1]
 
+  /-- A `HetRenMap` for which applying the identity renaming is the identity. -/
   class HetRenMapId (S T : Type) [HetRenMap S T] where
+    /-- Applying the identity heterogeneous renaming leaves a value unchanged. -/
     apply_id {t : S} : t⟨HetRen.id T⟩ = t
 
+  /-- A `HetRenMap` for which heterogeneous renaming is functorial in composition. -/
   class HetRenMapCompose (S T : Type) [HetRenMap S T] where
+    /-- Applying two renamings in sequence equals applying their composition. -/
     apply_compose {s : S} {r1 r2 : HetRen T} : s⟨r1⟩⟨r2⟩ = s⟨r1 ∘ r2⟩
 
   @[simp, grind =]

--- a/LeanPool/LeanSubst/Laws.lean
+++ b/LeanPool/LeanSubst/Laws.lean
@@ -10,25 +10,39 @@ namespace LeanSubst
   universe u
   variable {S T : Type}
 
+  /-- A `SubstMap` for which applying the identity substitution is the identity. -/
   class SubstMapId (S T : Type) [RenMap T] [SubstMap S T] where
+    /-- Applying the identity substitution leaves a value unchanged. -/
     apply_id {t : S} : t[+0:T] = t
 
+  /-- A `SubstMap` whose substitution action agrees with renaming on renamings. -/
   class SubstMapStable (S : Type) [RenMap S] [SubstMap S S] where
+    /-- Applying a renaming as a substitution agrees with applying it as a renaming. -/
     apply_stable (r : Ren) (σ : Subst S) : r = σ -> rmap (T := S) r = smap σ
 
+  /-- A `SubstMap` for which renaming commutes with substitution. -/
   class SubstMapRenCommute (S T : Type) [RenMap S] [RenMap T] [SubstMap S T] where
+    /-- Renaming after substituting equals substituting after renaming. -/
     apply_ren_commute {s : S} (r : Ren) (τ : Subst T) : s⟨r⟩[τ:T] = s[τ:T]⟨r⟩
 
+  /-- A `SubstMap` for which a renaming followed by a substitution fuses on the left. -/
   class SubstMapRenComposeLeft (S T : Type) [RenMap S] [RenMap T] [SubstMap T T] [SubstMap S T] where
+    /-- Substituting by a renaming then by `τ` equals substituting by their composition. -/
     apply_ren_compose_left {s : S} {r : Ren} {τ : Subst T} : s[r.to:T][τ:_] = s[r.to ∘ τ:T]
 
+  /-- A `SubstMap` for which a substitution followed by a renaming fuses on the right. -/
   class SubstMapRenComposeRight (S T : Type) [RenMap S] [RenMap T] [SubstMap T T] [SubstMap S T] where
+    /-- Substituting by `σ` then by a renaming equals substituting by their composition. -/
     apply_ren_compose_right {s : S} {r : Ren} {σ : Subst T} : s[σ:_][r.to:T] = s[σ ∘ r.to:T]
 
+  /-- A `SubstMap` for which composed substitutions fuse. -/
   class SubstMapCompose (S T : Type) [RenMap S] [RenMap T] [SubstMap T T] [SubstMap S T] where
+    /-- Substituting by `σ` then by `τ` equals substituting by their composition. -/
     apply_compose {s : S} {σ τ : Subst T} : s[σ:T][τ:_] = s[σ ∘ τ:T]
 
+  /-- A `SubstMap` for which heterogeneously composed substitutions fuse. -/
   class SubstMapHetCompose (S T : Type) [RenMap S] [RenMap T] [SubstMap S S] [SubstMap S T] where
+    /-- Substituting by `σ` then by `τ` equals substituting by their heterogeneous composition. -/
     apply_hcompose {s : S} {σ : Subst S} {τ : Subst T} : s[σ][τ:T] = s[τ:T][σ ◾ τ]
 
   namespace Subst
@@ -59,11 +73,13 @@ namespace LeanSubst
         cases x; all_goals (simp [Subst.lift, Subst.id])
         grind
 
+      omit [RenMap T] in
       @[simp, grind =]
       theorem rewrite2 [SubstMap T T] {σ : Subst T} : +0 ∘ σ = σ := by
         funext; case _ x =>
         unfold Subst.compose; simp [Subst.id]
 
+      omit [RenMap T] in
       @[simp, grind =]
       theorem rewrite3_replace [SubstMap T T] {σ τ : Subst T} {s : T}
         : (su s :: σ) ∘ τ = su s[τ] :: (σ ∘ τ)
@@ -72,6 +88,7 @@ namespace LeanSubst
         funext; case _ x =>
         cases x; all_goals simp
 
+      omit [RenMap T] in
       @[simp, grind =]
       theorem rewrite3_rename [SubstMap T T] {s} {σ τ : Subst T}
         : (re s :: σ) ∘ τ = (τ.act s) :: (σ ∘ τ)
@@ -80,12 +97,14 @@ namespace LeanSubst
         funext; case _ x =>
         cases x; all_goals simp
 
+      omit [RenMap T] in
       @[simp, grind =]
       theorem rewrite4 [SubstMap T T]  {s} {σ : Subst T} : +1 ∘ (s :: σ) = σ := by
         simp [Subst.cons]
         funext; case _ x =>
         cases x; all_goals (simp [Subst.compose, Subst.succ])
 
+      omit [RenMap T] in
       @[simp, grind =]
       theorem rewrite5 [SubstMap T T] {σ : Subst T} : σ.act 0 :: (+1 ∘ σ) = σ := by
         simp [Subst.cons, Subst.compose]; congr
@@ -273,7 +292,7 @@ namespace LeanSubst
       : (σ ∘ r.to) ◾ (+1@T) = (σ ◾ +1@T) ∘ r.to
     := by
       have lem := hcomp_distr_ren_right (T := T) r σ +1
-      simp at lem; exact lem
+      exact lem
 
     @[simp, grind =]
     theorem apply_hcompose
@@ -541,12 +560,14 @@ namespace LeanSubst
       rw [rewrite_lift_succ (σ := τ)]
       rw [rewrite_lift_compose_k1]
 
+  /-- Tactic that discharges a `SubstMapId.apply_id` obligation by induction on the term. -/
   macro "subst_solve_id" : tactic => `(tactic| {
     intro t; induction t
     any_goals solve | simp +instances [*]
     all_goals try simp at *; simp  +instances [*]; grind
   })
 
+  /-- Tactic that discharges a `SubstMapStable.apply_stable` obligation by induction on the term. -/
   macro "subst_solve_stable" : tactic => `(tactic| {
     intro r σ h
     funext; case _ t =>
@@ -556,6 +577,7 @@ namespace LeanSubst
     all_goals try repeat funext; grind
   })
 
+  /-- Tactic that discharges a `SubstMapCompose.apply_compose` obligation by induction on the term. -/
   macro "subst_solve_compose" : tactic => `(tactic| {
     intro s σ τ
     induction s generalizing σ τ

--- a/LeanPool/LeanSubst/Laws.lean
+++ b/LeanPool/LeanSubst/Laws.lean
@@ -561,14 +561,14 @@ namespace LeanSubst
       rw [rewrite_lift_compose_k1]
 
   /-- Tactic that discharges a `SubstMapId.apply_id` obligation by induction on the term. -/
-  macro "subst_solve_id" : tactic => `(tactic| {
+  macro "substSolveId" : tactic => `(tactic| {
     intro t; induction t
     any_goals solve | simp +instances [*]
     all_goals try simp at *; simp  +instances [*]; grind
   })
 
   /-- Tactic that discharges a `SubstMapStable.apply_stable` obligation by induction on the term. -/
-  macro "subst_solve_stable" : tactic => `(tactic| {
+  macro "substSolveStable" : tactic => `(tactic| {
     intro r σ h
     funext; case _ t =>
     induction t generalizing r σ
@@ -578,7 +578,7 @@ namespace LeanSubst
   })
 
   /-- Tactic that discharges a `SubstMapCompose.apply_compose` obligation by induction on the term. -/
-  macro "subst_solve_compose" : tactic => `(tactic| {
+  macro "substSolveCompose" : tactic => `(tactic| {
     intro s σ τ
     induction s generalizing σ τ
     any_goals solve | simp +instances [*]

--- a/LeanPool/LeanSubst/Laws.lean
+++ b/LeanPool/LeanSubst/Laws.lean
@@ -1,0 +1,571 @@
+/-
+Copyright (c) 2026 Andrew Marmaduke. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Marmaduke
+-/
+import LeanPool.LeanSubst.Ren
+import LeanPool.LeanSubst.Subst
+
+namespace LeanSubst
+  universe u
+  variable {S T : Type}
+
+  class SubstMapId (S T : Type) [RenMap T] [SubstMap S T] where
+    apply_id {t : S} : t[+0:T] = t
+
+  class SubstMapStable (S : Type) [RenMap S] [SubstMap S S] where
+    apply_stable (r : Ren) (σ : Subst S) : r = σ -> rmap (T := S) r = smap σ
+
+  class SubstMapRenCommute (S T : Type) [RenMap S] [RenMap T] [SubstMap S T] where
+    apply_ren_commute {s : S} (r : Ren) (τ : Subst T) : s⟨r⟩[τ:T] = s[τ:T]⟨r⟩
+
+  class SubstMapRenComposeLeft (S T : Type) [RenMap S] [RenMap T] [SubstMap T T] [SubstMap S T] where
+    apply_ren_compose_left {s : S} {r : Ren} {τ : Subst T} : s[r.to:T][τ:_] = s[r.to ∘ τ:T]
+
+  class SubstMapRenComposeRight (S T : Type) [RenMap S] [RenMap T] [SubstMap T T] [SubstMap S T] where
+    apply_ren_compose_right {s : S} {r : Ren} {σ : Subst T} : s[σ:_][r.to:T] = s[σ ∘ r.to:T]
+
+  class SubstMapCompose (S T : Type) [RenMap S] [RenMap T] [SubstMap T T] [SubstMap S T] where
+    apply_compose {s : S} {σ τ : Subst T} : s[σ:T][τ:_] = s[σ ∘ τ:T]
+
+  class SubstMapHetCompose (S T : Type) [RenMap S] [RenMap T] [SubstMap S S] [SubstMap S T] where
+    apply_hcompose {s : S} {σ : Subst S} {τ : Subst T} : s[σ][τ:T] = s[τ:T][σ ◾ τ]
+
+  namespace Subst
+    export SubstMapStable (apply_stable)
+    export SubstMapRenCommute (apply_ren_commute)
+    export SubstMapRenComposeLeft (apply_ren_compose_left)
+    export SubstMapRenComposeRight (apply_ren_compose_right)
+  end Subst
+
+  theorem Ren.lift_eq_from_eq [RenMap T] [SubstMap S T] {r : Ren} {σ : Subst T}
+    : r = σ -> r.lift = σ.lift
+  := by intro h; rw [<-h, to_lift]
+
+  namespace Subst
+    section
+      @[simp, grind =]
+      theorem rewrite1 : re 0 :: +1 = +0@T := by
+        simp [Subst.cons, Subst.id]
+        funext; case _ x =>
+        cases x; all_goals simp
+
+      open SubstMap
+      variable [RenMap T]
+
+      @[simp, grind =]
+      theorem I_lift {k} : +0.lift k = +0@T := by
+        funext; case _ x =>
+        cases x; all_goals (simp [Subst.lift, Subst.id])
+        grind
+
+      @[simp, grind =]
+      theorem rewrite2 [SubstMap T T] {σ : Subst T} : +0 ∘ σ = σ := by
+        funext; case _ x =>
+        unfold Subst.compose; simp [Subst.id]
+
+      @[simp, grind =]
+      theorem rewrite3_replace [SubstMap T T] {σ τ : Subst T} {s : T}
+        : (su s :: σ) ∘ τ = su s[τ] :: (σ ∘ τ)
+      := by
+        simp [Subst.cons, Subst.compose]
+        funext; case _ x =>
+        cases x; all_goals simp
+
+      @[simp, grind =]
+      theorem rewrite3_rename [SubstMap T T] {s} {σ τ : Subst T}
+        : (re s :: σ) ∘ τ = (τ.act s) :: (σ ∘ τ)
+      := by
+        simp [Subst.cons, Subst.compose]
+        funext; case _ x =>
+        cases x; all_goals simp
+
+      @[simp, grind =]
+      theorem rewrite4 [SubstMap T T]  {s} {σ : Subst T} : +1 ∘ (s :: σ) = σ := by
+        simp [Subst.cons]
+        funext; case _ x =>
+        cases x; all_goals (simp [Subst.compose, Subst.succ])
+
+      @[simp, grind =]
+      theorem rewrite5 [SubstMap T T] {σ : Subst T} : σ.act 0 :: (+1 ∘ σ) = σ := by
+        simp [Subst.cons, Subst.compose]; congr
+        funext; case _ x =>
+        cases x <;> simp
+    end
+
+    @[simp, grind =]
+    theorem apply_I_is_id [RenMap T] [SubstMap S T] [SubstMapId S T] {s : S}
+      : s[+0:T] = s
+    := SubstMapId.apply_id
+
+    @[simp, grind =]
+    theorem rewrite_lift [RenMap T] [SubstMap T T] [SubstMapStable T] {σ : Subst T}
+      : σ.lift = re 0 :: (σ ∘ +1)
+    := by
+      simp [Subst.cons, Subst.lift, Subst.compose]
+      funext; case _ x =>
+      cases x; simp
+      case _ n =>
+        simp [Subst.succ]
+        generalize tdef : σ.act n = t
+        cases t <;> simp at *
+        case _ y =>
+          rw [apply_stable (σ := +1)]
+          simp [Subst.succ]
+          rw [Ren.to_succ]
+
+    @[simp, grind =]
+    theorem rewrite_lift_zero [RenMap S] [RenMapId S] {σ : Subst S}
+      : σ.lift 0 = σ
+    := by
+      simp [Subst.lift]; congr; funext; case _ i =>
+      generalize zdef : σ.act i = z
+      cases z <;> simp [Ren.add]; case _ s =>
+      have lem := RenMapId.apply_id (t := s)
+      simp [Ren.id] at lem; exact lem
+
+    @[grind =]
+    theorem rewrite_lift_succ
+      [RenMap S] [RenMapId S] [RenMapCompose S]
+      {k} {σ : Subst S}
+      : σ.lift (k + 1) = (σ.lift k).lift
+    := by
+      induction k; simp
+      case _ n ih =>
+        replace ih i : (σ.lift (n + 1)).act i = ((σ.lift n).lift 1).act i := by rw [ih]
+        simp [Subst.lift]
+        funext; case _ i =>
+        have lem := ih i
+        cases i <;> simp
+        case _ i =>
+          simp [Subst.lift] at lem
+          split; simp; case _ h1 =>
+          simp at h1
+          have lem2 : n ≤ i := by omega
+          generalize zdef : σ.act (i - (n + 1)) = z
+          cases z <;> simp; omega
+          congr
+
+    @[simp, grind =]
+    theorem rewrite6 [RenMap T] [SubstMap T T] [SubstMapId T T] {σ : Subst T}
+      : σ ∘ +0 = σ
+    := by
+      simp [Subst.compose, Subst.id]; congr
+      funext; case _ x =>
+      generalize zdef : σ.act x = z
+      cases z <;> simp at *; case _ s =>
+      have lem := SubstMapId.apply_id (T := T) (t := s)
+      simp [Subst.id] at lem; exact lem
+
+    @[simp, grind =]
+    theorem apply_compose
+      [RenMap S] [RenMap T] [SubstMap T T] [SubstMap S T] [SubstMapCompose S T]
+      {s : S} {σ τ : Subst T}
+      : s[σ:T][τ:_] = s[σ ∘ τ:T]
+    := SubstMapCompose.apply_compose
+
+    @[simp, grind =]
+    theorem rewrite7
+      [RenMap T] [SubstMap T T] [SubstMapCompose T T]
+      {σ τ μ : Subst T}
+      : (σ ∘ τ) ∘ μ = σ ∘ τ ∘ μ
+    := by
+      simp [Subst.compose]
+      funext; case _ x =>
+      cases σ.act x <;> simp [Subst.compose]
+
+    @[simp, grind =]
+    theorem hrewrite1
+      [RenMap T] [SubstMap S T] [SubstMapId S T]
+      {σ : Subst S}
+      : σ ◾ (+0@T) = σ
+    := by
+      simp [Subst.hcompose]; congr
+      funext; case _ x =>
+      generalize zdef : σ.act x = z
+      cases z <;> simp
+
+    @[simp, grind =]
+    theorem hcomp_ren_left
+      [RenMap S] [RenMap T] [SubstMap S T]
+      (r : Ren) (σ : Subst T)
+      : (@Ren.to S r) ◾ σ = r.to
+    := by
+      funext; case _ x =>
+      induction x <;> simp [Subst.hcompose, Ren.to]
+
+    @[simp, grind =]
+    theorem hrewrite2
+      [RenMap S] [RenMap T] [SubstMap S T]
+      {σ : Subst T}
+      : (+0@S) ◾ σ = +0
+    := by
+      apply hcomp_ren_left (S := S) (T := T) Ren.id σ
+
+    @[simp, grind =]
+    theorem hrewrite3
+      [RenMap S] [RenMap T] [SubstMap S T]
+      {σ : Subst T}
+      : (+1@S) ◾ σ = +1
+    := by
+      have lem := hcomp_ren_left (S := S) (T := T) (Ren.add 1) σ
+      simp at lem; exact lem
+
+    @[simp, grind =]
+    theorem hrewrite4
+      [RenMap T] [SubstMap S T]
+      {x} {σ : Subst S} {τ : Subst T}
+      : (re x :: σ) ◾ τ = re x :: (σ ◾ τ)
+    := by
+      simp [Subst.hcompose]; congr
+      funext; case _ i =>
+      cases i <;> simp [Subst.cons]
+
+    @[grind =]
+    theorem hcomp_dist_ren_left
+      [RenMap S] [RenMap T] [SubstMap S S] [SubstMap S T]
+      (r : Ren) {σ : Subst S} {τ : Subst T}
+      : (r.to ∘ σ) ◾ τ = r.to ∘ σ ◾ τ
+    := by
+      funext; case _ x =>
+      simp [Subst.hcompose, Subst.compose, Ren.to]
+
+    @[simp, grind =]
+    theorem hrewrite5
+      [RenMap S] [RenMap T] [SubstMap T T] [SubstMap S T] [SubstMapCompose S T]
+      {σ : Subst S} {τ μ : Subst T}
+      : (σ ◾ τ) ◾ μ = σ ◾ (τ ∘ μ)
+    := by
+      simp [Subst.hcompose]
+      funext; case _ x =>
+      generalize zdef : σ.act x = z
+      cases z <;> simp
+
+    @[grind =]
+    theorem hcomp_distr_ren_right
+      [RenMap S] [RenMap T] [SubstMap S S] [SubstMap S T]
+      [SubstMapStable S] [SubstMapRenCommute S T]
+      (r : Ren) (σ : Subst S) (μ : Subst T)
+      : (σ ∘ r.to) ◾ μ = (σ ◾ μ) ∘ r.to
+    := by
+      simp [Subst.hcompose, Subst.compose, Ren.to]
+      funext; case _ x =>
+      generalize zdef : σ.act x = z
+      cases z <;> simp
+      rw [<-apply_stable r ⟨λ n => re (r.act n)⟩ rfl]
+      rw [SubstMapRenCommute.apply_ren_commute r μ]
+
+    @[grind =]
+    theorem hcomp_distr_ren_right_p1
+      [RenMap S] [RenMap T] [SubstMap S S] [SubstMap S T]
+      [SubstMapStable S] [SubstMapRenCommute S T]
+      (σ : Subst S) (μ : Subst T)
+      : (σ ∘ +1) ◾ μ = (σ ◾ μ) ∘ +1
+    := by
+      have lem : @Subst.succ S = Ren.to (Ren.add 1) := by simp
+      rw [lem, hcomp_distr_ren_right]
+
+    @[simp, grind =]
+    theorem hrewrite6
+      [RenMap S] [RenMap T] [SubstMap S S] [SubstMap S T]
+      [SubstMapStable S] [SubstMapRenCommute S T]
+      (r : Ren) (σ : Subst S)
+      : (σ ∘ r.to) ◾ (+1@T) = (σ ◾ +1@T) ∘ r.to
+    := by
+      have lem := hcomp_distr_ren_right (T := T) r σ +1
+      simp at lem; exact lem
+
+    @[simp, grind =]
+    theorem apply_hcompose
+      [RenMap S] [RenMap T] [SubstMap S S] [SubstMap S T] [SubstMapHetCompose S T]
+      {s : S} {σ : Subst S} {τ : Subst T}
+      : s[σ][τ:T] = s[τ:T][σ ◾ τ]
+    := by exact SubstMapHetCompose.apply_hcompose
+
+    @[simp, grind =]
+    theorem hrewrite7
+      [RenMap S] [RenMap T] [SubstMap S S] [SubstMap S T] [SubstMapHetCompose S T]
+      {σ τ : Subst S} (μ : Subst T)
+      : (σ ∘ τ) ◾ μ = (σ ◾ μ) ∘ τ ◾ μ
+    := by
+      simp [Subst.hcompose, Subst.compose]
+      funext; case _ x =>
+      generalize zdef : σ.act x = z
+      cases z <;> simp [Subst.hcompose]
+
+    theorem hrewrite_lift1
+      [RenMap S] [RenMap T] [SubstMap S T] [SubstMapRenCommute S T]
+      {σ : Subst S} {τ : Subst T}
+      : (σ ◾ τ).lift = σ.lift ◾ τ
+    := by
+      simp [Subst.lift]; congr; funext; case _ i =>
+      cases i <;> simp [hcompose]
+      case _ n =>
+        generalize zdef : σ.act n = z
+        cases z <;> simp; case _ t =>
+        rw [SubstMapRenCommute.apply_ren_commute]
+
+    @[simp, grind =]
+    theorem hrewrite_lift
+      [RenMap S] [RenMap T] [SubstMap S T] [RenMapId S] [RenMapCompose S] [SubstMapRenCommute S T]
+      {k} {σ : Subst S} {τ : Subst T}
+      : (σ ◾ τ).lift k = σ.lift k ◾ τ
+    := by
+      induction k generalizing σ τ
+      case _ => simp
+      case _ i ih =>
+        rw [rewrite_lift_succ]
+        rw [rewrite_lift_succ]
+        simp; rw [ih, hrewrite_lift1]
+        grind
+  end Subst
+
+  @[grind =]
+  theorem Subst.Compose.lemma1
+    [RenMap S] [SubstMap S S] [RenMapId S] [RenMapCompose S] [SubstMapStable S]
+    {k} {τ : Subst S}
+    : (Ren.to (Ren.add 1)) ∘ τ.lift (k + 1) = τ.lift k ∘ (Ren.to (Ren.add 1))
+  := by
+    simp [Subst.compose]
+    funext; case _ x =>
+    cases x
+    all_goals
+      unfold Subst.lift; simp
+      split; simp; split
+    any_goals solve | congr 1
+    all_goals
+      rw [<-apply_stable _ +1 rfl]
+      simp; congr
+
+  @[grind =]
+  theorem Subst.Compose.lemma1s
+    [RenMap S] [SubstMap S S] [RenMapId S] [RenMapCompose S] [SubstMapStable S]
+    {k} {τ : Subst S}
+    : +1 ∘ τ.lift (k + 1) = τ.lift k ∘ +1
+  := by
+    have lem : @Subst.succ S = Ren.to (Ren.add 1) := by simp
+    rw [lem]; grind
+
+  @[grind =]
+  theorem Subst.Compose.lemma2_k1
+    [RenMap S] [SubstMap S S] [RenMapId S] [RenMapCompose S]
+    {σ : Subst S} {r : Ren}
+    : (r ∘ σ).lift = (Ren.to r).lift ∘ σ.lift
+  := by
+    simp [Subst.lift, Subst.compose, Ren.to]
+    funext; case _ x =>
+    cases x <;> simp
+
+  @[grind =]
+  theorem Subst.Compose.lemma2
+    [RenMap S] [SubstMap S S] [RenMapId S] [RenMapCompose S]
+    {k} {σ : Subst S} {r : Ren}
+    : (r ∘ σ).lift k = (Ren.to r).lift k ∘ σ.lift k
+  := by
+    induction k generalizing r σ; simp
+    case _ k ih =>
+    rw [Subst.rewrite_lift_succ, ih]
+    rw [<-Ren.to_lift, Subst.Compose.lemma2_k1]
+    rw [Subst.rewrite_lift_succ (σ := r.to)]
+    rw [Subst.rewrite_lift_succ (σ := σ)]
+    grind
+
+  @[grind =]
+  theorem Subst.Compose.lemma2s
+    [RenMap S] [SubstMap S S] [RenMapId S] [RenMapCompose S]
+    {k} {σ : Subst S}
+    : (+1 ∘ σ).lift k = +1.lift k ∘ σ.lift k
+  := by
+    have lem : @Subst.succ S = Ren.to (Ren.add 1) := by simp
+    rw [lem]; grind
+
+  @[grind =]
+  theorem Subst.Compose.lemma3
+    [RenMap S] [RenMap T] [SubstMap T T] [SubstMap S T] [SubstMapRenComposeLeft S T]
+    {s : S} {σ : Subst T}
+    : s[+1:T][σ:_] = s[+1 ∘ σ:_]
+  := by
+    have lem : @Subst.succ T = Ren.to (Ren.add 1) := by simp
+    rw [lem, apply_ren_compose_left]
+
+  @[grind =]
+  theorem Subst.Compose.lemma4
+    [RenMap T] [SubstMap T T]
+    {σ τ : Subst T}
+    : +1 ∘ τ ∘ σ = (+1 ∘ τ) ∘ σ
+  := by
+    funext; case _ x =>
+    cases x <;> simp [Subst.compose, Subst.succ]
+
+  @[grind =]
+  theorem Subst.compose.lemma5
+    [RenMap T] [SubstMap T T] [RenMapCompose T] [SubstMapStable T]
+    {r1 r2 : Ren} {τ : Subst T}
+    : (τ ∘ r2.to) ∘ r1.to = τ ∘ r2.to ∘ r1.to
+  := by
+    simp [Subst.compose]
+    funext; case _ x =>
+    cases τ.act x <;> simp [*]
+    simp [Ren.to]
+    rw [<-apply_stable r2 ⟨λ n => re (r2.act n)⟩ rfl]
+    rw [<-apply_stable r1 ⟨λ n => re (r1.act n)⟩ rfl]
+    simp
+    rw [apply_stable _ _ rfl]
+    rw [Ren.to_compose]
+    unfold Subst.compose; simp [Ren.to]
+
+  @[grind =]
+  theorem Subst.Compose.lemma6_k1
+    [RenMap S] [SubstMap S S] [SubstMapStable S] [SubstMapRenComposeLeft S S]
+    {σ : Subst S} {r : Ren}
+    : (σ ∘ r.to).lift = σ.lift ∘ (Ren.to r).lift
+  := by
+    simp [Subst.lift, Subst.compose]
+    funext; case _ x =>
+    cases x <;> simp
+    case _ x =>
+      cases σ.act x <;> simp
+      rw [apply_stable (Ren.add 1) _ rfl]
+      rw [apply_ren_compose_left]
+      rw [apply_ren_compose_left]
+      simp [Ren.to, Subst.compose, Ren.add]
+
+  @[grind =]
+  theorem Subst.Compose.lemma6
+    [RenMap S] [SubstMap S S] [RenMapId S] [RenMapCompose S]
+    [SubstMapStable S] [SubstMapRenComposeLeft S S]
+    {k} {σ : Subst S} {r : Ren}
+    : (σ ∘ r.to).lift k = σ.lift k ∘ (Ren.to r).lift k
+  := by
+    induction k generalizing r σ; simp
+    case _ k ih =>
+    rw [Subst.rewrite_lift_succ, ih]
+    rw [<-Ren.to_lift, Subst.Compose.lemma6_k1]
+    rw [Subst.rewrite_lift_succ (σ := r.to)]
+    rw [Subst.rewrite_lift_succ (σ := σ)]
+    grind
+
+  @[grind =]
+  theorem Subst.Compose.lemma6s
+    [RenMap S] [SubstMap S S] [RenMapId S] [RenMapCompose S]
+    [SubstMapStable S] [SubstMapRenComposeLeft S S]
+    {k} {σ : Subst S}
+    : (σ ∘ +1).lift k = σ.lift k ∘ +1.lift k
+  := by
+    have lem : @Subst.succ S = Ren.to (Ren.add 1) := by simp
+    rw [lem]; grind
+
+  @[grind =]
+  theorem Subst.Compose.lemma7
+    [RenMap S] [RenMap T] [SubstMap T T] [SubstMap S T] [SubstMapRenComposeRight S T]
+    {s : S} {τ : Subst T}
+    : s[τ:_][+1:T] = s[τ ∘ +1:_]
+  := by
+    have lem : @Subst.succ T = Ren.to (Ren.add 1) := by simp
+    rw [lem, apply_ren_compose_right]
+
+  @[grind =]
+  theorem Subst.Compose.lemma8
+    [RenMap T] [SubstMap T T] [SubstMapRenComposeLeft T T]
+    {σ τ : Subst T}
+    : (σ ∘ +1) ∘ τ = σ ∘ +1 ∘ τ
+  := by
+    simp [Subst.compose]
+    funext; case _ x =>
+    cases σ.act x <;> simp at *
+    rw [lemma3]
+    unfold Subst.compose; simp
+
+  @[grind =]
+  theorem Subst.Compose.lemma9
+    [RenMap T] [SubstMap T T] [SubstMapRenComposeRight T T]
+    {σ τ : Subst T}
+    : ((σ ∘ τ) ∘ +1) = σ ∘ τ ∘ +1
+  := by
+    simp [Subst.compose]
+    funext; case _ x =>
+    cases σ.act x <;> simp at *
+    rw [lemma7]
+    unfold Subst.compose; simp
+
+  @[grind =]
+  theorem Subst.Compose.lemma10
+    [RenMap S] [RenMap T] [SubstMap S S] [SubstMap S T]
+    [SubstMapStable S] [SubstMapRenCommute S T]
+    {σ : Subst S} {μ : Subst T} {r : Ren}
+    : (σ ∘ r.to) ◾ μ = (σ ◾ μ) ∘ r.to
+  := by
+    simp [Subst.hcompose, Subst.compose]
+    funext; case _ x =>
+    generalize zdef : σ.act x = z
+    cases z <;> simp [Ren.to]
+    rw [<-apply_stable r ⟨λ n => re (r.act n)⟩ rfl]
+    rw [Subst.apply_ren_commute]
+
+  @[grind =]
+  theorem Subst.Compose.lemma10s
+    [RenMap S] [RenMap T] [SubstMap S S] [SubstMap S T]
+    [SubstMapStable S] [SubstMapRenCommute S T]
+    {σ : Subst S} {μ : Subst T}
+    : (σ ∘ +1) ◾ μ = (σ ◾ μ) ∘ +1
+  := by
+    have lem := lemma10 (σ := σ) (μ := μ) (r := (Ren.add 1))
+    simp at lem; exact lem
+
+  theorem Subst.rewrite_lift_compose_k1
+    [RenMap T] [SubstMap T T] [SubstMapStable T]
+    [SubstMapRenComposeLeft T T] [SubstMapRenComposeRight T T]
+    {σ τ : Subst T}
+    : (σ ∘ τ).lift = σ.lift ∘ τ.lift
+  := by
+    simp [Subst.lift, Subst.compose]
+    funext; case _ x =>
+    cases x <;> simp
+    case _ x =>
+    cases σ.act x <;> simp
+    rw [apply_stable _ (Ren.add 1) rfl]; simp
+    rw [Compose.lemma7, Compose.lemma3]
+    simp [Subst.compose]
+
+  @[simp, grind =]
+  theorem Subst.rewrite_lift_compose
+    [RenMap T] [SubstMap T T] [RenMapId T] [RenMapCompose T] [SubstMapStable T]
+    [SubstMapRenComposeLeft T T] [SubstMapRenComposeRight T T]
+    {k} {σ τ : Subst T}
+    : (σ ∘ τ).lift k = σ.lift k ∘ τ.lift k
+  := by
+    induction k generalizing σ τ; simp
+    case _ k ih =>
+      rw [rewrite_lift_succ, ih]
+      rw [rewrite_lift_succ (σ := σ)]
+      rw [rewrite_lift_succ (σ := τ)]
+      rw [rewrite_lift_compose_k1]
+
+  macro "subst_solve_id" : tactic => `(tactic| {
+    intro t; induction t
+    any_goals solve | simp +instances [*]
+    all_goals try simp at *; simp  +instances [*]; grind
+  })
+
+  macro "subst_solve_stable" : tactic => `(tactic| {
+    intro r σ h
+    funext; case _ t =>
+    induction t generalizing r σ
+    all_goals simp [rmap, smap, *] at *; try simp +instances [*]
+    any_goals solve | (rw [<-h]; simp +instances [Ren.to])
+    all_goals try repeat funext; grind
+  })
+
+  macro "subst_solve_compose" : tactic => `(tactic| {
+    intro s σ τ
+    induction s generalizing σ τ
+    any_goals solve | simp +instances [*]
+    try any_goals solve | (
+      try simp [-Subst.rewrite_lift, *]
+      try funext; case _ x =>
+      try rw [<-Ren.to_lift]
+      try simp [-Subst.rewrite_lift, *]
+      try grind)
+  })
+
+end LeanSubst

--- a/LeanPool/LeanSubst/List.lean
+++ b/LeanPool/LeanSubst/List.lean
@@ -60,46 +60,46 @@ where
 
 /-- Look up the `n`-th element of a context list, substituting all binders crossed. -/
 @[simp, grind =]
-def List.dep_subst_get [SubstMap S T] (σ : Subst T) : List S -> Nat -> Option S
+def List.depSubstGet [SubstMap S T] (σ : Subst T) : List S -> Nat -> Option S
 | .nil, _ => none
 | .cons h _, 0 => return h[σ:_]
-| .cons _ t, n + 1 => (dep_subst_get σ t n)[σ:_]
+| .cons _ t, n + 1 => (depSubstGet σ t n)[σ:_]
 
-/-- Homogeneous variant of `List.dep_subst_get` (the `S = T` case). -/
-abbrev List.dep_subst_get1 [SubstMap S S] (σ : Subst S) : List S -> Nat -> Option S :=
-  dep_subst_get σ
+/-- Homogeneous variant of `List.depSubstGet` (the `S = T` case). -/
+abbrev List.depSubstGet1 [SubstMap S S] (σ : Subst S) : List S -> Nat -> Option S :=
+  depSubstGet σ
 
-/-- Notation `t[x|σ : T]` for `List.dep_subst_get` over `T`. -/
+/-- Notation `t[x|σ : T]` for `List.depSubstGet` over `T`. -/
 macro:max t:term noWs "[" x:term "|" σ:term  ":" T:term "]" : term =>
-  `(List.dep_subst_get (T := $T) $σ $t $x)
+  `(List.depSubstGet (T := $T) $σ $t $x)
 
-/-- Notation `t[x|σ]` for the homogeneous `List.dep_subst_get1`. -/
+/-- Notation `t[x|σ]` for the homogeneous `List.depSubstGet1`. -/
 macro:max t:term noWs "[" x:term "|" σ:term "]" : term =>
-  `(List.dep_subst_get1 $σ $t $x)
+  `(List.depSubstGet1 $σ $t $x)
 
-/-- Pretty-printer that displays `List.dep_subst_get1 σ t x` as `t[x|σ]`. -/
-@[app_unexpander List.dep_subst_get1]
-def unexpand_list_dep_subst_get1 : Lean.PrettyPrinter.Unexpander
+/-- Pretty-printer that displays `List.depSubstGet1 σ t x` as `t[x|σ]`. -/
+@[app_unexpander List.depSubstGet1]
+def unexpandListDepSubstGet1 : Lean.PrettyPrinter.Unexpander
 | `($_ $σ $t $x) => `($t[$x|$σ])
 | _ => throw ()
 
-/-- Pretty-printer that displays `List.dep_subst_get σ t x` as `t[x|σ : _]`. -/
+/-- Pretty-printer that displays `List.depSubstGet σ t x` as `t[x|σ : _]`. -/
 @[app_unexpander smap]
-def unexpand_list_dep_subst_get : Lean.PrettyPrinter.Unexpander
+def unexpandListDepSubstGet : Lean.PrettyPrinter.Unexpander
 | `($_ $σ $t $x) => `($t[$x|$σ : _])
 | `($_ (T := $T) $σ $t $x) => `($t[$x|$σ : $T])
 | _ => throw ()
 
 @[simp, grind =]
-theorem List.dep_subst_get_zero [SubstMap S T] {σ : Subst T} {A : S} {Γ : List S}
+theorem List.depSubstGetZero [SubstMap S T] {σ : Subst T} {A : S} {Γ : List S}
   : (A::Γ)[0|σ:_] = A[σ:_]
 := by
-  simp [dep_subst_get]
+  simp [depSubstGet]
 
 @[simp, grind =]
-theorem List.dep_subst_get_succ [SubstMap S T] {σ : Subst T} {A : S} {Γ : List S} {x}
+theorem List.depSubstGetSucc [SubstMap S T] {σ : Subst T} {A : S} {Γ : List S} {x}
   : (A::Γ)[x + 1|σ:_] = Γ[x|σ:_][σ:_]
 := by
-  simp [dep_subst_get]
+  simp [depSubstGet]
 
 end LeanSubst

--- a/LeanPool/LeanSubst/List.lean
+++ b/LeanPool/LeanSubst/List.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 Andrew Marmaduke. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Marmaduke
+-/
+import LeanPool.LeanSubst.Ren
+import LeanPool.LeanSubst.Subst
+import LeanPool.LeanSubst.Laws
+import LeanPool.LeanSubst.Option
+
+namespace LeanSubst
+
+variable {S T : Type}
+
+def List.rmap [i : RenMap S] (r : Ren) : List S -> List S
+| [] => []
+| .cons x tl => (i.rmap r x) :: rmap r tl
+
+instance [RenMap S] : RenMap (List S) where
+  rmap := List.rmap
+
+@[simp, grind =]
+theorem List.rmap_nil [RenMap S] {r : Ren} : (@List.nil S)⟨r⟩ = [] := by
+  simp [RenMap.rmap, List.rmap]
+
+@[simp, grind =]
+theorem List.rmap_cons [RenMap S] {x} {tl : List S} {r : Ren}
+  : (x :: tl)⟨r⟩ = x⟨r⟩ :: tl⟨r⟩
+:= by
+  simp [RenMap.rmap, List.rmap]
+
+def List.smap [SubstMap S T] (σ : Subst T) : List S -> List S
+| [] => []
+| .cons x tl => x[σ:_] :: smap σ tl
+
+instance [SubstMap S T] : SubstMap (List S) T where
+  smap := List.smap
+
+@[simp, grind =]
+theorem List.smap_nil [SubstMap S T] {σ : Subst T} : (@List.nil S)[σ:_] = [] := by
+  simp [SubstMap.smap, List.smap]
+
+@[simp, grind =]
+theorem List.smap_cons [SubstMap S T] {x} {tl : List S} {σ : Subst T}
+  : (x :: tl)[σ:_] = x[σ:_] :: tl[σ:_]
+:= by
+  simp [SubstMap.smap, List.smap]
+
+instance [RenMap T] [SubstMap S T] [SubstMapId S T]
+  : SubstMapId (List S) T
+where
+  apply_id := by intro t; induction t <;> simp [*]
+
+instance [RenMap S] [RenMap T] [SubstMap T T] [SubstMap S T] [SubstMapCompose S T]
+  : SubstMapCompose (List S) T
+where
+  apply_compose := by intro s σ τ; induction s <;> simp [*]
+
+@[simp, grind =]
+def List.dep_subst_get [SubstMap S T] (σ : Subst T) : List S -> Nat -> Option S
+| .nil, _ => none
+| .cons h _, 0 => return h[σ:_]
+| .cons _ t, n + 1 => (dep_subst_get σ t n)[σ:_]
+
+abbrev List.dep_subst_get1 [SubstMap S S] (σ : Subst S) : List S -> Nat -> Option S :=
+  dep_subst_get σ
+
+macro:max t:term noWs "[" x:term "|" σ:term  ":" T:term "]" : term =>
+  `(List.dep_subst_get (T := $T) $σ $t $x)
+
+macro:max t:term noWs "[" x:term "|" σ:term "]" : term =>
+  `(List.dep_subst_get1 $σ $t $x)
+
+@[app_unexpander List.dep_subst_get1]
+def unexpand_list_dep_subst_get1 : Lean.PrettyPrinter.Unexpander
+| `($_ $σ $t $x) => `($t[$x|$σ])
+| _ => throw ()
+
+@[app_unexpander smap]
+def unexpand_list_dep_subst_get : Lean.PrettyPrinter.Unexpander
+| `($_ $σ $t $x) => `($t[$x|$σ : _])
+| `($_ (T := $T) $σ $t $x) => `($t[$x|$σ : $T])
+| _ => throw ()
+
+@[simp, grind =]
+theorem List.dep_subst_get_zero [SubstMap S T] {σ : Subst T} {A : S} {Γ : List S}
+  : (A::Γ)[0|σ:_] = A[σ:_]
+:= by
+  simp [dep_subst_get]
+
+@[simp, grind =]
+theorem List.dep_subst_get_succ [SubstMap S T] {σ : Subst T} {A : S} {Γ : List S} {x}
+  : (A::Γ)[x + 1|σ:_] = Γ[x|σ:_][σ:_]
+:= by
+  simp [dep_subst_get]
+
+end LeanSubst

--- a/LeanPool/LeanSubst/List.lean
+++ b/LeanPool/LeanSubst/List.lean
@@ -12,6 +12,7 @@ namespace LeanSubst
 
 variable {S T : Type}
 
+/-- Apply a renaming pointwise to every element of a list. -/
 def List.rmap [i : RenMap S] (r : Ren) : List S -> List S
 | [] => []
 | .cons x tl => (i.rmap r x) :: rmap r tl
@@ -29,6 +30,7 @@ theorem List.rmap_cons [RenMap S] {x} {tl : List S} {r : Ren}
 := by
   simp [RenMap.rmap, List.rmap]
 
+/-- Apply a substitution pointwise to every element of a list. -/
 def List.smap [SubstMap S T] (σ : Subst T) : List S -> List S
 | [] => []
 | .cons x tl => x[σ:_] :: smap σ tl
@@ -56,26 +58,32 @@ instance [RenMap S] [RenMap T] [SubstMap T T] [SubstMap S T] [SubstMapCompose S 
 where
   apply_compose := by intro s σ τ; induction s <;> simp [*]
 
+/-- Look up the `n`-th element of a context list, substituting all binders crossed. -/
 @[simp, grind =]
 def List.dep_subst_get [SubstMap S T] (σ : Subst T) : List S -> Nat -> Option S
 | .nil, _ => none
 | .cons h _, 0 => return h[σ:_]
 | .cons _ t, n + 1 => (dep_subst_get σ t n)[σ:_]
 
+/-- Homogeneous variant of `List.dep_subst_get` (the `S = T` case). -/
 abbrev List.dep_subst_get1 [SubstMap S S] (σ : Subst S) : List S -> Nat -> Option S :=
   dep_subst_get σ
 
+/-- Notation `t[x|σ : T]` for `List.dep_subst_get` over `T`. -/
 macro:max t:term noWs "[" x:term "|" σ:term  ":" T:term "]" : term =>
   `(List.dep_subst_get (T := $T) $σ $t $x)
 
+/-- Notation `t[x|σ]` for the homogeneous `List.dep_subst_get1`. -/
 macro:max t:term noWs "[" x:term "|" σ:term "]" : term =>
   `(List.dep_subst_get1 $σ $t $x)
 
+/-- Pretty-printer that displays `List.dep_subst_get1 σ t x` as `t[x|σ]`. -/
 @[app_unexpander List.dep_subst_get1]
 def unexpand_list_dep_subst_get1 : Lean.PrettyPrinter.Unexpander
 | `($_ $σ $t $x) => `($t[$x|$σ])
 | _ => throw ()
 
+/-- Pretty-printer that displays `List.dep_subst_get σ t x` as `t[x|σ : _]`. -/
 @[app_unexpander smap]
 def unexpand_list_dep_subst_get : Lean.PrettyPrinter.Unexpander
 | `($_ $σ $t $x) => `($t[$x|$σ : _])

--- a/LeanPool/LeanSubst/Normal.lean
+++ b/LeanPool/LeanSubst/Normal.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 Andrew Marmaduke. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Marmaduke
+-/
+import Init.WF
+import LeanPool.LeanSubst.Ren
+import LeanPool.LeanSubst.Subst
+import LeanPool.LeanSubst.Reduction
+
+namespace LeanSubst
+  universe u
+
+  section
+    variable {T : Type}
+
+    def Reducible (R : T -> T -> Prop) (t : T) := ∃ t', R t t'
+    def Normal (R : T -> T -> Prop) (t : T) := ¬ (Reducible R t)
+    def NormalForm (R : T -> T -> Prop) (t : T) (t' : T) := Star R t t' ∧ Normal R t'
+    def WN (R : T -> T -> Prop) (t : T) := ∃ t', NormalForm R t t'
+
+    inductive SN (R : T -> T -> Prop) : T -> Prop where
+    | sn {x} : (∀ y, R x y -> SN R y) -> SN R x
+
+    inductive SNPlus (R : T -> T -> Prop) : T -> Prop where
+    | sn {x} : (∀ y, Plus R x y -> SNPlus R y) -> SNPlus R x
+
+    variable {R R1 R2 : T -> T -> Prop}
+
+    namespace SNPlus
+      theorem impies_sn {t} : SNPlus R t -> SN R t := by
+        intro h; induction h; case _ t' _ ih =>
+        constructor; intro t'' r
+        apply ih t'' (Plus.start r)
+
+      theorem preservation_step {t t'} : SNPlus R t -> R t t' -> SNPlus R t' := by
+        intro h r; induction h; case _ z h _ =>
+          apply h _ (Plus.start r)
+
+      theorem preservation {t t'} : SNPlus R t -> Star R t t' -> SNPlus R t' := by
+        intro h r; induction r
+        case _ => apply h
+        case _ _ r2 ih =>
+          apply preservation_step ih r2
+    end SNPlus
+
+    namespace SN
+      theorem preimage (f : T -> T) x :
+        (∀ x y, R x y -> R (f x) (f y)) ->
+        SN R (f x) ->
+        SN R x
+      := by
+        intro h sh
+        generalize zdef : f x = z at sh
+        induction sh generalizing f x
+        case _ x' h' ih =>
+          subst zdef; constructor
+          intro y r
+          apply ih (f y) (h _ _ r) f y h rfl
+
+      theorem preservation_step {t t'} : SN R t -> R t t' -> SN R t' := by
+        intro h red
+        induction h
+        case _ z h1 _h2 =>
+          apply h1 _ red
+
+      theorem preservation {t t'} : SN R t -> Star R t t' -> SN R t' := by
+        intro h red
+        induction red
+        case _ => simp [*]
+        case _ _ r2 ih => apply preservation_step ih r2
+
+      theorem star {t} : (∀ y, Star R t y -> SN R y) -> SN R t := by
+        intro h
+        constructor
+        intro y r
+        apply h y (Star.step Star.refl r)
+
+      theorem implies_snplus {t} : SN R t -> SNPlus R t := by
+        intro h; induction h; case _ t' _ ih =>
+        constructor; intro t'' r
+        have lem := Plus.destruct r
+        cases lem; case _ z lem =>
+          have lem2 := ih z lem.1
+          apply SNPlus.preservation lem2 lem.2
+
+      theorem expansion_step {t t' : T} (f : FunctionalTerm R t) : SN R t' -> R t t' -> SN R t := by
+        intro h r
+        apply SN.sn; intro y r'
+        rw [<-f r r']
+        apply h
+
+      theorem expansion {t t' : T} [Functional R] : SN R t' -> Star R t t' -> SN R t := by
+        intro h r
+        induction r; apply h
+        case _ r1 r2 ih =>
+          have lem := expansion_step Functional.functional h r2
+          apply ih lem
+
+      theorem equiv_acc {t} : SN R t <-> Acc (flip $ R) t := by
+        apply Iff.intro
+        case _ =>
+          intro h; induction h
+          case _ x h ih =>
+          constructor
+          simp [flip]
+          exact ih
+        case _ =>
+          intro h; induction h
+          case _ x h ih =>
+          constructor
+          simp [flip] at ih
+          exact ih
+
+      theorem wellfounded : (∀ t, SN R t) -> WellFounded (flip $ R) := by
+        intro h; constructor
+        intro a; replace h := h a
+        apply equiv_acc.1 h
+
+      variable [RenMap T] [SubstMap T T] [Substitutive R]
+
+      theorem subst_preimage {σ : Subst T} {t} : SN R t[σ] -> SN R t := by
+        intro r; apply preimage (smap σ) t _ r
+        intro x y r; apply Substitutive.subst
+        apply r
+    end SN
+  end
+end LeanSubst

--- a/LeanPool/LeanSubst/Normal.lean
+++ b/LeanPool/LeanSubst/Normal.lean
@@ -14,14 +14,20 @@ namespace LeanSubst
   section
     variable {T : Type}
 
+    /-- A term is reducible under `R` if it has at least one `R`-successor. -/
     def Reducible (R : T -> T -> Prop) (t : T) := ∃ t', R t t'
+    /-- A term is normal under `R` if it is not reducible. -/
     def Normal (R : T -> T -> Prop) (t : T) := ¬ (Reducible R t)
+    /-- `t'` is a normal form of `t` if `t` reduces to `t'` and `t'` is normal. -/
     def NormalForm (R : T -> T -> Prop) (t : T) (t' : T) := Star R t t' ∧ Normal R t'
+    /-- A term is weakly normalizing if it has some normal form. -/
     def WN (R : T -> T -> Prop) (t : T) := ∃ t', NormalForm R t t'
 
+    /-- Strong normalization: every `R`-reduction sequence from `t` terminates. -/
     inductive SN (R : T -> T -> Prop) : T -> Prop where
     | sn {x} : (∀ y, R x y -> SN R y) -> SN R x
 
+    /-- Strong normalization phrased over the transitive closure `Plus R`. -/
     inductive SNPlus (R : T -> T -> Prop) : T -> Prop where
     | sn {x} : (∀ y, Plus R x y -> SNPlus R y) -> SNPlus R x
 

--- a/LeanPool/LeanSubst/Option.lean
+++ b/LeanPool/LeanSubst/Option.lean
@@ -11,6 +11,7 @@ namespace LeanSubst
 
 variable {S T : Type}
 
+/-- Apply a renaming under an `Option`, leaving `none` unchanged. -/
 def Option.rmap [i : RenMap S] (r : Ren) : Option S -> Option S
 | none => none
 | some t => some (i.rmap r t)
@@ -18,6 +19,7 @@ def Option.rmap [i : RenMap S] (r : Ren) : Option S -> Option S
 instance [RenMap S] : RenMap (Option S) where
   rmap := Option.rmap
 
+/-- Apply a substitution under an `Option`, leaving `none` unchanged. -/
 def Option.smap [SubstMap S T] (σ : Subst T) : Option S -> Option S
 | none => none
 | some t => some t[σ:_]

--- a/LeanPool/LeanSubst/Option.lean
+++ b/LeanPool/LeanSubst/Option.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2026 Andrew Marmaduke. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Marmaduke
+-/
+import LeanPool.LeanSubst.Ren
+import LeanPool.LeanSubst.Subst
+import LeanPool.LeanSubst.Laws
+
+namespace LeanSubst
+
+variable {S T : Type}
+
+def Option.rmap [i : RenMap S] (r : Ren) : Option S -> Option S
+| none => none
+| some t => some (i.rmap r t)
+
+instance [RenMap S] : RenMap (Option S) where
+  rmap := Option.rmap
+
+def Option.smap [SubstMap S T] (σ : Subst T) : Option S -> Option S
+| none => none
+| some t => some t[σ:_]
+
+instance [SubstMap S T] : SubstMap (Option S) T where
+  smap := Option.smap
+
+@[simp, grind =]
+theorem Option.smap_none [SubstMap S T] {σ : Subst T}
+  : (@Option.none S)[σ:_] = none
+:= by
+  simp [SubstMap.smap, Option.smap]
+
+@[simp, grind =]
+theorem Option.smap_some [SubstMap S T] {x : S} {σ : Subst T}
+  : (some x)[σ:_] = some x[σ:_]
+:= by
+  simp [SubstMap.smap, Option.smap]
+
+instance [RenMap T] [SubstMap S T] [SubstMapId S T]
+  : SubstMapId (Option S) T
+where
+  apply_id := by intro t; cases t <;> simp
+
+instance [RenMap S] [RenMap T] [SubstMap T T] [SubstMap S T] [SubstMapCompose S T]
+  : SubstMapCompose (Option S) T
+where
+  apply_compose := by intro s σ τ; cases s <;> simp
+
+end LeanSubst

--- a/LeanPool/LeanSubst/Reduction.lean
+++ b/LeanPool/LeanSubst/Reduction.lean
@@ -9,33 +9,41 @@ import LeanPool.LeanSubst.Subst
 namespace LeanSubst
   universe u
 
+  /-- A reduction relation that is preserved by substitution. -/
   class Substitutive {T : Type} [RenMap T] [SubstMap T T] (R : T -> T -> Prop) where
     subst {t s} (σ : Subst T) : R t s -> R (t[σ]) (s[σ])
 
+  /-- A reduction relation with the triangle property, given by a completion function. -/
   class HasTriangle {T : Type u} (R : T -> T -> Prop) where
+    /-- The completion of a term: every one-step reduct reduces to it. -/
     complete : T -> T
     triangle {t s} : R t s -> R s (complete t)
 
   section
     variable {T : Type}
 
+    /-- Lift a reduction `R` to substitution actions: reduce inside `su`, fix `re`. -/
     inductive ActionRed (R : T -> T -> Prop) : Subst.Action T -> Subst.Action T -> Prop where
     | su {x y} : R x y -> ActionRed R (.su x) (.su y)
     | re {x} : ActionRed R (.re x) (.re x)
 
+    /-- The reflexive-transitive closure of a reduction relation `R`. -/
     inductive Star (R : T -> T -> Prop) : T -> T -> Prop where
     | refl {t} : Star R t t
     | step {x y z} : Star R x y -> R y z -> Star R x z
 
+    /-- The transitive closure of a reduction relation `R`. -/
     inductive Plus (R : T -> T -> Prop) : T -> T -> Prop where
     | start {t s} : R t s -> Plus R t s
     | step {x y z} : Plus R x y -> R y z -> Plus R x z
 
+    /-- The conversion relation: the equivalence closure of `R`. -/
     inductive Conv (R : T -> T -> Prop) : T -> T -> Prop where
     | refl {x} : Conv R x x
     | forward {x y z} : Conv R x z -> R x y -> Conv R y z
     | backward {x y z} : Conv R y z -> R x y -> Conv R x z
 
+    /-- A reduction relation that is confluent. -/
     class HasConfluence (R : T -> T -> Prop) where
       confluence {s t1 t2} : Star R s t1 -> Star R s t2 -> ∃ t, Star R t1 t ∧ Star R t2 t
 
@@ -318,10 +326,12 @@ namespace LeanSubst
   section
     variable {T : Type u} (R : T -> T -> Prop) {t t' : T}
 
+    /-- A term is functional under `R` if it has at most one one-step reduct. -/
     @[simp]
     def FunctionalTerm (t : T) :=
       ∀ {x y}, R t x -> R t y -> x = y
 
+    /-- A reduction relation under which every term is functional (deterministic). -/
     class Functional where
       functional : ∀ {t}, FunctionalTerm R t
   end

--- a/LeanPool/LeanSubst/Reduction.lean
+++ b/LeanPool/LeanSubst/Reduction.lean
@@ -1,0 +1,329 @@
+/-
+Copyright (c) 2026 Andrew Marmaduke. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Marmaduke
+-/
+import LeanPool.LeanSubst.Ren
+import LeanPool.LeanSubst.Subst
+
+namespace LeanSubst
+  universe u
+
+  class Substitutive {T : Type} [RenMap T] [SubstMap T T] (R : T -> T -> Prop) where
+    subst {t s} (σ : Subst T) : R t s -> R (t[σ]) (s[σ])
+
+  class HasTriangle {T : Type u} (R : T -> T -> Prop) where
+    complete : T -> T
+    triangle {t s} : R t s -> R s (complete t)
+
+  section
+    variable {T : Type}
+
+    inductive ActionRed (R : T -> T -> Prop) : Subst.Action T -> Subst.Action T -> Prop where
+    | su {x y} : R x y -> ActionRed R (.su x) (.su y)
+    | re {x} : ActionRed R (.re x) (.re x)
+
+    inductive Star (R : T -> T -> Prop) : T -> T -> Prop where
+    | refl {t} : Star R t t
+    | step {x y z} : Star R x y -> R y z -> Star R x z
+
+    inductive Plus (R : T -> T -> Prop) : T -> T -> Prop where
+    | start {t s} : R t s -> Plus R t s
+    | step {x y z} : Plus R x y -> R y z -> Plus R x z
+
+    inductive Conv (R : T -> T -> Prop) : T -> T -> Prop where
+    | refl {x} : Conv R x x
+    | forward {x y z} : Conv R x z -> R x y -> Conv R y z
+    | backward {x y z} : Conv R y z -> R x y -> Conv R x z
+
+    class HasConfluence (R : T -> T -> Prop) where
+      confluence {s t1 t2} : Star R s t1 -> Star R s t2 -> ∃ t, Star R t1 t ∧ Star R t2 t
+
+    variable {R R1 R2 : T -> T -> Prop}
+
+    namespace Star
+      theorem trans {x y z} : Star R x y -> Star R y z -> Star R x z := by
+        intro r1 r2; induction r2 generalizing x
+        case _ => apply r1
+        case _ a b _ r2 ih => apply Star.step (ih r1) r2
+
+      theorem promote {x y} (Rprm : ∀ {x y}, R1 x y -> R2 x y) :
+        Star R1 x y -> Star R2 x y
+      := by
+        intro r; induction r
+        case _ => constructor
+        case _ _ r ih => constructor; apply ih; apply Rprm r
+
+      theorem stepr {x y z} : R x y -> Star R y z -> Star R x z := by
+        intro h r; induction r generalizing x
+        case _ => apply Star.step Star.refl h
+        case _ r1 r2 ih =>
+          replace ih := ih h
+          apply Star.step ih r2
+
+      theorem destruct {x z} : Star R x z -> (∃ y, R x y ∧ Star R y z) ∨ x = z := by
+        intro h; induction h
+        case _ => apply Or.inr rfl
+        case _ u v r1 r2 ih =>
+          cases ih
+          case _ ih =>
+            cases ih; case _ w ih =>
+            apply Or.inl; apply Exists.intro w
+            apply And.intro ih.1
+            apply Star.step ih.2 r2
+          case _ ih =>
+            subst ih; apply Or.inl
+            apply Exists.intro v; apply And.intro r2 Star.refl
+
+      theorem congr3_1 {t1 t1'} t2 t3 (f : T -> T -> T -> T) :
+        (∀ {t1 t2 t3 t1'}, R t1 t1' -> R (f t1 t2 t3) (f t1' t2 t3)) ->
+        Star R t1 t1' ->
+        Star R (f t1 t2 t3) (f t1' t2 t3)
+      := by
+        intro fh h2
+        induction h2
+        case _ => apply refl
+        case _ h4 ih =>
+          have h5 := @fh _ t2 t3 _ h4
+          apply trans ih (Star.step Star.refl h5)
+
+      theorem congr3_2 {t2 t2'} t1 t3 (f : T -> T -> T -> T) :
+        (∀ {t1 t2 t3 t2'}, R t2 t2' -> R (f t1 t2 t3) (f t1 t2' t3)) ->
+        Star R t2 t2' ->
+        Star R (f t1 t2 t3) (f t1 t2' t3)
+      := by
+        intro fh h2
+        induction h2
+        case _ => apply refl
+        case _ h4 ih =>
+          have h5 := @fh t1 _ t3 _ h4
+          apply trans ih (Star.step Star.refl h5)
+
+      theorem congr3_3 {t3 t3'} t1 t2 (f : T -> T -> T -> T) :
+        (∀ {t1 t2 t3 t3'}, R t3 t3' -> R (f t1 t2 t3) (f t1 t2 t3')) ->
+        Star R t3 t3' ->
+        Star R (f t1 t2 t3) (f t1 t2 t3')
+      := by
+        intro fh h2
+        induction h2
+        case _ => apply refl
+        case _ h4 ih =>
+          have h5 := @fh t1 t2 _ _ h4
+          apply trans ih (Star.step Star.refl h5)
+
+      theorem congr3 {t1 t1' t2 t2' t3 t3'} (f : T -> T -> T -> T) :
+        (∀ {t1 t2 t3 t1'}, R t1 t1' -> R (f t1 t2 t3) (f t1' t2 t3)) ->
+        (∀ {t1 t2 t3 t2'}, R t2 t2' -> R (f t1 t2 t3) (f t1 t2' t3)) ->
+        (∀ {t1 t2 t3 t3'}, R t3 t3' -> R (f t1 t2 t3) (f t1 t2 t3')) ->
+        Star R t1 t1' -> Star R t2 t2' -> Star R t3 t3' ->
+        Star R (f t1 t2 t3) (f t1' t2' t3')
+      := by
+        intro f1 f2 f3 h1 h2 h3
+        have r1 := congr3_1 t2 t3 f f1 h1
+        have r2 := congr3_2 t1' t3 f f2 h2
+        have r3 := congr3_3 t1' t2' f f3 h3
+        apply trans r1; apply trans r2; apply trans r3; apply refl
+
+      theorem congr2_1 {t1 t1'} t2 (f : T -> T -> T) :
+        (∀ {t1 t2 t1'}, R t1 t1' -> R (f t1 t2) (f t1' t2)) ->
+        Star R t1 t1' ->
+        Star R (f t1 t2) (f t1' t2)
+      := by
+        intro fh h
+        apply congr3_1 t2 t2 (λ t1 t2 _t3 => f t1 t2)
+        intro t1 t2 _t3 t1' h; apply fh h
+        exact h
+
+      theorem congr2_2 {t2 t2'} t1 (f : T -> T -> T) :
+        (∀ {t1 t2 t2'}, R t2 t2' -> R (f t1 t2) (f t1 t2')) ->
+        Star R t2 t2' ->
+        Star R (f t1 t2) (f t1 t2')
+      := by
+        intro fh h
+        apply congr3_2 t1 t1 (λ t1 t2 _t3 => f t1 t2)
+        intro t1 t2 _t3 t1' h; apply fh h
+        exact h
+
+      theorem congr2 {t1 t1' t2 t2'} (f : T -> T -> T) :
+        (∀ {t1 t2 t1'}, R t1 t1' -> R (f t1 t2) (f t1' t2)) ->
+        (∀ {t1 t2 t2'}, R t2 t2' -> R (f t1 t2) (f t1 t2')) ->
+        Star R t1 t1' -> Star R t2 t2' ->
+        Star R (f t1 t2) (f t1' t2')
+      := by
+        intro f1 f2 h1 h2
+        have r1 := congr2_1 t2 f f1 h1
+        have r2 := congr2_2 t1' f f2 h2
+        apply trans r1; apply trans r2; apply refl
+
+      theorem congr1 {t1 t1'} (f : T -> T) :
+        (∀ {t1 t1'}, R t1 t1' -> R (f t1) (f t1')) ->
+        Star R t1 t1' ->
+        Star R (f t1) (f t1')
+      := by
+        intro fh h
+        apply congr2_1 t1 (λ t1 _t2 => f t1)
+        intro t1 _t2 t1' h; apply fh h
+        exact h
+
+      variable [HasTriangle R]
+
+      theorem strip {s t1 t2} : R s t1 -> Star R s t2 -> ∃ t, Star R t1 t ∧ R t2 t := by
+        intro h1 h2
+        induction h2 generalizing t1
+        case _ t' => exists t1; apply And.intro; apply Star.refl; apply h1
+        case _ x y z _r1 r2 ih =>
+          replace ih := ih h1
+          cases ih
+          case _ w ih =>
+            replace r2 := HasTriangle.triangle r2
+            have lem := HasTriangle.triangle ih.2
+            replace lem := Star.step ih.1 lem
+            exists (HasTriangle.complete R y)
+
+      theorem confluence {s t1 t2} : Star R s t1 -> Star R s t2 -> ∃ t, Star R t1 t ∧ Star R t2 t := by
+        intro h1 h2
+        induction h1 generalizing t2
+        case _ z =>
+          exists t2; apply And.intro
+          apply h2; apply Star.refl
+        case _ s y t1 _r1 r2 ih =>
+          replace ih := ih h2
+          cases ih; case _ w ih =>
+            have lem := strip r2 ih.1
+            cases lem; case _ q lem =>
+              exists q; apply And.intro
+              apply lem.1; apply Star.step ih.2 lem.2
+
+      variable [RenMap T] [SubstMap T T] [Substitutive R]
+
+      omit [HasTriangle R] in
+      theorem subst {x y} (σ : Subst T) : Star R x y -> Star R x[σ] y[σ] := by
+        intro r; induction r
+        case _ => apply Star.refl
+        case _ r1 r2 ih =>
+          replace r2 := Substitutive.subst σ r2
+          apply Star.step ih r2
+    end Star
+
+    instance HasConfluence_from_HasTriangle {T : Type} {R : T -> T -> Prop} [HasTriangle R] : HasConfluence R where
+      confluence := Star.confluence
+
+    namespace Plus
+      theorem destruct {x z} : Plus R x z -> ∃ y, R x y ∧ Star R y z := by
+        intro r; induction r
+        case _ b r =>
+          exists b; apply And.intro r Star.refl
+        case _ r1 r2 ih =>
+          cases ih; case _ u ih =>
+            exists u; apply And.intro ih.1
+            apply Star.step ih.2 r2
+
+      theorem stepr {x y z} : R x y -> Plus R y z -> Plus R x z := by
+        intro r1 r2
+        induction r2 generalizing x
+        case _ r2 => apply Plus.step (Plus.start r1) r2
+        case _ r3 r4 ih => apply Plus.step (ih r1) r4
+
+      theorem stepr_from_star {x y z} : R x y -> Star R y z -> Plus R x z := by
+        intro r1 r2
+        induction r2 generalizing x
+        case _ => apply Plus.start; apply r1
+        case _ r3 r4 ih => apply Plus.step (ih r1) r4
+    end Plus
+
+    namespace Conv
+      theorem forward_right {x y z} : Conv R x y -> R y z -> Conv R x z := by
+        intro h r; induction h generalizing z
+        case _ => apply backward refl r
+        case _ r2 ih => apply forward (ih r) r2
+        case _ r2 ih => apply backward (ih r) r2
+
+      theorem backward_right {x y z} : Conv R x y -> R z y -> Conv R x z := by
+        intro h r; induction h generalizing z
+        case _ => apply forward refl r
+        case _ r2 ih => apply forward (ih r) r2
+        case _ r2 ih => apply backward (ih r) r2
+
+      theorem sym {x y} : Conv R x y -> Conv R y x := by
+        intro h; induction h
+        case _ => constructor
+        case _ r ih => apply forward_right ih r
+        case _ r ih => apply backward_right ih r
+
+      theorem star_forward {x y z} : Conv R x z -> Star R x y -> Conv R y z := by
+        intro cv r
+        induction r; simp [*]
+        case _ r1 r2 ih => apply forward ih r2
+
+      theorem star_backward {x y z} : Conv R y z -> Star R x y -> Conv R x z := by
+        intro cv r
+        induction r; simp [*]
+        case _ r1 r2 ih =>
+          apply ih
+          apply backward cv r2
+
+      theorem star_forward_right {x y z} : Conv R x y -> Star R y z -> Conv R x z := by
+        intro cv r
+        induction r; simp [*]
+        case _ r1 r2 ih => apply forward_right ih r2
+
+      theorem star_backward_right {x y z} : Conv R x y -> Star R z y -> Conv R x z := by
+        intro cv r
+        induction r; simp [*]
+        case _ r1 r2 ih =>
+          apply ih
+          apply backward_right cv r2
+
+      theorem star_equiv {x y} [HasConfluence R] : Conv R x y <-> (∃ t, Star R x t ∧ Star R y t) := by
+        apply Iff.intro
+        case _ =>
+          intro cv
+          induction cv
+          case _ t =>
+            exists t
+            apply And.intro Star.refl Star.refl
+          case _ a b c cv r ih =>
+            cases ih; case _ t ih =>
+            have lem := HasConfluence.confluence (Star.step Star.refl r) ih.1
+            cases lem; case _ z lem =>
+            have lem2 := Star.trans ih.2 lem.2
+            exists z; apply And.intro lem.1 lem2
+          case _ a b c cv r ih =>
+            cases ih; case _ t ih =>
+            have lem := Star.stepr r ih.1
+            exists t; simp [*]
+        case _ =>
+          intro h
+          cases h; case _ t h =>
+          apply star_backward _ h.1
+          apply star_backward_right _ h.2
+          apply refl
+
+      theorem trans {x y z} [HasConfluence R] : Conv R x y -> Conv R y z -> Conv R x z := by
+        intro h1 h2
+        replace h1 := star_equiv.1 h1
+        replace h2 := star_equiv.1 h2
+        cases h1; case _ t1 h1 =>
+        cases h2; case _ t2 h2 =>
+        have lem := HasConfluence.confluence h1.2 h2.1
+        cases lem; case _ w lem =>
+        replace h1 := Star.trans h1.1 lem.1
+        replace h2 := Star.trans h2.2 lem.2
+        apply star_backward _ h1
+        apply star_backward_right _ h2
+        apply refl
+    end Conv
+  end
+
+  section
+    variable {T : Type u} (R : T -> T -> Prop) {t t' : T}
+
+    @[simp]
+    def FunctionalTerm (t : T) :=
+      ∀ {x y}, R t x -> R t y -> x = y
+
+    class Functional where
+      functional : ∀ {t}, FunctionalTerm R t
+  end
+
+end LeanSubst

--- a/LeanPool/LeanSubst/Ren.lean
+++ b/LeanPool/LeanSubst/Ren.lean
@@ -53,9 +53,9 @@ namespace LeanSubst
   /-- Notation `t⟨r⟩` for applying renaming `r` to value `t`. -/
   macro:max t:term noWs "⟨" r:term "⟩" : term => `(rmap $r $t)
   /-- Notation `a :: r` for `Ren.cons`. -/
-  infixr:67 (name := Ren.cons_notation) " :: " => Ren.cons
+  infixr:67 (name := Ren.consNotation) " :: " => Ren.cons
   /-- Notation `r1 ∘ r2` for `Ren.compose`. -/
-  infixr:85 (name := Ren.compose_notation) " ∘ " => Ren.compose
+  infixr:85 (name := Ren.composeNotation) " ∘ " => Ren.compose
 
   /-- Pretty-printer that displays `rmap r t` as `t⟨r⟩`. -/
   @[app_unexpander rmap]

--- a/LeanPool/LeanSubst/Ren.lean
+++ b/LeanPool/LeanSubst/Ren.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 Andrew Marmaduke. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Marmaduke
+-/
+namespace LeanSubst
+  universe u
+  variable {S T : Type}
+
+  structure Ren where
+    act : Nat -> Nat
+
+  def Ren.id : Ren := ⟨λ x => x⟩
+
+  def Ren.add (k : Nat) : Ren := ⟨(· + k)⟩
+
+  def Ren.sub (k : Nat) : Ren := ⟨(· - k)⟩
+
+  def Ren.lift (r : Ren) (k : Nat := 1) : Ren := .mk λ n =>
+    if n < k then n else r.act (n - k) + k
+
+  def Ren.cons (a : Nat) (r : Ren) : Ren := .mk λ n =>
+    match n with
+    | 0 => a
+    | n + 1 => r.act n
+
+  def Ren.append : List Nat -> Ren -> Ren
+  | .nil, r => r
+  | .cons hd tl, r => append tl (r.cons hd)
+
+  instance : HAppend (List Nat) Ren Ren where
+    hAppend := Ren.append
+
+  def Ren.compose : Ren -> Ren -> Ren
+  | r1, r2 => .mk λ n => r2.act (r1.act n)
+
+  class RenMap (T : Type) where
+    rmap : Ren -> T -> T
+
+  export RenMap (rmap)
+
+  macro:max t:term noWs "⟨" r:term "⟩" : term => `(rmap $r $t)
+  infixr:67 (name := Ren.cons_notation) " :: " => Ren.cons
+  infixr:85 (name := Ren.compose_notation) " ∘ " => Ren.compose
+
+  @[app_unexpander rmap]
+  def unexpandRenApply : Lean.PrettyPrinter.Unexpander
+  | `($_ $r $t) => `($t⟨$r⟩)
+  | _ => throw ()
+
+  @[simp, grind =]
+  theorem Ren.lift_zero {r : Ren} : r.lift 0 = r := by
+    unfold Ren.lift; congr
+
+  @[grind =]
+  theorem Ren.lift_succ {r : Ren} {k} : r.lift (k + 1) = (r.lift k).lift := by
+    induction k; simp
+    case _ n ih =>
+      unfold Ren.lift; congr; funext; case _ i =>
+      simp; unfold Ren.lift at ih; simp at ih
+      grind
+
+  @[simp]
+  theorem Ren.id_action {x} : Ren.id.act x = x := by simp [Ren.id]
+
+  @[simp]
+  theorem Ren.lift_id {k} : Ren.lift Ren.id k = Ren.id := by
+    simp [Ren.id, Ren.lift]; congr; funext; case _ x =>
+    cases x <;> simp; omega
+
+  @[simp]
+  theorem Ren.cons_head_action {n} {r : Ren} : (n::r).act 0 = n := by simp [Ren.cons]
+
+  @[simp]
+  theorem Ren.cons_tail_action {n i} {r : Ren} : (n::r).act (i + 1) = r.act i := by simp [Ren.cons]
+
+  @[simp]
+  theorem Ren.compose_id_left {r : Ren} : id ∘ r = r := by
+    simp [Ren.compose, Ren.id]
+
+  @[simp]
+  theorem Ren.compose_id_right {r : Ren} : r ∘ id = r := by
+    simp [Ren.compose, Ren.id]
+
+  @[simp]
+  theorem Ren.compose_assoc {r1 r2 r3 : Ren} : (r1 ∘ r2) ∘ r3 = r1 ∘ r2 ∘ r3 := by
+    simp [Ren.compose]
+
+  @[simp]
+  theorem Ren.compose_action {r1 r2 : Ren} {x} : (r1 ∘ r2).act x = r2.act (r1.act x) := by
+    simp [Ren.compose]
+
+  theorem Ren.compose_lift_k1 {r1 r2 : Ren} : (r1 ∘ r2).lift = r1.lift ∘ r2.lift := by
+    simp [Ren.compose, Ren.lift]
+    funext; case _ x =>
+    cases x <;> simp
+
+  @[simp]
+  theorem Ren.compose_lift {k} {r1 r2 : Ren} : (r1 ∘ r2).lift k = r1.lift k ∘ r2.lift k := by
+    induction k generalizing r1 r2; simp
+    case _ k ih =>
+      rw [lift_succ, ih]
+      rw [lift_succ (r := r1)]
+      rw [lift_succ (r := r2)]
+      rw [compose_lift_k1]
+
+  class RenMapId (S : Type) [RenMap S] where
+    apply_id {t : S} : t⟨Ren.id⟩ = t
+
+  class RenMapCompose (S : Type) [RenMap S] where
+    apply_compose {s : S} {r1 r2 : Ren} : s⟨r1⟩⟨r2⟩ = s⟨r1 ∘ r2⟩
+
+  @[simp, grind =]
+  theorem Ren.apply_id [RenMap T] [RenMapId T] {t : T} : t⟨id⟩ = t := RenMapId.apply_id
+
+  @[simp, grind =]
+  theorem Ren.apply_compose [RenMap T] [RenMapCompose T] {t : T} {r1 r2 : Ren}
+    : t⟨r1⟩⟨r2⟩ = t⟨r1 ∘ r2⟩
+  := RenMapCompose.apply_compose
+
+end LeanSubst

--- a/LeanPool/LeanSubst/Ren.lean
+++ b/LeanPool/LeanSubst/Ren.lean
@@ -7,23 +7,31 @@ namespace LeanSubst
   universe u
   variable {S T : Type}
 
+  /-- A renaming, represented as its action on De Bruijn indices. -/
   structure Ren where
+    /-- The underlying function on De Bruijn indices. -/
     act : Nat -> Nat
 
+  /-- The identity renaming. -/
   def Ren.id : Ren := ⟨λ x => x⟩
 
+  /-- The renaming that shifts every index up by `k`. -/
   def Ren.add (k : Nat) : Ren := ⟨(· + k)⟩
 
+  /-- The renaming that shifts every index down by `k` (truncating at zero). -/
   def Ren.sub (k : Nat) : Ren := ⟨(· - k)⟩
 
+  /-- Lift a renaming under `k` binders, leaving the first `k` indices fixed. -/
   def Ren.lift (r : Ren) (k : Nat := 1) : Ren := .mk λ n =>
     if n < k then n else r.act (n - k) + k
 
+  /-- Extend a renaming by mapping the zeroth index to `a` and shifting the rest. -/
   def Ren.cons (a : Nat) (r : Ren) : Ren := .mk λ n =>
     match n with
     | 0 => a
     | n + 1 => r.act n
 
+  /-- Prepend a list of indices to a renaming via repeated `Ren.cons`. -/
   def Ren.append : List Nat -> Ren -> Ren
   | .nil, r => r
   | .cons hd tl, r => append tl (r.cons hd)
@@ -31,18 +39,25 @@ namespace LeanSubst
   instance : HAppend (List Nat) Ren Ren where
     hAppend := Ren.append
 
+  /-- Sequential composition of renamings: apply `r1` then `r2`. -/
   def Ren.compose : Ren -> Ren -> Ren
   | r1, r2 => .mk λ n => r2.act (r1.act n)
 
+  /-- A type whose values support being acted on by a renaming. -/
   class RenMap (T : Type) where
+    /-- Apply a renaming to a value. -/
     rmap : Ren -> T -> T
 
   export RenMap (rmap)
 
+  /-- Notation `t⟨r⟩` for applying renaming `r` to value `t`. -/
   macro:max t:term noWs "⟨" r:term "⟩" : term => `(rmap $r $t)
+  /-- Notation `a :: r` for `Ren.cons`. -/
   infixr:67 (name := Ren.cons_notation) " :: " => Ren.cons
+  /-- Notation `r1 ∘ r2` for `Ren.compose`. -/
   infixr:85 (name := Ren.compose_notation) " ∘ " => Ren.compose
 
+  /-- Pretty-printer that displays `rmap r t` as `t⟨r⟩`. -/
   @[app_unexpander rmap]
   def unexpandRenApply : Lean.PrettyPrinter.Unexpander
   | `($_ $r $t) => `($t⟨$r⟩)
@@ -104,10 +119,14 @@ namespace LeanSubst
       rw [lift_succ (r := r2)]
       rw [compose_lift_k1]
 
+  /-- A `RenMap` for which applying the identity renaming is the identity. -/
   class RenMapId (S : Type) [RenMap S] where
+    /-- Applying the identity renaming leaves a value unchanged. -/
     apply_id {t : S} : t⟨Ren.id⟩ = t
 
+  /-- A `RenMap` for which renaming is functorial in composition. -/
   class RenMapCompose (S : Type) [RenMap S] where
+    /-- Applying two renamings in sequence equals applying their composition. -/
     apply_compose {s : S} {r1 r2 : Ren} : s⟨r1⟩⟨r2⟩ = s⟨r1 ∘ r2⟩
 
   @[simp, grind =]

--- a/LeanPool/LeanSubst/Subst.lean
+++ b/LeanPool/LeanSubst/Subst.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 Andrew Marmaduke. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Marmaduke
+-/
+import LeanPool.LeanSubst.Ren
+
+namespace LeanSubst
+  universe u
+  variable {S T : Type}
+
+  inductive Subst.Action (T : Type) where
+  | re : Nat -> Subst.Action T
+  | su : T -> Subst.Action T
+  deriving Repr
+
+  export Subst.Action (re su)
+
+  structure Subst (T : Type) where
+    act : Nat -> Subst.Action T
+
+  @[coe]
+  def Ren.to : Ren -> Subst T
+  | r  => .mk λ n => re (r.act n)
+
+  instance : Coe Ren (Subst T) where
+    coe := Ren.to
+
+  class SubstMap (S T : Type) where
+    smap : Subst T -> S -> S
+
+  export SubstMap (smap)
+
+  def Subst.lift [RenMap T] (σ : Subst T) (k : Nat := 1) : Subst T := .mk λ n =>
+    if n < k then re n else
+      match σ.act (n - k) with
+      | su t => su (rmap (Ren.add k) t)
+      | re i => re (i + k)
+
+  def Subst.cons (a : Subst.Action T) (σ : Subst T) : Subst T := .mk λ n =>
+    match n with
+    | 0 => a
+    | n + 1 => σ.act n
+
+  def Subst.append : List (Subst.Action T) -> Subst T -> Subst T
+  | .nil, σ => σ
+  | .cons hd tl, σ => append tl (σ.cons hd)
+
+  instance : HAppend (List $ Subst.Action T) (Subst T) (Subst T) where
+    hAppend := Subst.append
+
+  @[simp]
+  abbrev smap1 [SubstMap S S] := smap (S := S) (T := S)
+
+  def Subst.compose [RenMap T] [SubstMap T T] : Subst T -> Subst T -> Subst T
+  | σ, τ => .mk λ n =>
+    match σ.act n with
+    | su t => su (smap τ t)
+    | re k => τ.act k
+
+  def Subst.hcompose [RenMap T] [SubstMap S T] : Subst S -> Subst T -> Subst S
+  | σ, τ => .mk λ n =>
+    match σ.act n with
+    | su t => su (smap τ t)
+    | re k => re k
+
+  def Subst.id : Subst T := ⟨λ n => re n⟩
+  def Subst.succ : Subst T := ⟨λ n => re (n + 1)⟩
+  def Subst.pred : Subst T := ⟨λ n => re (n - 1)⟩
+
+  notation "+0" => Subst.id
+  macro "+0@" noWs T:term : term =>`(@Subst.id $T)
+  notation "+1" => Subst.succ
+  macro "+1@" noWs T:term : term =>`(@Subst.succ $T)
+  notation "-1" => Subst.pred
+  macro "-1@" noWs T:term : term =>`(@Subst.pred $T)
+
+  @[simp, grind =]
+  theorem Subst.id_action {n} : (+0@T).act n = re n := by simp [Subst.id]
+
+  @[simp, grind =]
+  theorem Subst.succ_action {n} : (+1@T).act n = re (n + 1) := by simp [Subst.succ]
+
+  @[simp, grind =]
+  theorem Subst.pred_action {n} : (-1@T).act n = re (n - 1) := by simp [Subst.pred]
+
+  @[simp, grind =]
+  theorem Ren.to_id : Ren.to (T := T) id = +0 := by
+    unfold Ren.to; unfold Subst.id; simp [id]
+
+  @[simp, grind =]
+  theorem Ren.to_succ : Ren.to (T := T) (Ren.add 1) = +1 := by
+    unfold Ren.to; simp; unfold Subst.succ; simp [Ren.add]
+
+  @[simp, grind =]
+  theorem Ren.to_pred : Ren.to (T := T) (Ren.sub 1) = -1 := by
+    unfold Ren.to; simp; unfold Subst.pred; simp [Ren.sub]
+
+  @[simp, grind =]
+  theorem Ren.pred_succ [RenMap T] [SubstMap T T] : Subst.compose (T := T) +1 -1 = +0 := by
+    unfold Subst.compose; simp
+    unfold Subst.id; rfl
+
+  @[grind =]
+  theorem Ren.to_lift [RenMap T] {r : Ren} {k} : (r.lift k).to = (@Ren.to T r).lift k := by
+    cases r; simp [Ren.lift, Ren.to, Subst.lift]; case _ act =>
+    funext; case _ x =>
+    cases x
+    case zero => grind
+    case _ n => cases Nat.decLt (n + 1) k <;> simp [ite]
+
+  macro:max t:term noWs "[" σ:term "]" : term => `(smap1 $σ $t)
+  macro:max t:term noWs "[" σ:term ":" T:term "]" : term => `(smap (T := $T) $σ $t)
+  infixr:67 (name := Subst.cons_notation) " :: " => Subst.cons
+  infixr:85 (name := Subst.compose_notation) " ∘ " => Subst.compose
+  infixr:85 " ◾ " => Subst.hcompose
+
+  @[app_unexpander smap1]
+  def unexpandSubstApply1 : Lean.PrettyPrinter.Unexpander
+  | `($_ $σ $t) => `($t[$σ])
+  | _ => throw ()
+
+  @[app_unexpander smap]
+  def unexpandSubstApply : Lean.PrettyPrinter.Unexpander
+  | `($_ $σ $t) => `($t[$σ : _])
+  | `($_ (T := $T) $σ $t) => `($t[$σ : $T])
+  | _ => throw ()
+
+  @[simp, grind =]
+  theorem Ren.to_compose {r1 r2 : Ren} [RenMap T] [SubstMap T T]
+    : Ren.to (T := T) (r1 ∘ r2) = Subst.compose r1 r2
+  := by
+    funext; case _ x =>
+    cases x <;> simp [Ren.to, Subst.compose, Ren.compose]
+
+  @[simp]
+  theorem Subst.cons_head_action {t} {σ : Subst T} : (t::σ).act 0 = t := by simp [Subst.cons]
+
+  @[simp]
+  theorem Subst.cons_tail_action {t i} {σ : Subst T} : (t::σ).act (i + 1) = σ.act i := by simp [Subst.cons]
+
+end LeanSubst

--- a/LeanPool/LeanSubst/Subst.lean
+++ b/LeanPool/LeanSubst/Subst.lean
@@ -135,9 +135,9 @@ namespace LeanSubst
   /-- Notation `t[σ : T]` for applying a substitution `σ` over `T` to `t`. -/
   macro:max t:term noWs "[" σ:term ":" T:term "]" : term => `(smap (T := $T) $σ $t)
   /-- Notation `a :: σ` for `Subst.cons`. -/
-  infixr:67 (name := Subst.cons_notation) " :: " => Subst.cons
+  infixr:67 (name := Subst.consNotation) " :: " => Subst.cons
   /-- Notation `σ ∘ τ` for `Subst.compose`. -/
-  infixr:85 (name := Subst.compose_notation) " ∘ " => Subst.compose
+  infixr:85 (name := Subst.composeNotation) " ∘ " => Subst.compose
   /-- Notation `σ ◾ τ` for `Subst.hcompose`. -/
   infixr:85 " ◾ " => Subst.hcompose
 

--- a/LeanPool/LeanSubst/Subst.lean
+++ b/LeanPool/LeanSubst/Subst.lean
@@ -9,6 +9,7 @@ namespace LeanSubst
   universe u
   variable {S T : Type}
 
+  /-- A single substitution action: either a renamed variable (`re`) or a term (`su`). -/
   inductive Subst.Action (T : Type) where
   | re : Nat -> Subst.Action T
   | su : T -> Subst.Action T
@@ -16,9 +17,12 @@ namespace LeanSubst
 
   export Subst.Action (re su)
 
+  /-- A substitution, represented as its action on each De Bruijn index. -/
   structure Subst (T : Type) where
+    /-- The substitution action assigned to each De Bruijn index. -/
     act : Nat -> Subst.Action T
 
+  /-- Embed a renaming into a substitution. -/
   @[coe]
   def Ren.to : Ren -> Subst T
   | r  => .mk λ n => re (r.act n)
@@ -26,22 +30,27 @@ namespace LeanSubst
   instance : Coe Ren (Subst T) where
     coe := Ren.to
 
+  /-- A type `S` whose values support being acted on by a substitution over `T`. -/
   class SubstMap (S T : Type) where
+    /-- Apply a substitution to a value. -/
     smap : Subst T -> S -> S
 
   export SubstMap (smap)
 
+  /-- Lift a substitution under `k` binders, leaving the first `k` indices fixed. -/
   def Subst.lift [RenMap T] (σ : Subst T) (k : Nat := 1) : Subst T := .mk λ n =>
     if n < k then re n else
       match σ.act (n - k) with
       | su t => su (rmap (Ren.add k) t)
       | re i => re (i + k)
 
+  /-- Extend a substitution by assigning action `a` to index `0` and shifting the rest. -/
   def Subst.cons (a : Subst.Action T) (σ : Subst T) : Subst T := .mk λ n =>
     match n with
     | 0 => a
     | n + 1 => σ.act n
 
+  /-- Prepend a list of actions to a substitution via repeated `Subst.cons`. -/
   def Subst.append : List (Subst.Action T) -> Subst T -> Subst T
   | .nil, σ => σ
   | .cons hd tl, σ => append tl (σ.cons hd)
@@ -49,30 +58,42 @@ namespace LeanSubst
   instance : HAppend (List $ Subst.Action T) (Subst T) (Subst T) where
     hAppend := Subst.append
 
+  /-- Apply a homogeneous substitution (the `S = T` case of `smap`). -/
   @[simp]
   abbrev smap1 [SubstMap S S] := smap (S := S) (T := S)
 
-  def Subst.compose [RenMap T] [SubstMap T T] : Subst T -> Subst T -> Subst T
+  /-- Homogeneous composition of substitutions: apply `σ` then `τ`. -/
+  def Subst.compose [SubstMap T T] : Subst T -> Subst T -> Subst T
   | σ, τ => .mk λ n =>
     match σ.act n with
     | su t => su (smap τ t)
     | re k => τ.act k
 
-  def Subst.hcompose [RenMap T] [SubstMap S T] : Subst S -> Subst T -> Subst S
+  /-- Heterogeneous composition: substitute over `S` then over `T`. -/
+  def Subst.hcompose [SubstMap S T] : Subst S -> Subst T -> Subst S
   | σ, τ => .mk λ n =>
     match σ.act n with
     | su t => su (smap τ t)
     | re k => re k
 
+  /-- The identity substitution, mapping each index to itself. -/
   def Subst.id : Subst T := ⟨λ n => re n⟩
+  /-- The shift-up substitution, mapping each index `n` to `n + 1`. -/
   def Subst.succ : Subst T := ⟨λ n => re (n + 1)⟩
+  /-- The shift-down substitution, mapping each index `n` to `n - 1`. -/
   def Subst.pred : Subst T := ⟨λ n => re (n - 1)⟩
 
+  /-- Notation `+0` for the identity substitution. -/
   notation "+0" => Subst.id
+  /-- Notation `+0@T` for the identity substitution at type `T`. -/
   macro "+0@" noWs T:term : term =>`(@Subst.id $T)
+  /-- Notation `+1` for the shift-up substitution. -/
   notation "+1" => Subst.succ
+  /-- Notation `+1@T` for the shift-up substitution at type `T`. -/
   macro "+1@" noWs T:term : term =>`(@Subst.succ $T)
+  /-- Notation `-1` for the shift-down substitution. -/
   notation "-1" => Subst.pred
+  /-- Notation `-1@T` for the shift-down substitution at type `T`. -/
   macro "-1@" noWs T:term : term =>`(@Subst.pred $T)
 
   @[simp, grind =]
@@ -109,17 +130,24 @@ namespace LeanSubst
     case zero => grind
     case _ n => cases Nat.decLt (n + 1) k <;> simp [ite]
 
+  /-- Notation `t[σ]` for applying a homogeneous substitution `σ` to `t`. -/
   macro:max t:term noWs "[" σ:term "]" : term => `(smap1 $σ $t)
+  /-- Notation `t[σ : T]` for applying a substitution `σ` over `T` to `t`. -/
   macro:max t:term noWs "[" σ:term ":" T:term "]" : term => `(smap (T := $T) $σ $t)
+  /-- Notation `a :: σ` for `Subst.cons`. -/
   infixr:67 (name := Subst.cons_notation) " :: " => Subst.cons
+  /-- Notation `σ ∘ τ` for `Subst.compose`. -/
   infixr:85 (name := Subst.compose_notation) " ∘ " => Subst.compose
+  /-- Notation `σ ◾ τ` for `Subst.hcompose`. -/
   infixr:85 " ◾ " => Subst.hcompose
 
+  /-- Pretty-printer that displays `smap1 σ t` as `t[σ]`. -/
   @[app_unexpander smap1]
   def unexpandSubstApply1 : Lean.PrettyPrinter.Unexpander
   | `($_ $σ $t) => `($t[$σ])
   | _ => throw ()
 
+  /-- Pretty-printer that displays `smap σ t` as `t[σ : _]`. -/
   @[app_unexpander smap]
   def unexpandSubstApply : Lean.PrettyPrinter.Unexpander
   | `($_ $σ $t) => `($t[$σ : _])

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -1900,3 +1900,40 @@ projects:
     msc:
       - "11F11"
       - "30E20"
+  - slug: lean-subst
+    title: De Bruijn substitution framework (lean-subst)
+    summary: An Autosubst-inspired framework for De Bruijn substitution over non-indexed syntax, proving the convergent substitution-calculus rewriting laws and using them to derive abstract metatheory such as confluence and strong normalization.
+    branch: type theory
+    entry_module: LeanPool.LeanSubst
+    authors:
+      - Andrew Marmaduke
+    source:
+      url: "https://github.com/amarmaduke/lean-subst"
+      github_repo: amarmaduke/lean-subst
+    status: verified
+    main_declarations:
+      - LeanSubst.Subst.compose
+      - LeanSubst.Ren.apply_compose
+      - LeanSubst.Star.confluence
+      - LeanSubst.Conv.star_equiv
+      - LeanSubst.SN.wellfounded
+    main_results:
+      - declaration: LeanSubst.Subst.compose
+        informal: Defines composition of De Bruijn substitutions over non-indexed syntax.
+      - declaration: LeanSubst.Ren.apply_compose
+        informal: States that applying two renamings in sequence equals applying their composition.
+      - declaration: LeanSubst.Star.confluence
+        informal: Proves confluence of the reflexive-transitive closure of a reduction relation that has the triangle property.
+      - declaration: LeanSubst.Conv.star_equiv
+        informal: Characterizes the conversion relation as joinability via the reflexive-transitive closure under confluence.
+      - declaration: LeanSubst.SN.wellfounded
+        informal: Shows that strong normalization of every term yields well-foundedness of the flipped reduction relation.
+    tags:
+      - type-theory
+      - de-bruijn
+      - substitution
+      - autosubst
+      - rewriting
+    msc:
+      - "03B40"
+      - "68N18"


### PR DESCRIPTION
Imports the amarmaduke/lean-subst formalization (De Bruijn substitution framework (lean-subst)) into Lean Pool.

- Upstream: https://github.com/amarmaduke/lean-subst (MIT)
- Vendored under `LeanPool/LeanSubst/`, registered in `projects.yml`.
- **Draft / Phase 1: vendored only, not yet bumped to v4.31-rc1 — CI is expected red.**

Source root `lean_lib` is `LeanSubst` (8 modules + root aggregator), Lean-core only (`Init.WF`); no Mathlib dependency. Excluded the separate `Examples` lean_lib (demonstration lambda-calculus / STLC files), the stale `Archive/` dir (imports a nonexistent `LeanSubst.Basic`), and `Main.lean` (the `IO` executable entry point) — none are part of the core library. No actual `sorry`s exist; the three upstream files reported as containing `sorry` only had it inside comments, and one dead commented-out theorem stub in `Reduction.lean` was deleted.

MIT-licensed upstream (sublicensed): copyright line `Copyright (c) 2025 Andrew Marmaduke` — a NOTICE entry should be added later.