### PR TITLE
Add Pythagorean polynomial parametrization

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -1534,6 +1534,14 @@ import LeanPool.PumpingCfg.ParseTree
 import LeanPool.PumpingCfg.Pumping
 import LeanPool.PumpingCfg.ToMathlib
 import LeanPool.PumpingCfg.Utils
+import LeanPool.PythagoreanPolynomialParametrization
+import LeanPool.PythagoreanPolynomialParametrization.Basic
+import LeanPool.PythagoreanPolynomialParametrization.Explanatory
+import LeanPool.PythagoreanPolynomialParametrization.IntegerValued
+import LeanPool.PythagoreanPolynomialParametrization.Main
+import LeanPool.PythagoreanPolynomialParametrization.Obstructions
+import LeanPool.PythagoreanPolynomialParametrization.Positive
+import LeanPool.PythagoreanPolynomialParametrization.SourceLemmas
 import LeanPool.QuasiBorelSpaces
 import LeanPool.QuasiBorelSpaces.Basic
 import LeanPool.QuasiBorelSpaces.Chain

--- a/LeanPool/PythagoreanPolynomialParametrization.lean
+++ b/LeanPool/PythagoreanPolynomialParametrization.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2026 Lazar Milikic. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Lazar Milikic
+-/
+
+import LeanPool.PythagoreanPolynomialParametrization.Main
+
+/-!
+# Polynomial parametrizations of Pythagorean triples
+
+Source: arxiv:0706.0290, doi:10.1016/j.jpaa.2007.05.019
+Authors: Lazar Milikic
+Status: verified
+Main declarations: `LeanPool.PythagoreanPolynomialParametrization.exists_int_valued_parametrization`
+Tags: number-theory, pythagorean-triples, integer-valued-polynomials
+MSC: 11D09, 11D85, 13F20
+-/

--- a/LeanPool/PythagoreanPolynomialParametrization/Basic.lean
+++ b/LeanPool/PythagoreanPolynomialParametrization/Basic.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 Lazar Milikic. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Lazar Milikic
+-/
+
+import Mathlib.Algebra.MvPolynomial.Funext
+import Mathlib.Algebra.MvPolynomial.Monad
+import Mathlib.NumberTheory.PythagoreanTriples
+import Mathlib.NumberTheory.SumFourSquares
+import Mathlib.RingTheory.Binomial
+import Mathlib.RingTheory.MvPolynomial.Basic
+import Mathlib.Algebra.MvPolynomial.NoZeroDivisors
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.FinCases
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.NormNum.Prime
+import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Ring
+
+/-! # Basic definitions for Pythagorean polynomial parametrizations
+
+This file contains the shared definitions used by the Frisch--Vaserstein
+formalization setup.
+-/
+
+namespace LeanPool.PythagoreanPolynomialParametrization
+
+open MvPolynomial
+
+
+
+/-- A triple of integers (x,y,z) is a Pythagorean triple if x² + y² = z². -/
+def IsPythagoreanTriple (x y z : ℤ) : Prop := x^2 + y^2 = z^2
+
+/-- The set of all Pythagorean triples. -/
+def pythagoreanTriples : Set (ℤ × ℤ × ℤ) := {(x, y, z) | IsPythagoreanTriple x y z}
+
+/-- The set of all positive Pythagorean triples (x,y,z > 0). -/
+def positivePythagoreanTriples : Set (ℤ × ℤ × ℤ) :=
+  {(x, y, z) | 0 < x ∧ 0 < y ∧ 0 < z ∧ IsPythagoreanTriple x y z}
+
+/-- Multivariate polynomials with integer coefficients in n variables. -/
+abbrev IntPoly (n : ℕ) := MvPolynomial (Fin n) ℤ
+
+/-- Multivariate polynomials with rational coefficients in n variables. -/
+abbrev RatPoly (n : ℕ) := MvPolynomial (Fin n) ℚ
+
+/-- A rational-coefficient polynomial is integer-valued if it evaluates to an integer
+at every integer tuple. -/
+def IsIntValued {n : ℕ} (p : RatPoly n) : Prop :=
+  ∀ a : Fin n → ℤ, ∃ k : ℤ, eval (fun i => (a i : ℚ)) p = (k : ℚ)
+
+/-- The paper's ring `Int(ℤⁿ)` of integer-valued rational polynomials, represented as
+a subring of `ℚ[x₁, ..., xₙ]`. -/
+def IntValuedSubring (n : ℕ) : Subring (RatPoly n) where
+  carrier := {p | IsIntValued p}
+  zero_mem' := by
+    intro a
+    use 0
+    simp
+  one_mem' := by
+    intro a
+    use 1
+    simp
+  add_mem' := by
+    intro p q hp hq a
+    rcases hp a with ⟨m, hm⟩
+    rcases hq a with ⟨l, hl⟩
+    use m + l
+    simp [hm, hl]
+  neg_mem' := by
+    intro p hp a
+    rcases hp a with ⟨m, hm⟩
+    use -m
+    simp [hm]
+  mul_mem' := by
+    intro p q hp hq a
+    rcases hp a with ⟨m, hm⟩
+    rcases hq a with ⟨l, hl⟩
+    use m * l
+    simp [hm, hl]
+
+/-- The type of integer-valued rational polynomials in `n` variables. -/
+abbrev IntegerValuedPoly (n : ℕ) : Type := IntValuedSubring n
+
+/-- Evaluate an integer-coefficient polynomial at an integer tuple. -/
+noncomputable def intPolyEval {n : ℕ} (p : IntPoly n) (a : Fin n → ℤ) : ℤ :=
+  eval a p
+
+/-- Evaluate a rational-coefficient polynomial at an integer tuple. -/
+noncomputable def ratPolyEval {n : ℕ} (p : RatPoly n) (a : Fin n → ℤ) : ℚ :=
+  eval (fun i => (a i : ℚ)) p
+
+/-- General `k`-tuple version of parametrization by one tuple of integer-coefficient
+polynomials, matching `pyth.tex` lines 104--116. -/
+def IntPolyTupleParametrizes {n k : ℕ} (F : Fin k → IntPoly n)
+    (S : Set (Fin k → ℤ)) : Prop :=
+  S = {v | ∃ a : Fin n → ℤ, ∀ i : Fin k, intPolyEval (F i) a = v i}
+
+/-- General `k`-tuple version of parametrization by one tuple of integer-valued
+polynomials, matching `pyth.tex` lines 104--116. -/
+def IntValuedTupleParametrizes {n k : ℕ} (F : Fin k → RatPoly n)
+    (S : Set (Fin k → ℤ)) : Prop :=
+  (∀ i : Fin k, IsIntValued (F i)) ∧
+    S = {v | ∃ a : Fin n → ℤ, ∀ i : Fin k, ratPolyEval (F i) a = (v i : ℚ)}
+
+/-- Parametrization by a finite number of `k`-tuples of integer-coefficient
+polynomials, matching `pyth.tex` lines 118--125. -/
+def FiniteIntPolyTupleParametrizes {m n k : ℕ} (F : Fin m → Fin k → IntPoly n)
+    (S : Set (Fin k → ℤ)) : Prop :=
+  S = {v | ∃ j : Fin m, ∃ a : Fin n → ℤ, ∀ i : Fin k,
+    intPolyEval (F j i) a = v i}
+
+/-- Parametrization by a finite number of `k`-tuples of integer-valued polynomials,
+matching `pyth.tex` lines 118--125. -/
+def FiniteIntValuedTupleParametrizes {m n k : ℕ} (F : Fin m → Fin k → RatPoly n)
+    (S : Set (Fin k → ℤ)) : Prop :=
+  (∀ j : Fin m, ∀ i : Fin k, IsIntValued (F j i)) ∧
+    S = {v | ∃ j : Fin m, ∃ a : Fin n → ℤ, ∀ i : Fin k,
+      ratPolyEval (F j i) a = (v i : ℚ)}
+
+/-- A triple of integer-coefficient polynomials parametrizes a set S ⊆ ℤ³
+if S equals the image of the polynomial map ℤⁿ → ℤ³. -/
+def IntPolyParametrizes {n : ℕ} (f g h : IntPoly n) (S : Set (ℤ × ℤ × ℤ)) : Prop :=
+  S = {(x, y, z) | ∃ a : Fin n → ℤ,
+    intPolyEval f a = x ∧ intPolyEval g a = y ∧ intPolyEval h a = z}
+
+/-- A triple of rational-coefficient polynomials parametrizes a set S ⊆ ℤ³
+if each is integer-valued and S equals the image of the polynomial map. -/
+def IntValuedParametrizes {n : ℕ} (f g h : RatPoly n) (S : Set (ℤ × ℤ × ℤ)) : Prop :=
+  IsIntValued f ∧ IsIntValued g ∧ IsIntValued h ∧
+  S = {(x, y, z) | ∃ a : Fin n → ℤ,
+    ratPolyEval f a = (x : ℚ) ∧ ratPolyEval g a = (y : ℚ) ∧ ratPolyEval h a = (z : ℚ)}
+
+end LeanPool.PythagoreanPolynomialParametrization

