### PR TITLE
ci: post profile and LLM-review comments on fork PRs

### DIFF
--- a/.github/workflows/llm-review.yml
+++ b/.github/workflows/llm-review.yml
@@ -32,7 +32,7 @@ jobs:
     if: >-
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.pull_requests[0] != null) ||
+       github.event.workflow_run.event == 'pull_request') ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request != null &&
@@ -49,6 +49,8 @@ jobs:
           PR_FROM_WORKFLOW_RUN: ${{ github.event.workflow_run.pull_requests[0].number }}
           SHA_FROM_WORKFLOW_RUN: ${{ github.event.workflow_run.head_sha }}
           CONCLUSION_FROM_WORKFLOW_RUN: ${{ github.event.workflow_run.conclusion }}
+          HEAD_OWNER_FROM_WORKFLOW_RUN: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH_FROM_WORKFLOW_RUN: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
           head_sha=""
@@ -60,6 +62,13 @@ jobs:
               pr="$PR_FROM_WORKFLOW_RUN"
               head_sha="$SHA_FROM_WORKFLOW_RUN"
               lean_ci_conclusion="$CONCLUSION_FROM_WORKFLOW_RUN"
+              if [ -z "$pr" ]; then
+                # PRs from forks leave workflow_run.pull_requests empty, so
+                # resolve the PR number from the run's head repo and branch.
+                pr=$(gh api \
+                  "repos/$REPO/pulls?state=open&head=$HEAD_OWNER_FROM_WORKFLOW_RUN:$HEAD_BRANCH_FROM_WORKFLOW_RUN" \
+                  --jq '.[0].number // empty')
+              fi
               ;;
             *) echo "::error::Unexpected event $EVENT_NAME"; exit 1 ;;
           esac

--- a/.github/workflows/proof-profile-comment.yml
+++ b/.github/workflows/proof-profile-comment.yml
@@ -1,0 +1,88 @@
+name: Proof Profile Comment
+
+# Companion to the `Proof Profile` workflow. That workflow runs the PR's Lean
+# code to profile it, so it must run on the `pull_request` event — where a PR
+# from a fork only gets a read-only GITHUB_TOKEN and cannot post a comment.
+# This workflow fires when it finishes, runs in the base-repo context with a
+# writable token, and posts the already-rendered profile for every PR, fork or
+# not. It never checks out or runs PR code; it only downloads the pre-rendered
+# `proof-profile-comment` artifact and posts it, so the writable token is never
+# exposed to untrusted PR code.
+on:
+  workflow_run:
+    workflows: ["Proof Profile"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  # Needed to list and download artifacts from the triggering run.
+  actions: read
+
+# Serialize posters for the same source branch so two profile runs of one PR
+# cannot race into duplicate comments; the latest profile wins.
+concurrency:
+  group: >-
+    proof-profile-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    name: Proof profile comment
+    steps:
+      - name: Find the comment payload artifact
+        id: artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          # The profile run only uploads this artifact when it actually
+          # profiled files; absent means there is nothing to post.
+          id=$(gh api "repos/$REPO/actions/runs/$RUN_ID/artifacts" --paginate \
+                 --jq '.artifacts[] | select(.name == "proof-profile-comment") | .id' \
+               | head -n1)
+          if [ -z "$id" ]; then
+            echo "No proof-profile-comment artifact on run $RUN_ID; nothing to post."
+          fi
+          echo "id=$id" >> "$GITHUB_OUTPUT"
+
+      - name: Post sticky PR comment with profile
+        if: steps.artifact.outputs.id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ARTIFACT_ID: ${{ steps.artifact.outputs.id }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$REPO/actions/artifacts/$ARTIFACT_ID/zip" > payload.zip
+          unzip -o -q payload.zip -d payload
+
+          # The PR number is attacker-influenced (it rode in an artifact built
+          # from a fork's run), so reduce it to digits before using it in any
+          # API path.
+          pr=$(tr -dc '0-9' < payload/proof-profile-pr.txt)
+          if [ -z "$pr" ]; then
+            echo "::error::No valid PR number in the comment payload."
+            exit 1
+          fi
+
+          # Marker so subsequent runs update the same comment instead of
+          # stacking new ones.
+          marker="<!-- proof-profile-comment -->"
+          {
+            printf '%s\n' "$marker"
+            cat payload/proof-profile.md
+          } > comment-body.md
+
+          existing=$(gh api "repos/$REPO/issues/$pr/comments" --paginate \
+            --jq "[.[] | select(.body | startswith(\"$marker\"))] | first | .id // empty")
+
+          if [ -n "$existing" ]; then
+            jq -n --rawfile body comment-body.md '{body: $body}' \
+              | gh api -X PATCH "repos/$REPO/issues/comments/$existing" --input -
+          else
+            gh pr comment "$pr" --repo "$REPO" --body-file comment-body.md
+          fi

--- a/.github/workflows/proof-profile.yml
+++ b/.github/workflows/proof-profile.yml
@@ -18,7 +18,9 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  # This job runs the PR's Lean code, so it stays least-privilege: it reads PR
+  # metadata but no longer posts (the `Proof Profile Comment` workflow does).
+  pull-requests: read
 
 # Workflow-level concurrency applies to every run regardless of the job-level
 # `if:`, so an `issue_comment` event for a non-`/profile` comment (e.g. `/review`)
@@ -565,31 +567,32 @@ jobs:
               f.write(rendered)
           PY
 
-      - name: Post sticky PR comment with profile
+      # A `pull_request` run from a fork gets a read-only GITHUB_TOKEN and
+      # cannot post a PR comment, so the comment is posted by the separate
+      # `Proof Profile Comment` workflow (workflow_run), which runs in the
+      # base-repo context with a writable token. Here we only stage the
+      # rendered profile and the PR number as an artifact for it to consume —
+      # this keeps the untrusted, PR-code-executing job (this one) read-only
+      # while the privileged poster never runs PR code.
+      - name: Stage comment payload for the companion workflow
         if: steps.files.outputs.files != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # Marker so we can find and update the same comment on subsequent
-          # runs instead of stacking new ones.
-          marker="<!-- proof-profile-comment -->"
-          {
-            printf '%s\n' "$marker"
-            cat proof-profile.md
-          } > comment-body.md
+          # proof-profile.md is written by the render step above; the PR number
+          # is re-validated as numeric by the poster before use.
+          printf '%s\n' "$PR_NUMBER" > proof-profile-pr.txt
 
-          existing=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-            --jq "[.[] | select(.body | startswith(\"$marker\"))] | first | .id // empty")
-
-          if [ -n "$existing" ]; then
-            jq -n --rawfile body comment-body.md '{body: $body}' \
-              | gh api -X PATCH "repos/$REPO/issues/comments/$existing" --input -
-          else
-            gh pr comment "$PR_NUMBER" --body-file comment-body.md
-          fi
+      - name: Upload comment payload
+        if: steps.files.outputs.files != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: proof-profile-comment
+          path: |
+            proof-profile.md
+            proof-profile-pr.txt
+          if-no-files-found: ignore
 
       - name: Upload proof profile
         if: always() && steps.files.outputs.files != ''


### PR DESCRIPTION
## Treat fork PRs like same-repo PRs for the profiler and LLM reviewer

Fork PRs currently fail in two different ways (surfaced by #179):

| Workflow | On a fork PR | Root cause |
|---|---|---|
| **Proof Profile** | ran, but the comment step failed → red advisory check | `pull_request` from a fork → read-only `GITHUB_TOKEN`; `addComment` denied |
| **LLM Review** | never ran at all | auto-trigger required `workflow_run.pull_requests[0]`, which is empty for forks |

### Changes
1. **`proof-profile.yml`** — the profile job (which builds + runs the PR's Lean code) keeps its read-only token and no longer posts; it stages the rendered profile + PR number as the `proof-profile-comment` artifact. Dropped to `pull-requests: read`. The advisory check is now green on forks.
2. **`proof-profile-comment.yml`** (new) — a `workflow_run` companion that posts the sticky comment from the base-repo context with a writable token, for every PR. It never checks out or runs PR code (downloads a pre-rendered artifact only), so the writable token is never exposed to untrusted code — the secure alternative to `pull_request_target`.
3. **`llm-review.yml`** — auto-trigger now keys on `workflow_run.event == 'pull_request'` and resolves the fork PR number from the run's head `repo:branch` when `pull_requests` is empty.

Validated locally with `actionlint` (clean) and shell dry-runs of the poster and every `jq` filter. End-to-end `workflow_run` plumbing will be exercised by re-running CI on #179 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