--- a/LeanPool/PythagoreanPolynomialParametrization/Explanatory.lean
+++ b/LeanPool/PythagoreanPolynomialParametrization/Explanatory.lean
@@ -1,0 +1,522 @@
+/-
+Copyright (c) 2026 Lazar Milikic. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Lazar Milikic
+-/
+
+import LeanPool.PythagoreanPolynomialParametrization.Basic
+
+/-! # Explanatory and cited source statements
+
+This file records source-level material from Frisch--Vaserstein that is not used by
+the main parametrization proof.
+-/
+
+namespace LeanPool.PythagoreanPolynomialParametrization
+
+open MvPolynomial
+
+
+
+/-! ## Finite integer-polynomial cover from one integer-valued tuple -/
+
+private lemma bind_affine_sub_const_dvd {σ : Type*}
+    (P : MvPolynomial σ ℤ) (D : ℤ) (r : σ → ℤ) :
+    ∃ H : MvPolynomial σ ℤ,
+      bind₁ (fun i => C (r i) + C D * X i) P =
+        C (eval₂ (RingHom.id ℤ) r P) + C D * H := by
+  induction P using MvPolynomial.induction_on with
+  | C a =>
+      refine ⟨0, ?_⟩
+      simp
+  | add P Q hP hQ =>
+      rcases hP with ⟨HP, hHP⟩
+      rcases hQ with ⟨HQ, hHQ⟩
+      refine ⟨HP + HQ, ?_⟩
+      rw [map_add, hHP, hHQ, eval₂_add, C_add]
+      ring
+  | mul_X P i hP =>
+      rcases hP with ⟨HP, hHP⟩
+      refine ⟨C (eval₂ (RingHom.id ℤ) r P) * X i + C (r i) * HP + C D * HP * X i, ?_⟩
+      rw [map_mul, bind₁_X_right, hHP, eval₂_mul, eval₂_X, C_mul]
+      ring
+
+private lemma rat_scaled_num_den_cast_eq (N : ℕ) (q : ℚ) (hdiv : q.den ∣ N) :
+    (((N : ℤ) / (q.den : ℤ) * q.num : ℤ) : ℚ) = (N : ℚ) * q := by
+  rcases hdiv with ⟨m, hm⟩
+  have hden_ne_zero : (q.den : ℤ) ≠ 0 := by
+    have h : q.den ≠ 0 := q.den_ne_zero
+    exact_mod_cast h
+  have hN_eq : (N : ℤ) = (q.den : ℤ) * (m : ℤ) := by
+    have h : (N : ℕ) = q.den * m := hm
+    have h' : (N : ℤ) = ((q.den * m : ℕ) : ℤ) := by exact_mod_cast h
+    rw [h']
+    norm_num [Nat.cast_mul]
+  have h1 : ((N : ℤ) / (q.den : ℤ) : ℤ) = (m : ℤ) := by
+    rw [hN_eq]
+    exact Int.mul_ediv_cancel_left m hden_ne_zero
+  have h2 : (N : ℚ) = (q.den : ℚ) * (m : ℚ) := by
+    have h : (N : ℕ) = q.den * m := hm
+    have h' : (N : ℚ) = ((q.den * m : ℕ) : ℚ) := by exact_mod_cast h
+    rw [h']
+    norm_num [Nat.cast_mul]
+  have h3 : (q.den : ℚ) * q = (q.num : ℚ) := by
+    exact_mod_cast Rat.den_mul_eq_num q
+  calc
+    (((N : ℤ) / (q.den : ℤ) * q.num : ℤ) : ℚ)
+        = (((m : ℤ) * q.num : ℤ) : ℚ) := by rw [h1]
+    _ = (m : ℚ) * (q.num : ℚ) := by norm_num
+    _ = (m : ℚ) * ((q.den : ℚ) * q) := by rw [h3]
+    _ = (q.den : ℚ) * (m : ℚ) * q := by ring
+    _ = (N : ℚ) * q := by rw [h2]
+
+private lemma coeff_mapRange_scaled_rat {n : ℕ} (F : RatPoly n) (N : ℕ)
+    (hf_map : (fun q : ℚ => (N : ℤ) / (q.den : ℤ) * q.num) 0 = 0)
+    (hdiv : ∀ s ∈ MvPolynomial.support F, (MvPolynomial.coeff s F).den ∣ N)
+    (s : Fin n →₀ ℕ) :
+    let P : MvPolynomial (Fin n) ℤ :=
+      Finsupp.mapRange (fun q : ℚ => (N : ℤ) / (q.den : ℤ) * q.num) hf_map F
+    (Int.cast (MvPolynomial.coeff s P) : ℚ) = (N : ℚ) * MvPolynomial.coeff s F := by
+  intro P
+  change
+    (Int.cast (MvPolynomial.coeff s
+      (Finsupp.mapRange (fun q : ℚ => (N : ℤ) / (q.den : ℤ) * q.num) hf_map F)) :
+        ℚ) =
+      (N : ℚ) * MvPolynomial.coeff s F
+  by_cases hs : s ∈ MvPolynomial.support F
+  · have hdiv_s := hdiv s hs
+    have h1 :
+        MvPolynomial.coeff s
+          (Finsupp.mapRange (fun q : ℚ => (N : ℤ) / (q.den : ℤ) * q.num) hf_map F) =
+            (N / (MvPolynomial.coeff s F).den : ℤ) * (MvPolynomial.coeff s F).num := by
+      simp [MvPolynomial.coeff, Finsupp.mapRange_apply]
+    rw [h1]
+    exact rat_scaled_num_den_cast_eq N (MvPolynomial.coeff s F) hdiv_s
+  · have hq : F s = 0 := by
+      rwa [MvPolynomial.notMem_support_iff] at hs
+    simp [MvPolynomial.coeff, Finsupp.mapRange_apply, hq]
+
+private lemma map_intPoly_eq_nat_smul_of_coeff {n : ℕ}
+    (F : RatPoly n) (P : MvPolynomial (Fin n) ℤ) (N : ℕ)
+    (hcoeff : ∀ s : Fin n →₀ ℕ,
+      (Int.cast (MvPolynomial.coeff s P) : ℚ) = (N : ℚ) * MvPolynomial.coeff s F) :
+    MvPolynomial.map (Int.castRingHom ℚ) P = (N : ℚ) • F := by
+  apply MvPolynomial.ext
+  intro s
+  simp [MvPolynomial.coeff_map, hcoeff s]
+
+private lemma eval_bind1_affine_int {n : ℕ}
+    (P : MvPolynomial (Fin n) ℤ) (D : ℕ) (r y : Fin n → ℤ) :
+    MvPolynomial.eval y
+      (MvPolynomial.bind₁ (fun j : Fin n =>
+        MvPolynomial.C (D : ℤ) * MvPolynomial.X j + MvPolynomial.C (r j)) P) =
+    MvPolynomial.eval (fun j : Fin n => (D : ℤ) * y j + r j) P := by
+  induction P using MvPolynomial.induction_on with
+  | C c =>
+      simp
+  | add p q hp hq =>
+      rw [map_add, MvPolynomial.eval_add, hp, hq, MvPolynomial.eval_add]
+  | mul_X p j hp =>
+      rw [map_mul, MvPolynomial.bind₁_X_right, MvPolynomial.eval_mul, hp]
+      simp [MvPolynomial.eval_add, MvPolynomial.eval_mul, MvPolynomial.eval_X]
+
+private lemma int_eval_cast_eq_rat_eval_map {n : ℕ} (a : Fin n → ℤ)
+    (P : MvPolynomial (Fin n) ℤ) :
+    (MvPolynomial.eval a P : ℚ) =
+      MvPolynomial.eval (fun j => (a j : ℚ))
+        (MvPolynomial.map (Int.castRingHom ℚ) P) := by
+  induction P using MvPolynomial.induction_on with
+  | C c =>
+      simp
+  | add p q hp hq =>
+      simp [hp, hq, MvPolynomial.eval_add]
+  | mul_X p j hp =>
+      simp [hp, MvPolynomial.eval_mul, MvPolynomial.eval_X]
+
+private lemma ratPolyEval_eq_intPolyEval_on_residue {n : ℕ}
+    {F : RatPoly n} {P Q H : MvPolynomial (Fin n) ℤ} {D : ℕ}
+    (hD_pos : 0 < D) (hF_int : IsIntValued F)
+    (hP_eval : ∀ a : Fin n → ℤ, (eval a P : ℚ) = D * ratPolyEval F a)
+    (r b a : Fin n → ℤ)
+    (ha : a = fun j => (D : ℤ) * b j + r j)
+    (hH : bind₁ (fun j => C (r j) + C (D : ℤ) * X j) P =
+      C (eval₂ (RingHom.id ℤ) r P) + C (D : ℤ) * H)
+    (hQ : Q = C (eval r P / (D : ℤ)) + H) :
+    ratPolyEval F a = (intPolyEval Q b : ℚ) := by
+  have h1 : eval a P = eval r P + D * eval b H := by
+    rw [ha]
+    have h3 := eval_bind1_affine_int P D r b
+    rw [← h3]
+    have h4 :
+        bind₁ (fun j => C (D : ℤ) * X j + C (r j)) P =
+          bind₁ (fun j => C (r j) + C (D : ℤ) * X j) P := by
+      congr
+      funext j
+      ring
+    rw [h4]
+    have hH' :
+        bind₁ (fun j => C (r j) + C (D : ℤ) * X j) P =
+          C (eval r P) + C (D : ℤ) * H := by
+      have h5 :
+          bind₁ (fun j => C (r j) + C (D : ℤ) * X j) P =
+            C (eval₂ (RingHom.id ℤ) r P) + C (D : ℤ) * H := hH
+      rw [h5]
+      have : eval₂ (RingHom.id ℤ) r P = eval r P := by
+        rw [MvPolynomial.eval₂_id]
+      rw [this]
+    rw [hH']
+    simp [eval_add, eval_mul]
+  have h2 : (eval a P : ℚ) = D * ratPolyEval F a := hP_eval a
+  have h3 :
+      (eval r P : ℚ) =
+        D * ((eval r P / (D : ℤ) : ℤ) : ℚ) := by
+    obtain ⟨w, hw⟩ := hF_int r
+    have hqr : (eval r P : ℚ) = (D : ℚ) * (w : ℚ) := by
+      simpa [ratPolyEval, hw] using hP_eval r
+    have hz : eval r P = (D : ℤ) * w := by
+      exact_mod_cast hqr
+    have hdiv : eval r P / (D : ℤ) = w := by
+      apply Int.ediv_eq_of_eq_mul_left
+      · exact_mod_cast (ne_of_gt hD_pos)
+      · simpa [mul_comm] using hz
+    rw [hdiv, hqr]
+  have hG :
+      (intPolyEval Q b : ℚ) =
+        ((eval r P / (D : ℤ) : ℤ) : ℚ) + (eval b H : ℚ) := by
+    rw [hQ]
+    simp [intPolyEval]
+  have h4 :
+      D * ratPolyEval F a =
+        D * (intPolyEval Q b : ℚ) := by
+    have h1' :
+        (eval a P : ℚ) = (eval r P : ℚ) + D * (eval b H : ℚ) := by
+      exact_mod_cast h1
+    rw [← h2, h1', h3, hG]
+    ring
+  exact mul_left_cancel₀ (by positivity : (D : ℚ) ≠ 0) h4
+
+/-- Source-cited result, `pyth.tex` lines 138--141: every set of integer tuples
+parametrized by a single integer-valued polynomial tuple is parametrized by a finite
+number of integer-coefficient polynomial tuples.
+
+The paper cites this from Frisch's work and does not use it in the proof of the main
+Pythagorean-triple parametrization theorem. -/
+theorem single_intValued_parametrization_yields_finite_intPoly_parametrization
+    {n k : ℕ} {F : Fin k → RatPoly n} {S : Set (Fin k → ℤ)}
+    (hF : IntValuedTupleParametrizes F S) :
+    ∃ (m : ℕ) (G : Fin m → Fin k → IntPoly n),
+      FiniteIntPolyTupleParametrizes G S := by
+  rcases hF with ⟨hF_int, hF_eq⟩
+  have hD :
+      ∀ i : Fin k, ∃ D : ℕ, 0 < D ∧
+        ∀ s, s ∈ (F i).support → (MvPolynomial.coeff s (F i)).den ∣ D := by
+    intro i
+    refine ⟨Finset.prod (F i).support fun s => (MvPolynomial.coeff s (F i)).den, ?_, ?_⟩
+    · exact Finset.prod_pos fun s _ =>
+        Nat.pos_of_ne_zero (Rat.den_ne_zero (MvPolynomial.coeff s (F i)))
+    · intro s hs
+      exact Finset.dvd_prod_of_mem _ hs
+  choose D hD_pos hD_div using hD
+  let D_total : ℕ := Finset.prod Finset.univ D
+  have hD_total_pos : 0 < D_total := Finset.prod_pos fun i _ => hD_pos i
+  have hD_total_div :
+      ∀ (i : Fin k) (s : Fin n →₀ ℕ),
+        s ∈ (F i).support → (MvPolynomial.coeff s (F i)).den ∣ D_total := by
+    intro i s hs
+    exact dvd_trans (hD_div i s hs) (Finset.dvd_prod_of_mem _ (Finset.mem_univ i))
+  have hf_map : (fun q : ℚ => (D_total / q.den : ℤ) * q.num) 0 = 0 := by simp
+  let P : Fin k → MvPolynomial (Fin n) ℤ := fun i =>
+    Finsupp.mapRange (fun q => (D_total / q.den : ℤ) * q.num) hf_map (F i)
+  have hP_coeff :
+      ∀ (i : Fin k) (s : Fin n →₀ ℕ),
+        (Int.cast (MvPolynomial.coeff s (P i)) : ℚ) =
+          D_total * MvPolynomial.coeff s (F i) := by
+    intro i s
+    exact coeff_mapRange_scaled_rat (F i) D_total hf_map (hD_total_div i) s
+  have hP_eval :
+      ∀ (i : Fin k) (a : Fin n → ℤ),
+        (eval a (P i) : ℚ) = D_total * eval (fun j => (a j : ℚ)) (F i) := by
+    intro i a
+    rw [int_eval_cast_eq_rat_eval_map a (P i)]
+    have hmap :
+        MvPolynomial.map (Int.castRingHom ℚ) (P i) = (D_total : ℚ) • (F i) := by
+      exact map_intPoly_eq_nat_smul_of_coeff (F i) (P i) D_total (hP_coeff i)
+    rw [hmap]
+    simp
+  let m := D_total ^ n
+  have hcard : Fintype.card (Fin n → Fin D_total) = m := by
+    simp [m]
+  let e : Fin m ≃ (Fin n → Fin D_total) :=
+    (finCongr hcard.symm).trans (Fintype.equivFin _).symm
+  let G : Fin m → Fin k → MvPolynomial (Fin n) ℤ := fun idx i =>
+    let r : Fin n → ℤ := fun j => ((e idx j : ℕ) : ℤ)
+    let H := Classical.choose (bind_affine_sub_const_dvd (P i) D_total r)
+    C (eval₂ (RingHom.id ℤ) r (P i) / (D_total : ℤ)) + H
+  refine ⟨m, G, ?_⟩
+  rw [FiniteIntPolyTupleParametrizes]
+  ext v
+  simp only [Set.mem_setOf_eq, hF_eq]
+  constructor
+  · rintro ⟨a, ha⟩
+    let b : Fin n → ℤ := fun j => a j / D_total
+    let r_nat : Fin n → ℕ := fun j => (a j % D_total).toNat
+    have hr_nat : ∀ j, r_nat j < D_total := by
+      intro j
+      have hnonneg : 0 ≤ a j % D_total := Int.emod_nonneg (a j) (by positivity)
+      have hlt : a j % D_total < D_total := Int.emod_lt_of_pos (a j) (by positivity)
+      have htoNat : (a j % D_total).toNat = a j % D_total :=
+        Int.toNat_of_nonneg hnonneg
+      simp [r_nat]
+      omega
+    let r_fin : Fin n → Fin D_total := fun j => ⟨r_nat j, hr_nat j⟩
+    let idx : Fin m := e.symm r_fin
+    refine ⟨idx, b, ?_⟩
+    intro i
+    let r : Fin n → ℤ := fun j => ((e idx j : ℕ) : ℤ)
+    let H := Classical.choose (bind_affine_sub_const_dvd (P i) D_total r)
+    have hH := Classical.choose_spec (bind_affine_sub_const_dvd (P i) D_total r)
+    have hr_eq : ∀ j, r j = r_nat j := by
+      intro j
+      simp [r, idx, r_fin]
+    have ha_eq : ∀ j, a j = D_total * b j + r_nat j := by
+      intro j
+      have hnonneg : 0 ≤ a j % D_total := Int.emod_nonneg (a j) (by positivity)
+      have htoNat : (a j % D_total).toNat = a j % D_total :=
+        Int.toNat_of_nonneg hnonneg
+      change
+        a j = (D_total : ℤ) * (a j / (D_total : ℤ)) +
+          (((a j % (D_total : ℤ)).toNat : ℕ) : ℤ)
+      rw [htoNat]
+      rw [Int.mul_ediv_add_emod (a j) D_total]
+    have h_key : ratPolyEval (F i) a = (intPolyEval (G idx i) b : ℚ) := by
+      have ha' : a = fun j => (D_total : ℤ) * b j + r j := by
+        funext j
+        rw [ha_eq j, hr_eq j]
+      exact ratPolyEval_eq_intPolyEval_on_residue
+        (F := F i) (P := P i) (Q := G idx i) (H := H)
+        hD_total_pos (hF_int i) (hP_eval i) r b a ha' hH rfl
+    have h_eq : intPolyEval (G idx i) b = v i := by
+      have h : (intPolyEval (G idx i) b : ℚ) = (v i : ℚ) := by
+        rw [← h_key]
+        exact ha i
+      exact_mod_cast h
+    exact h_eq
+  · rintro ⟨idx, b, hGb⟩
+    let r : Fin n → ℤ := fun j => ((e idx j : ℕ) : ℤ)
+    let a : Fin n → ℤ := fun j => D_total * b j + r j
+    refine ⟨a, ?_⟩
+    intro i
+    let H := Classical.choose (bind_affine_sub_const_dvd (P i) D_total r)
+    have hH := Classical.choose_spec (bind_affine_sub_const_dvd (P i) D_total r)
+    have h_key : ratPolyEval (F i) a = (intPolyEval (G idx i) b : ℚ) := by
+      exact ratPolyEval_eq_intPolyEval_on_residue
+        (F := F i) (P := P i) (Q := G idx i) (H := H)
+        hD_total_pos (hF_int i) (hP_eval i) r b a rfl hH rfl
+    have h_eq : ratPolyEval (F i) a = (v i : ℚ) := by
+      rw [h_key]
+      exact_mod_cast hGb i
+    exact h_eq
+
+/-! ## The displayed integer-valued factorization example -/
+
+/-- The falling factorial polynomial `x(x-1)...(x-k+1)` in `ℚ[x]`. -/
+noncomputable def fallingFactorialRatPoly (k : ℕ) : RatPoly 1 :=
+  Finset.prod (Finset.range k) fun i => X (0 : Fin 1) - C (i : ℚ)
+
+/-- The binomial-coefficient polynomial `(x choose k)` over `ℚ[x]`, represented as
+`(x(x-1)...(x-k+1))/k!`. -/
+noncomputable def binomialRatPoly (k : ℕ) : RatPoly 1 :=
+  C ((Nat.factorial k : ℚ)⁻¹) * fallingFactorialRatPoly k
+
+/-- Source claim behind `pyth.tex` lines 185--186: the binomial-coefficient polynomial
+is integer-valued. -/
+theorem binomialRatPoly_intValued (k : ℕ) : IsIntValued (binomialRatPoly k) := by
+  intro a
+  refine ⟨(Ring.choose (a 0) k : ℤ), ?_⟩
+  simp only [binomialRatPoly, fallingFactorialRatPoly, eval_mul, eval_C, eval_prod,
+    eval_sub, eval_X]
+  have hprod :
+      ∏ x ∈ Finset.range k, ((a 0 : ℚ) - x) =
+        (Nat.factorial k : ℚ) * ((Ring.choose (a 0) k : ℤ) : ℚ) := by
+    rw [← descPochhammer_eval_eq_prod_range (R := ℚ) k (a 0 : ℚ)]
+    rw [← descPochhammer_eval_cast (R := ℚ) k (a 0)]
+    have hz :=
+      Ring.descPochhammer_eq_factorial_smul_choose (R := ℤ) (r := a 0) (n := k)
+    simpa [Polynomial.eval_eq_smeval, nsmul_eq_mul] using
+      congrArg (fun z : ℤ => (z : ℚ)) hz
+  rw [hprod]
+  field_simp [Nat.factorial_ne_zero]
+
+/-- The displayed identity `x(x-1)...(x-k+1) = k! * (x choose k)` from
+`pyth.tex` lines 185--186. -/
+theorem fallingFactorial_eq_factorial_mul_binomialRatPoly (k : ℕ) :
+    fallingFactorialRatPoly k =
+      C (Nat.factorial k : ℚ) * binomialRatPoly k := by
+  rw [binomialRatPoly]
+  rw [← mul_assoc, ← C_mul]
+  simp [Nat.factorial_ne_zero]
+
+/-- Source-level placeholder for `pyth.tex` lines 179--189: `Int(ℤ)` does not have
+unique factorization into irreducibles. The displayed falling-factorial identity above
+is the motivating example described in the paper. -/
+theorem integerValued_polynomial_ring_not_uniqueFactorization :
+    ¬ UniqueFactorizationMonoid (IntegerValuedPoly 1) := by
+  classical
+  let x : IntegerValuedPoly 1 := ⟨X (0 : Fin 1), by
+    intro a
+    exact ⟨a 0, by simp⟩⟩
+  let b : IntegerValuedPoly 1 := ⟨binomialRatPoly 2, binomialRatPoly_intValued 2⟩
+  have hdivprod : (2 : IntegerValuedPoly 1) ∣ x * (x - 1) := by
+    refine ⟨b, ?_⟩
+    apply Subtype.ext
+    change
+      (X (0 : Fin 1)) * ((X (0 : Fin 1)) - 1) =
+        (C (2 : ℚ) * binomialRatPoly 2)
+    trans fallingFactorialRatPoly 2
+    · simp [fallingFactorialRatPoly, Finset.prod_range_succ]
+    · have hf := fallingFactorial_eq_factorial_mul_binomialRatPoly 2
+      norm_num at hf
+      exact hf
+  have hnotdivx : ¬ (2 : IntegerValuedPoly 1) ∣ x := by
+    rintro ⟨q, hq⟩
+    obtain ⟨z, hz⟩ := q.2 (fun _ : Fin 1 => (1 : ℤ))
+    have h :=
+      congrArg
+        (fun p : RatPoly 1 => eval (fun _ : Fin 1 => (1 : ℚ)) p)
+        (congrArg Subtype.val hq)
+    have hz' : eval (fun _ : Fin 1 => (1 : ℚ)) q.1 = (z : ℚ) := hz
+    have hrat :
+        (1 : ℚ) =
+          (eval (fun _ : Fin 1 => (1 : ℚ))
+            ((2 : IntegerValuedPoly 1) : RatPoly 1)) * (z : ℚ) := by
+      simpa [x, hz'] using h
+    have htwo :
+        eval (fun _ : Fin 1 => (1 : ℚ))
+          ((2 : IntegerValuedPoly 1) : RatPoly 1) = (2 : ℚ) := by
+      change eval (fun _ : Fin 1 => (1 : ℚ)) (C (2 : ℚ) : RatPoly 1) = (2 : ℚ)
+      simp
+    rw [htwo] at hrat
+    have hint : (1 : ℤ) = 2 * z := by
+      exact_mod_cast hrat
+    omega
+  have hnotdivxm1 : ¬ (2 : IntegerValuedPoly 1) ∣ x - 1 := by
+    rintro ⟨q, hq⟩
+    obtain ⟨z, hz⟩ := q.2 (fun _ : Fin 1 => (0 : ℤ))
+    have h :=
+      congrArg
+        (fun p : RatPoly 1 => eval (fun _ : Fin 1 => (0 : ℚ)) p)
+        (congrArg Subtype.val hq)
+    have hz' : eval (fun _ : Fin 1 => (0 : ℚ)) q.1 = (z : ℚ) := hz
+    have hz0 : constantCoeff (q.1 : RatPoly 1) = (z : ℚ) := by
+      simpa using hz'
+    have hrat :
+        (-1 : ℚ) =
+          constantCoeff (((2 : IntegerValuedPoly 1) : RatPoly 1)) * (z : ℚ) := by
+      simpa [x, hz0] using h
+    have htwo :
+        constantCoeff (((2 : IntegerValuedPoly 1) : RatPoly 1)) = (2 : ℚ) := by
+      change constantCoeff (C (2 : ℚ) : RatPoly 1) = (2 : ℚ)
+      simp
+    rw [htwo] at hrat
+    have hint : (-1 : ℤ) = 2 * z := by
+      exact_mod_cast hrat
+    omega
+  have hnotprime : ¬ Prime (2 : IntegerValuedPoly 1) := by
+    intro hp
+    exact (hp.not_dvd_mul hnotdivx hnotdivxm1) hdivprod
+  have isUnit_of_val_C_int :
+      ∀ (p : IntegerValuedPoly 1) (z : ℤ),
+        p.1 = (C (z : ℚ) : RatPoly 1) → IsUnit z → IsUnit p := by
+    intro p z hp hzunit
+    rw [isUnit_iff_dvd_one]
+    obtain ⟨w, hw⟩ := (isUnit_iff_dvd_one.mp hzunit)
+    refine ⟨⟨(C (w : ℚ) : RatPoly 1), ?_⟩, ?_⟩
+    · intro a
+      exact ⟨w, by simp⟩
+    · apply Subtype.ext
+      change (1 : RatPoly 1) = p.1 * C (w : ℚ)
+      rw [hp]
+      have hwq : (1 : ℚ) = (z : ℚ) * (w : ℚ) := by
+        exact_mod_cast hw
+      calc
+        (1 : RatPoly 1) = C (1 : ℚ) := by simp
+        _ = C ((z : ℚ) * (w : ℚ)) := by rw [hwq]
+        _ = C (z : ℚ) * C (w : ℚ) := by simp
+  intro hUFM
+  haveI := hUFM
+  have hirr : Irreducible (2 : IntegerValuedPoly 1) := by
+    refine ⟨?notunit, ?factor⟩
+    · intro hunit
+      exact hnotdivx (hunit.dvd : (2 : IntegerValuedPoly 1) ∣ x)
+    · intro a c hac
+      have hacv : (a.1 : RatPoly 1) * c.1 = (C (2 : ℚ) : RatPoly 1) := by
+        have h := congrArg Subtype.val hac
+        have htwo :
+            (((2 : IntegerValuedPoly 1) : RatPoly 1)) = (C (2 : ℚ) : RatPoly 1) := by
+          rfl
+        simpa [htwo] using h.symm
+      have hprod_ne : (a.1 * c.1 : RatPoly 1) ≠ 0 := by
+        rw [hacv]
+        norm_num
+      have ha_ne : (a.1 : RatPoly 1) ≠ 0 := by
+        intro ha
+        exact hprod_ne (by simp [ha])
+      have hc_ne : (c.1 : RatPoly 1) ≠ 0 := by
+        intro hc
+        exact hprod_ne (by simp [hc])
+      have htd :=
+        MvPolynomial.totalDegree_mul_of_isDomain
+          (f := (a.1 : RatPoly 1)) (g := (c.1 : RatPoly 1)) ha_ne hc_ne
+      have hsum : (a.1 : RatPoly 1).totalDegree + (c.1 : RatPoly 1).totalDegree = 0 := by
+        rw [hacv] at htd
+        simp at htd
+        exact htd.symm
+      have ha_td0 : (a.1 : RatPoly 1).totalDegree = 0 := by omega
+      have hc_td0 : (c.1 : RatPoly 1).totalDegree = 0 := by omega
+      have ha_const : (a.1 : RatPoly 1) = C (constantCoeff (a.1 : RatPoly 1)) := by
+        exact MvPolynomial.totalDegree_eq_zero_iff_eq_C.mp ha_td0
+      have hc_const : (c.1 : RatPoly 1) = C (constantCoeff (c.1 : RatPoly 1)) := by
+        exact MvPolynomial.totalDegree_eq_zero_iff_eq_C.mp hc_td0
+      obtain ⟨za, hza⟩ := a.2 (fun _ : Fin 1 => (0 : ℤ))
+      obtain ⟨zc, hzc⟩ := c.2 (fun _ : Fin 1 => (0 : ℤ))
+      have hza_eval : eval (fun _ : Fin 1 => (0 : ℚ)) (a.1 : RatPoly 1) = (za : ℚ) := hza
+      have hzc_eval : eval (fun _ : Fin 1 => (0 : ℚ)) (c.1 : RatPoly 1) = (zc : ℚ) := hzc
+      have hza_eval_const :
+          eval (fun _ : Fin 1 => (0 : ℚ)) (a.1 : RatPoly 1) =
+            constantCoeff (a.1 : RatPoly 1) := by
+        rw [ha_const]
+        simp
+      have hzc_eval_const :
+          eval (fun _ : Fin 1 => (0 : ℚ)) (c.1 : RatPoly 1) =
+            constantCoeff (c.1 : RatPoly 1) := by
+        rw [hc_const]
+        simp
+      have hza_coeff : constantCoeff (a.1 : RatPoly 1) = (za : ℚ) := by
+        exact hza_eval_const.symm.trans hza_eval
+      have hzc_coeff : constantCoeff (c.1 : RatPoly 1) = (zc : ℚ) := by
+        exact hzc_eval_const.symm.trans hzc_eval
+      have ha_const_z : a.1 = (C (za : ℚ) : RatPoly 1) := by
+        rw [ha_const, hza_coeff]
+      have hc_const_z : c.1 = (C (zc : ℚ) : RatPoly 1) := by
+        rw [hc_const, hzc_coeff]
+      have hccprod := congrArg (fun p : RatPoly 1 => constantCoeff p) hacv
+      have hratprod :
+          constantCoeff (a.1 : RatPoly 1) * constantCoeff (c.1 : RatPoly 1) =
+            (2 : ℚ) := by
+        simpa using hccprod
+      have hintprod : za * zc = (2 : ℤ) := by
+        exact_mod_cast
+          (by
+            simpa [hza_coeff, hzc_coeff] using hratprod :
+              (za : ℚ) * (zc : ℚ) = (2 : ℚ))
+      have hIz : IsUnit za ∨ IsUnit zc := by
+        have hp : Prime (2 : ℤ) := by norm_num
+        exact hp.irreducible.isUnit_or_isUnit hintprod.symm
+      rcases hIz with hzaunit | hzcunit
+      · left
+        exact isUnit_of_val_C_int a za ha_const_z hzaunit
+      · right
+        exact isUnit_of_val_C_int c zc hc_const_z hzcunit
+  exact hnotprime (UniqueFactorizationMonoid.irreducible_iff_prime.mp hirr)
+
+end LeanPool.PythagoreanPolynomialParametrization

--- a/LeanPool/PythagoreanPolynomialParametrization/IntegerValued.lean
+++ b/LeanPool/PythagoreanPolynomialParametrization/IntegerValued.lean
@@ -54,13 +54,7 @@ noncomputable def gParam : RatPoly 4 := cParam * aParam * bParam
 In the paper: ((2x-xw)((y+zw)²+(z-yw)²))/2 -/
 noncomputable def hParam : RatPoly 4 := C (1 / 2 : ℚ) * cParam * (aParam ^ 2 + bParam ^ 2)
 
-/-- fParam is integer-valued.
-
-**Prover notes:** Expand the definition of fParam and IsIntValued. For any integer tuple
-(x,y,z,w), fParam evaluates to ((2x-xw)((y+zw)²-(z-yw)²))/2. Show this is always an integer
-by case analysis on the parity of w: if w is even, then 2x-xw is even; if w is odd, then
-(y+zw) and (z-yw) have the same parity, so their squares differ by a multiple of 4, making
-the product divisible by 2. -/
+/-- The first coordinate polynomial in the four-variable parametrization is integer-valued. -/
 theorem f_param_intValued : IsIntValued fParam := by
   intro v
   let x : ℤ := v (0 : Fin 4)
@@ -80,11 +74,7 @@ theorem f_param_intValued : IsIntValued fParam := by
   simp [fParam, cParam, aParam, bParam, xVar, yVar, zVar, wVar, A, B, Cc]
   ring
 
-/-- gParam is integer-valued.
-
-**Prover notes:** Expand the definition of gParam and IsIntValued. For any integer tuple
-(x,y,z,w), gParam evaluates to (2x-xw)(y+zw)(z-yw), which is clearly an integer product
-of integers. -/
+/-- The second coordinate polynomial in the four-variable parametrization is integer-valued. -/
 theorem g_param_intValued : IsIntValued gParam := by
   intro v
   let x : ℤ := v (0 : Fin 4)
@@ -98,12 +88,7 @@ theorem g_param_intValued : IsIntValued gParam := by
   simp [gParam, cParam, aParam, bParam, xVar, yVar, zVar, wVar, A, B, Cc]
   ring
 
-/-- hParam is integer-valued.
-
-**Prover notes:** Expand the definition of hParam and IsIntValued. For any integer tuple
-(x,y,z,w), hParam evaluates to ((2x-xw)((y+zw)²+(z-yw)²))/2. Show this is always an integer
-by case analysis on the parity of w: if w is even, then 2x-xw is even; if w is odd, then
-(y+zw) and (z-yw) have the same parity, so the sum of their squares is even. -/
+/-- The third coordinate polynomial in the four-variable parametrization is integer-valued. -/
 theorem h_param_intValued : IsIntValued hParam := by
   intro v
   let x : ℤ := v (0 : Fin 4)
@@ -123,18 +108,8 @@ theorem h_param_intValued : IsIntValued hParam := by
   simp [hParam, cParam, aParam, bParam, xVar, yVar, zVar, wVar, A, B, Cc]
   ring
 
-/-- There exist f,g,h ∈ Int(ℤ⁴) such that (f,g,h) parametrizes the set of Pythagorean triples.
-
-**Source proof sketch:** Every primitive PT (x,y,z) with gcd(x,y,z)=1 and z>0 is either of
-the form T₁(a,b) = (a²-b², 2ab, a²+b²) or T₂(a,b) = (2ab, a²-b², a²+b²) with a,b ∈ ℤ.
-Since 2·T₂(a,b) = T₁(a+b, a-b), every primitive PT is of the form c·T₁(a,b)/2 with
-c ∈ {1,2} and a,b ∈ ℤ. Let T(a,b,c) = (c(a²-b²)/2, cab, c(a²+b²)/2).
-Then every PT is T(a,b,c) for some a,b,c ∈ ℤ. Also, every T(a,b,c) is a rational solution
-of x²+y²=z². The set of PTs is precisely the integer triples in the range of T.
-Now T(a,b,c) ∈ ℤ³ iff c ≡ 0 (mod 2) or a ≡ b (mod 2). Triples satisfying this condition
-are parametrized by (y+zw, z-yw, 2x-xw). If w is even then c ≡ 0 (mod 2);
-if w is odd then a ≡ b (mod 2); and all such triples occur for some (x,y,z,w) ∈ ℤ⁴
-(as seen by setting w=0 or w=1). Substituting yields the parametrization. -/
+/-- Frisch--Vaserstein's four-variable integer-valued polynomial parametrization of all
+Pythagorean triples. -/
 theorem exists_int_valued_parametrization :
     IntValuedParametrizes fParam gParam hParam pythagoreanTriples := by
   refine ⟨f_param_intValued, g_param_intValued, h_param_intValued, ?_⟩

--- a/LeanPool/PythagoreanPolynomialParametrization/IntegerValued.lean
+++ b/LeanPool/PythagoreanPolynomialParametrization/IntegerValued.lean
@@ -1,0 +1,205 @@
+/-
+Copyright (c) 2026 Lazar Milikic. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Lazar Milikic
+-/
+
+import LeanPool.PythagoreanPolynomialParametrization.SourceLemmas
+
+/-! # Integer-valued parametrization of all Pythagorean triples
+
+This file contains the explicit four-variable integer-valued polynomial triple from
+Frisch and Vaserstein's main theorem.
+-/
+
+namespace LeanPool.PythagoreanPolynomialParametrization
+
+open MvPolynomial
+
+
+
+/-- Variable x (index 0) in the 4-variable rational polynomial ring. -/
+noncomputable def xVar : RatPoly 4 := X 0
+
+/-- Variable y (index 1) in the 4-variable rational polynomial ring. -/
+noncomputable def yVar : RatPoly 4 := X 1
+
+/-- Variable z (index 2) in the 4-variable rational polynomial ring. -/
+noncomputable def zVar : RatPoly 4 := X 2
+
+/-- Variable w (index 3) in the 4-variable rational polynomial ring. -/
+noncomputable def wVar : RatPoly 4 := X 3
+
+/-- a = y + z·w -/
+noncomputable def aParam : RatPoly 4 := yVar + zVar * wVar
+
+/-- b = z - y·w -/
+noncomputable def bParam : RatPoly 4 := zVar - yVar * wVar
+
+/-- c = 2x - x·w -/
+noncomputable def cParam : RatPoly 4 := C (2 : ℚ) * xVar - xVar * wVar
+
+/-- f = c·(a² - b²)/2
+
+In the paper: ((2x-xw)((y+zw)²-(z-yw)²))/2 -/
+noncomputable def fParam : RatPoly 4 := C (1 / 2 : ℚ) * cParam * (aParam ^ 2 - bParam ^ 2)
+
+/-- g = c·a·b
+
+In the paper: (2x-xw)(y+zw)(z-yw) -/
+noncomputable def gParam : RatPoly 4 := cParam * aParam * bParam
+
+/-- h = c·(a² + b²)/2
+
+In the paper: ((2x-xw)((y+zw)²+(z-yw)²))/2 -/
+noncomputable def hParam : RatPoly 4 := C (1 / 2 : ℚ) * cParam * (aParam ^ 2 + bParam ^ 2)
+
+/-- fParam is integer-valued.
+
+**Prover notes:** Expand the definition of fParam and IsIntValued. For any integer tuple
+(x,y,z,w), fParam evaluates to ((2x-xw)((y+zw)²-(z-yw)²))/2. Show this is always an integer
+by case analysis on the parity of w: if w is even, then 2x-xw is even; if w is odd, then
+(y+zw) and (z-yw) have the same parity, so their squares differ by a multiple of 4, making
+the product divisible by 2. -/
+theorem f_param_intValued : IsIntValued fParam := by
+  intro v
+  let x : ℤ := v (0 : Fin 4)
+  let y : ℤ := v (1 : Fin 4)
+  let z : ℤ := v (2 : Fin 4)
+  let w : ℤ := v (3 : Fin 4)
+  let A : ℤ := y + z * w
+  let B : ℤ := z - y * w
+  let Cc : ℤ := (2 : ℤ) * x - x * w
+  have hpar : PaperParityCondition A B Cc := by
+    exact (parity_condition_parametrized A B Cc).mpr ⟨x, y, z, w, rfl, rfl, rfl⟩
+  rcases (TMap_integral_iff_parity A B Cc).mpr hpar with ⟨fx, gy, hz, hT⟩
+  refine ⟨fx, ?_⟩
+  have hfcoord : (Cc : ℚ) * ((A : ℚ) ^ 2 - (B : ℚ) ^ 2) / 2 = (fx : ℚ) := by
+    simpa [TMap] using congrArg Prod.fst hT
+  rw [← hfcoord]
+  simp [fParam, cParam, aParam, bParam, xVar, yVar, zVar, wVar, A, B, Cc]
+  ring
+
+/-- gParam is integer-valued.
+
+**Prover notes:** Expand the definition of gParam and IsIntValued. For any integer tuple
+(x,y,z,w), gParam evaluates to (2x-xw)(y+zw)(z-yw), which is clearly an integer product
+of integers. -/
+theorem g_param_intValued : IsIntValued gParam := by
+  intro v
+  let x : ℤ := v (0 : Fin 4)
+  let y : ℤ := v (1 : Fin 4)
+  let z : ℤ := v (2 : Fin 4)
+  let w : ℤ := v (3 : Fin 4)
+  let A : ℤ := y + z * w
+  let B : ℤ := z - y * w
+  let Cc : ℤ := (2 : ℤ) * x - x * w
+  refine ⟨Cc * A * B, ?_⟩
+  simp [gParam, cParam, aParam, bParam, xVar, yVar, zVar, wVar, A, B, Cc]
+  ring
+
+/-- hParam is integer-valued.
+
+**Prover notes:** Expand the definition of hParam and IsIntValued. For any integer tuple
+(x,y,z,w), hParam evaluates to ((2x-xw)((y+zw)²+(z-yw)²))/2. Show this is always an integer
+by case analysis on the parity of w: if w is even, then 2x-xw is even; if w is odd, then
+(y+zw) and (z-yw) have the same parity, so the sum of their squares is even. -/
+theorem h_param_intValued : IsIntValued hParam := by
+  intro v
+  let x : ℤ := v (0 : Fin 4)
+  let y : ℤ := v (1 : Fin 4)
+  let z : ℤ := v (2 : Fin 4)
+  let w : ℤ := v (3 : Fin 4)
+  let A : ℤ := y + z * w
+  let B : ℤ := z - y * w
+  let Cc : ℤ := (2 : ℤ) * x - x * w
+  have hpar : PaperParityCondition A B Cc := by
+    exact (parity_condition_parametrized A B Cc).mpr ⟨x, y, z, w, rfl, rfl, rfl⟩
+  rcases (TMap_integral_iff_parity A B Cc).mpr hpar with ⟨fx, gy, hz, hT⟩
+  refine ⟨hz, ?_⟩
+  have hhcoord : (Cc : ℚ) * ((A : ℚ) ^ 2 + (B : ℚ) ^ 2) / 2 = (hz : ℚ) := by
+    simpa [TMap] using congrArg (fun p : ℚ × ℚ × ℚ => p.2.2) hT
+  rw [← hhcoord]
+  simp [hParam, cParam, aParam, bParam, xVar, yVar, zVar, wVar, A, B, Cc]
+  ring
+
+/-- There exist f,g,h ∈ Int(ℤ⁴) such that (f,g,h) parametrizes the set of Pythagorean triples.
+
+**Source proof sketch:** Every primitive PT (x,y,z) with gcd(x,y,z)=1 and z>0 is either of
+the form T₁(a,b) = (a²-b², 2ab, a²+b²) or T₂(a,b) = (2ab, a²-b², a²+b²) with a,b ∈ ℤ.
+Since 2·T₂(a,b) = T₁(a+b, a-b), every primitive PT is of the form c·T₁(a,b)/2 with
+c ∈ {1,2} and a,b ∈ ℤ. Let T(a,b,c) = (c(a²-b²)/2, cab, c(a²+b²)/2).
+Then every PT is T(a,b,c) for some a,b,c ∈ ℤ. Also, every T(a,b,c) is a rational solution
+of x²+y²=z². The set of PTs is precisely the integer triples in the range of T.
+Now T(a,b,c) ∈ ℤ³ iff c ≡ 0 (mod 2) or a ≡ b (mod 2). Triples satisfying this condition
+are parametrized by (y+zw, z-yw, 2x-xw). If w is even then c ≡ 0 (mod 2);
+if w is odd then a ≡ b (mod 2); and all such triples occur for some (x,y,z,w) ∈ ℤ⁴
+(as seen by setting w=0 or w=1). Substituting yields the parametrization. -/
+theorem exists_int_valued_parametrization :
+    IntValuedParametrizes fParam gParam hParam pythagoreanTriples := by
+  refine ⟨f_param_intValued, g_param_intValued, h_param_intValued, ?_⟩
+  ext p
+  rcases p with ⟨x, y, z⟩
+  constructor
+  · intro hp
+    have hpy : IsPythagoreanTriple x y z := by
+      simpa [pythagoreanTriples] using hp
+    rcases (pythagorean_iff_mem_TMap_range x y z).mp hpy with ⟨a, b, c, hT⟩
+    have hIntegral : IsIntegralTValue a b c := ⟨x, y, z, hT⟩
+    have hpar : PaperParityCondition a b c := (TMap_integral_iff_parity a b c).mp hIntegral
+    rcases (parity_condition_parametrized a b c).mp hpar with
+      ⟨x0, y0, z0, w0, ha, hb, hc⟩
+    let v : Fin 4 → ℤ := fun i =>
+      if i = (0 : Fin 4) then x0 else
+      if i = (1 : Fin 4) then y0 else
+      if i = (2 : Fin 4) then z0 else w0
+    refine ⟨v, ?_, ?_, ?_⟩
+    · have hfcoord : (c : ℚ) * ((a : ℚ) ^ 2 - (b : ℚ) ^ 2) / 2 = (x : ℚ) := by
+        simpa [TMap] using congrArg Prod.fst hT
+      rw [← hfcoord]
+      rw [ha, hb, hc]
+      simp [ratPolyEval, fParam, cParam, aParam, bParam, xVar, yVar, zVar, wVar, v]
+      ring
+    · have hgcoord : (c : ℚ) * (a : ℚ) * (b : ℚ) = (y : ℚ) := by
+        simpa [TMap] using congrArg (fun p : ℚ × ℚ × ℚ => p.2.1) hT
+      rw [← hgcoord]
+      rw [ha, hb, hc]
+      simp [ratPolyEval, gParam, cParam, aParam, bParam, xVar, yVar, zVar, wVar, v]
+    · have hhcoord : (c : ℚ) * ((a : ℚ) ^ 2 + (b : ℚ) ^ 2) / 2 = (z : ℚ) := by
+        simpa [TMap] using congrArg (fun p : ℚ × ℚ × ℚ => p.2.2) hT
+      rw [← hhcoord]
+      rw [ha, hb, hc]
+      simp [ratPolyEval, hParam, cParam, aParam, bParam, xVar, yVar, zVar, wVar, v]
+      ring
+  · rintro ⟨v, hf, hg, hh⟩
+    let x0 : ℤ := v (0 : Fin 4)
+    let y0 : ℤ := v (1 : Fin 4)
+    let z0 : ℤ := v (2 : Fin 4)
+    let w0 : ℤ := v (3 : Fin 4)
+    let A : ℤ := y0 + z0 * w0
+    let B : ℤ := z0 - y0 * w0
+    let Cc : ℤ := (2 : ℤ) * x0 - x0 * w0
+    have hfcoord : (Cc : ℚ) * ((A : ℚ) ^ 2 - (B : ℚ) ^ 2) / 2 = (x : ℚ) := by
+      rw [← hf]
+      simp [ratPolyEval, fParam, cParam, aParam, bParam,
+        xVar, yVar, zVar, wVar, A, B, Cc, x0, y0, z0, w0]
+      ring
+    have hgcoord : (Cc : ℚ) * (A : ℚ) * (B : ℚ) = (y : ℚ) := by
+      rw [← hg]
+      simp [ratPolyEval, gParam, cParam, aParam, bParam,
+        xVar, yVar, zVar, wVar, A, B, Cc, x0, y0, z0, w0]
+    have hhcoord : (Cc : ℚ) * ((A : ℚ) ^ 2 + (B : ℚ) ^ 2) / 2 = (z : ℚ) := by
+      rw [← hh]
+      simp [ratPolyEval, hParam, cParam, aParam, bParam,
+        xVar, yVar, zVar, wVar, A, B, Cc, x0, y0, z0, w0]
+      ring
+    have hT : ∃ a b c : ℤ, TMap a b c = ((x : ℚ), (y : ℚ), (z : ℚ)) := by
+      refine ⟨A, B, Cc, ?_⟩
+      ext
+      · simpa [TMap] using hfcoord
+      · simpa [TMap] using hgcoord
+      · simpa [TMap] using hhcoord
+    have hpy : IsPythagoreanTriple x y z := (pythagorean_iff_mem_TMap_range x y z).mpr hT
+    simpa [pythagoreanTriples] using hpy
+
+end LeanPool.PythagoreanPolynomialParametrization

--- a/LeanPool/PythagoreanPolynomialParametrization/Main.lean
+++ b/LeanPool/PythagoreanPolynomialParametrization/Main.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2026 Lazar Milikic. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Lazar Milikic
+-/
+
+import LeanPool.PythagoreanPolynomialParametrization.Basic
+import LeanPool.PythagoreanPolynomialParametrization.SourceLemmas
+import LeanPool.PythagoreanPolynomialParametrization.Obstructions
+import LeanPool.PythagoreanPolynomialParametrization.IntegerValued
+import LeanPool.PythagoreanPolynomialParametrization.Positive
+import LeanPool.PythagoreanPolynomialParametrization.Explanatory
+
+/-! # Parametrization of Pythagorean Triples by Polynomials
+
+This directory sets up source-backed Lean statements for results from Frisch and
+Vaserstein's paper "Parametrization of Pythagorean triples by a single triple of
+polynomials". Externally cited or explanatory source claims are recorded separately
+from the main parametrization proofs.
+
+## File layout
+
+- `Basic`: shared definitions of Pythagorean triples, integer-valued polynomials,
+  and parametrization predicates.
+- `SourceLemmas`: source-level proof handoff lemmas for the `T(a,b,c)` map, parity
+  conditions, positive parameters, and four-square substitutions.
+- `Obstructions`: no single integer-coefficient polynomial triple parametrizes all
+  Pythagorean triples.
+- `IntegerValued`: the explicit four-variable integer-valued parametrization of all
+  Pythagorean triples.
+- `Positive`: the positive-triple parametrization and the 16-parameter unrestricted
+  variant.
+- `Explanatory`: reusable finite-family parametrization statements, the cited
+  finite-cover theorem, and the integer-valued factorization discussion.
+-/
+
+namespace LeanPool.PythagoreanPolynomialParametrization
+
+
+
+end LeanPool.PythagoreanPolynomialParametrization

--- a/LeanPool/PythagoreanPolynomialParametrization/Obstructions.lean
+++ b/LeanPool/PythagoreanPolynomialParametrization/Obstructions.lean
@@ -1,0 +1,152 @@
+/-
+Copyright (c) 2026 Lazar Milikic. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Lazar Milikic
+-/
+
+import LeanPool.PythagoreanPolynomialParametrization.Basic
+
+/-! # Integer-coefficient obstruction
+
+This file contains the paper's impossibility result for a single triple of
+integer-coefficient polynomials.
+-/
+
+namespace LeanPool.PythagoreanPolynomialParametrization
+
+
+
+/-- There do not exist f,g,h ∈ ℤ[x₁,…,xₙ] for any n such that (f,g,h) parametrizes
+the set of Pythagorean triples.
+
+**Source proof sketch:** Suppose (f,g,h) parametrizes the PTs. As ℤ[x] is a UFD,
+there exists d = gcd(g,h) (unique up to sign), which also divides f since f²+g²=h².
+Let φ = f/d, ψ = g/d, θ = h/d. Then φ² = θ² - ψ² = (θ+ψ)(θ-ψ).
+The gcd of (θ+ψ) and (θ-ψ) is either 1 or 2, but it cannot be 2 because there exist
+PTs with odd first coordinate (e.g. (3,4,5)). Since they are coprime and their product
+is a square, both are squares (up to sign, which we eliminate by adjusting the sign of d).
+So θ+ψ = s² and θ-ψ = t², giving θ = (s²+t²)/2 and ψ = (s²-t²)/2.
+Since s²-t² = (s+t)(s-t) is divisible by 2, it is actually divisible by 4,
+so ψ is divisible by 2, contradicting the existence of PTs with odd second coordinate
+(e.g. (4,3,5)). -/
+private lemma intPolyParametrizes_hits {n : ℕ} {f g h : IntPoly n} {x y z : ℤ}
+    (hp : IntPolyParametrizes f g h pythagoreanTriples)
+    (hxyz : IsPythagoreanTriple x y z) :
+    ∃ a : Fin n → ℤ,
+      intPolyEval f a = x ∧ intPolyEval g a = y ∧ intPolyEval h a = z := by
+  have hmem : (x, y, z) ∈ pythagoreanTriples := by
+    simpa [pythagoreanTriples] using hxyz
+  rw [hp] at hmem
+  simpa using hmem
+
+private lemma intPolyParametrizes_identity {n : ℕ} {f g h : IntPoly n}
+    (hp : IntPolyParametrizes f g h pythagoreanTriples) :
+    f ^ 2 + g ^ 2 = h ^ 2 := by
+  apply MvPolynomial.funext
+  intro a
+  have hmem : (intPolyEval f a, intPolyEval g a, intPolyEval h a) ∈
+      {(x, y, z) | ∃ a : Fin n → ℤ,
+        intPolyEval f a = x ∧ intPolyEval g a = y ∧ intPolyEval h a = z} := by
+    exact ⟨a, rfl, rfl, rfl⟩
+  have hpy : (intPolyEval f a, intPolyEval g a, intPolyEval h a) ∈ pythagoreanTriples := by
+    rw [hp]
+    simpa using hmem
+  have hEq : intPolyEval f a ^ 2 + intPolyEval g a ^ 2 = intPolyEval h a ^ 2 := by
+    simpa [pythagoreanTriples, IsPythagoreanTriple] using hpy
+  simpa [intPolyEval] using hEq
+
+private lemma parametrization_not_C_two_dvd_second {n : ℕ} {f g h : IntPoly n}
+    (hp : IntPolyParametrizes f g h pythagoreanTriples) :
+    ¬ MvPolynomial.C (2 : ℤ) ∣ g := by
+  intro hg
+  rcases hg with ⟨q, hq⟩
+  have h435 : IsPythagoreanTriple 4 3 5 := by
+    norm_num [IsPythagoreanTriple]
+  rcases intPolyParametrizes_hits hp h435 with ⟨a, _hf, hgval, _hh⟩
+  have hEval : intPolyEval g a = 2 * intPolyEval q a := by
+    rw [hq]
+    simp [intPolyEval]
+  have hodd : (3 : ℤ) = 2 * intPolyEval q a := by
+    rw [← hgval]
+    exact hEval
+  omega
+
+theorem no_int_poly_parametrization :
+    ¬∃ (n : ℕ) (f g h : IntPoly n), IntPolyParametrizes f g h pythagoreanTriples := by
+  rintro ⟨n, f, g, h, hp⟩
+  let two : IntPoly n := 2
+  have hId : f ^ 2 + g ^ 2 = h ^ 2 := intPolyParametrizes_identity hp
+  have htwo_ne : two ≠ 0 := by
+    dsimp [two]
+    norm_num
+  have htwo_prime : Prime two := by
+    dsimp [two]
+    simpa using ((MvPolynomial.prime_C_iff (σ := Fin n) (R := ℤ) (r := (2 : ℤ))).2
+      (by norm_num : Prime (2 : ℤ)))
+  have hfac : (h - f - g) * (h + f + g) = two * (-(f * g)) := by
+    dsimp [two]
+    calc
+      (h - f - g) * (h + f + g) =
+          h ^ 2 - (f ^ 2 + g ^ 2) - (2 : IntPoly n) * (f * g) := by
+        ring
+      _ = (2 : IntPoly n) * (-(f * g)) := by
+        rw [← hId]
+        ring
+  have hfac_dvd : two ∣ (h - f - g) * (h + f + g) := by
+    refine ⟨-(f * g), ?_⟩
+    exact hfac
+  have hfg_of_left (hleft : two ∣ h - f - g) : two ∣ f * g := by
+    rcases hleft with ⟨r, hr⟩
+    have hleft' : two ∣ h - f - g := ⟨r, hr⟩
+    have hright : two ∣ h + f + g := by
+      refine ⟨r + f + g, ?_⟩
+      calc
+        h + f + g = (h - f - g) + two * (f + g) := by
+          dsimp [two]
+          ring
+        _ = two * r + two * (f + g) := by rw [hr]
+        _ = two * (r + f + g) := by ring
+    have hfour : two * two ∣ (h - f - g) * (h + f + g) :=
+      mul_dvd_mul hleft' hright
+    have hfour' : two * two ∣ two * (-(f * g)) := by
+      simpa [hfac] using hfour
+    have hdivneg : two ∣ -(f * g) := (mul_dvd_mul_iff_left htwo_ne).mp hfour'
+    rcases hdivneg with ⟨s, hs⟩
+    refine ⟨-s, ?_⟩
+    rw [← neg_neg (f * g), hs]
+    ring
+  have hfg_of_right (hright : two ∣ h + f + g) : two ∣ f * g := by
+    rcases hright with ⟨r, hr⟩
+    have hleft : two ∣ h - f - g := by
+      refine ⟨r - f - g, ?_⟩
+      calc
+        h - f - g = (h + f + g) - two * (f + g) := by
+          dsimp [two]
+          ring
+        _ = two * r - two * (f + g) := by rw [hr]
+        _ = two * (r - f - g) := by ring
+    exact hfg_of_left hleft
+  have hfg : two ∣ f * g := by
+    rcases htwo_prime.dvd_or_dvd hfac_dvd with hleft | hright
+    · exact hfg_of_left hleft
+    · exact hfg_of_right hright
+  have hfg_or : two ∣ f ∨ two ∣ g := htwo_prime.dvd_or_dvd hfg
+  have hnotf : ¬ two ∣ f := by
+    intro hf
+    rcases hf with ⟨q, hq⟩
+    have h345 : IsPythagoreanTriple 3 4 5 := by
+      norm_num [IsPythagoreanTriple]
+    rcases intPolyParametrizes_hits hp h345 with ⟨a, hfval, _hgval, _hhval⟩
+    have hEval : intPolyEval f a = 2 * intPolyEval q a := by
+      rw [hq]
+      simp [intPolyEval, two]
+    have hodd : (3 : ℤ) = 2 * intPolyEval q a := by
+      rw [← hfval]
+      exact hEval
+    omega
+  have hnotg : ¬ two ∣ g := by
+    dsimp [two]
+    exact parametrization_not_C_two_dvd_second hp
+  exact hfg_or.elim hnotf hnotg
+
+end LeanPool.PythagoreanPolynomialParametrization

--- a/LeanPool/PythagoreanPolynomialParametrization/Obstructions.lean
+++ b/LeanPool/PythagoreanPolynomialParametrization/Obstructions.lean
@@ -14,21 +14,6 @@ integer-coefficient polynomials.
 
 namespace LeanPool.PythagoreanPolynomialParametrization
 
-
-
-/-- There do not exist f,g,h ∈ ℤ[x₁,…,xₙ] for any n such that (f,g,h) parametrizes
-the set of Pythagorean triples.
-
-**Source proof sketch:** Suppose (f,g,h) parametrizes the PTs. As ℤ[x] is a UFD,
-there exists d = gcd(g,h) (unique up to sign), which also divides f since f²+g²=h².
-Let φ = f/d, ψ = g/d, θ = h/d. Then φ² = θ² - ψ² = (θ+ψ)(θ-ψ).
-The gcd of (θ+ψ) and (θ-ψ) is either 1 or 2, but it cannot be 2 because there exist
-PTs with odd first coordinate (e.g. (3,4,5)). Since they are coprime and their product
-is a square, both are squares (up to sign, which we eliminate by adjusting the sign of d).
-So θ+ψ = s² and θ-ψ = t², giving θ = (s²+t²)/2 and ψ = (s²-t²)/2.
-Since s²-t² = (s+t)(s-t) is divisible by 2, it is actually divisible by 4,
-so ψ is divisible by 2, contradicting the existence of PTs with odd second coordinate
-(e.g. (4,3,5)). -/
 private lemma intPolyParametrizes_hits {n : ℕ} {f g h : IntPoly n} {x y z : ℤ}
     (hp : IntPolyParametrizes f g h pythagoreanTriples)
     (hxyz : IsPythagoreanTriple x y z) :
@@ -71,6 +56,8 @@ private lemma parametrization_not_C_two_dvd_second {n : ℕ} {f g h : IntPoly n}
     exact hEval
   omega
 
+/-- Frisch--Vaserstein's obstruction: no finite-variable triple of integer-coefficient
+polynomials parametrizes all Pythagorean triples. -/
 theorem no_int_poly_parametrization :
     ¬∃ (n : ℕ) (f g h : IntPoly n), IntPolyParametrizes f g h pythagoreanTriples := by
   rintro ⟨n, f, g, h, hp⟩

--- a/LeanPool/PythagoreanPolynomialParametrization/Positive.lean
+++ b/LeanPool/PythagoreanPolynomialParametrization/Positive.lean
@@ -44,10 +44,7 @@ In the paper: ((x+(1-w)²x)((y+(1+w)z)²+y²))/2 -/
 noncomputable def hPosParam : RatPoly 4 :=
   C (1 / 2 : ℚ) * cPosParam * (aPosParam ^ 2 + bPosParam ^ 2)
 
-/-- fPosParam is integer-valued.
-
-**Prover notes:** Similar to f_param_intValued. For any integer tuple (x,y,z,w),
-fPosParam evaluates to ((x+(1-w)²x)((y+(1+w)z)²-y²))/2. Show this is always an integer. -/
+/-- The first coordinate polynomial in the positive parametrization is integer-valued. -/
 theorem f_pos_param_intValued : IsIntValued fPosParam := by
   intro v
   let x : ℤ := v (0 : Fin 4)
@@ -80,10 +77,7 @@ theorem f_pos_param_intValued : IsIntValued fPosParam := by
     A, B, Cc]
   ring
 
-/-- gPosParam is integer-valued.
-
-**Prover notes:** For any integer tuple (x,y,z,w), gPosParam evaluates to
-(x+(1-w)²x)(y+(1+w)z)y, which is clearly an integer product of integers. -/
+/-- The second coordinate polynomial in the positive parametrization is integer-valued. -/
 theorem g_pos_param_intValued : IsIntValued gPosParam := by
   intro v
   let x : ℤ := v (0 : Fin 4)
@@ -98,10 +92,7 @@ theorem g_pos_param_intValued : IsIntValued gPosParam := by
     A, B, Cc]
   ring
 
-/-- hPosParam is integer-valued.
-
-**Prover notes:** Similar to h_param_intValued. For any integer tuple (x,y,z,w),
-hPosParam evaluates to ((x+(1-w)²x)((y+(1+w)z)²+y²))/2. Show this is always an integer. -/
+/-- The third coordinate polynomial in the positive parametrization is integer-valued. -/
 theorem h_pos_param_intValued : IsIntValued hPosParam := by
   intro v
   let x : ℤ := v (0 : Fin 4)
@@ -138,18 +129,8 @@ theorem h_pos_param_intValued : IsIntValued hPosParam := by
 def mkRatPolyInput4 (x' y' z' w' : ℤ) : Fin 4 → ℤ := fun i =>
   if i = 0 then x' else if i = 1 then y' else if i = 2 then z' else w'
 
-/-- Parametrization of positive Pythagorean triples.
-
-**Source statement:** The set of positive PTs is parametrized by
-((x+(1-w)²x)((y+(1+w)z)²-y²)/2, (x+(1-w)²x)(y+(1+w)z)y, (x+(1-w)²x)((y+(1+w)z)²+y²)/2)
-where x,y,z range through the positive integers and w through the non-negative integers.
-
-**Source proof sketch:** As in the main theorem, positive PTs are precisely the triples
-with positive integer coordinates in the range of T. Now T(a,b,c) is a positive triple
-iff a,b,c are positive integers with a > b and either c ≡ 0 (mod 2) or a ≡ b (mod 2).
-Such triples are parametrized by (y+(1+w)z, y, x+(1-w)²x) with x,y,z > 0 and w ≥ 0.
-Substituting gives the parametrization. The 4-square theorem allows converting this to
-a parametrization with 16 integer parameters. -/
+/-- Frisch--Vaserstein's positive Pythagorean-triple parametrization, with positive
+parameters `x`, `y`, `z` and nonnegative parameter `w`. -/
 theorem positive_triples_parametrization :
     IsIntValued fPosParam ∧ IsIntValued gPosParam ∧ IsIntValued hPosParam ∧
     positivePythagoreanTriples =

--- a/LeanPool/PythagoreanPolynomialParametrization/Positive.lean
+++ b/LeanPool/PythagoreanPolynomialParametrization/Positive.lean
@@ -1,0 +1,512 @@
+/-
+Copyright (c) 2026 Lazar Milikic. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Lazar Milikic
+-/
+
+import LeanPool.PythagoreanPolynomialParametrization.IntegerValued
+
+/-! # Positive Pythagorean triples and 16-parameter variant
+
+This file contains the positive-triple remark and the unrestricted 16-parameter
+substitution obtained from the four-square theorem.
+-/
+
+namespace LeanPool.PythagoreanPolynomialParametrization
+
+open MvPolynomial
+
+
+
+/-- a_pos = y + (1+w)·z -/
+noncomputable def aPosParam : RatPoly 4 := yVar + (C (1 : ℚ) + wVar) * zVar
+
+/-- b_pos = y -/
+noncomputable def bPosParam : RatPoly 4 := yVar
+
+/-- c_pos = x + (1-w)²·x -/
+noncomputable def cPosParam : RatPoly 4 := xVar + (C (1 : ℚ) - wVar) ^ 2 * xVar
+
+/-- f_pos = c_pos·(a_pos² - b_pos²)/2
+
+In the paper: ((x+(1-w)²x)((y+(1+w)z)²-y²))/2 -/
+noncomputable def fPosParam : RatPoly 4 :=
+  C (1 / 2 : ℚ) * cPosParam * (aPosParam ^ 2 - bPosParam ^ 2)
+
+/-- g_pos = c_pos·a_pos·b_pos
+
+In the paper: (x+(1-w)²x)(y+(1+w)z)y -/
+noncomputable def gPosParam : RatPoly 4 := cPosParam * aPosParam * bPosParam
+
+/-- h_pos = c_pos·(a_pos² + b_pos²)/2
+
+In the paper: ((x+(1-w)²x)((y+(1+w)z)²+y²))/2 -/
+noncomputable def hPosParam : RatPoly 4 :=
+  C (1 / 2 : ℚ) * cPosParam * (aPosParam ^ 2 + bPosParam ^ 2)
+
+/-- fPosParam is integer-valued.
+
+**Prover notes:** Similar to f_param_intValued. For any integer tuple (x,y,z,w),
+fPosParam evaluates to ((x+(1-w)²x)((y+(1+w)z)²-y²))/2. Show this is always an integer. -/
+theorem f_pos_param_intValued : IsIntValued fPosParam := by
+  intro v
+  let x : ℤ := v (0 : Fin 4)
+  let y : ℤ := v (1 : Fin 4)
+  let z : ℤ := v (2 : Fin 4)
+  let w : ℤ := v (3 : Fin 4)
+  let A : ℤ := y + ((1 : ℤ) + w) * z
+  let B : ℤ := y
+  let Cc : ℤ := x + ((1 : ℤ) - w) ^ 2 * x
+  have hpar : PaperParityCondition A B Cc := by
+    rcases Int.even_or_odd w with hw | hw
+    · left
+      rcases hw with ⟨t, ht⟩
+      refine ⟨x * (1 - 2 * t + 2 * t ^ 2), ?_⟩
+      dsimp [Cc]
+      rw [ht]
+      ring
+    · right
+      rcases hw with ⟨t, ht⟩
+      refine ⟨z * (t + 1), ?_⟩
+      dsimp [A, B]
+      rw [ht]
+      ring
+  rcases (TMap_integral_iff_parity A B Cc).mpr hpar with ⟨fx, gy, hz, hT⟩
+  refine ⟨fx, ?_⟩
+  have hfcoord : (Cc : ℚ) * ((A : ℚ) ^ 2 - (B : ℚ) ^ 2) / 2 = (fx : ℚ) := by
+    simpa [TMap] using congrArg Prod.fst hT
+  rw [← hfcoord]
+  simp [fPosParam, cPosParam, aPosParam, bPosParam, xVar, yVar, zVar, wVar,
+    A, B, Cc]
+  ring
+
+/-- gPosParam is integer-valued.
+
+**Prover notes:** For any integer tuple (x,y,z,w), gPosParam evaluates to
+(x+(1-w)²x)(y+(1+w)z)y, which is clearly an integer product of integers. -/
+theorem g_pos_param_intValued : IsIntValued gPosParam := by
+  intro v
+  let x : ℤ := v (0 : Fin 4)
+  let y : ℤ := v (1 : Fin 4)
+  let z : ℤ := v (2 : Fin 4)
+  let w : ℤ := v (3 : Fin 4)
+  let A : ℤ := y + ((1 : ℤ) + w) * z
+  let B : ℤ := y
+  let Cc : ℤ := x + ((1 : ℤ) - w) ^ 2 * x
+  refine ⟨Cc * A * B, ?_⟩
+  simp [gPosParam, cPosParam, aPosParam, bPosParam, xVar, yVar, zVar, wVar,
+    A, B, Cc]
+  ring
+
+/-- hPosParam is integer-valued.
+
+**Prover notes:** Similar to h_param_intValued. For any integer tuple (x,y,z,w),
+hPosParam evaluates to ((x+(1-w)²x)((y+(1+w)z)²+y²))/2. Show this is always an integer. -/
+theorem h_pos_param_intValued : IsIntValued hPosParam := by
+  intro v
+  let x : ℤ := v (0 : Fin 4)
+  let y : ℤ := v (1 : Fin 4)
+  let z : ℤ := v (2 : Fin 4)
+  let w : ℤ := v (3 : Fin 4)
+  let A : ℤ := y + ((1 : ℤ) + w) * z
+  let B : ℤ := y
+  let Cc : ℤ := x + ((1 : ℤ) - w) ^ 2 * x
+  have hpar : PaperParityCondition A B Cc := by
+    rcases Int.even_or_odd w with hw | hw
+    · left
+      rcases hw with ⟨t, ht⟩
+      refine ⟨x * (1 - 2 * t + 2 * t ^ 2), ?_⟩
+      dsimp [Cc]
+      rw [ht]
+      ring
+    · right
+      rcases hw with ⟨t, ht⟩
+      refine ⟨z * (t + 1), ?_⟩
+      dsimp [A, B]
+      rw [ht]
+      ring
+  rcases (TMap_integral_iff_parity A B Cc).mpr hpar with ⟨fx, gy, hz, hT⟩
+  refine ⟨hz, ?_⟩
+  have hhcoord : (Cc : ℚ) * ((A : ℚ) ^ 2 + (B : ℚ) ^ 2) / 2 = (hz : ℚ) := by
+    simpa [TMap] using congrArg (fun p : ℚ × ℚ × ℚ => p.2.2) hT
+  rw [← hhcoord]
+  simp [hPosParam, cPosParam, aPosParam, bPosParam, xVar, yVar, zVar, wVar,
+    A, B, Cc]
+  ring
+
+/-- Construct a 4-tuple input for polynomial evaluation from individual components. -/
+def mkRatPolyInput4 (x' y' z' w' : ℤ) : Fin 4 → ℤ := fun i =>
+  if i = 0 then x' else if i = 1 then y' else if i = 2 then z' else w'
+
+/-- Parametrization of positive Pythagorean triples.
+
+**Source statement:** The set of positive PTs is parametrized by
+((x+(1-w)²x)((y+(1+w)z)²-y²)/2, (x+(1-w)²x)(y+(1+w)z)y, (x+(1-w)²x)((y+(1+w)z)²+y²)/2)
+where x,y,z range through the positive integers and w through the non-negative integers.
+
+**Source proof sketch:** As in the main theorem, positive PTs are precisely the triples
+with positive integer coordinates in the range of T. Now T(a,b,c) is a positive triple
+iff a,b,c are positive integers with a > b and either c ≡ 0 (mod 2) or a ≡ b (mod 2).
+Such triples are parametrized by (y+(1+w)z, y, x+(1-w)²x) with x,y,z > 0 and w ≥ 0.
+Substituting gives the parametrization. The 4-square theorem allows converting this to
+a parametrization with 16 integer parameters. -/
+theorem positive_triples_parametrization :
+    IsIntValued fPosParam ∧ IsIntValued gPosParam ∧ IsIntValued hPosParam ∧
+    positivePythagoreanTriples =
+      {(x, y, z) | ∃ (x' y' z' w' : ℤ),
+        0 < x' ∧ 0 < y' ∧ 0 < z' ∧ 0 ≤ w' ∧
+        ratPolyEval fPosParam (mkRatPolyInput4 x' y' z' w') = (x : ℚ) ∧
+        ratPolyEval gPosParam (mkRatPolyInput4 x' y' z' w') = (y : ℚ) ∧
+        ratPolyEval hPosParam (mkRatPolyInput4 x' y' z' w') = (z : ℚ)} := by
+  have hPositiveRange (x y z : ℤ) :
+      (0 < x ∧ 0 < y ∧ 0 < z ∧ IsPythagoreanTriple x y z) ↔
+        ∃ a b c : ℤ, PositiveTParameters a b c ∧
+          TMap a b c = ((x : ℚ), (y : ℚ), (z : ℚ)) := by
+    constructor
+    · rintro ⟨hxpos, hypos, hzpos, hpy⟩
+      rcases (pythagorean_iff_mem_TMap_range x y z).mp hpy with ⟨a, b, c, hT⟩
+      have hxcoord : (c : ℚ) * ((a : ℚ) ^ 2 - (b : ℚ) ^ 2) / 2 = (x : ℚ) := by
+        simpa [TMap] using congrArg Prod.fst hT
+      have hycoord : (c : ℚ) * (a : ℚ) * (b : ℚ) = (y : ℚ) := by
+        simpa [TMap] using congrArg (fun p : ℚ × ℚ × ℚ => p.2.1) hT
+      have hzcoord : (c : ℚ) * ((a : ℚ) ^ 2 + (b : ℚ) ^ 2) / 2 = (z : ℚ) := by
+        simpa [TMap] using congrArg (fun p : ℚ × ℚ × ℚ => p.2.2) hT
+      have hzqpos : (0 : ℚ) < (z : ℚ) := by exact_mod_cast hzpos
+      have hyqpos : (0 : ℚ) < (y : ℚ) := by exact_mod_cast hypos
+      have hxqpos : (0 : ℚ) < (x : ℚ) := by exact_mod_cast hxpos
+      have hsum_nonneg : (0 : ℚ) ≤ (a : ℚ) ^ 2 + (b : ℚ) ^ 2 := by
+        nlinarith [sq_nonneg (a : ℚ), sq_nonneg (b : ℚ)]
+      have hczprod_pos : (0 : ℚ) < (c : ℚ) * ((a : ℚ) ^ 2 + (b : ℚ) ^ 2) := by
+        nlinarith [hzcoord, hzqpos]
+      have hcqpos : (0 : ℚ) < (c : ℚ) :=
+        pos_of_mul_pos_right (by simpa [mul_comm] using hczprod_pos) hsum_nonneg
+      have hcpos : 0 < c := by exact_mod_cast hcqpos
+      have hycoord' : (c : ℚ) * ((a : ℚ) * (b : ℚ)) = (y : ℚ) := by
+        simpa [mul_assoc] using hycoord
+      have hcabprod_pos : (0 : ℚ) < (c : ℚ) * ((a : ℚ) * (b : ℚ)) := by
+        nlinarith [hycoord', hyqpos]
+      have habqpos : (0 : ℚ) < (a : ℚ) * (b : ℚ) :=
+        pos_of_mul_pos_right hcabprod_pos (le_of_lt hcqpos)
+      have habpos : 0 < a * b := by exact_mod_cast habqpos
+      have ha_ne : a ≠ 0 := by
+        intro ha
+        subst a
+        norm_num at habpos
+      have hb_ne : b ≠ 0 := by
+        intro hb
+        subst b
+        norm_num at habpos
+      have hapos : 0 < |a| := abs_pos.mpr ha_ne
+      have hbpos : 0 < |b| := abs_pos.mpr hb_ne
+      have hcxprod_pos : (0 : ℚ) < (c : ℚ) * ((a : ℚ) ^ 2 - (b : ℚ) ^ 2) := by
+        nlinarith [hxcoord, hxqpos]
+      have hdiffqpos : (0 : ℚ) < (a : ℚ) ^ 2 - (b : ℚ) ^ 2 :=
+        pos_of_mul_pos_right hcxprod_pos (le_of_lt hcqpos)
+      have hsq_lt_q : (b : ℚ) ^ 2 < (a : ℚ) ^ 2 := by nlinarith
+      have hsq_lt_int : b ^ 2 < a ^ 2 := by exact_mod_cast hsq_lt_q
+      have hblta : |b| < |a| := by
+        rwa [abs_lt_iff_mul_self_lt, ← pow_two, ← pow_two]
+      have hprod_abs_int : |a| * |b| = a * b := by
+        rw [← abs_mul, abs_of_nonneg (le_of_lt habpos)]
+      have hprod_abs_q : ((|a| : ℤ) : ℚ) * ((|b| : ℤ) : ℚ) = (a : ℚ) * (b : ℚ) := by
+        exact_mod_cast hprod_abs_int
+      have hprod_abs_q' : |(a : ℚ)| * |(b : ℚ)| = (a : ℚ) * (b : ℚ) := by
+        simpa [Int.cast_abs] using hprod_abs_q
+      have hTabs : TMap (|a|) (|b|) c = ((x : ℚ), (y : ℚ), (z : ℚ)) := by
+        rw [← hT]
+        ext
+        · simp [TMap, Int.cast_abs]
+        · simp only [TMap, Int.cast_abs]
+          rw [mul_assoc, hprod_abs_q', ← mul_assoc]
+        · simp [TMap, Int.cast_abs]
+      have hpar : PaperParityCondition (|a|) (|b|) c := by
+        exact (TMap_integral_iff_parity (|a|) (|b|) c).mp ⟨x, y, z, hTabs⟩
+      refine ⟨|a|, |b|, c, ?_, hTabs⟩
+      exact ⟨hapos, hbpos, hcpos, hblta, hpar⟩
+    · rintro ⟨a, b, c, hpos, hT⟩
+      rcases hpos with ⟨hapos, hbpos, hcpos, hblta, hpar⟩
+      have hxcoord : (c : ℚ) * ((a : ℚ) ^ 2 - (b : ℚ) ^ 2) / 2 = (x : ℚ) := by
+        simpa [TMap] using congrArg Prod.fst hT
+      have hycoord : (c : ℚ) * (a : ℚ) * (b : ℚ) = (y : ℚ) := by
+        simpa [TMap] using congrArg (fun p : ℚ × ℚ × ℚ => p.2.1) hT
+      have hzcoord : (c : ℚ) * ((a : ℚ) ^ 2 + (b : ℚ) ^ 2) / 2 = (z : ℚ) := by
+        simpa [TMap] using congrArg (fun p : ℚ × ℚ × ℚ => p.2.2) hT
+      have hcqpos : (0 : ℚ) < (c : ℚ) := by exact_mod_cast hcpos
+      have haqpos : (0 : ℚ) < (a : ℚ) := by exact_mod_cast hapos
+      have hbqpos : (0 : ℚ) < (b : ℚ) := by exact_mod_cast hbpos
+      have hbaq : (b : ℚ) < (a : ℚ) := by exact_mod_cast hblta
+      have hdiffqpos : (0 : ℚ) < (a : ℚ) ^ 2 - (b : ℚ) ^ 2 := by
+        nlinarith
+      have hxqpos : (0 : ℚ) < (x : ℚ) := by
+        rw [← hxcoord]
+        positivity
+      have hyqpos : (0 : ℚ) < (y : ℚ) := by
+        rw [← hycoord]
+        positivity
+      have hzqpos : (0 : ℚ) < (z : ℚ) := by
+        rw [← hzcoord]
+        positivity
+      have hxpos : 0 < x := by exact_mod_cast hxqpos
+      have hypos : 0 < y := by exact_mod_cast hyqpos
+      have hzpos : 0 < z := by exact_mod_cast hzqpos
+      have hpy : IsPythagoreanTriple x y z := by
+        exact (pythagorean_iff_mem_TMap_range x y z).mpr ⟨a, b, c, hT⟩
+      exact ⟨hxpos, hypos, hzpos, hpy⟩
+  refine ⟨f_pos_param_intValued, g_pos_param_intValued, h_pos_param_intValued, ?_⟩
+  ext p
+  rcases p with ⟨x, y, z⟩
+  simp only [positivePythagoreanTriples, exists_and_left, Set.mem_setOf_eq]
+  rw [hPositiveRange x y z]
+  constructor
+  · rintro ⟨a, b, c, hpos, hT⟩
+    rcases (positive_T_parameters_parametrized a b c).mp hpos with
+      ⟨x', y', z', w', hxpos, hypos, hzpos, hwnonneg, ha, hb, hc⟩
+    refine ⟨x', hxpos, y', hypos, z', hzpos, w', hwnonneg, ?_, ?_, ?_⟩
+    · have hxcoord : (c : ℚ) * ((a : ℚ) ^ 2 - (b : ℚ) ^ 2) / 2 = (x : ℚ) := by
+        simpa [TMap] using congrArg Prod.fst hT
+      rw [← hxcoord]
+      rw [ha, hb, hc]
+      simp [ratPolyEval, fPosParam, cPosParam, aPosParam, bPosParam, xVar, yVar,
+        zVar, wVar, mkRatPolyInput4]
+      ring_nf
+    · have hycoord : (c : ℚ) * (a : ℚ) * (b : ℚ) = (y : ℚ) := by
+        simpa [TMap] using congrArg (fun p : ℚ × ℚ × ℚ => p.2.1) hT
+      rw [← hycoord]
+      rw [ha, hb, hc]
+      simp [ratPolyEval, gPosParam, cPosParam, aPosParam, bPosParam, xVar, yVar,
+        zVar, wVar, mkRatPolyInput4]
+    · have hzcoord : (c : ℚ) * ((a : ℚ) ^ 2 + (b : ℚ) ^ 2) / 2 = (z : ℚ) := by
+        simpa [TMap] using congrArg (fun p : ℚ × ℚ × ℚ => p.2.2) hT
+      rw [← hzcoord]
+      rw [ha, hb, hc]
+      simp [ratPolyEval, hPosParam, cPosParam, aPosParam, bPosParam, xVar, yVar,
+        zVar, wVar, mkRatPolyInput4]
+      ring_nf
+  · rintro ⟨x', hxpos, y', hypos, z', hzpos, w', hwnonneg, hf, hg, hh⟩
+    let a : ℤ := y' + ((1 : ℤ) + w') * z'
+    let b : ℤ := y'
+    let c : ℤ := x' + ((1 : ℤ) - w') ^ 2 * x'
+    have hpos : PositiveTParameters a b c := by
+      exact (positive_T_parameters_parametrized a b c).mpr
+        ⟨x', y', z', w', hxpos, hypos, hzpos, hwnonneg, rfl, rfl, rfl⟩
+    have hxcoord : (c : ℚ) * ((a : ℚ) ^ 2 - (b : ℚ) ^ 2) / 2 = (x : ℚ) := by
+      rw [← hf]
+      simp [ratPolyEval, fPosParam, cPosParam, aPosParam, bPosParam, xVar, yVar,
+        zVar, wVar, mkRatPolyInput4, a, b, c]
+      ring_nf
+    have hycoord : (c : ℚ) * (a : ℚ) * (b : ℚ) = (y : ℚ) := by
+      rw [← hg]
+      simp [ratPolyEval, gPosParam, cPosParam, aPosParam, bPosParam, xVar, yVar,
+        zVar, wVar, mkRatPolyInput4, a, b, c]
+    have hzcoord : (c : ℚ) * ((a : ℚ) ^ 2 + (b : ℚ) ^ 2) / 2 = (z : ℚ) := by
+      rw [← hh]
+      simp [ratPolyEval, hPosParam, cPosParam, aPosParam, bPosParam, xVar, yVar,
+        zVar, wVar, mkRatPolyInput4, a, b, c]
+      ring_nf
+    have hT : TMap a b c = ((x : ℚ), (y : ℚ), (z : ℚ)) := by
+      ext
+      · simpa [TMap] using hxcoord
+      · simpa [TMap] using hycoord
+      · simpa [TMap] using hzcoord
+    exact ⟨a, b, c, hpos, hT⟩
+
+/-! ## 16-parameter parametrization via four-square theorem -/
+
+/-- xSub = x₁² + x₂² + x₃² + x₄² + 1 -/
+noncomputable def xSub : RatPoly 16 :=
+  (X 0)^2 + (X 1)^2 + (X 2)^2 + (X 3)^2 + C (1 : ℚ)
+
+/-- ySub = y₁² + y₂² + y₃² + y₄² + 1 -/
+noncomputable def ySub : RatPoly 16 :=
+  (X 4)^2 + (X 5)^2 + (X 6)^2 + (X 7)^2 + C (1 : ℚ)
+
+/-- zSub = z₁² + z₂² + z₃² + z₄² + 1 -/
+noncomputable def zSub : RatPoly 16 :=
+  (X 8)^2 + (X 9)^2 + (X 10)^2 + (X 11)^2 + C (1 : ℚ)
+
+/-- wSub = w₁² + w₂² + w₃² + w₄² -/
+noncomputable def wSub : RatPoly 16 :=
+  (X 12)^2 + (X 13)^2 + (X 14)^2 + (X 15)^2
+
+/-- a_16 = ySub + (1 + wSub) * zSub -/
+noncomputable def a16Param : RatPoly 16 := ySub + (C (1 : ℚ) + wSub) * zSub
+
+/-- b_16 = ySub -/
+noncomputable def b16Param : RatPoly 16 := ySub
+
+/-- c_16 = xSub + (1 - wSub)² * xSub -/
+noncomputable def c16Param : RatPoly 16 := xSub + (C (1 : ℚ) - wSub) ^ 2 * xSub
+
+/-- f_16 = c_16·(a_16² - b_16²)/2
+
+In the paper: ((xSub+(1-wSub)²xSub)((ySub+(1+wSub)zSub)²-ySub²))/2 -/
+noncomputable def f16Param : RatPoly 16 :=
+  C (1 / 2 : ℚ) * c16Param * (a16Param ^ 2 - b16Param ^ 2)
+
+/-- g_16 = c_16·a_16·b_16
+
+In the paper: (xSub+(1-wSub)²xSub)(ySub+(1+wSub)zSub)ySub -/
+noncomputable def g16Param : RatPoly 16 := c16Param * a16Param * b16Param
+
+/-- h_16 = c_16·(a_16² + b_16²)/2
+
+In the paper: ((xSub+(1-wSub)²xSub)((ySub+(1+wSub)zSub)²+ySub²))/2 -/
+noncomputable def h16Param : RatPoly 16 :=
+  C (1 / 2 : ℚ) * c16Param * (a16Param ^ 2 + b16Param ^ 2)
+
+/-- The positive-triple parametrization with unrestricted integer parameters, obtained
+from the four-variable positive parametrization by replacing the positive/nonnegative
+parameters with four-square expressions. -/
+theorem exists_16_param_parametrization :
+    IsIntValued f16Param ∧ IsIntValued g16Param ∧ IsIntValued h16Param ∧
+    positivePythagoreanTriples =
+      {(x, y, z) | ∃ (a : Fin 16 → ℤ),
+        ratPolyEval f16Param a = (x : ℚ) ∧
+        ratPolyEval g16Param a = (y : ℚ) ∧
+        ratPolyEval h16Param a = (z : ℚ)} := by
+  let lift16ToPosInput : (Fin 16 → ℤ) → Fin 4 → ℤ := fun a =>
+    mkRatPolyInput4
+      (a (0 : Fin 16) ^ 2 + a (1 : Fin 16) ^ 2 + a (2 : Fin 16) ^ 2 +
+        a (3 : Fin 16) ^ 2 + 1)
+      (a (4 : Fin 16) ^ 2 + a (5 : Fin 16) ^ 2 + a (6 : Fin 16) ^ 2 +
+        a (7 : Fin 16) ^ 2 + 1)
+      (a (8 : Fin 16) ^ 2 + a (9 : Fin 16) ^ 2 + a (10 : Fin 16) ^ 2 +
+        a (11 : Fin 16) ^ 2 + 1)
+      (a (12 : Fin 16) ^ 2 + a (13 : Fin 16) ^ 2 + a (14 : Fin 16) ^ 2 +
+        a (15 : Fin 16) ^ 2)
+  have hf_eval (a : Fin 16 → ℤ) :
+      ratPolyEval f16Param a = ratPolyEval fPosParam (lift16ToPosInput a) := by
+    simp [ratPolyEval, f16Param, fPosParam, c16Param, a16Param, b16Param,
+      xSub, ySub, zSub, wSub, cPosParam, aPosParam, bPosParam, xVar, yVar,
+      zVar, wVar, lift16ToPosInput, mkRatPolyInput4]
+  have hg_eval (a : Fin 16 → ℤ) :
+      ratPolyEval g16Param a = ratPolyEval gPosParam (lift16ToPosInput a) := by
+    simp [ratPolyEval, g16Param, gPosParam, c16Param, a16Param, b16Param,
+      xSub, ySub, zSub, wSub, cPosParam, aPosParam, bPosParam, xVar, yVar,
+      zVar, wVar, lift16ToPosInput, mkRatPolyInput4]
+  have hh_eval (a : Fin 16 → ℤ) :
+      ratPolyEval h16Param a = ratPolyEval hPosParam (lift16ToPosInput a) := by
+    simp [ratPolyEval, h16Param, hPosParam, c16Param, a16Param, b16Param,
+      xSub, ySub, zSub, wSub, cPosParam, aPosParam, bPosParam, xVar, yVar,
+      zVar, wVar, lift16ToPosInput, mkRatPolyInput4]
+  have hf16 : IsIntValued f16Param := by
+    intro a
+    rcases f_pos_param_intValued (lift16ToPosInput a) with ⟨k, hk⟩
+    refine ⟨k, ?_⟩
+    change ratPolyEval f16Param a = (k : ℚ)
+    have hk' : ratPolyEval fPosParam (lift16ToPosInput a) = (k : ℚ) := by
+      simpa [ratPolyEval] using hk
+    exact (hf_eval a).trans hk'
+  have hg16 : IsIntValued g16Param := by
+    intro a
+    rcases g_pos_param_intValued (lift16ToPosInput a) with ⟨k, hk⟩
+    refine ⟨k, ?_⟩
+    change ratPolyEval g16Param a = (k : ℚ)
+    have hk' : ratPolyEval gPosParam (lift16ToPosInput a) = (k : ℚ) := by
+      simpa [ratPolyEval] using hk
+    exact (hg_eval a).trans hk'
+  have hh16 : IsIntValued h16Param := by
+    intro a
+    rcases h_pos_param_intValued (lift16ToPosInput a) with ⟨k, hk⟩
+    refine ⟨k, ?_⟩
+    change ratPolyEval h16Param a = (k : ℚ)
+    have hk' : ratPolyEval hPosParam (lift16ToPosInput a) = (k : ℚ) := by
+      simpa [ratPolyEval] using hk
+    exact (hh_eval a).trans hk'
+  rcases positive_triples_parametrization with ⟨_, _, _, hpos4⟩
+  refine ⟨hf16, hg16, hh16, ?_⟩
+  rw [hpos4]
+  ext p
+  rcases p with ⟨x, y, z⟩
+  constructor
+  · rintro ⟨x', y', z', w', hxpos, hypos, hzpos, hwnonneg, hf, hg, hh⟩
+    rcases (int_positive_iff_four_squares_add_one x').mp hxpos with
+      ⟨x0, x1, x2, x3, hxsum⟩
+    rcases (int_positive_iff_four_squares_add_one y').mp hypos with
+      ⟨y0, y1, y2, y3, hysum⟩
+    rcases (int_positive_iff_four_squares_add_one z').mp hzpos with
+      ⟨z0, z1, z2, z3, hzsum⟩
+    rcases (int_nonneg_iff_four_squares w').mp hwnonneg with
+      ⟨w0, w1, w2, w3, hwsum⟩
+    let a : Fin 16 → ℤ := fun i =>
+      if i = (0 : Fin 16) then x0 else
+      if i = (1 : Fin 16) then x1 else
+      if i = (2 : Fin 16) then x2 else
+      if i = (3 : Fin 16) then x3 else
+      if i = (4 : Fin 16) then y0 else
+      if i = (5 : Fin 16) then y1 else
+      if i = (6 : Fin 16) then y2 else
+      if i = (7 : Fin 16) then y3 else
+      if i = (8 : Fin 16) then z0 else
+      if i = (9 : Fin 16) then z1 else
+      if i = (10 : Fin 16) then z2 else
+      if i = (11 : Fin 16) then z3 else
+      if i = (12 : Fin 16) then w0 else
+      if i = (13 : Fin 16) then w1 else
+      if i = (14 : Fin 16) then w2 else w3
+    have hinput : lift16ToPosInput a = mkRatPolyInput4 x' y' z' w' := by
+      funext i
+      fin_cases i <;> simp [lift16ToPosInput, mkRatPolyInput4, a, hxsum, hysum, hzsum,
+        hwsum]
+    refine ⟨a, ?_, ?_, ?_⟩
+    · calc
+        ratPolyEval f16Param a = ratPolyEval fPosParam (lift16ToPosInput a) :=
+          hf_eval a
+        _ = ratPolyEval fPosParam (mkRatPolyInput4 x' y' z' w') := by rw [hinput]
+        _ = (x : ℚ) := hf
+    · calc
+        ratPolyEval g16Param a = ratPolyEval gPosParam (lift16ToPosInput a) :=
+          hg_eval a
+        _ = ratPolyEval gPosParam (mkRatPolyInput4 x' y' z' w') := by rw [hinput]
+        _ = (y : ℚ) := hg
+    · calc
+        ratPolyEval h16Param a = ratPolyEval hPosParam (lift16ToPosInput a) :=
+          hh_eval a
+        _ = ratPolyEval hPosParam (mkRatPolyInput4 x' y' z' w') := by rw [hinput]
+        _ = (z : ℚ) := hh
+  · rintro ⟨a, hf, hg, hh⟩
+    let x' : ℤ := a (0 : Fin 16) ^ 2 + a (1 : Fin 16) ^ 2 + a (2 : Fin 16) ^ 2 +
+      a (3 : Fin 16) ^ 2 + 1
+    let y' : ℤ := a (4 : Fin 16) ^ 2 + a (5 : Fin 16) ^ 2 + a (6 : Fin 16) ^ 2 +
+      a (7 : Fin 16) ^ 2 + 1
+    let z' : ℤ := a (8 : Fin 16) ^ 2 + a (9 : Fin 16) ^ 2 + a (10 : Fin 16) ^ 2 +
+      a (11 : Fin 16) ^ 2 + 1
+    let w' : ℤ := a (12 : Fin 16) ^ 2 + a (13 : Fin 16) ^ 2 + a (14 : Fin 16) ^ 2 +
+      a (15 : Fin 16) ^ 2
+    have hxpos : 0 < x' := by
+      dsimp [x']
+      nlinarith [sq_nonneg (a (0 : Fin 16)), sq_nonneg (a (1 : Fin 16)),
+        sq_nonneg (a (2 : Fin 16)), sq_nonneg (a (3 : Fin 16))]
+    have hypos : 0 < y' := by
+      dsimp [y']
+      nlinarith [sq_nonneg (a (4 : Fin 16)), sq_nonneg (a (5 : Fin 16)),
+        sq_nonneg (a (6 : Fin 16)), sq_nonneg (a (7 : Fin 16))]
+    have hzpos : 0 < z' := by
+      dsimp [z']
+      nlinarith [sq_nonneg (a (8 : Fin 16)), sq_nonneg (a (9 : Fin 16)),
+        sq_nonneg (a (10 : Fin 16)), sq_nonneg (a (11 : Fin 16))]
+    have hwnonneg : 0 ≤ w' := by
+      dsimp [w']
+      nlinarith [sq_nonneg (a (12 : Fin 16)), sq_nonneg (a (13 : Fin 16)),
+        sq_nonneg (a (14 : Fin 16)), sq_nonneg (a (15 : Fin 16))]
+    have hinput : lift16ToPosInput a = mkRatPolyInput4 x' y' z' w' := by
+      funext i
+      fin_cases i <;> simp [lift16ToPosInput, mkRatPolyInput4, x', y', z', w']
+    refine ⟨x', y', z', w', hxpos, hypos, hzpos, hwnonneg, ?_, ?_, ?_⟩
+    · calc
+        ratPolyEval fPosParam (mkRatPolyInput4 x' y' z' w') =
+            ratPolyEval fPosParam (lift16ToPosInput a) := by rw [hinput]
+        _ = ratPolyEval f16Param a := (hf_eval a).symm
+        _ = (x : ℚ) := hf
+    · calc
+        ratPolyEval gPosParam (mkRatPolyInput4 x' y' z' w') =
+            ratPolyEval gPosParam (lift16ToPosInput a) := by rw [hinput]
+        _ = ratPolyEval g16Param a := (hg_eval a).symm
+        _ = (y : ℚ) := hg
+    · calc
+        ratPolyEval hPosParam (mkRatPolyInput4 x' y' z' w') =
+            ratPolyEval hPosParam (lift16ToPosInput a) := by rw [hinput]
+        _ = ratPolyEval h16Param a := (hh_eval a).symm
+        _ = (z : ℚ) := hh
+
+end LeanPool.PythagoreanPolynomialParametrization

--- a/LeanPool/PythagoreanPolynomialParametrization/SourceLemmas.lean
+++ b/LeanPool/PythagoreanPolynomialParametrization/SourceLemmas.lean
@@ -1,0 +1,298 @@
+/-
+Copyright (c) 2026 Lazar Milikic. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Lazar Milikic
+-/
+
+import LeanPool.PythagoreanPolynomialParametrization.Basic
+
+/-! # Source-level handoff lemmas
+
+These declarations mirror the intermediate claims used in the paper's proofs. They are
+kept separate from the explicit polynomial witnesses so each proof obligation has a
+small, source-located target.
+-/
+
+namespace LeanPool.PythagoreanPolynomialParametrization
+
+
+
+/-- The rational map
+T(a,b,c) = (c(a²-b²)/2, cab, c(a²+b²)/2)
+used in the proof of the main parametrization theorem. -/
+def TMap (a b c : ℤ) : ℚ × ℚ × ℚ :=
+  ((c : ℚ) * ((a : ℚ) ^ 2 - (b : ℚ) ^ 2) / 2,
+    (c : ℚ) * (a : ℚ) * (b : ℚ),
+    (c : ℚ) * ((a : ℚ) ^ 2 + (b : ℚ) ^ 2) / 2)
+
+/-- A value of `TMap` is integral when all three rational coordinates are integers. -/
+def IsIntegralTValue (a b c : ℤ) : Prop :=
+  ∃ x y z : ℤ, TMap a b c = ((x : ℚ), (y : ℚ), (z : ℚ))
+
+/-- The paper's parity condition for `T(a,b,c)` to have integer coordinates:
+`c` is even or `a` and `b` have the same parity. -/
+def PaperParityCondition (a b c : ℤ) : Prop :=
+  Even c ∨ Even (a - b)
+
+/-- Positive parameters for the paper's positive-triple variant of `T(a,b,c)`. -/
+def PositiveTParameters (a b c : ℤ) : Prop :=
+  0 < a ∧ 0 < b ∧ 0 < c ∧ b < a ∧ PaperParityCondition a b c
+
+/-- The introductory source claim: every Pythagorean triple is covered by one of two
+integer-coefficient polynomial families, and every value of those families is a
+Pythagorean triple. -/
+theorem pythagoreanTriple_two_integer_polynomial_families (x y z : ℤ) :
+    IsPythagoreanTriple x y z ↔
+      ∃ a b c : ℤ,
+        (x = c * (a ^ 2 - b ^ 2) ∧
+          y = (2 : ℤ) * c * a * b ∧
+          z = c * (a ^ 2 + b ^ 2)) ∨
+        (x = (2 : ℤ) * c * a * b ∧
+          y = c * (a ^ 2 - b ^ 2) ∧
+          z = c * (a ^ 2 + b ^ 2)) := by
+  constructor
+  · intro h
+    have hp : PythagoreanTriple x y z := by
+      simpa [IsPythagoreanTriple, PythagoreanTriple, pow_two] using h
+    rcases (PythagoreanTriple.classification (x := x) (y := y) (z := z)).mp hp with
+      ⟨k, m, n, hxy, hz⟩
+    rcases hxy with hxy | hxy
+    · rcases hxy with ⟨hx, hy⟩
+      rcases hz with hz | hz
+      · refine ⟨m, n, k, Or.inl ⟨?_, ?_, ?_⟩⟩
+        · simpa using hx
+        · rw [hy]
+          ring
+        · simpa using hz
+      · refine ⟨-n, m, -k, Or.inl ⟨?_, ?_, ?_⟩⟩
+        · rw [hx]
+          ring
+        · rw [hy]
+          ring
+        · rw [hz]
+          ring
+    · rcases hxy with ⟨hx, hy⟩
+      rcases hz with hz | hz
+      · refine ⟨m, n, k, Or.inr ⟨?_, ?_, ?_⟩⟩
+        · rw [hx]
+          ring
+        · simpa using hy
+        · simpa using hz
+      · refine ⟨-n, m, -k, Or.inr ⟨?_, ?_, ?_⟩⟩
+        · rw [hx]
+          ring
+        · rw [hy]
+          ring
+        · rw [hz]
+          ring
+  · rintro ⟨a, b, c, (⟨rfl, rfl, rfl⟩ | ⟨rfl, rfl, rfl⟩)⟩
+    · simp [IsPythagoreanTriple]
+      ring
+    · simp [IsPythagoreanTriple]
+      ring
+
+/-- Source proof handoff lemma: the set of Pythagorean triples is exactly the set of
+integer triples in the range of `TMap`. -/
+theorem pythagorean_iff_mem_TMap_range (x y z : ℤ) :
+    IsPythagoreanTriple x y z ↔
+      ∃ a b c : ℤ, TMap a b c = ((x : ℚ), (y : ℚ), (z : ℚ)) := by
+  constructor
+  · intro h
+    rcases (pythagoreanTriple_two_integer_polynomial_families x y z).mp h with
+      ⟨a, b, c, hfam⟩
+    rcases hfam with hfam | hfam
+    · rcases hfam with ⟨hx, hy, hz⟩
+      refine ⟨a, b, (2 : ℤ) * c, ?_⟩
+      ext <;> simp [TMap, hx, hy, hz] <;> ring
+    · rcases hfam with ⟨hx, hy, hz⟩
+      refine ⟨a + b, a - b, c, ?_⟩
+      ext <;> simp [TMap, hx, hy, hz] <;> ring
+  · rintro ⟨a, b, c, hT⟩
+    dsimp [IsPythagoreanTriple]
+    have hq : ((x : ℚ) ^ 2 + (y : ℚ) ^ 2 = (z : ℚ) ^ 2) := by
+      have hpy : (TMap a b c).1 ^ 2 + (TMap a b c).2.1 ^ 2 = (TMap a b c).2.2 ^ 2 := by
+        simp [TMap]
+        ring
+      simpa [hT] using hpy
+    exact_mod_cast hq
+
+private lemma rat_half_int_iff_even (n : ℤ) :
+    (∃ k : ℤ, ((n : ℚ) / 2 = (k : ℚ))) ↔ Even n := by
+  constructor
+  · rintro ⟨k, hk⟩
+    have hmul : (n : ℚ) = (2 : ℚ) * k := by
+      nlinarith
+    have hInt : n = 2 * k := by
+      exact_mod_cast hmul
+    simp [hInt]
+  · intro hn
+    rcases hn with ⟨k, hk⟩
+    refine ⟨k, ?_⟩
+    rw [hk]
+    norm_num
+
+private lemma even_sq_iff_even_int (n : ℤ) : Even (n ^ 2) ↔ Even n := by
+  simpa [pow_two] using (Int.even_mul (m := n) (n := n))
+
+private lemma even_sq_sub_sq_iff_even_sub (a b : ℤ) :
+    Even (a ^ 2 - b ^ 2) ↔ Even (a - b) := by
+  simp [Int.even_sub, even_sq_iff_even_int]
+
+private lemma even_sq_add_sq_of_even_sub {a b : ℤ} (h : Even (a - b)) :
+    Even (a ^ 2 + b ^ 2) := by
+  have hab : Even a ↔ Even b := (Int.even_sub.mp h)
+  exact Int.even_add.mpr (by simpa [even_sq_iff_even_int] using hab)
+
+/-- Source proof handoff lemma: `T(a,b,c)` has integer coordinates iff the paper's
+parity condition holds. -/
+theorem TMap_integral_iff_parity (a b c : ℤ) :
+    IsIntegralTValue a b c ↔ PaperParityCondition a b c := by
+  constructor
+  · rintro ⟨x, y, z, hT⟩
+    have hxq : (c : ℚ) * ((a : ℚ) ^ 2 - (b : ℚ) ^ 2) / 2 = (x : ℚ) := by
+      simpa [TMap] using congrArg Prod.fst hT
+    have hprod : Even (c * (a ^ 2 - b ^ 2)) := by
+      exact (rat_half_int_iff_even (c * (a ^ 2 - b ^ 2))).mp ⟨x, by
+        simpa [pow_two] using hxq⟩
+    rcases (Int.even_mul.mp hprod) with hc | hsq
+    · exact Or.inl hc
+    · exact Or.inr ((even_sq_sub_sq_iff_even_sub a b).mp hsq)
+  · intro hpar
+    have hdiff : Even (c * (a ^ 2 - b ^ 2)) := by
+      rcases hpar with hc | hab
+      · exact Int.even_mul.mpr (Or.inl hc)
+      · exact Int.even_mul.mpr (Or.inr ((even_sq_sub_sq_iff_even_sub a b).mpr hab))
+    have hsum : Even (c * (a ^ 2 + b ^ 2)) := by
+      rcases hpar with hc | hab
+      · exact Int.even_mul.mpr (Or.inl hc)
+      · exact Int.even_mul.mpr (Or.inr (even_sq_add_sq_of_even_sub hab))
+    rcases (rat_half_int_iff_even (c * (a ^ 2 - b ^ 2))).mpr hdiff with ⟨x, hx⟩
+    rcases (rat_half_int_iff_even (c * (a ^ 2 + b ^ 2))).mpr hsum with ⟨z, hz⟩
+    refine ⟨x, c * a * b, z, ?_⟩
+    ext
+    · simpa [TMap, pow_two] using hx
+    · simp [TMap]
+    · simpa [TMap, pow_two] using hz
+
+/-- Source proof handoff lemma: the parity condition is parametrized by
+`(y + zw, z - yw, 2x - xw)`. -/
+theorem parity_condition_parametrized (a b c : ℤ) :
+    PaperParityCondition a b c ↔
+      ∃ x y z w : ℤ,
+        a = y + z * w ∧
+        b = z - y * w ∧
+        c = (2 : ℤ) * x - x * w := by
+  constructor
+  · intro h
+    rcases h with hc | hab
+    · rcases hc with ⟨x, hx⟩
+      refine ⟨x, a, b, 0, ?_, ?_, ?_⟩
+      · ring
+      · ring
+      · rw [hx]
+        ring
+    · rcases hab with ⟨t, ht⟩
+      refine ⟨c, t, b + t, 1, ?_, ?_, ?_⟩
+      · nlinarith
+      · ring
+      · ring
+  · rintro ⟨x, y, z, w, ha, hb, hc⟩
+    rcases Int.even_or_odd w with hw | hw
+    · left
+      rw [hc]
+      have h2mw : Even ((2 : ℤ) - w) := by
+        exact Int.even_sub.mpr (by simp [hw])
+      have hmul : Even (x * ((2 : ℤ) - w)) := Int.even_mul.mpr (Or.inr h2mw)
+      convert hmul using 1
+      ring
+    · right
+      rcases hw with ⟨k, hk⟩
+      rw [ha, hb, hk]
+      use (k + 1) * y + k * z
+      ring
+
+/-- Source proof handoff lemma for the positive remark: the restricted positive
+parameters are parametrized by `(y + (1+w)z, y, x + (1-w)^2 x)`. -/
+theorem positive_T_parameters_parametrized (a b c : ℤ) :
+    PositiveTParameters a b c ↔
+      ∃ x y z w : ℤ,
+        0 < x ∧ 0 < y ∧ 0 < z ∧ 0 ≤ w ∧
+        a = y + ((1 : ℤ) + w) * z ∧
+        b = y ∧
+        c = x + ((1 : ℤ) - w) ^ 2 * x := by
+  constructor
+  · intro h
+    rcases h with ⟨ha, hb, hcpos, hba, hpar⟩
+    rcases hpar with hcEven | habEven
+    · rcases hcEven with ⟨x, hx⟩
+      have hxpos : 0 < x := by
+        rw [hx] at hcpos
+        nlinarith
+      refine ⟨x, b, a - b, 0, hxpos, hb, ?_, by norm_num, ?_, rfl, ?_⟩
+      · nlinarith
+      · ring
+      · rw [hx]
+        ring
+    · rcases habEven with ⟨z, hz⟩
+      have hzpos : 0 < z := by
+        have hdiffpos : 0 < a - b := by nlinarith
+        rw [hz] at hdiffpos
+        nlinarith
+      refine ⟨c, b, z, 1, hcpos, hb, hzpos, by norm_num, ?_, rfl, ?_⟩
+      · nlinarith [hz]
+      · ring
+  · rintro ⟨x, y, z, w, hxpos, hypos, hzpos, hw_nonneg, haeq, hbeq, hceq⟩
+    have hw1pos : 0 < (1 : ℤ) + w := by nlinarith
+    have hprodpos : 0 < ((1 : ℤ) + w) * z := mul_pos hw1pos hzpos
+    refine ⟨?_, ?_, ?_, ?_, ?_⟩
+    · rw [haeq]
+      nlinarith
+    · rw [hbeq]
+      exact hypos
+    · rw [hceq]
+      have hsq_nonneg : 0 ≤ ((1 : ℤ) - w) ^ 2 := sq_nonneg ((1 : ℤ) - w)
+      have hmul_nonneg : 0 ≤ ((1 : ℤ) - w) ^ 2 * x :=
+        mul_nonneg hsq_nonneg (le_of_lt hxpos)
+      nlinarith
+    · rw [haeq, hbeq]
+      nlinarith
+    · dsimp [PaperParityCondition]
+      rcases Int.even_or_odd w with hw | hw
+      · left
+        rcases hw with ⟨k, hk⟩
+        rw [hceq, hk]
+        use x * (1 - 2 * k + 2 * k ^ 2)
+        ring
+      · right
+        rcases hw with ⟨k, hk⟩
+        rw [haeq, hbeq, hk]
+        use (k + 1) * z
+        ring
+
+/-- Lagrange four-square handoff: every nonnegative integer is a sum of four squares. -/
+theorem int_nonneg_iff_four_squares (n : ℤ) :
+    0 ≤ n ↔ ∃ a b c d : ℤ, n = a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2 := by
+  constructor
+  · intro hn
+    rcases Nat.sum_four_squares n.toNat with ⟨a, b, c, d, hsum⟩
+    refine ⟨a, b, c, d, ?_⟩
+    have hn' : (n.toNat : ℤ) = n := Int.toNat_of_nonneg hn
+    rw [← hn']
+    exact_mod_cast hsum.symm
+  · rintro ⟨a, b, c, d, rfl⟩
+    nlinarith [sq_nonneg a, sq_nonneg b, sq_nonneg c, sq_nonneg d]
+
+/-- Four-square corollary used by the 16-parameter substitution: every positive integer
+is one plus a sum of four squares. -/
+theorem int_positive_iff_four_squares_add_one (n : ℤ) :
+    0 < n ↔ ∃ a b c d : ℤ, n = a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2 + 1 := by
+  constructor
+  · intro hn
+    have hn' : 0 ≤ n - 1 := by nlinarith
+    rcases (int_nonneg_iff_four_squares (n - 1)).mp hn' with ⟨a, b, c, d, hsum⟩
+    refine ⟨a, b, c, d, ?_⟩
+    nlinarith
+  · rintro ⟨a, b, c, d, rfl⟩
+    nlinarith [sq_nonneg a, sq_nonneg b, sq_nonneg c, sq_nonneg d]
+
+end LeanPool.PythagoreanPolynomialParametrization

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -1,4 +1,43 @@
 projects:
+  - slug: pythagorean-polynomial-parametrization
+    title: Polynomial parametrizations of Pythagorean triples
+    summary: Formalizes Frisch and Vaserstein's result that Pythagorean triples are not parametrizable by one triple of integer-coefficient polynomials in any number of variables, but are parametrizable by a single triple of integer-valued rational polynomials, including the positive and sixteen-parameter variants.
+    branch: number theory
+    entry_module: LeanPool.PythagoreanPolynomialParametrization
+    authors:
+      - Lazar Milikic
+    source:
+      title: Parametrization of Pythagorean triples by a single triple of polynomials
+      authors:
+        - Sophie Frisch
+        - Leonid Vaserstein
+      arxiv: "0706.0290"
+      doi: "10.1016/j.jpaa.2007.05.019"
+      github_repo: epfl-lara/AutoformalizedProjects
+    status: verified
+    main_declarations:
+      - LeanPool.PythagoreanPolynomialParametrization.exists_int_valued_parametrization
+    main_results:
+      - declaration: LeanPool.PythagoreanPolynomialParametrization.no_int_poly_parametrization
+        informal: Proves that no single triple of integer-coefficient polynomials in any number of variables parametrizes all Pythagorean triples.
+      - declaration: LeanPool.PythagoreanPolynomialParametrization.exists_int_valued_parametrization
+        informal: Gives the explicit four-variable integer-valued polynomial parametrization of all Pythagorean triples.
+      - declaration: LeanPool.PythagoreanPolynomialParametrization.positive_triples_parametrization
+        informal: Formalizes the positive Pythagorean-triple parametrization with positive parameters and a nonnegative auxiliary parameter.
+      - declaration: LeanPool.PythagoreanPolynomialParametrization.exists_16_param_parametrization
+        informal: Converts the positive parametrization to an unrestricted sixteen-integer-parameter parametrization using the four-square theorem.
+      - declaration: LeanPool.PythagoreanPolynomialParametrization.single_intValued_parametrization_yields_finite_intPoly_parametrization
+        informal: Proves the cited reduction from one integer-valued polynomial tuple to finitely many integer-coefficient polynomial tuples.
+      - declaration: LeanPool.PythagoreanPolynomialParametrization.integerValued_polynomial_ring_not_uniqueFactorization
+        informal: Records the integer-valued polynomial ring non-UFD phenomenon behind the paper's motivating discussion.
+    tags:
+      - number-theory
+      - pythagorean-triples
+      - integer-valued-polynomials
+    msc:
+      - "11D09"
+      - "11D85"
+      - "13F20"
   - slug: demazureoperatorslean
     title: Demazure Operators and Lean
     summary: Formalizes Demazure operators on multivariate polynomials and their nilpotence, braid, commutation, and symmetric-polynomial linearity relations, with auxiliary Coxeter-theory support including strong exchange and a conditional Matsumoto theorem.


### PR DESCRIPTION
## Summary

This adds a new Lean Pool project formalizing Frisch and Vaserstein's parametrization results for Pythagorean triples by polynomial tuples.

The project includes:

- the obstruction showing no single tuple of integer-coefficient polynomials parametrizes all Pythagorean triples;
- the explicit four-variable integer-valued rational-polynomial parametrization of all Pythagorean triples;
- the positive-triple parametrization and the unrestricted sixteen-integer-parameter variant using the four-square theorem;
- explanatory source lemmas around the finite integer-polynomial reduction and the integer-valued-polynomial non-UFD phenomenon.

Source paper: Sophie Frisch and Leonid Vaserstein, [Parametrization of Pythagorean triples by a single triple of polynomials](https://arxiv.org/abs/0706.0290), also available via [DOI:10.1016/j.jpaa.2007.05.019](https://doi.org/10.1016/j.jpaa.2007.05.019).

## Lean Pool prep

- Vendored the files under `LeanPool/PythagoreanPolynomialParametrization/` with Lean Pool headers and namespace.
- Replaced broad imports with explicit Mathlib imports.
- Registered the project in `LeanPool/projects.yml` and regenerated/checked `LeanPool.lean`.
- Split one long proof with a private helper lemma to satisfy the proof-size quality gate.
- Renamed helper definitions to satisfy `defsWithUnderscore`.
- Trimmed proof-sketch/prover-note comments into concise project docstrings.

## Validation

- `lake build LeanPool.PythagoreanPolynomialParametrization`
- `lake exe mk_all --check`
- `lake build LeanPool`
- `lake exe runLinter LeanPool`
- `lake exe lint-style LeanPool`
- `uv run python -m lean_pool.quality --repo ..` from `python/`
- `git diff --cached --check`
