### PR TITLE
[import] critical-portraits — counting degree-d critical portraits

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -381,6 +381,15 @@ import LeanPool.ComputableReal.SpecialFunctions.Basic
 import LeanPool.ComputableReal.SpecialFunctions.Exp
 import LeanPool.ComputableReal.SpecialFunctions.Pi
 import LeanPool.ComputableReal.SpecialFunctions.Sqrt
+import LeanPool.CriticalPortraits
+import LeanPool.CriticalPortraits.Census
+import LeanPool.CriticalPortraits.Core
+import LeanPool.CriticalPortraits.CycleLemma
+import LeanPool.CriticalPortraits.Denominator
+import LeanPool.CriticalPortraits.Forward
+import LeanPool.CriticalPortraits.Injectivity
+import LeanPool.CriticalPortraits.Portraits
+import LeanPool.CriticalPortraits.Surjectivity
 import LeanPool.DeadEnds
 import LeanPool.DeadEnds.Basic
 import LeanPool.DeadEnds.CRT

--- a/LeanPool/CriticalPortraits.lean
+++ b/LeanPool/CriticalPortraits.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2026 Keston Aquino-Michaels. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Keston Aquino-Michaels
+-/
+
+import LeanPool.CriticalPortraits.CycleLemma
+import LeanPool.CriticalPortraits.Core
+import LeanPool.CriticalPortraits.Denominator
+import LeanPool.CriticalPortraits.Portraits
+import LeanPool.CriticalPortraits.Forward
+import LeanPool.CriticalPortraits.Injectivity
+import LeanPool.CriticalPortraits.Surjectivity
+import LeanPool.CriticalPortraits.Census
+
+/-!
+# Counting Critical Portraits
+
+Source: doi:10.5281/zenodo.20737896
+Authors: Keston Aquino-Michaels
+Status: verified
+Main declarations: `CriticalPortraits.card_portraits`, `CriticalPortraits.Cycle.cycle_lemma`
+Tags: combinatorics, cycle-lemma, critical-portraits, enumeration
+MSC: 05A15, 37F20
+-/
+
+/-!
+# Full all-`d` proof of `census = C(N,d−1)/d` (Mathlib)
+
+Aggregator root. Positions are `ZMod N` (`N = d*m`); `level i = i.val / m`,
+`fiber i = i.val % m`. A `(d−1)`-subset is **level-canonical** iff `#{i ∈ S : level i ≤ j} ≤ j`
+for all `j < d`.
+
+Submodules:
+* `CriticalPortraits.CycleLemma`  — the cycle lemma (Raney, sum = 1), sorry-free.
+* `CriticalPortraits.Core`        — `level` / `fiber` / `LevelCanonical` + the count **numerator**
+                              `#{(d−1)-subsets of Z_N} = C(N, d−1)`.
+* `CriticalPortraits.Denominator` — the `/d` **denominator**: the free `ZMod d` rotation +
+                              cycle-lemma bridge give `d · #{canonical} = C(N, d−1)`, hence
+                              `#{canonical} = C(N, d−1) / d`.
+* `CriticalPortraits.Portraits`   — the geometric **foundation**: `IsCriticalSet` / `Unlinked` /
+                              `Portrait` / the delete-min map `T`, with the weight identity
+                              `#T(P) = d − 1` proved.  Model is faithful to the verified census.
+-/

--- a/LeanPool/CriticalPortraits/Census.lean
+++ b/LeanPool/CriticalPortraits/Census.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 Keston Aquino-Michaels. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Keston Aquino-Michaels
+-/
+
+import LeanPool.CriticalPortraits.Surjectivity
+import LeanPool.CriticalPortraits.Injectivity
+import LeanPool.CriticalPortraits.Forward
+import LeanPool.CriticalPortraits.Denominator
+
+/-!
+# The headline census theorem: `#{portraits} = C(N, d−1) / d` for all `d`
+
+This module assembles the four proved, sorry-free ingredients into the final count.
+With positions in `ZMod N` (`N = d*m`) and the delete-min map `T`:
+
+* **Forward** (`T_levelCanonical`) + **weight** (`T_card`): `T` maps each portrait to a
+  level-canonical `(d−1)`-subset, i.e. `Set.MapsTo T {P | Portrait} {U | U.card = d−1 ∧ …}`.
+* **Injectivity** (`T_injOn`) and **Surjectivity** (`T_surjOn`) upgrade this to `Set.BijOn`.
+* `Set.BijOn.equiv` then gives an equivalence of the two subtypes, so their `Fintype.card`s
+  agree; composing with the **denominator** count `card_levelCanonical_mul` yields the result.
+-/
+
+namespace CriticalPortraits
+open Finset
+
+/-- **PRIMARY (multiplicative form).** `d · #{portraits} = C(d*m, d-1)`.
+
+The cleanest statement: the count of portraits times `d` equals the binomial numerator.
+Proved by the `T`-bijection onto level-canonical `(d−1)`-subsets composed with
+`card_levelCanonical_mul`. -/
+theorem card_portraits_mul {d m : ℕ} (hd : 0 < d) (hm : 0 < m) :
+    d * Fintype.card {P : Finset (Finset (ZMod (d*m))) // Portrait d m P}
+      = (d*m).choose (d-1) := by
+  -- `T` is a bijection from portraits onto level-canonical `(d−1)`-subsets.
+  have hbij : Set.BijOn (T (N := d*m)) {P | Portrait d m P}
+      {U | U.card = d - 1 ∧ LevelCanonical d m U} :=
+    ⟨fun P hP => ⟨T_card hP, T_levelCanonical hd hm hP⟩,
+     T_injOn hd hm, T_surjOn hd hm⟩
+  -- The induced equivalence of subtypes equates their cardinalities.
+  have hcard : Fintype.card {P : Finset (Finset (ZMod (d*m))) // Portrait d m P}
+      = Fintype.card {U : Finset (ZMod (d*m)) // U.card = d - 1 ∧ LevelCanonical d m U} :=
+    Fintype.card_congr hbij.equiv
+  rw [hcard]
+  exact card_levelCanonical_mul d m hd hm
+
+/-- **HEADLINE CENSUS THEOREM.** `#{portraits} = C(d*m, d-1) / d` for all `d` (and all `m`).
+
+The number of degree-`d` portraits at level `m` equals `C(d·m, d−1) / d`. Follows from the
+multiplicative form by `Nat.div_eq_of_eq_mul_right` (exact `ℕ`-division, no remainder). -/
+theorem card_portraits {d m : ℕ} (hd : 0 < d) (hm : 0 < m) :
+    Fintype.card {P : Finset (Finset (ZMod (d*m))) // Portrait d m P}
+      = (d*m).choose (d-1) / d :=
+  (Nat.div_eq_of_eq_mul_right hd (card_portraits_mul hd hm).symm).symm
+
+/-- **Exactness of the `/ d`.** The denominator divides the numerator: `d ∣ C(d*m, d-1)`. Hence the
+`/ d` in `card_portraits` is *exact* `ℕ`-division (the count is a genuine integer), not floor
+rounding — the witness is the portrait count itself, read off `card_portraits_mul`. -/
+theorem d_dvd_choose {d m : ℕ} (hd : 0 < d) (hm : 0 < m) :
+    d ∣ (d * m).choose (d - 1) :=
+  ⟨_, (card_portraits_mul hd hm).symm⟩
+
+end CriticalPortraits

--- a/LeanPool/CriticalPortraits/Core.lean
+++ b/LeanPool/CriticalPortraits/Core.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 Keston Aquino-Michaels. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Keston Aquino-Michaels
+-/
+
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Data.Finset.Max
+import Mathlib.Data.Fintype.Powerset
+import Mathlib.Data.Fintype.BigOperators
+import Mathlib.Data.Fintype.EquivFin
+import Mathlib.Data.Nat.Choose.Basic
+import Mathlib.Algebra.BigOperators.Intervals
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Algebra.Group.PUnit
+import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.NormNum
+import LeanPool.CriticalPortraits.CycleLemma  -- the cycle lemma (Raney, sum=1), PROVED sorry-free
+
+/-!
+# Core definitions + the count numerator (Mathlib)
+
+Positions are `ZMod N` (`N = d*m`); `level i = i.val / m`, `fiber i = i.val % m`. A `(d−1)`-subset
+is **level-canonical** iff `#{i ∈ S : level i ≤ j} ≤ j` for all `j < d`.
+
+Proved here (sorry-free): the count **numerator** `#{(d−1)-subsets of Z_N} = C(N, d−1)`, via
+Mathlib's `Fintype.card_finset_len` + `ZMod.card`.
+-/
+
+namespace CriticalPortraits
+
+open Finset
+
+/-- The `k`-subsets of `Z_N` number `C(N, k)` (the count numerator). -/
+theorem card_kSubsets (N k : ℕ) [NeZero N] :
+    Fintype.card {S : Finset (ZMod N) // S.card = k} = N.choose k := by
+  rw [Fintype.card_finset_len, ZMod.card]
+
+/-- `level i = ⌊i / m⌋` for a position `i ∈ Z_N` (intended `N = d*m`). -/
+def level {N : ℕ} (m : ℕ) (i : ZMod N) : ℕ := i.val / m
+
+/-- `fiber i = i mod m`. -/
+def fiber {N : ℕ} (m : ℕ) (i : ZMod N) : ℕ := i.val % m
+
+/-- `S ⊆ Z_{d*m}` is **level-canonical** iff `#{i ∈ S : level i ≤ j} ≤ j` for every `j < d`. -/
+def LevelCanonical (d m : ℕ) (S : Finset (ZMod (d * m))) : Prop :=
+  ∀ j < d, (S.filter (fun i => i.val / m ≤ j)).card ≤ j
+
+instance (d m : ℕ) (S : Finset (ZMod (d * m))) : Decidable (LevelCanonical d m S) := by
+  unfold LevelCanonical; infer_instance
+
+end CriticalPortraits

--- a/LeanPool/CriticalPortraits/CycleLemma.lean
+++ b/LeanPool/CriticalPortraits/CycleLemma.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2026 Keston Aquino-Michaels. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Keston Aquino-Michaels
+-/
+
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Data.Finset.Max
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.Ring
+
+/-!
+# The cycle lemma (Raney / Dvoretzky–Motzkin), sum = 1 case — PROVED
+
+Sorry-free, kernel-axiom-clean (`propext, Classical.choice, Quot.sound`).
+
+Raney's lemma: any integers summing to `1` have **exactly one** cyclic shift with all partial
+sums positive. We formalize it on a period-`n` sequence `a : ℕ → ℤ` with period-sum `1`, via the
+partial sums `Q k = ∑_{j<k} a j` (so `Q (k+n) = Q k + 1`). A shift `i` is *good* iff
+`Q i < Q t` for all `t ∈ (i, i+n)`; the unique good `i ∈ [0,n)` is the **last** argmin of `Q`
+over `[0,n)`. The count `#level-canonical = C(N,d-1)/d` will follow (`a_k = 1 - (level counts)`).
+-/
+
+namespace CriticalPortraits.Cycle
+
+variable {n : ℕ}
+
+/-- Partial sums of `a`. -/
+def Q (a : ℕ → ℤ) (k : ℕ) : ℤ := ∑ j ∈ Finset.range k, a j
+
+lemma Q_zero (a : ℕ → ℤ) : Q a 0 = 0 := by simp [Q]
+
+lemma Q_succ (a : ℕ → ℤ) (k : ℕ) : Q a (k + 1) = Q a k + a k := by
+  simp [Q, Finset.sum_range_succ]
+
+/-- A window of length `n` of a period-`n` sequence sums to the period sum. -/
+lemma window_sum (a : ℕ → ℤ) (hper : ∀ k, a (k + n) = a k)
+    (k : ℕ) : Q a (k + n) - Q a k = Q a n - Q a 0 := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    have e1 : Q a (k + 1 + n) = Q a (k + n) + a (k + n) := by
+      have : k + 1 + n = (k + n) + 1 := by ring
+      rw [this, Q_succ]
+    rw [e1, Q_succ a k, hper k]
+    linarith [ih]
+
+/-- Periodicity of the partial sums: `Q (k+n) = Q k + (period sum)`. -/
+lemma Q_periodic (a : ℕ → ℤ) (hper : ∀ k, a (k + n) = a k) (hsum : Q a n = 1)
+    (k : ℕ) : Q a (k + n) = Q a k + 1 := by
+  have := window_sum a hper k
+  rw [Q_zero] at this
+  linarith [this, hsum]
+
+/-- Shift `i` is *good*: every partial sum of the shifted sequence is positive, i.e.
+    `Q i` is a strict minimum of `Q` over the half-open window `(i, i+n)`. -/
+def Good (n : ℕ) (a : ℕ → ℤ) (i : ℕ) : Prop := ∀ t, i < t → t < i + n → Q a i < Q a t
+
+/-- **The cycle lemma (Raney), sum = 1.** For a period-`n` integer sequence with period-sum `1`,
+    exactly one shift `i ∈ [0,n)` is good. The witness is the *last* argmin of `Q` over `[0,n)`. -/
+theorem cycle_lemma (a : ℕ → ℤ) (hn : 0 < n) (hper : ∀ k, a (k + n) = a k)
+    (hsum : Q a n = 1) : ∃! i, i < n ∧ Good n a i := by
+  classical
+  have hne : (Finset.range n).Nonempty := Finset.nonempty_range_iff.mpr hn.ne'
+  obtain ⟨i0, hi0r, hi0min⟩ := Finset.exists_min_image (Finset.range n) (Q a) hne
+  -- the last argmin (max index among minimizers)
+  set S := (Finset.range n).filter (fun i => Q a i = Q a i0) with hSdef
+  have hSne : S.Nonempty := ⟨i0, Finset.mem_filter.mpr ⟨hi0r, rfl⟩⟩
+  set istar := S.max' hSne with hist
+  have histS : istar ∈ S := Finset.max'_mem _ _
+  have histrange : istar < n := Finset.mem_range.mp (Finset.filter_subset _ _ histS)
+  have histeq : Q a istar = Q a i0 := (Finset.mem_filter.mp histS).2
+  have hMle : ∀ t, t < n → Q a istar ≤ Q a t := by
+    intro t ht; rw [histeq]; exact hi0min t (Finset.mem_range.mpr ht)
+  -- existence: istar is good
+  have hGoodStar : Good n a istar := by
+    intro t hlt hlt2
+    rcases lt_or_ge t n with htn | htn
+    · have hle : Q a istar ≤ Q a t := hMle t htn
+      rcases eq_or_lt_of_le hle with heq | hlt3
+      · exfalso
+        have hQt : Q a t = Q a i0 := by rw [← heq]; exact histeq
+        have htS : t ∈ S := Finset.mem_filter.mpr ⟨Finset.mem_range.mpr htn, hQt⟩
+        have : t ≤ istar := Finset.le_max' _ _ htS
+        omega
+      · exact hlt3
+    · have hsub : t - n + n = t := Nat.sub_add_cancel htn
+      have hper' := Q_periodic a hper hsum (t - n)
+      rw [hsub] at hper'
+      have hle : Q a istar ≤ Q a (t - n) := hMle (t - n) (by omega)
+      rw [hper']; omega
+  -- uniqueness
+  refine ⟨istar, ⟨histrange, hGoodStar⟩, ?_⟩
+  rintro y ⟨hyn, hyGood⟩
+  rcases lt_trichotomy y istar with h | h | h
+  · have h1 : Q a y < Q a istar := hyGood istar (by omega) (by omega)
+    have h2 : Q a istar < Q a (y + n) := hGoodStar (y + n) (by omega) (by omega)
+    rw [Q_periodic a hper hsum y] at h2; omega
+  · exact h
+  · have h1 : Q a istar < Q a y := hGoodStar y (by omega) (by omega)
+    have h2 : Q a y < Q a (istar + n) := hyGood (istar + n) (by omega) (by omega)
+    rw [Q_periodic a hper hsum istar] at h2; omega
+
+end CriticalPortraits.Cycle

--- a/LeanPool/CriticalPortraits/Denominator.lean
+++ b/LeanPool/CriticalPortraits/Denominator.lean
@@ -1,0 +1,663 @@
+/-
+Copyright (c) 2026 Keston Aquino-Michaels. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Keston Aquino-Michaels
+-/
+
+import LeanPool.CriticalPortraits.Core
+
+/-!
+# The `/d` denominator: `#level-canonical = C(N, d-1)/d` (all d), Mathlib, sorry-free.
+
+PRIMARY (multiplicative form):
+  `d * #{S // S.card = d-1 ∧ LevelCanonical d m S} = (d*m).choose (d-1)`
+COROLLARY (division form), one-liner from the above.
+
+Route: rotation `rhoPow t` (translate by `+(t*m)`), the per-level count vector `cnt`,
+the cycle-lemma bridge (`∃!` canonical rotation index per `(d-1)`-subset), assembled into a
+bijection `{(d-1)-subsets} ≃ {canonical} × Fin d` (uniqueness of the canonical index supplies
+freeness for free), giving `card = #canonical * d`.
+-/
+
+namespace CriticalPortraits
+
+open Finset
+open scoped BigOperators
+
+/-! ## Part 0: a Fintype instance for the target subtype (all `d, m`).
+
+The TARGET statement uses `Fintype.card {S : Finset (ZMod (d*m)) // …}` with no `[NeZero (d*m)]`
+binder, so we must provide the `Fintype` instance unconditionally. When `d*m ≠ 0` it comes from
+`NeZero`; in the degenerate case `d*m = 0` the predicate forces every `S = ∅` (a singleton),
+so the subtype is still finite. -/
+
+instance instFiniteCanonical (d m : ℕ) :
+    Finite {S : Finset (ZMod (d * m)) // S.card = d - 1 ∧ LevelCanonical d m S} := by
+  rcases Nat.eq_zero_or_pos (d * m) with h0 | hpos
+  · have hsub : ∀ S : {S : Finset (ZMod (d * m)) // S.card = d - 1 ∧ LevelCanonical d m S},
+        S.1 = ∅ := by
+      rintro ⟨S, hcard, hLC⟩
+      simp only
+      apply Finset.card_eq_zero.mp
+      rcases Nat.eq_zero_or_pos d with hd0 | hdpos
+      · have hd1 : d - 1 = 0 := by omega
+        rw [hd1] at hcard; exact hcard
+      · have hm0 : m = 0 := by
+          rcases Nat.eq_zero_or_pos m with h | h
+          · exact h
+          · exfalso; have : 0 < d * m := Nat.mul_pos hdpos h; omega
+        have hLC0 := hLC 0 hdpos
+        have hfilter : (S.filter (fun i => i.val / m ≤ 0)) = S := by
+          apply Finset.filter_true_of_mem
+          intro i _
+          have hdiv : i.val / m = 0 := (congrArg (i.val / ·) hm0).trans (Nat.div_zero i.val)
+          rw [hdiv]
+        rw [hfilter] at hLC0
+        exact Nat.le_zero.mp hLC0
+    exact Finite.of_injective (fun _ => (0 : Unit)) (by
+      intro a b _; exact Subtype.ext ((hsub a).trans (hsub b).symm))
+  · haveI : NeZero (d * m) := ⟨hpos.ne'⟩
+    infer_instance
+
+noncomputable instance instFintypeCanonical (d m : ℕ) :
+    Fintype {S : Finset (ZMod (d * m)) // S.card = d - 1 ∧ LevelCanonical d m S} :=
+  Fintype.ofFinite _
+
+/-! ## Part 1: level arithmetic. -/
+
+/-- Every level is `< d` (when `N = d*m`, `m > 0`). -/
+lemma level_lt {d m : ℕ} (hd : 0 < d) (hm : 0 < m) (i : ZMod (d * m)) :
+    i.val / m < d := by
+  haveI : NeZero (d * m) := ⟨by positivity⟩
+  have hi : i.val < d * m := ZMod.val_lt i
+  have hi' : i.val < m * d := by rw [Nat.mul_comm m d]; exact hi
+  exact Nat.div_lt_of_lt_mul hi'
+
+/-- The shift element `t*m` reduces to `(t%d)*m` in `ZMod (d*m)`. -/
+lemma shift_cast {d m : ℕ} (t : ℕ) :
+    ((t * m : ℕ) : ZMod (d * m)) = (((t % d) * m : ℕ) : ZMod (d * m)) := by
+  rw [ZMod.natCast_eq_natCast_iff, Nat.ModEq]
+  rw [Nat.mul_mod_mul_right m t d, Nat.mul_mod_mul_right m (t % d) d, Nat.mod_mod_of_dvd t dvd_rfl]
+
+/-- `(t%d)*m < d*m`, so its `val` is itself. -/
+lemma shift_val_lt {d m : ℕ} (hd : 0 < d) (hm : 0 < m) (t : ℕ) :
+    (t % d) * m < d * m := by
+  have h : t % d < d := Nat.mod_lt _ hd
+  exact (Nat.mul_lt_mul_right hm).mpr h
+
+/-- The fundamental level-shift identity: translating by `+(t*m)` adds `t` to the level
+    cyclically. -/
+lemma level_add {d m : ℕ} (hd : 0 < d) (hm : 0 < m) (t : ℕ) (i : ZMod (d * m)) :
+    (i + ((t * m : ℕ) : ZMod (d * m))).val / m = (i.val / m + t % d) % d := by
+  haveI : NeZero (d * m) := ⟨by positivity⟩
+  set t' := t % d with ht'
+  have ht'd : t' < d := Nat.mod_lt _ hd
+  have hcval : (((t * m : ℕ) : ZMod (d * m))).val = t' * m := by
+    rw [shift_cast t, ZMod.val_natCast, Nat.mod_eq_of_lt (shift_val_lt hd hm t)]
+  have hsum : (i + ((t * m : ℕ) : ZMod (d * m))).val = (i.val + t' * m) % (d * m) := by
+    rw [ZMod.val_add, hcval]
+  rw [hsum]
+  set q := i.val / m with hq
+  set r := i.val % m with hr
+  have hival : i.val = q * m + r := by
+    rw [hq, hr]; exact (Nat.div_add_mod' i.val m).symm
+  have hrm : r < m := Nat.mod_lt _ hm
+  have hqd : q < d := level_lt hd hm i
+  have hrewrite : i.val + t' * m = (q + t') * m + r := by rw [hival]; ring
+  rw [hrewrite]
+  set a := q + t' with ha
+  have hbound : (a % d) * m + r < d * m := by
+    have : a % d < d := Nat.mod_lt _ hd
+    have h2 : (a % d) * m + r < (a % d) * m + m := by omega
+    have h3 : (a % d) * m + m = (a % d + 1) * m := by ring
+    have h4 : (a % d + 1) * m ≤ d * m := by
+      apply Nat.mul_le_mul_right; omega
+    omega
+  have hmod2 : (a * m + r) % (d * m) = (a % d) * m + r := by
+    have hdecomp : a * m + r = ((a % d) * m + r) + (a / d) * (d * m) := by
+      have hh : a = (a / d) * d + a % d := (Nat.div_add_mod' a d).symm
+      calc a * m + r = ((a / d) * d + a % d) * m + r := by rw [← hh]
+        _ = ((a % d) * m + r) + (a / d) * (d * m) := by ring
+    rw [hdecomp, Nat.add_mul_mod_self_right]
+    exact Nat.mod_eq_of_lt hbound
+  rw [hmod2]
+  rw [Nat.add_comm ((a % d) * m) r, Nat.add_mul_div_right r (a % d) hm,
+      Nat.div_eq_of_lt hrm, Nat.zero_add]
+
+/-! ## Part 2: counts and prefix sums. -/
+
+/-- Number of elements of `S` at level exactly `j`. -/
+def cnt {d m : ℕ} (S : Finset (ZMod (d * m))) (j : ℕ) : ℕ :=
+  (S.filter (fun i => i.val / m = j)).card
+
+/-- `S` is partitioned by level into `range d`: total count is `S.card`. -/
+lemma sum_cnt {d m : ℕ} (hd : 0 < d) (hm : 0 < m) (S : Finset (ZMod (d * m))) :
+    ∑ j ∈ Finset.range d, cnt S j = S.card := by
+  classical
+  unfold cnt
+  rw [← Finset.card_eq_sum_card_fiberwise
+    (f := fun i => i.val / m) (s := S) (t := Finset.range d)
+    (by intro i _; exact Finset.mem_range.mpr (level_lt hd hm i))]
+
+/-- Prefix count: `#{i ∈ S : level i ≤ j} = ∑_{l ≤ j} cnt S l`. -/
+lemma prefix_cnt {d m : ℕ} (S : Finset (ZMod (d * m))) (j : ℕ) :
+    (S.filter (fun i => i.val / m ≤ j)).card = ∑ l ∈ Finset.range (j + 1), cnt S l := by
+  classical
+  unfold cnt
+  rw [Finset.card_eq_sum_card_fiberwise
+    (f := fun i => i.val / m) (s := S.filter (fun i => i.val / m ≤ j))
+    (t := Finset.range (j + 1))
+    (by intro i hi
+        rw [Finset.mem_coe, Finset.mem_filter] at hi
+        change i.val / m ∈ Finset.range (j + 1)
+        exact Finset.mem_range.mpr (by omega))]
+  apply Finset.sum_congr rfl
+  intro l hl
+  rw [Finset.mem_range] at hl
+  congr 1
+  ext i
+  simp only [Finset.mem_filter]
+  constructor
+  · rintro ⟨⟨hiS, _⟩, hil⟩; exact ⟨hiS, hil⟩
+  · rintro ⟨hiS, hil⟩; exact ⟨⟨hiS, by omega⟩, hil⟩
+
+/-! ## Part 3: the rotation `rhoPow` and the count-shift. -/
+
+/-- Cyclic round-trip: for `a, b < d`, `(((a + (d-b)) % d) + b) % d = a`. -/
+lemma cyc_round (a b d : ℕ) (_hd : 0 < d) (ha : a < d) (hb : b < d) :
+    (((a + (d - b)) % d) + b) % d = a := by
+  have h1 : (((a + (d - b)) % d) + b) ≡ (a + (d - b) + b) [MOD d] :=
+    (Nat.mod_modEq _ _).add_right b
+  have h2 : a + (d - b) + b = a + d := by omega
+  have h3 : (a + d) ≡ a [MOD d] := Nat.add_mod_right a d
+  have h4 : (((a + (d - b)) % d) + b) ≡ a [MOD d] := by
+    rw [h2] at h1; exact h1.trans h3
+  have hlt : (((a + (d - b)) % d) + b) % d = a % d := h4
+  rw [Nat.mod_eq_of_lt ha] at hlt
+  exact hlt
+
+/-- The inverse cyclic relation. -/
+lemma cyc_inv (a b c d : ℕ) (_hd : 0 < d) (ha : a < d) (hb : b < d) (_hc : c < d)
+    (h : c = (a + b) % d) : a = (c + (d - b)) % d := by
+  have h1 : (c + (d - b)) ≡ ((a + b) + (d - b)) [MOD d] := by
+    rw [h]; exact (Nat.mod_modEq _ _).add_right (d - b)
+  have h2 : (a + b) + (d - b) = a + d := by omega
+  have h3 : (a + d) ≡ a [MOD d] := Nat.add_mod_right a d
+  have h4 : (c + (d - b)) ≡ a [MOD d] := by rw [h2] at h1; exact h1.trans h3
+  have hlt : (c + (d - b)) % d = a % d := h4
+  rw [Nat.mod_eq_of_lt ha] at hlt
+  exact hlt.symm
+
+/-- `t`-fold rotation: translate every element by `+(t*m)`. -/
+def rhoPow {d m : ℕ} (t : ℕ) (S : Finset (ZMod (d * m))) : Finset (ZMod (d * m)) :=
+  S.map (Equiv.addRight (((t * m : ℕ) : ZMod (d * m)))).toEmbedding
+
+@[simp] lemma card_rhoPow {d m : ℕ} (t : ℕ) (S : Finset (ZMod (d * m))) :
+    (rhoPow t S).card = S.card := by
+  unfold rhoPow; rw [Finset.card_map]
+
+lemma mem_rhoPow {d m : ℕ} (t : ℕ) (S : Finset (ZMod (d * m))) (x : ZMod (d * m)) :
+    x ∈ rhoPow t S ↔ ∃ y ∈ S, y + ((t * m : ℕ) : ZMod (d * m)) = x := by
+  unfold rhoPow
+  rw [Finset.mem_map]
+  constructor
+  · rintro ⟨y, hy, rfl⟩; exact ⟨y, hy, by rw [Equiv.coe_toEmbedding, Equiv.coe_addRight]⟩
+  · rintro ⟨y, hy, rfl⟩; exact ⟨y, hy, by rw [Equiv.coe_toEmbedding, Equiv.coe_addRight]⟩
+
+/-- Composing rotations: `rhoPow t (rhoPow u S) = rhoPow (t + u) S`. -/
+lemma rhoPow_add {d m : ℕ} (t u : ℕ) (S : Finset (ZMod (d * m))) :
+    rhoPow t (rhoPow u S) = rhoPow (t + u) S := by
+  unfold rhoPow
+  rw [Finset.map_map]
+  congr 1
+  ext x
+  simp only [Function.Embedding.trans_apply, Equiv.coe_toEmbedding, Equiv.coe_addRight]
+  rw [add_assoc]
+  congr 1
+  push_cast
+  ring
+
+/-- `rhoPow 0 S = S`. -/
+@[simp] lemma rhoPow_zero {d m : ℕ} (S : Finset (ZMod (d * m))) : rhoPow 0 S = S := by
+  unfold rhoPow
+  simp only [Nat.zero_mul, Nat.cast_zero]
+  rw [show (Equiv.addRight (0 : ZMod (d * m))) = Equiv.refl _ from by ext x; simp]
+  simp
+
+/-- `rhoPow d S = S` (a full cycle is the identity). -/
+lemma rhoPow_period {d m : ℕ} (S : Finset (ZMod (d * m))) : rhoPow d S = S := by
+  unfold rhoPow
+  have : ((d * m : ℕ) : ZMod (d * m)) = 0 := by rw [ZMod.natCast_self]
+  rw [this]
+  rw [show (Equiv.addRight (0 : ZMod (d * m))) = Equiv.refl _ from by ext x; simp]
+  simp
+
+/-- `rhoPow` only depends on `t % d`. -/
+lemma rhoPow_mod {d m : ℕ} (t : ℕ) (S : Finset (ZMod (d * m))) :
+    rhoPow (t % d) S = rhoPow t S := by
+  unfold rhoPow
+  rw [shift_cast t]
+
+/-- The count-shift: rotating by `t` shifts the level-count vector cyclically.
+    For `j < d`, the elements of `rhoPow t S` at level `j` biject (via `+t'*m`) with the
+    elements of `S` at level `(j + (d - t%d)) % d`. -/
+lemma cnt_rhoPow {d m : ℕ} (hd : 0 < d) (hm : 0 < m) (t : ℕ) (S : Finset (ZMod (d * m)))
+    (j : ℕ) (hj : j < d) :
+    cnt (rhoPow t S) j = cnt S ((j + (d - t % d)) % d) := by
+  classical
+  haveI : NeZero (d * m) := ⟨by positivity⟩
+  have ht'd : t % d < d := Nat.mod_lt _ hd
+  unfold cnt
+  have hcancel_ts : ∀ y : ZMod (d * m),
+      y + ((t * m : ℕ) : ZMod (d * m)) + (((d - t % d) * m : ℕ) : ZMod (d * m)) = y := by
+    intro y
+    rw [shift_cast t]; push_cast
+    have h0 : ((t % d : ℕ) : ZMod (d * m)) * m + ((d - t % d : ℕ) : ZMod (d * m)) * m = 0 := by
+      rw [← add_mul]
+      have he : (((t % d : ℕ) : ZMod (d * m)) + ((d - t % d : ℕ) : ZMod (d * m)))
+          = ((d : ℕ) : ZMod (d * m)) := by
+        rw [← Nat.cast_add]; congr 1; omega
+      rw [he, show ((d : ℕ) : ZMod (d * m)) * m = ((d * m : ℕ) : ZMod (d * m)) by push_cast; ring,
+        ZMod.natCast_self]
+    rw [add_assoc, h0, add_zero]
+  have hcancel_st : ∀ x : ZMod (d * m),
+      x + (((d - t % d) * m : ℕ) : ZMod (d * m)) + ((t * m : ℕ) : ZMod (d * m)) = x := by
+    intro x
+    rw [shift_cast t]; push_cast
+    have h0 : ((d - t % d : ℕ) : ZMod (d * m)) * m + ((t % d : ℕ) : ZMod (d * m)) * m = 0 := by
+      rw [← add_mul]
+      have he : (((d - t % d : ℕ) : ZMod (d * m)) + ((t % d : ℕ) : ZMod (d * m)))
+          = ((d : ℕ) : ZMod (d * m)) := by
+        rw [← Nat.cast_add]; congr 1; omega
+      rw [he, show ((d : ℕ) : ZMod (d * m)) * m = ((d * m : ℕ) : ZMod (d * m)) by push_cast; ring,
+        ZMod.natCast_self]
+    rw [add_assoc, h0, add_zero]
+  apply Finset.card_nbij'
+    (i := fun x => x + (((d - t % d) * m : ℕ) : ZMod (d * m)))
+    (j := fun y => y + ((t * m : ℕ) : ZMod (d * m)))
+  · intro x hx
+    rw [Finset.mem_coe, Finset.mem_filter] at hx
+    obtain ⟨hxR, hxlev⟩ := hx
+    obtain ⟨y, hyS, rfl⟩ := (mem_rhoPow t S x).mp hxR
+    simp only [Finset.mem_coe, Finset.mem_filter, hcancel_ts y]
+    refine ⟨hyS, ?_⟩
+    have hlev := level_add hd hm t y
+    rw [hxlev] at hlev
+    have hqd : y.val / m < d := level_lt hd hm y
+    exact cyc_inv (y.val / m) (t % d) j d hd hqd ht'd hj hlev
+  · intro y hy
+    rw [Finset.mem_coe, Finset.mem_filter] at hy
+    obtain ⟨hyS, hylev⟩ := hy
+    simp only [Finset.mem_coe, Finset.mem_filter]
+    refine ⟨(mem_rhoPow t S _).mpr ⟨y, hyS, rfl⟩, ?_⟩
+    rw [level_add hd hm t y, hylev]
+    exact cyc_round j (t % d) d hd hj ht'd
+  · intro x hx
+    exact hcancel_st x
+  · intro y hy
+    exact hcancel_ts y
+
+/-! ## Part 4: the period-`d` count sequence and the cycle-lemma bridge. -/
+
+open Cycle
+
+/-- The period-`d` natural count sequence: `aP S l = cnt S (l % d)`. -/
+def aP {d m : ℕ} (S : Finset (ZMod (d * m))) (l : ℕ) : ℕ := cnt S (l % d)
+
+/-- The integer complement sequence whose partial sums drive the cycle lemma:
+    `bSeq S l = 1 - (aP S l : ℤ)`. -/
+def bSeq {d m : ℕ} (S : Finset (ZMod (d * m))) (l : ℕ) : ℤ := 1 - (aP S l : ℤ)
+
+lemma aP_lt {d m : ℕ} (S : Finset (ZMod (d * m))) {l : ℕ} (hl : l < d) :
+    aP S l = cnt S l := by unfold aP; rw [Nat.mod_eq_of_lt hl]
+
+lemma bSeq_periodic {d m : ℕ} (S : Finset (ZMod (d * m))) (k : ℕ) :
+    bSeq S (k + d) = bSeq S k := by
+  unfold bSeq aP; rw [Nat.add_mod_right]
+
+/-- Period sum of `aP` is `S.card`. -/
+lemma sum_aP {d m : ℕ} (hd : 0 < d) (hm : 0 < m) (S : Finset (ZMod (d * m))) :
+    ∑ l ∈ Finset.range d, (aP S l : ℤ) = (S.card : ℤ) := by
+  rw [← Nat.cast_sum]
+  congr 1
+  rw [← sum_cnt hd hm S]
+  apply Finset.sum_congr rfl
+  intro l hl
+  rw [Finset.mem_range] at hl
+  exact aP_lt S hl
+
+/-- Period sum of `bSeq` over `range d` is `d - S.card`. -/
+lemma Q_bSeq_d {d m : ℕ} (hd : 0 < d) (hm : 0 < m) (S : Finset (ZMod (d * m))) :
+    Q (bSeq S) d = (d : ℤ) - (S.card : ℤ) := by
+  unfold Q bSeq
+  rw [Finset.sum_sub_distrib, Finset.sum_const, Finset.card_range, nsmul_eq_mul, mul_one,
+      sum_aP hd hm S]
+
+/-- For a `(d-1)`-subset, the period sum of `bSeq` is exactly `1`. -/
+lemma Q_bSeq_d_one {d m : ℕ} (hd : 0 < d) (hm : 0 < m) (S : Finset (ZMod (d * m)))
+    (hcard : S.card = d - 1) : Q (bSeq S) d = 1 := by
+  rw [Q_bSeq_d hd hm S, hcard]
+  have h1 : ((d - 1 : ℕ) : ℤ) = (d : ℤ) - 1 := by
+    have hle : 1 ≤ d := hd
+    rw [Nat.cast_sub hle, Nat.cast_one]
+  rw [h1]; ring
+
+/-- The integer partial sum `Q (bSeq S) k = k - (∑_{l<k} aP S l)`. -/
+lemma Q_bSeq_eq {d m : ℕ} (S : Finset (ZMod (d * m))) (k : ℕ) :
+    Q (bSeq S) k = (k : ℤ) - ∑ l ∈ Finset.range k, (aP S l : ℤ) := by
+  unfold Q bSeq
+  rw [Finset.sum_sub_distrib, Finset.sum_const, Finset.card_range, nsmul_eq_mul, mul_one]
+
+/-- Periodicity of the partial sums of `bSeq` for a `(d-1)`-subset. -/
+lemma Q_bSeq_period {d m : ℕ} (hd : 0 < d) (hm : 0 < m) (S : Finset (ZMod (d * m)))
+    (hcard : S.card = d - 1) (k : ℕ) : Q (bSeq S) (k + d) = Q (bSeq S) k + 1 := by
+  have hper : ∀ j, bSeq S (j + d) = bSeq S j := bSeq_periodic S
+  have hsum : Q (bSeq S) d = 1 := Q_bSeq_d_one hd hm S hcard
+  exact Q_periodic (bSeq S) hper hsum k
+
+/-! ## Part 5: the core equivalence `LevelCanonical ↔ Good`. -/
+
+/-- The prefix sum of the rotated count is a shifted window of `aP`.
+    For `t < d` and `j < d`, with `e = d - t`. -/
+lemma prefix_rhoPow {d m : ℕ} (hd : 0 < d) (hm : 0 < m) (t : ℕ) (ht : t < d)
+    (S : Finset (ZMod (d * m))) (j : ℕ) (hj : j < d) :
+    ∑ l ∈ Finset.range (j + 1), ((cnt (rhoPow t S) l : ℤ))
+      = ∑ l ∈ Finset.range (j + 1), (aP S (l + (d - t)) : ℤ) := by
+  apply Finset.sum_congr rfl
+  intro l hl
+  rw [Finset.mem_range] at hl
+  have hld : l < d := by omega
+  have hkey := cnt_rhoPow hd hm t S l hld
+  rw [Nat.mod_eq_of_lt ht] at hkey
+  -- cnt (rhoPow t S) l = cnt S ((l + (d-t)) % d) = aP S (l + (d-t))
+  have heq : cnt (rhoPow t S) l = aP S (l + (d - t)) := by
+    rw [hkey]; rfl
+  rw [heq]
+
+/-- Reindex: `∑_{l<j+1} f (l + e) = (∑_{l<e+j+1} f) - (∑_{l<e} f)`. -/
+lemma sum_shift_window (f : ℕ → ℤ) (e j : ℕ) :
+    ∑ l ∈ Finset.range (j + 1), f (l + e)
+      = (∑ l ∈ Finset.range (e + (j + 1)), f l) - (∑ l ∈ Finset.range e, f l) := by
+  have hIco : ∑ l ∈ Finset.range (j + 1), f (l + e)
+      = ∑ l ∈ Finset.Ico e (e + (j + 1)), f l := by
+    rw [Finset.sum_Ico_eq_sum_range]
+    apply Finset.sum_congr (by congr 1; omega)
+    intro l _; rw [Nat.add_comm e l]
+  have hcons : (∑ l ∈ Finset.Ico 0 e, f l) + (∑ l ∈ Finset.Ico e (e + (j + 1)), f l)
+      = ∑ l ∈ Finset.Ico 0 (e + (j + 1)), f l :=
+    Finset.sum_Ico_consecutive f (Nat.zero_le e) (by omega : e ≤ e + (j + 1))
+  rw [hIco, Finset.range_eq_Ico, Finset.range_eq_Ico]
+  linarith [hcons]
+
+/-- The LC prefix inequality (index `j`) for `rhoPow t S`, recast via partial sums of `bSeq`.
+    For `t < d`, `j < d`, with `e = d - t`:
+    `(#{i ∈ rhoPow t S : level i ≤ j} ≤ j)  ↔  Q b e < Q b (e + (j+1))`. -/
+lemma lc_index_iff {d m : ℕ} (hd : 0 < d) (hm : 0 < m) (t : ℕ) (ht : t < d)
+    (S : Finset (ZMod (d * m))) (j : ℕ) (hj : j < d) :
+    (((rhoPow t S).filter (fun i => i.val / m ≤ j)).card ≤ j)
+      ↔ Q (bSeq S) (d - t) < Q (bSeq S) ((d - t) + (j + 1)) := by
+  set e := d - t with he
+  -- cast the LC inequality to ℤ
+  rw [show (((rhoPow t S).filter (fun i => i.val / m ≤ j)).card ≤ j)
+        ↔ (((rhoPow t S).filter (fun i => i.val / m ≤ j)).card : ℤ) ≤ (j : ℤ) from by
+      exact_mod_cast Iff.rfl]
+  -- prefix card of rhoPow t S = window sum of aP
+  have hpref : (((rhoPow t S).filter (fun i => i.val / m ≤ j)).card : ℤ)
+      = ∑ l ∈ Finset.range (j + 1), (aP S (l + e) : ℤ) := by
+    rw [prefix_cnt (rhoPow t S) j]
+    push_cast
+    rw [prefix_rhoPow hd hm t ht S j hj]
+  rw [hpref, sum_shift_window (fun l => (aP S l : ℤ)) e j]
+  -- now: (Qa(e+j+1) - Qa e ≤ j) ↔ (Q b e < Q b (e+j+1))
+  rw [show ∑ l ∈ Finset.range (e + (j + 1)), (aP S l : ℤ)
+        = (↑(e + (j + 1)) : ℤ) - Q (bSeq S) (e + (j + 1)) from by
+      have := Q_bSeq_eq S (e + (j + 1)); linarith,
+      show ∑ l ∈ Finset.range e, (aP S l : ℤ) = (e : ℤ) - Q (bSeq S) e from by
+      have := Q_bSeq_eq S e; linarith]
+  push_cast
+  constructor <;> intro h <;> linarith
+
+/-- Cross-equality relating `Q b e` to `Q b c` where `c = e % d` and `e ≤ d`
+    (so `e = c`, or `e = d` with `c = 0`). -/
+lemma Q_e_c_cross {d m : ℕ} (hd : 0 < d) (hm : 0 < m) (S : Finset (ZMod (d * m)))
+    (hcard : S.card = d - 1) (t : ℕ) (ht : t < d) (x : ℕ) :
+    Q (bSeq S) (d - t) + Q (bSeq S) ((d - t) % d + x)
+      = Q (bSeq S) ((d - t) % d) + Q (bSeq S) ((d - t) + x) := by
+  rcases Nat.eq_zero_or_pos t with ht0 | htpos
+  · -- t = 0 : e = d, c = 0
+    subst ht0
+    simp only [Nat.sub_zero]
+    rw [Nat.mod_self]
+    -- Q b d + Q b (0 + x) = Q b 0 + Q b (d + x)
+    have hp1 : Q (bSeq S) d = Q (bSeq S) 0 + 1 := by
+      have := Q_bSeq_period hd hm S hcard 0; simpa using this
+    have hp2 : Q (bSeq S) (d + x) = Q (bSeq S) x + 1 := by
+      have := Q_bSeq_period hd hm S hcard x
+      rw [Nat.add_comm x d] at this; exact this
+    rw [hp1, hp2, Nat.zero_add]; ring
+  · -- t > 0 : e = d - t < d, so c = e
+    have helt : d - t < d := by omega
+    rw [Nat.mod_eq_of_lt helt]
+
+/-- **The cycle-lemma bridge (single rotation).** For `t < d` and a `(d-1)`-subset `S`,
+    `LevelCanonical d m (rhoPow t S) ↔ Good d (bSeq S) ((d - t) % d)`. -/
+lemma lc_iff_good {d m : ℕ} (hd : 0 < d) (hm : 0 < m) (S : Finset (ZMod (d * m)))
+    (hcard : S.card = d - 1) (t : ℕ) (ht : t < d) :
+    LevelCanonical d m (rhoPow t S) ↔ Good d (bSeq S) ((d - t) % d) := by
+  set e := d - t with he
+  set c := e % d with hc
+  -- LC ↔ ∀ j < d, Q b e < Q b (e + (j+1))
+  have hLCiff : LevelCanonical d m (rhoPow t S)
+      ↔ ∀ j, j < d → Q (bSeq S) e < Q (bSeq S) (e + (j + 1)) := by
+    unfold LevelCanonical
+    constructor
+    · intro h j hj
+      exact (lc_index_iff hd hm t ht S j hj).mp (h j hj)
+    · intro h j hj
+      exact (lc_index_iff hd hm t ht S j hj).mpr (h j hj)
+  rw [hLCiff]
+  -- relate e-form to c-form via cross equality, and drop the trivial j = d-1
+  unfold Good
+  constructor
+  · -- forward: from ∀ j < d (e-form), prove Good at c
+    intro h s hcs hsd
+    -- s = c + (s - c), with s - c = j + 1, j < d - 1 hence j < d
+    obtain ⟨w, hw⟩ : ∃ w, s = c + (w + 1) := ⟨s - c - 1, by omega⟩
+    have hwd : w < d := by
+      have hcd : c < d := Nat.mod_lt _ hd
+      omega
+    have hcross := Q_e_c_cross hd hm S hcard t ht (w + 1)
+    have he_lt := h w hwd
+    rw [hw]
+    -- from he_lt : Q b e < Q b (e + (w+1)); cross : Q b e + Q b (c+(w+1)) = Q b c + Q b (e+(w+1))
+    have : Q (bSeq S) e + Q (bSeq S) (c + (w + 1))
+        = Q (bSeq S) c + Q (bSeq S) (e + (w + 1)) := hcross
+    linarith
+  · -- backward: from Good at c, prove ∀ j < d (e-form)
+    intro h j hj
+    rcases Nat.lt_or_ge j (d - 1) with hjlt | hjge
+    · -- j < d - 1 : s = c + (j+1) is in window (c, c+d)
+      have hcd : c < d := Nat.mod_lt _ hd
+      have hgs := h (c + (j + 1)) (by omega) (by omega)
+      have hcross := Q_e_c_cross hd hm S hcard t ht (j + 1)
+      have : Q (bSeq S) e + Q (bSeq S) (c + (j + 1))
+          = Q (bSeq S) c + Q (bSeq S) (e + (j + 1)) := hcross
+      linarith
+    · -- j = d - 1 : automatic from periodicity, Q b (e + d) = Q b e + 1
+      have hjeq : j = d - 1 := by omega
+      subst hjeq
+      have hrw : e + (d - 1 + 1) = e + d := by omega
+      rw [hrw, Q_bSeq_period hd hm S hcard e]
+      linarith
+
+/-! ## Part 7: the unique canonical rotation index. -/
+
+/-- `σ t = (d - t) % d` is `< d`. -/
+lemma sigma_lt {d : ℕ} (hd : 0 < d) (t : ℕ) : (d - t) % d < d := Nat.mod_lt _ hd
+
+/-- `σ` is an involution on `[0, d)`: `(d - ((d - t) % d)) % d = t` for `t < d`. -/
+lemma sigma_invol {d : ℕ} (_hd : 0 < d) {t : ℕ} (ht : t < d) :
+    (d - ((d - t) % d)) % d = t := by
+  rcases Nat.eq_zero_or_pos t with ht0 | htpos
+  · subst ht0; simp [Nat.mod_self]
+  · have h1 : d - t < d := by omega
+    rw [Nat.mod_eq_of_lt h1]
+    have h2 : d - (d - t) = t := by omega
+    rw [h2, Nat.mod_eq_of_lt ht]
+
+/-- **The unique canonical rotation.** For a `(d-1)`-subset `S`, exactly one `t ∈ [0,d)`
+    makes `rhoPow t S` level-canonical. -/
+theorem canonical_unique {d m : ℕ} (hd : 0 < d) (hm : 0 < m) (S : Finset (ZMod (d * m)))
+    (hcard : S.card = d - 1) :
+    ∃! t, t < d ∧ LevelCanonical d m (rhoPow t S) := by
+  -- apply the cycle lemma to bSeq S
+  have hper : ∀ k, bSeq S (k + d) = bSeq S k := bSeq_periodic S
+  have hsum : Q (bSeq S) d = 1 := Q_bSeq_d_one hd hm S hcard
+  obtain ⟨i0, ⟨hi0d, hi0good⟩, hi0uniq⟩ := cycle_lemma (bSeq S) hd hper hsum
+  refine ⟨(d - i0) % d, ⟨sigma_lt hd i0, ?_⟩, ?_⟩
+  · -- LC at t0 = σ i0
+    rw [lc_iff_good hd hm S hcard _ (sigma_lt hd i0)]
+    rw [sigma_invol hd hi0d]
+    exact hi0good
+  · -- uniqueness
+    rintro t ⟨htd, htLC⟩
+    rw [lc_iff_good hd hm S hcard t htd] at htLC
+    -- htLC : Good d (bSeq S) ((d - t) % d)
+    have hgood_idx : (d - t) % d = i0 := hi0uniq ((d - t) % d) ⟨sigma_lt hd t, htLC⟩
+    -- t = σ ((d-t)%d) = σ i0 = (d - i0) % d
+    have := sigma_invol hd htd
+    rw [hgood_idx] at this
+    omega
+
+/-! ## Part 8: the bijection `{(d-1)-subsets} ≃ {canonical} × Fin d`. -/
+
+open Classical in
+/-- The canonical rotation index of a `(d-1)`-subset (junk `0` for non-`(d-1)`-subsets). -/
+noncomputable def canIdx {d m : ℕ} (hd : 0 < d) (hm : 0 < m) (S : Finset (ZMod (d * m))) : ℕ :=
+  if h : S.card = d - 1 then (canonical_unique hd hm S h).choose else 0
+
+lemma canIdx_spec {d m : ℕ} (hd : 0 < d) (hm : 0 < m) (S : Finset (ZMod (d * m)))
+    (hcard : S.card = d - 1) :
+    canIdx hd hm S < d ∧ LevelCanonical d m (rhoPow (canIdx hd hm S) S) := by
+  unfold canIdx
+  rw [dif_pos hcard]
+  exact (canonical_unique hd hm S hcard).choose_spec.1
+
+/-- Uniqueness characterization of `canIdx`. -/
+lemma canIdx_eq {d m : ℕ} (hd : 0 < d) (hm : 0 < m) (S : Finset (ZMod (d * m)))
+    (hcard : S.card = d - 1) {t : ℕ} (htd : t < d) (htLC : LevelCanonical d m (rhoPow t S)) :
+    t = canIdx hd hm S := by
+  unfold canIdx
+  rw [dif_pos hcard]
+  exact (canonical_unique hd hm S hcard).choose_spec.2 t ⟨htd, htLC⟩
+
+/-- For a canonical `(d-1)`-subset, the canonical index is `0`. -/
+lemma canIdx_of_canonical {d m : ℕ} (hd : 0 < d) (hm : 0 < m) (c : Finset (ZMod (d * m)))
+    (hcard : c.card = d - 1) (hLC : LevelCanonical d m c) : canIdx hd hm c = 0 := by
+  symm
+  apply canIdx_eq hd hm c hcard hd
+  rw [rhoPow_zero]; exact hLC
+
+/-- `rhoPow` is "mod-d periodic with the round-trip cancelling to identity". -/
+lemma rhoPow_round {d m : ℕ} (t : ℕ) (ht : t < d) (S : Finset (ZMod (d * m))) :
+    rhoPow ((d - t) % d) (rhoPow t S) = S := by
+  rw [rhoPow_add, ← rhoPow_mod]
+  have : ((d - t) % d + t) % d = 0 := by
+    rcases Nat.eq_zero_or_pos t with h0 | hpos
+    · subst h0; simp [Nat.mod_self]
+    · rw [Nat.mod_eq_of_lt (by omega : d - t < d)]
+      have : d - t + t = d := by omega
+      rw [this, Nat.mod_self]
+  rw [this, rhoPow_zero]
+
+variable {d m : ℕ}
+
+/-- The Fintype subtype of `(d-1)`-subsets. -/
+abbrev Asub (d m : ℕ) := {S : Finset (ZMod (d * m)) // S.card = d - 1}
+
+/-- The Fintype subtype of canonical `(d-1)`-subsets (the TARGET). -/
+abbrev Csub (d m : ℕ) := {S : Finset (ZMod (d * m)) // S.card = d - 1 ∧ LevelCanonical d m S}
+
+open Classical in
+/-- The bijection `Asub ≃ Csub × Fin d`. -/
+noncomputable def equivCanFin (hd : 0 < d) (hm : 0 < m) : Asub d m ≃ Csub d m × Fin d where
+  toFun := fun S =>
+    (⟨rhoPow (canIdx hd hm S.1) S.1,
+        ⟨by rw [card_rhoPow]; exact S.2, (canIdx_spec hd hm S.1 S.2).2⟩⟩,
+      ⟨canIdx hd hm S.1, (canIdx_spec hd hm S.1 S.2).1⟩)
+  invFun := fun p =>
+    ⟨rhoPow ((d - (p.2 : ℕ)) % d) p.1.1, by rw [card_rhoPow]; exact p.1.2.1⟩
+  left_inv := by
+    rintro ⟨S, hS⟩
+    apply Subtype.ext
+    simp only
+    exact rhoPow_round (canIdx hd hm S) (canIdx_spec hd hm S hS).1 S
+  right_inv := by
+    rintro ⟨⟨c, hc1, hc2⟩, s, hs⟩
+    -- T := rhoPow ((d - s) % d) c
+    set e := (d - (s : ℕ)) % d with he
+    have hcard_T : (rhoPow e c).card = d - 1 := by rw [card_rhoPow]; exact hc1
+    -- canIdx of T = s, and rhoPow (canIdx T) T = c
+    have hsd : (s : ℕ) < d := hs
+    have hed : e < d := Nat.mod_lt _ hd
+    -- s makes rhoPow s T = rhoPow s (rhoPow e c) = rhoPow (s + e) c = c canonical
+    have hsT_LC : LevelCanonical d m (rhoPow (s : ℕ) (rhoPow e c)) := by
+      rw [rhoPow_add]
+      have hmod0 : ((s : ℕ) + e) % d = 0 := by
+        rw [he]
+        rcases Nat.eq_zero_or_pos (s : ℕ) with h0 | hpos
+        · rw [h0]; simp [Nat.mod_self]
+        · rw [Nat.mod_eq_of_lt (by omega : d - (s : ℕ) < d)]
+          have : (s : ℕ) + (d - (s : ℕ)) = d := by omega
+          rw [this, Nat.mod_self]
+      rw [← rhoPow_mod, hmod0, rhoPow_zero]
+      exact hc2
+    have hcanT : (s : ℕ) = canIdx hd hm (rhoPow e c) :=
+      canIdx_eq hd hm (rhoPow e c) hcard_T hsd hsT_LC
+    -- now build the pair equality
+    apply Prod.ext
+    · -- first component: rhoPow (canIdx T) T = c (as Csub element)
+      apply Subtype.ext
+      simp only
+      rw [← hcanT, rhoPow_add]
+      have hmod0 : ((s : ℕ) + e) % d = 0 := by
+        rw [he]
+        rcases Nat.eq_zero_or_pos (s : ℕ) with h0 | hpos
+        · rw [h0]; simp [Nat.mod_self]
+        · rw [Nat.mod_eq_of_lt (by omega : d - (s : ℕ) < d)]
+          have : (s : ℕ) + (d - (s : ℕ)) = d := by omega
+          rw [this, Nat.mod_self]
+      rw [← rhoPow_mod, hmod0, rhoPow_zero]
+    · -- second component: canIdx T = s (as Fin d)
+      apply Fin.ext
+      simp only
+      exact hcanT.symm
+
+/-! ## Part 9: the final count. -/
+
+/-- **PRIMARY.** `d · #{canonical (d-1)-subsets} = C(d*m, d-1)`. -/
+theorem card_levelCanonical_mul (d m : ℕ) (hd : 0 < d) (hm : 0 < m) :
+    d * Fintype.card {S : Finset (ZMod (d * m)) // S.card = d - 1 ∧ LevelCanonical d m S}
+      = (d * m).choose (d - 1) := by
+  haveI : NeZero (d * m) := ⟨by positivity⟩
+  -- card Asub = card Csub * d  via the bijection
+  have hbij : Fintype.card (Asub d m) = Fintype.card (Csub d m × Fin d) :=
+    Fintype.card_congr (equivCanFin hd hm)
+  rw [Fintype.card_prod, Fintype.card_fin] at hbij
+  -- card Asub = C(d*m, d-1)
+  have hA : Fintype.card (Asub d m) = (d * m).choose (d - 1) := by
+    unfold Asub
+    rw [card_kSubsets (d * m) (d - 1)]
+  -- combine
+  rw [hA] at hbij
+  -- hbij : C(d*m,d-1) = card Csub * d
+  rw [Nat.mul_comm d _]
+  exact hbij.symm
+
+/-- **COROLLARY.** `#{canonical (d-1)-subsets} = C(d*m, d-1) / d`. -/
+theorem card_levelCanonical (d m : ℕ) (hd : 0 < d) (hm : 0 < m) :
+    Fintype.card {S : Finset (ZMod (d * m)) // S.card = d - 1 ∧ LevelCanonical d m S}
+      = (d * m).choose (d - 1) / d :=
+  (Nat.div_eq_of_eq_mul_right hd (card_levelCanonical_mul d m hd hm).symm).symm
+
+end CriticalPortraits

--- a/LeanPool/CriticalPortraits/Forward.lean
+++ b/LeanPool/CriticalPortraits/Forward.lean
@@ -1,0 +1,861 @@
+/-
+Copyright (c) 2026 Keston Aquino-Michaels. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Keston Aquino-Michaels
+-/
+
+import LeanPool.CriticalPortraits.Core
+import LeanPool.CriticalPortraits.Portraits
+
+/-!
+# Forward bound (brick 3b): `T P` is level-canonical, for every degree `d`.
+
+The crux geometric half of the Reconstruction Lemma: the delete-min survivors `T P` of a
+critical portrait are always level-canonical, `∀ j < d, #{u ∈ T P : level u ≤ j} ≤ j`.
+This is the global non-crossing/ballot "Catalan heart" of the general census proof, here
+proved for ALL `d` (sorry-free, native_decide-free; axioms ⊆ {propext, Classical.choice,
+Quot.sound}). Follows the paper proof `docs/b2_forward_reconstruction_2026-06-16.md`
+(Lemma A laminar, Lemma B monotone columns, the Kernel, the laminar-forest recursion);
+probe `probes/check_b2_forward.py` confirms `d ≤ 6`.
+
+The proof has two parts.
+
+* **PART I (`AbstractLaminar`)** — a self-contained combinatorial result about a finite
+  family of half-open integer intervals `(lo e, hi e]` with columns `col e`, pairwise
+  laminar (Lemma A), interval-injective, with the Lemma-B column monotonicities
+  (`bRight`/`bLeft`/`bSeam`). The master bound `N(a,b) ≤ b - a` packages the Kernel
+  (`g(e) ≤ h(e) - 1`), the laminar-forest recursion, and the no-tiling crux
+  (a column scan `c* < q₁ ≤ ⋯ ≤ qₖ < c*`).
+
+* **PART II (`CriticalPortraits`)** — the geometric edge model. Edges ARE the survivors:
+  each survivor
+  `x ∈ T P` is the top of a unique edge whose other endpoint is its immediate predecessor
+  `predIn x` in its host critical set. `hi x = level x`, `col x = fiber x`,
+  `lo x = level (predIn x)`. Lemmas A/B + interval-injectivity all reduce to ONE master
+  non-alternation lemma `no_alt` (no two survivors' endpoints alternate `px < py < x < y`),
+  which dispatches cross-host via the portrait's `Unlinked` clause and same-host via
+  predecessor immediacy. Assembling the `Family` and applying the master bound at window
+  `(0, j]` gives `T_levelCanonical`.
+-/
+
+/-! # PART I — Abstract laminar interval family: Kernel + forest recursion.
+
+A finite family `E : Finset ι` of half-open integer intervals `(lo e, hi e]` with columns
+`col e`, pairwise laminar (Lemma A), intervals identifying edges (`inj`), and the Lemma-B
+column properties (`bRight`/`bLeft`/`bSeam`). The master bound
+`N(a,b) := #{e ∈ E : a ≤ lo e ∧ hi e ≤ b} ≤ b - a` packages the Kernel + the
+laminar-forest recursion + the no-tiling crux. -/
+
+namespace AbstractLaminar
+
+open Finset
+
+variable {ι : Type*} [DecidableEq ι]
+
+/-- An abstract laminar family: an index set with low/high endpoints and a column. -/
+structure Family (ι : Type*) [DecidableEq ι] where
+  /-- The carrier index set of the family. -/
+  E : Finset ι
+  /-- The low endpoint of each index. -/
+  lo : ι → ℕ
+  /-- The high endpoint of each index. -/
+  hi : ι → ℕ
+  /-- The column of each index. -/
+  col : ι → ℕ
+  lh : ∀ e ∈ E, lo e < hi e
+  inj : ∀ e ∈ E, ∀ f ∈ E, lo e = lo f → hi e = hi f → e = f
+  laminar : ∀ e ∈ E, ∀ f ∈ E, ¬ (lo e < lo f ∧ lo f < hi e ∧ hi e < hi f)
+  bRight : ∀ e ∈ E, ∀ f ∈ E, hi e = hi f → lo e < lo f → col f < col e
+  bLeft : ∀ e ∈ E, ∀ f ∈ E, lo e = lo f → hi f < hi e → col e < col f
+  bSeam : ∀ e ∈ E, ∀ f ∈ E, hi e = lo f → col e ≤ col f
+
+variable (fam : Family ι)
+
+/-- Edges contained in the window `(a, b]`. -/
+def contained (a b : ℕ) : Finset ι :=
+  fam.E.filter (fun e => a ≤ fam.lo e ∧ fam.hi e ≤ b)
+
+/-- The count `N(a,b)`. -/
+def N (a b : ℕ) : ℕ := (contained fam a b).card
+
+lemma mem_contained {a b : ℕ} {e : ι} :
+    e ∈ contained fam a b ↔ e ∈ fam.E ∧ a ≤ fam.lo e ∧ fam.hi e ≤ b := by
+  unfold contained; rw [mem_filter]
+
+/-- Empty window: no contained edges. -/
+lemma N_eq_zero_of_le {a b : ℕ} (hba : b ≤ a) : N fam a b = 0 := by
+  unfold N contained
+  rw [Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+  intro e he
+  rintro ⟨ha, hb⟩
+  have := fam.lh e he
+  omega
+
+/-- Two overlapping edges are nested (laminarity). -/
+lemma overlap_imp_nested {e f : ι} (he : e ∈ fam.E) (hf : f ∈ fam.E)
+    (h1 : fam.lo e < fam.hi f) (h2 : fam.lo f < fam.hi e) :
+    (fam.lo f ≤ fam.lo e ∧ fam.hi e ≤ fam.hi f) ∨
+    (fam.lo e ≤ fam.lo f ∧ fam.hi f ≤ fam.hi e) := by
+  have lam1 := fam.laminar e he f hf
+  have lam2 := fam.laminar f hf e he
+  omega
+
+/-- "strict": interval not exactly the window. -/
+def IsStrict (a b : ℕ) (e : ι) : Prop := fam.lo e ≠ a ∨ fam.hi e ≠ b
+
+instance (a b : ℕ) (e : ι) : Decidable (IsStrict fam a b e) := by unfold IsStrict; infer_instance
+
+/-- The strictly-contained indices of `fam` on the window `[a, b]`. -/
+def Sstrict (a b : ℕ) : Finset ι := (contained fam a b).filter (IsStrict fam a b)
+
+lemma mem_Sstrict {a b : ℕ} {e : ι} :
+    e ∈ Sstrict fam a b ↔ (e ∈ fam.E ∧ a ≤ fam.lo e ∧ fam.hi e ≤ b) ∧
+      (fam.lo e ≠ a ∨ fam.hi e ≠ b) := by
+  unfold Sstrict IsStrict; rw [mem_filter, mem_contained]
+
+/-- Strict edges containing `f`. -/
+def containersS (a b : ℕ) (f : ι) : Finset ι :=
+  (Sstrict fam a b).filter (fun g => fam.lo g ≤ fam.lo f ∧ fam.hi f ≤ fam.hi g)
+
+lemma mem_containersS {a b : ℕ} {f g : ι} :
+    g ∈ containersS fam a b f ↔
+      ((g ∈ fam.E ∧ a ≤ fam.lo g ∧ fam.hi g ≤ b) ∧ (fam.lo g ≠ a ∨ fam.hi g ≠ b)) ∧
+        fam.lo g ≤ fam.lo f ∧ fam.hi f ≤ fam.hi g := by
+  unfold containersS; rw [mem_filter, mem_Sstrict]
+
+lemma containersS_nonempty {a b : ℕ} {f : ι} (hf : f ∈ Sstrict fam a b) :
+    (containersS fam a b f).Nonempty := by
+  refine ⟨f, ?_⟩
+  rw [mem_containersS]
+  rw [mem_Sstrict] at hf
+  exact ⟨hf, le_refl _, le_refl _⟩
+
+open Classical in
+/-- The strict root of `f`: widest strict containing edge (total; junk = `f` off `Sstrict`). -/
+noncomputable def rootS (a b : ℕ) (f : ι) : ι :=
+  if hf : f ∈ Sstrict fam a b then
+    (Finset.exists_max_image (containersS fam a b f) (fun g => fam.hi g - fam.lo g)
+      (containersS_nonempty fam hf)).choose
+  else f
+
+lemma rootS_mem_containersS {a b : ℕ} {f : ι} (hf : f ∈ Sstrict fam a b) :
+    rootS fam a b f ∈ containersS fam a b f := by
+  unfold rootS; rw [dif_pos hf]
+  exact (Finset.exists_max_image (containersS fam a b f) (fun g => fam.hi g - fam.lo g)
+    (containersS_nonempty fam hf)).choose_spec.1
+
+lemma rootS_max {a b : ℕ} {f : ι} (hf : f ∈ Sstrict fam a b) :
+    ∀ g ∈ containersS fam a b f,
+      fam.hi g - fam.lo g ≤ fam.hi (rootS fam a b f) - fam.lo (rootS fam a b f) := by
+  unfold rootS; rw [dif_pos hf]
+  exact (Finset.exists_max_image (containersS fam a b f) (fun g => fam.hi g - fam.lo g)
+    (containersS_nonempty fam hf)).choose_spec.2
+
+variable {a b : ℕ}
+
+lemma rootS_mem_E {f : ι} (hf : f ∈ Sstrict fam a b) : rootS fam a b f ∈ fam.E := by
+  have := rootS_mem_containersS fam hf; rw [mem_containersS] at this; exact this.1.1.1
+
+lemma rootS_mem_Sstrict {f : ι} (hf : f ∈ Sstrict fam a b) : rootS fam a b f ∈ Sstrict fam a b := by
+  have := rootS_mem_containersS fam hf; rw [mem_containersS] at this
+  rw [mem_Sstrict]; exact this.1
+
+lemma rootS_window {f : ι} (hf : f ∈ Sstrict fam a b) :
+    a ≤ fam.lo (rootS fam a b f) ∧ fam.hi (rootS fam a b f) ≤ b := by
+  have := rootS_mem_containersS fam hf; rw [mem_containersS] at this; exact this.1.1.2
+
+lemma rootS_strict {f : ι} (hf : f ∈ Sstrict fam a b) :
+    fam.lo (rootS fam a b f) ≠ a ∨ fam.hi (rootS fam a b f) ≠ b := by
+  have := rootS_mem_containersS fam hf; rw [mem_containersS] at this; exact this.1.2
+
+lemma rootS_contains {f : ι} (hf : f ∈ Sstrict fam a b) :
+    fam.lo (rootS fam a b f) ≤ fam.lo f ∧ fam.hi f ≤ fam.hi (rootS fam a b f) := by
+  have := rootS_mem_containersS fam hf; rw [mem_containersS] at this; exact this.2
+
+/-- The root's width is strictly less than the window's width. -/
+lemma rootS_width_lt {f : ι} (hf : f ∈ Sstrict fam a b) :
+    fam.hi (rootS fam a b f) - fam.lo (rootS fam a b f) < b - a := by
+  obtain ⟨hwlo, hwhi⟩ := rootS_window fam hf
+  have hlh := fam.lh (rootS fam a b f) (rootS_mem_E fam hf)
+  rcases rootS_strict fam hf with h | h <;> omega
+
+/-- The root is maximal among strict edges. -/
+lemma rootS_maximal {f : ι} (hf : f ∈ Sstrict fam a b)
+    {g : ι} (hg : g ∈ Sstrict fam a b)
+    (h1 : fam.lo g ≤ fam.lo (rootS fam a b f)) (h2 : fam.hi (rootS fam a b f) ≤ fam.hi g) :
+    fam.lo g = fam.lo (rootS fam a b f) ∧ fam.hi g = fam.hi (rootS fam a b f) := by
+  obtain ⟨hrlo, hrhi⟩ := rootS_contains fam hf
+  have hgf : g ∈ containersS fam a b f := by
+    rw [mem_containersS]
+    rw [mem_Sstrict] at hg
+    exact ⟨hg, le_trans h1 hrlo, le_trans hrhi h2⟩
+  have hmax := rootS_max fam hf g hgf
+  have hlhr := fam.lh (rootS fam a b f) (rootS_mem_E fam hf)
+  omega
+
+/-- Root is idempotent. -/
+lemma rootS_idem {f : ι} (hf : f ∈ Sstrict fam a b) :
+    rootS fam a b (rootS fam a b f) = rootS fam a b f := by
+  set r := rootS fam a b f with hr
+  have hrS : r ∈ Sstrict fam a b := rootS_mem_Sstrict fam hf
+  obtain ⟨hc1, hc2⟩ := rootS_contains fam hrS
+  have hmax := rootS_maximal fam hf (rootS_mem_Sstrict fam hrS) hc1 hc2
+  exact (fam.inj _ (rootS_mem_E fam hrS) _ (rootS_mem_E fam hf) hmax.1 hmax.2)
+
+/-- The roots in window `(a,b]`: maximal strict edges. -/
+noncomputable def Roots (a b : ℕ) : Finset ι :=
+  (Sstrict fam a b).filter (fun r => rootS fam a b r = r)
+
+lemma mem_Roots {r : ι} : r ∈ Roots fam a b ↔ r ∈ Sstrict fam a b ∧ rootS fam a b r = r := by
+  unfold Roots; rw [mem_filter]
+
+lemma rootS_mem_Roots {f : ι} (hf : f ∈ Sstrict fam a b) : rootS fam a b f ∈ Roots fam a b := by
+  rw [mem_Roots]
+  exact ⟨rootS_mem_Sstrict fam hf, rootS_idem fam hf⟩
+
+lemma root_self_props {r : ι} (hr : r ∈ Roots fam a b) :
+    r ∈ fam.E ∧ a ≤ fam.lo r ∧ fam.hi r ≤ b ∧ (fam.lo r ≠ a ∨ fam.hi r ≠ b) := by
+  rw [mem_Roots] at hr
+  have := hr.1; rw [mem_Sstrict] at this
+  exact ⟨this.1.1, this.1.2.1, this.1.2.2, this.2⟩
+
+/-- Uniqueness: two roots that both contain `g`'s interval coincide. -/
+lemma root_unique {r r' : ι} (hr : r ∈ Roots fam a b) (hr' : r' ∈ Roots fam a b)
+    {g : ι} (hg : g ∈ fam.E)
+    (h1 : fam.lo r ≤ fam.lo g) (h2 : fam.hi g ≤ fam.hi r)
+    (h1' : fam.lo r' ≤ fam.lo g) (h2' : fam.hi g ≤ fam.hi r') :
+    r = r' := by
+  obtain ⟨hrE, hra, hrb, hrs⟩ := root_self_props fam hr
+  obtain ⟨hr'E, hr'a, hr'b, hr's⟩ := root_self_props fam hr'
+  have hlg := fam.lh g hg
+  have hov := overlap_imp_nested fam hrE hr'E (by omega) (by omega)
+  rw [mem_Roots] at hr hr'
+  have hrS : r ∈ Sstrict fam a b := hr.1
+  have hr'S : r' ∈ Sstrict fam a b := hr'.1
+  rcases hov with ⟨hle1, hle2⟩ | ⟨hle1, hle2⟩
+  · have hmax := rootS_maximal fam hrS hr'S (g := r')
+        (by rw [hr.2]; exact hle1) (by rw [hr.2]; exact hle2)
+    rw [hr.2] at hmax
+    exact fam.inj r hrE r' hr'E (by omega) (by omega)
+  · have hmax := rootS_maximal fam hr'S hrS (g := r)
+        (by rw [hr'.2]; exact hle1) (by rw [hr'.2]; exact hle2)
+    rw [hr'.2] at hmax
+    exact fam.inj r hrE r' hr'E (by omega) (by omega)
+
+/-- The fiber of a root `r` equals the subtree `contained (lo r) (hi r)`. -/
+lemma fiber_eq_contained {r : ι} (hr : r ∈ Roots fam a b) :
+    (Sstrict fam a b).filter (fun g => rootS fam a b g = r) =
+      contained fam (fam.lo r) (fam.hi r) := by
+  obtain ⟨hrE, hra, hrb, hrs⟩ := root_self_props fam hr
+  ext g
+  rw [mem_filter, mem_Sstrict, mem_contained]
+  constructor
+  · rintro ⟨hgS, hgr⟩
+    have hgSmem : g ∈ Sstrict fam a b := by rw [mem_Sstrict]; exact hgS
+    have hcont := rootS_contains fam hgSmem
+    rw [hgr] at hcont
+    exact ⟨hgS.1.1, hcont.1, hcont.2⟩
+  · rintro ⟨hgE, hglo, hghi⟩
+    have hgwin : a ≤ fam.lo g ∧ fam.hi g ≤ b := ⟨le_trans hra hglo, le_trans hghi hrb⟩
+    have hglh := fam.lh g hgE
+    have hgstrict : fam.lo g ≠ a ∨ fam.hi g ≠ b := by
+      rcases hrs with h | h
+      · left; omega
+      · right; omega
+    have hgS : g ∈ Sstrict fam a b := by
+      rw [mem_Sstrict]; exact ⟨⟨hgE, hgwin.1, hgwin.2⟩, hgstrict⟩
+    refine ⟨⟨⟨hgE, hgwin.1, hgwin.2⟩, hgstrict⟩, ?_⟩
+    have hrootg := rootS_mem_Roots fam hgS
+    have hcontg := rootS_contains fam hgS
+    exact root_unique fam hrootg hr hgE hcontg.1 hcontg.2 hglo hghi
+
+/-- Strict edges decompose as the sum of root subtrees. -/
+lemma Sstrict_card_eq_sum :
+    (Sstrict fam a b).card = ∑ r ∈ Roots fam a b, N fam (fam.lo r) (fam.hi r) := by
+  have hmaps : ∀ g ∈ Sstrict fam a b, rootS fam a b g ∈ Roots fam a b :=
+    fun g hg => rootS_mem_Roots fam hg
+  rw [Finset.card_eq_sum_card_fiberwise hmaps]
+  apply Finset.sum_congr rfl
+  intro r hr
+  rw [fiber_eq_contained fam hr]
+  rfl
+
+/-- Edges with interval exactly the window. -/
+def topEdges (a b : ℕ) : Finset ι :=
+  (contained fam a b).filter (fun e => fam.lo e = a ∧ fam.hi e = b)
+
+/-- At most one top edge (intervals identify edges). -/
+lemma topEdges_card_le : (topEdges fam a b).card ≤ 1 := by
+  rw [Finset.card_le_one]
+  intro x hx y hy
+  unfold topEdges at hx hy
+  rw [mem_filter, mem_contained] at hx hy
+  exact fam.inj x hx.1.1 y hy.1.1 (by rw [hx.2.1, hy.2.1]) (by rw [hx.2.2, hy.2.2])
+
+/-- `Sstrict` is the complementary filter to `topEdges`. -/
+lemma Sstrict_eq_filter_not :
+    Sstrict fam a b = (contained fam a b).filter (fun e => ¬ (fam.lo e = a ∧ fam.hi e = b)) := by
+  unfold Sstrict
+  apply Finset.filter_congr
+  intro e _
+  unfold IsStrict
+  constructor
+  · rintro (h | h) ⟨h1, h2⟩ <;> [exact h h1; exact h h2]
+  · intro h
+    rw [not_and_or] at h
+    exact h
+
+/-- `N = #topEdges + #Sstrict`. -/
+lemma N_split : N fam a b = (topEdges fam a b).card + (Sstrict fam a b).card := by
+  rw [Sstrict_eq_filter_not]
+  unfold N topEdges
+  exact (Finset.card_filter_add_card_filter_not (s := contained fam a b)
+    (fun e => fam.lo e = a ∧ fam.hi e = b)).symm
+
+/-- Distinct roots have disjoint half-open level-intervals. -/
+lemma roots_interval_disjoint {r r' : ι} (hr : r ∈ Roots fam a b) (hr' : r' ∈ Roots fam a b)
+    (hne : r ≠ r') : fam.hi r ≤ fam.lo r' ∨ fam.hi r' ≤ fam.lo r := by
+  by_contra hc
+  rw [not_or] at hc
+  obtain ⟨h1, h2⟩ := hc
+  rw [not_le] at h1 h2
+  obtain ⟨hrE, _, _, _⟩ := root_self_props fam hr
+  obtain ⟨hr'E, _, _, _⟩ := root_self_props fam hr'
+  have hov := overlap_imp_nested fam hrE hr'E (by omega) (by omega)
+  rcases hov with ⟨hle1, hle2⟩ | ⟨hle1, hle2⟩
+  · exact hne (root_unique fam hr hr' hrE (le_refl _) (le_refl _) hle1 hle2)
+  · exact hne (root_unique fam hr hr' hr'E hle1 hle2 (le_refl _) (le_refl _))
+
+/-- The `Finset.Ioc` intervals of distinct roots are disjoint. -/
+lemma roots_Ioc_disjoint :
+    (Roots fam a b : Set ι).PairwiseDisjoint (fun r => Finset.Ioc (fam.lo r) (fam.hi r)) := by
+  intro r hr r' hr' hne
+  simp only [Finset.disjoint_left, Finset.mem_Ioc]
+  rintro t ⟨ht1, ht2⟩ ⟨ht3, ht4⟩
+  rcases roots_interval_disjoint fam hr hr' hne with h | h <;> omega
+
+/-- Sum of root widths is at most the window width. -/
+lemma roots_width_sum_le :
+    ∑ r ∈ Roots fam a b, (fam.hi r - fam.lo r) ≤ b - a := by
+  have hcard : ∀ r ∈ Roots fam a b,
+      fam.hi r - fam.lo r = (Finset.Ioc (fam.lo r) (fam.hi r)).card := by
+    intro r _; rw [Nat.card_Ioc]
+  rw [Finset.sum_congr rfl hcard]
+  rw [← Finset.card_biUnion (roots_Ioc_disjoint fam)]
+  rw [← Nat.card_Ioc a b]
+  apply Finset.card_le_card
+  intro t ht
+  rw [Finset.mem_biUnion] at ht
+  obtain ⟨r, hr, htr⟩ := ht
+  rw [Finset.mem_Ioc] at htr ⊢
+  obtain ⟨_, hra, hrb, _⟩ := root_self_props fam hr
+  omega
+
+/-- THE CRUX: if the window has a top edge, the root subtree widths do not cover it. -/
+lemma crux (hab : a < b) (htop : (topEdges fam a b).Nonempty) :
+    ∑ r ∈ Roots fam a b, (fam.hi r - fam.lo r) ≤ b - a - 1 := by
+  by_contra hcon
+  rw [not_le] at hcon
+  have hle := roots_width_sum_le fam (a := a) (b := b)
+  have hsum : ∑ r ∈ Roots fam a b, (fam.hi r - fam.lo r) = b - a := by omega
+  have hbu : (Roots fam a b).biUnion (fun r => Finset.Ioc (fam.lo r) (fam.hi r)) =
+      Finset.Ioc a b := by
+    apply Finset.eq_of_subset_of_card_le
+    · intro t ht
+      rw [Finset.mem_biUnion] at ht
+      obtain ⟨r, hr, htr⟩ := ht
+      rw [Finset.mem_Ioc] at htr ⊢
+      obtain ⟨_, hra, hrb, _⟩ := root_self_props fam hr
+      omega
+    · rw [Finset.card_biUnion (roots_Ioc_disjoint fam)]
+      have : ∑ r ∈ Roots fam a b, (Finset.Ioc (fam.lo r) (fam.hi r)).card
+          = ∑ r ∈ Roots fam a b, (fam.hi r - fam.lo r) := by
+        apply Finset.sum_congr rfl; intro r _; rw [Nat.card_Ioc]
+      rw [this, hsum, Nat.card_Ioc]
+  obtain ⟨e0, he0⟩ := htop
+  unfold topEdges at he0
+  rw [mem_filter, mem_contained] at he0
+  obtain ⟨⟨he0E, _, _⟩, he0lo, he0hi⟩ := he0
+  have hcover : ∀ t, a < t → t ≤ b → ∃ r ∈ Roots fam a b, fam.lo r < t ∧ t ≤ fam.hi r := by
+    intro t ht1 ht2
+    have htmem : t ∈ Finset.Ioc a b := by rw [Finset.mem_Ioc]; exact ⟨ht1, ht2⟩
+    rw [← hbu, Finset.mem_biUnion] at htmem
+    obtain ⟨r, hr, htr⟩ := htmem
+    rw [Finset.mem_Ioc] at htr
+    exact ⟨r, hr, htr.1, htr.2⟩
+  have scan : ∀ t, a < t → t ≤ b → ∀ r ∈ Roots fam a b,
+      fam.lo r < t → t ≤ fam.hi r → fam.col e0 < fam.col r := by
+    intro t
+    induction t using Nat.strong_induction_on with
+    | _ t ih =>
+      intro ht1 ht2 r hr hrlo hrhi
+      obtain ⟨hrE, hra, hrb, hrs⟩ := root_self_props fam hr
+      rcases Nat.lt_or_ge a (t - 1) with hprev | hprev
+      · have hprev2 : t - 1 ≤ b := by omega
+        obtain ⟨r'', hr'', hr''lo, hr''hi⟩ := hcover (t - 1) hprev hprev2
+        have hihr'' := ih (t - 1) (by omega) hprev hprev2 r'' hr'' hr''lo hr''hi
+        by_cases hrr : r = r''
+        · rw [hrr]; exact hihr''
+        · obtain ⟨hr''E, hr''a, hr''b, _⟩ := root_self_props fam hr''
+          have hdisj := roots_interval_disjoint fam hr'' hr (fun h => hrr h.symm)
+          have hseam1 : fam.hi r'' = t - 1 := by omega
+          have hseam2 : fam.lo r = t - 1 := by omega
+          have hseam : fam.hi r'' = fam.lo r := by omega
+          have hbseam := fam.bSeam r'' hr''E r hrE hseam
+          omega
+      · have htea : t = a + 1 := by omega
+        have hrloa : fam.lo r = a := by omega
+        have hrhib : fam.hi r < b := by
+          rcases hrs with h | h
+          · exact absurd hrloa h
+          · omega
+        have hbl := fam.bLeft e0 he0E r hrE (by rw [he0lo, hrloa]) (by rw [he0hi]; exact hrhib)
+        exact hbl
+  obtain ⟨rb, hrb, hrblo, hrbhi⟩ := hcover b (by omega) (le_refl b)
+  obtain ⟨hrbE, hrba, hrbb, hrbs⟩ := root_self_props fam hrb
+  have hrbhib : fam.hi rb = b := by omega
+  have hrbloa : a < fam.lo rb := by
+    rcases hrbs with h | h
+    · omega
+    · exact absurd hrbhib h
+  have hscan := scan b (by omega) (le_refl b) rb hrb hrblo hrbhi
+  have hbr := fam.bRight e0 he0E rb hrbE (by rw [he0hi, hrbhib]) (by rw [he0lo]; exact hrbloa)
+  omega
+
+/-- The master counting bound `N(a,b) ≤ b - a`. -/
+theorem master (a b : ℕ) : N fam a b ≤ b - a := by
+  induction hw : b - a using Nat.strongRecOn generalizing a b with
+  | ind w ih =>
+    rcases Nat.lt_or_ge a b with hab | hba
+    · rw [N_split fam]
+      rw [Sstrict_card_eq_sum fam]
+      have hsub : ∑ r ∈ Roots fam a b, N fam (fam.lo r) (fam.hi r)
+          ≤ ∑ r ∈ Roots fam a b, (fam.hi r - fam.lo r) := by
+        apply Finset.sum_le_sum
+        intro r hr
+        have hwlt : fam.hi r - fam.lo r < w := by
+          rw [mem_Roots] at hr
+          have := rootS_width_lt fam hr.1
+          rw [hr.2] at this
+          omega
+        exact ih (fam.hi r - fam.lo r) hwlt (fam.lo r) (fam.hi r) rfl
+      rcases Finset.eq_empty_or_nonempty (topEdges fam a b) with htop | htop
+      · rw [htop, Finset.card_empty]
+        have := roots_width_sum_le fam (a := a) (b := b)
+        omega
+      · have hc := crux fam hab htop
+        have htle := topEdges_card_le fam (a := a) (b := b)
+        omega
+    · rw [N_eq_zero_of_le fam hba]; omega
+
+end AbstractLaminar
+
+/-! # PART II — The geometric edge model (edges = survivors) and the forward bound. -/
+
+namespace CriticalPortraits
+
+open Finset
+open scoped BigOperators
+
+/-! ## Phase -1: arithmetic engine reused everywhere. -/
+
+/-- `i.val = (i.val % m) + (i.val / m) * m`. -/
+lemma val_decomp {N m : ℕ} (i : ZMod N) : i.val = (i.val % m) + (i.val / m) * m := by
+  have := Nat.div_add_mod' i.val m; omega
+
+/-- ENGINE: a single level of separation beats any column offset, ANY fibers. -/
+lemma sameblock_lt {N m : ℕ} (hm : 0 < m) {x y : ZMod N}
+    (ha : x.val / m < y.val / m) : x.val < y.val := by
+  have hp : x.val % m < m := Nat.mod_lt _ hm
+  have hq : y.val % m < m := Nat.mod_lt _ hm
+  have hx := val_decomp (m := m) x; have hy := val_decomp (m := m) y
+  have := sep_master (m := m) (p := x.val % m) (q := y.val % m)
+      (a := x.val / m) (c := y.val / m) hp hq ha
+  omega
+
+/-- Members of a critical set share a fiber (column). -/
+lemma critical_sameFiber {d m : ℕ} {S : Finset (ZMod (d * m))} (hS : IsCriticalSet d m S)
+    {x y : ZMod (d * m)} (hx : x ∈ S) (hy : y ∈ S) : x.val % m = y.val % m := by
+  obtain ⟨⟨r, hr, hfib⟩, _⟩ := hS; rw [hfib _ hx, hfib _ hy]
+
+/-! ## Phase 0a: host-set recovery (the edge's home critical set). -/
+
+variable {d m : ℕ}
+
+/-- The host critical set of an edge `x` in `T P`. -/
+noncomputable def hostSet (P : Finset (Finset (ZMod (d * m)))) (x : ZMod (d * m))
+    (hx : x ∈ T P) : Finset (ZMod (d*m)) := (mem_T.mp hx).choose
+
+lemma hostSet_mem {P : Finset (Finset (ZMod (d * m)))} {x : ZMod (d * m)} (hx : x ∈ T P) :
+    hostSet P x hx ∈ P := (mem_T.mp hx).choose_spec.1
+
+lemma mem_eraseMin_hostSet {P : Finset (Finset (ZMod (d * m)))} {x : ZMod (d * m)} (hx : x ∈ T P) :
+    x ∈ eraseMin (hostSet P x hx) := (mem_T.mp hx).choose_spec.2
+
+lemma mem_hostSet {P : Finset (Finset (ZMod (d * m)))} {x : ZMod (d * m)} (hx : x ∈ T P) :
+    x ∈ hostSet P x hx := eraseMin_subset _ (mem_eraseMin_hostSet hx)
+
+/-! ## Phase 0b: predecessor = the other endpoint (immediate predecessor in the host). -/
+
+/-- The elements of `S` strictly below `x` in value. -/
+def belowIn (S : Finset (ZMod (d * m))) (x : ZMod (d * m)) : Finset (ZMod (d * m)) :=
+  S.filter (fun y => y.val < x.val)
+
+lemma belowIn_nonempty [NeZero (d * m)] {S : Finset (ZMod (d * m))} (h : S.Nonempty)
+    {x : ZMod (d * m)} (hx : x ∈ eraseMin S) : (belowIn S x).Nonempty := by
+  refine ⟨minVal S h, ?_⟩
+  rw [belowIn, mem_filter]
+  refine ⟨minVal_mem S h, ?_⟩
+  have hxS := eraseMin_subset S hx
+  have hxne := ((mem_eraseMin S h x).mp hx).2
+  rcases lt_or_eq_of_le (minVal_le S h x hxS) with hlt | heq
+  · exact hlt
+  · exact absurd (ZMod.val_injective _ heq).symm hxne
+
+/-- The immediate predecessor of survivor `x` inside its host set: the `.val`-greatest
+    element of the host strictly below `x`. -/
+noncomputable def predIn [NeZero (d * m)] (P : Finset (Finset (ZMod (d * m)))) (x : ZMod (d * m))
+    (hx : x ∈ T P) : ZMod (d*m) := by
+  classical
+  exact (Finset.exists_max_image (belowIn (hostSet P x hx) x) (fun y => y.val)
+    (belowIn_nonempty ⟨x, mem_hostSet hx⟩ (mem_eraseMin_hostSet hx))).choose
+
+lemma predIn_mem_belowIn [NeZero (d * m)] {P : Finset (Finset (ZMod (d * m)))} {x : ZMod (d * m)}
+    (hx : x ∈ T P) : predIn P x hx ∈ belowIn (hostSet P x hx) x :=
+  (Finset.exists_max_image (belowIn (hostSet P x hx) x) (fun y => y.val)
+    (belowIn_nonempty ⟨x, mem_hostSet hx⟩ (mem_eraseMin_hostSet hx))).choose_spec.1
+
+lemma predIn_max [NeZero (d * m)] {P : Finset (Finset (ZMod (d * m)))} {x : ZMod (d * m)}
+    (hx : x ∈ T P) : ∀ y ∈ belowIn (hostSet P x hx) x, y.val ≤ (predIn P x hx).val :=
+  (Finset.exists_max_image (belowIn (hostSet P x hx) x) (fun y => y.val)
+    (belowIn_nonempty ⟨x, mem_hostSet hx⟩ (mem_eraseMin_hostSet hx))).choose_spec.2
+
+lemma predIn_mem_host [NeZero (d * m)] {P : Finset (Finset (ZMod (d * m)))} {x : ZMod (d * m)}
+    (hx : x ∈ T P) : predIn P x hx ∈ hostSet P x hx :=
+  (mem_filter.mp (predIn_mem_belowIn hx)).1
+
+lemma predIn_val_lt [NeZero (d * m)] {P : Finset (Finset (ZMod (d * m)))} {x : ZMod (d * m)}
+    (hx : x ∈ T P) : (predIn P x hx).val < x.val :=
+  (mem_filter.mp (predIn_mem_belowIn hx)).2
+
+/-- The host set of a survivor is critical. -/
+lemma hostSet_critical {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P) {x : ZMod (d * m)}
+    (hx : x ∈ T P) : IsCriticalSet d m (hostSet P x hx) := hP.1 _ (hostSet_mem hx)
+
+/-- Predecessor shares the survivor's fiber. -/
+lemma predIn_sameFiber [NeZero (d * m)] {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {x : ZMod (d * m)} (hx : x ∈ T P) : (predIn P x hx).val % m = x.val % m :=
+  critical_sameFiber (hostSet_critical hP hx) (predIn_mem_host hx) (mem_hostSet hx)
+
+/-- The edge is nonempty: `lo < hi` in level. -/
+lemma predIn_level_lt (hd : 0 < d) (hm : 0 < m) {P : Finset (Finset (ZMod (d * m)))}
+    (hP : Portrait d m P) {x : ZMod (d * m)} (hx : x ∈ T P) :
+    haveI : NeZero (d*m) := ⟨by positivity⟩
+    (predIn P x hx).val / m < x.val / m := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  have hsame := predIn_sameFiber hP hx
+  have hvlt := predIn_val_lt hx
+  rcases lt_or_eq_of_le ((val_le_iff_level_le_of_sameFiber hsame).mp hvlt.le) with hlt | heq
+  · exact hlt
+  · exact absurd (congrArg ZMod.val (level_injOn_fiber hsame heq)) (Nat.ne_of_lt hvlt)
+
+/-- `predIn x` is the immediate predecessor: no host element strictly between it and `x`. -/
+lemma predIn_immediate [NeZero (d * m)] {P : Finset (Finset (ZMod (d * m)))} {x : ZMod (d * m)}
+    (hx : x ∈ T P) {z : ZMod (d * m)} (hz : z ∈ hostSet P x hx)
+    (h1 : (predIn P x hx).val < z.val) (h2 : z.val < x.val) : False := by
+  have hzb : z ∈ belowIn (hostSet P x hx) x := by
+    rw [belowIn, mem_filter]; exact ⟨hz, h2⟩
+  have := predIn_max hx z hzb
+  omega
+
+/-! ## Phase 1: the crossing engine. -/
+
+/-- Cross-host crossing: an alternating val-quadruple `px < py < x < y` with `px,x` in host `x`
+    and `py,y` in host `y` (distinct hosts) contradicts the portrait's Unlinked clause. -/
+lemma cross_false [NeZero (d * m)] {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {x y : ZMod (d * m)} (hx : x ∈ T P) (hy : y ∈ T P)
+    (hhost : hostSet P x hx ≠ hostSet P y hy)
+    (o1 : (predIn P x hx).val < (predIn P y hy).val)
+    (o2 : (predIn P y hy).val < x.val)
+    (o3 : x.val < y.val) : False := by
+  have hL : Linked (hostSet P x hx) (hostSet P y hy) :=
+    linked_of_lt (predIn_mem_host hx) (mem_hostSet hx) (predIn_mem_host hy) (mem_hostSet hy)
+      o1 o2 o3
+  exact (hP.2.2.1 _ (hostSet_mem hx) _ (hostSet_mem hy) hhost) hL
+
+/-! ## Phase 2: total edge data `(loV, hiV, colV)`. -/
+
+/-- The level index `x.val / m` of a position `x`. -/
+def hiV (x : ZMod (d * m)) : ℕ := x.val / m
+/-- The fiber index `x.val % m` of a position `x`. -/
+def colV (x : ZMod (d * m)) : ℕ := x.val % m
+/-- The low interval-endpoint value of `x` within its host critical set. -/
+noncomputable def loV [NeZero (d * m)] (P : Finset (Finset (ZMod (d * m))))
+    (x : ZMod (d * m)) : ℕ :=
+  if hx : x ∈ T P then (predIn P x hx).val / m else 0
+
+lemma loV_eq [NeZero (d * m)] {P : Finset (Finset (ZMod (d * m)))} {x : ZMod (d * m)}
+    (hx : x ∈ T P) :
+    loV P x = (predIn P x hx).val / m := by
+  unfold loV; rw [dif_pos hx]
+
+/-- The survivor's value decomposes as `colV + hiV*m`. -/
+lemma top_val_eq {x : ZMod (d * m)} : x.val = colV x + hiV x * m := by
+  unfold colV hiV; have := Nat.div_add_mod' x.val m; omega
+
+/-- The predecessor's value decomposes as `colV + loV*m` (same column as the survivor). -/
+lemma pred_val_eq [NeZero (d * m)] {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {x : ZMod (d * m)} (hx : x ∈ T P) : (predIn P x hx).val = colV x + loV P x * m := by
+  have hsame := predIn_sameFiber hP hx
+  rw [loV_eq hx]
+  unfold colV
+  rw [← hsame]
+  have := Nat.div_add_mod' (predIn P x hx).val m; omega
+
+/-! ## Phase 3: the master non-alternation + same-host glue. -/
+
+/-- THE MASTER NON-ALTERNATION LEMMA. No two survivors' endpoints alternate as
+    `px < py < x < y` (covers cross-host via Unlinked and same-host via immediacy). -/
+lemma no_alt [NeZero (d * m)] {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {x y : ZMod (d * m)} (hx : x ∈ T P) (hy : y ∈ T P)
+    (o1 : (predIn P x hx).val < (predIn P y hy).val)
+    (o2 : (predIn P y hy).val < x.val)
+    (o3 : x.val < y.val) : False := by
+  by_cases hhost : hostSet P x hx = hostSet P y hy
+  · -- same host: predIn y lies strictly between predIn x and x, in host x
+    apply predIn_immediate hx (z := predIn P y hy) ?_ o1 o2
+    rw [hhost]; exact predIn_mem_host hy
+  · exact cross_false hP hx hy hhost o1 o2 o3
+
+/-- If two survivors coincide as points they share a host (Portrait disjointness). -/
+lemma eq_imp_sameHost {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {x y : ZMod (d * m)} (hx : x ∈ T P) (hy : y ∈ T P) (hxy : x = y) :
+    hostSet P x hx = hostSet P y hy := by
+  by_contra hne
+  have hdisj := hP.2.1 _ (hostSet_mem hx) _ (hostSet_mem hy) hne
+  have hmemx : x ∈ hostSet P x hx := mem_hostSet hx
+  have hmemy : x ∈ hostSet P y hy := hxy ▸ mem_hostSet hy
+  exact (Finset.disjoint_left.mp hdisj hmemx) hmemy
+
+/-- If predecessors coincide as points the survivors share a host. -/
+lemma predEq_imp_sameHost {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {x y : ZMod (d * m)} (hx : x ∈ T P) (hy : y ∈ T P)
+    [NeZero (d * m)] (hpe : predIn P x hx = predIn P y hy) :
+    hostSet P x hx = hostSet P y hy := by
+  by_contra hne
+  have hdisj := hP.2.1 _ (hostSet_mem hx) _ (hostSet_mem hy) hne
+  have hmemx : predIn P x hx ∈ hostSet P x hx := predIn_mem_host hx
+  have hmemy : predIn P x hx ∈ hostSet P y hy := hpe ▸ predIn_mem_host hy
+  exact (Finset.disjoint_left.mp hdisj hmemx) hmemy
+
+/-! ## Phase 4: the LEMMA A / LEMMA B / inj axioms (in `loV/hiV/colV`). -/
+
+lemma colV_lt_m (hm : 0 < m) (x : ZMod (d * m)) : colV x < m := Nat.mod_lt _ hm
+
+/-- LEMMA A: laminar (no proper overlap of level-intervals). -/
+lemma lemmaA [NeZero (d * m)] (hm : 0 < m)
+    {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {e f : ZMod (d * m)} (he : e ∈ T P) (hf : f ∈ T P)
+    (h1 : loV P e < loV P f) (h2 : loV P f < hiV e) (h3 : hiV e < hiV f) : False := by
+  -- build the alternation px < py < e.val < f.val
+  have hpe := pred_val_eq hP he
+  have hpf := pred_val_eq hP hf
+  have hte := top_val_eq (x := e)
+  have htf := top_val_eq (x := f)
+  have hce := colV_lt_m hm e
+  have hcf := colV_lt_m hm f
+  -- o1: predIn e .val < predIn f .val   (loV e < loV f)
+  have o1 : (predIn P e he).val < (predIn P f hf).val := by
+    rw [hpe, hpf]; have := sep_master (m := m) (p := colV e) (q := colV f) hce hcf h1; omega
+  -- o2: predIn f .val < e.val   (loV f < hiV e)
+  have o2 : (predIn P f hf).val < e.val := by
+    rw [hpf, hte]; have := sep_master (m := m) (p := colV f) (q := colV e) hcf hce h2; omega
+  -- o3: e.val < f.val   (hiV e < hiV f)
+  have o3 : e.val < f.val := by
+    rw [hte, htf]; have := sep_master (m := m) (p := colV e) (q := colV f) hce hcf h3; omega
+  exact no_alt hP he hf o1 o2 o3
+
+/-- LEMMA B (seam): `e` tops where `f` bottoms ⇒ `col e ≤ col f`. -/
+lemma lemmaB_seam [NeZero (d * m)] (hd : 0 < d) (hm : 0 < m)
+    {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {e f : ZMod (d * m)} (he : e ∈ T P) (hf : f ∈ T P) (hseam : hiV e = loV P f) :
+    colV e ≤ colV f := by
+  by_contra hc
+  rw [not_le] at hc  -- colV f < colV e
+  have hpe := pred_val_eq hP he
+  have hpf := pred_val_eq hP hf
+  have hte := top_val_eq (x := e)
+  have htf := top_val_eq (x := f)
+  have hce := colV_lt_m hm e
+  have hcf := colV_lt_m hm f
+  have hlhe : loV P e < hiV e := by rw [loV_eq he]; exact predIn_level_lt hd hm hP he
+  have hlhf : loV P f < hiV f := by rw [loV_eq hf]; exact predIn_level_lt hd hm hP hf
+  -- o1: predIn e .val < predIn f .val
+  have o1 : (predIn P e he).val < (predIn P f hf).val := by
+    rw [hpe, hpf, ← hseam]
+    have := sep_master (m := m) (p := colV e) (q := colV f) hce hcf hlhe
+    omega
+  -- o2: predIn f .val < e.val
+  have o2 : (predIn P f hf).val < e.val := by
+    rw [hpf, hte, ← hseam]; omega
+  -- o3: e.val < f.val
+  have o3 : e.val < f.val := by
+    rw [hte, htf]
+    have hef : hiV e < hiV f := by rw [hseam]; exact hlhf
+    have := sep_master (m := m) (p := colV e) (q := colV f) hce hcf hef
+    omega
+  exact no_alt hP he hf o1 o2 o3
+
+/-- LEMMA B (right-aligned): share top, nested right ⇒ inner col smaller. -/
+lemma lemmaB_right [NeZero (d * m)] (hd : 0 < d) (hm : 0 < m)
+    {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {e f : ZMod (d * m)} (he : e ∈ T P) (hf : f ∈ T P)
+    (htop : hiV e = hiV f) (hlo : loV P e < loV P f) : colV f < colV e := by
+  by_contra hc
+  rw [not_lt] at hc  -- colV e ≤ colV f
+  have hpe := pred_val_eq hP he
+  have hpf := pred_val_eq hP hf
+  have hte := top_val_eq (x := e)
+  have htf := top_val_eq (x := f)
+  have hce := colV_lt_m hm e
+  have hcf := colV_lt_m hm f
+  have hlhf : loV P f < hiV f := by rw [loV_eq hf]; exact predIn_level_lt hd hm hP hf
+  rcases lt_or_eq_of_le hc with hclt | hceq
+  · -- colV e < colV f: alternation e,f
+    have o1 : (predIn P e he).val < (predIn P f hf).val := by
+      rw [hpe, hpf]
+      have := sep_master (m := m) (p := colV e) (q := colV f) hce hcf hlo
+      omega
+    have o2 : (predIn P f hf).val < e.val := by
+      rw [hpf, hte]
+      have hlt : loV P f < hiV e := by rw [htop]; exact hlhf
+      have := sep_master (m := m) (p := colV f) (q := colV e) hcf hce hlt
+      omega
+    have o3 : e.val < f.val := by
+      rw [hte, htf, ← htop]; omega
+    exact no_alt hP he hf o1 o2 o3
+  · -- colV e = colV f ⇒ e = f ⇒ loV e = loV f, contra loV e < loV f
+    have hval : e.val = f.val := by rw [hte, htf, htop, hceq]
+    have : e = f := ZMod.val_injective _ hval
+    rw [this] at hlo; omega
+
+/-- LEMMA B (left-aligned): share bottom, nested left ⇒ inner col larger. -/
+lemma lemmaB_left [NeZero (d * m)] (hd : 0 < d) (hm : 0 < m)
+    {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {e f : ZMod (d * m)} (he : e ∈ T P) (hf : f ∈ T P)
+    (hbot : loV P e = loV P f) (hhi : hiV f < hiV e) : colV e < colV f := by
+  by_contra hc
+  rw [not_lt] at hc  -- colV f ≤ colV e
+  have hpe := pred_val_eq hP he
+  have hpf := pred_val_eq hP hf
+  have hte := top_val_eq (x := e)
+  have htf := top_val_eq (x := f)
+  have hce := colV_lt_m hm e
+  have hcf := colV_lt_m hm f
+  have hlhf : loV P f < hiV f := by rw [loV_eq hf]; exact predIn_level_lt hd hm hP hf
+  rcases lt_or_eq_of_le hc with hclt | hceq
+  · -- colV f < colV e: alternation f,e
+    have o1 : (predIn P f hf).val < (predIn P e he).val := by
+      rw [hpf, hpe, ← hbot]; omega
+    have o2 : (predIn P e he).val < f.val := by
+      rw [hpe, htf, hbot]
+      have hlt : loV P f < hiV f := hlhf
+      have := sep_master (m := m) (p := colV e) (q := colV f) hce hcf hlt
+      omega
+    have o3 : f.val < e.val := by
+      rw [htf, hte]
+      have := sep_master (m := m) (p := colV f) (q := colV e) hcf hce hhi
+      omega
+    exact no_alt hP hf he o1 o2 o3
+  · -- colV f = colV e ⇒ predIn e = predIn f ⇒ same host ⇒ f between p and e ⇒ immediacy
+    have hpv : (predIn P e he).val = (predIn P f hf).val := by rw [hpe, hpf, hbot, hceq]
+    have hpeq : predIn P e he = predIn P f hf := ZMod.val_injective _ hpv
+    have hhost := predEq_imp_sameHost hP he hf hpeq
+    -- f ∈ hostSet e
+    have hfmem : f ∈ hostSet P e he := by rw [hhost]; exact mem_hostSet hf
+    -- p.val < f.val < e.val
+    have hlt1 : (predIn P e he).val < f.val := by
+      rw [hpe, htf, hbot]
+      have := sep_master (m := m) (p := colV e) (q := colV f) hce hcf hlhf
+      omega
+    have hlt2 : f.val < e.val := by
+      rw [htf, hte]
+      have := sep_master (m := m) (p := colV f) (q := colV e) hcf hce hhi
+      omega
+    exact predIn_immediate he hfmem hlt1 hlt2
+
+/-- INJECTIVITY: distinct survivors have distinct level-intervals. -/
+lemma edge_inj [NeZero (d * m)] (hd : 0 < d) (hm : 0 < m)
+    {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {e f : ZMod (d * m)} (he : e ∈ T P) (hf : f ∈ T P)
+    (hlo : loV P e = loV P f) (hhi : hiV e = hiV f) : e = f := by
+  by_contra hne
+  have hte := top_val_eq (x := e)
+  have htf := top_val_eq (x := f)
+  have hce := colV_lt_m hm e
+  have hcf := colV_lt_m hm f
+  have hpe := pred_val_eq hP he
+  have hpf := pred_val_eq hP hf
+  have hlhe : loV P e < hiV e := by rw [loV_eq he]; exact predIn_level_lt hd hm hP he
+  -- colV e ≠ colV f (else same val ⇒ equal)
+  have hcne : colV e ≠ colV f := by
+    intro h
+    exact hne (ZMod.val_injective _ (by rw [hte, htf, hhi, h]))
+  rcases Nat.lt_or_ge (colV e) (colV f) with hclt | hcge
+  · -- alternation e,f
+    have o1 : (predIn P e he).val < (predIn P f hf).val := by rw [hpe, hpf, hlo]; omega
+    have o2 : (predIn P f hf).val < e.val := by
+      rw [hpf, hte, ← hlo]
+      have := sep_master (m := m) (p := colV f) (q := colV e) hcf hce hlhe
+      omega
+    have o3 : e.val < f.val := by rw [hte, htf, ← hhi]; omega
+    exact no_alt hP he hf o1 o2 o3
+  · -- colV f < colV e (since ≠): alternation f,e
+    have hclt : colV f < colV e := lt_of_le_of_ne hcge (fun h => hcne h.symm)
+    have hlhf : loV P f < hiV f := by rw [loV_eq hf]; exact predIn_level_lt hd hm hP hf
+    have o1 : (predIn P f hf).val < (predIn P e he).val := by rw [hpf, hpe, ← hlo]; omega
+    have o2 : (predIn P e he).val < f.val := by
+      rw [hpe, htf, hlo]
+      have := sep_master (m := m) (p := colV e) (q := colV f) hce hcf hlhf
+      omega
+    have o3 : f.val < e.val := by rw [htf, hte, hhi]; omega
+    exact no_alt hP hf he o1 o2 o3
+
+/-! ## Phase 5: the `Family` instance and the forward bound. -/
+
+/-- The laminar interval family of a portrait's survivors (edges = survivors). -/
+noncomputable def survivorFamily [NeZero (d * m)] (hd : 0 < d) (hm : 0 < m)
+    {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P) :
+    AbstractLaminar.Family (ZMod (d*m)) where
+  E := T P
+  lo := loV P
+  hi := hiV
+  col := colV
+  lh := fun e he => by rw [loV_eq he]; exact predIn_level_lt hd hm hP he
+  inj := fun e he f hf hlo hhi => edge_inj hd hm hP he hf hlo hhi
+  laminar := fun e he f hf => fun ⟨h1, h2, h3⟩ => lemmaA hm hP he hf h1 h2 h3
+  bRight := fun e he f hf htop hlo => lemmaB_right hd hm hP he hf htop hlo
+  bLeft := fun e he f hf hbot hhi => lemmaB_left hd hm hP he hf hbot hhi
+  bSeam := fun e he f hf hseam => lemmaB_seam hd hm hP he hf hseam
+
+/-- **FORWARD BOUND.** `T P` is level-canonical, for every degree `d`. -/
+theorem T_levelCanonical {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P) :
+    LevelCanonical d m (T P) := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  intro j hj
+  -- The LevelCanonical filter equals `contained (survivorFamily) 0 j`.
+  have hfilter : (T P).filter (fun i => i.val / m ≤ j)
+      = AbstractLaminar.contained (survivorFamily hd hm hP) 0 j := by
+    unfold AbstractLaminar.contained
+    apply Finset.filter_congr
+    intro e he
+    constructor
+    · intro h; exact ⟨Nat.zero_le _, h⟩
+    · intro h; exact h.2
+  rw [hfilter]
+  have hm0 := AbstractLaminar.master (survivorFamily hd hm hP) 0 j
+  unfold AbstractLaminar.N at hm0
+  simpa using hm0
+
+end CriticalPortraits

--- a/LeanPool/CriticalPortraits/Injectivity.lean
+++ b/LeanPool/CriticalPortraits/Injectivity.lean
@@ -1,0 +1,1099 @@
+/-
+Copyright (c) 2026 Keston Aquino-Michaels. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Keston Aquino-Michaels
+-/
+
+import LeanPool.CriticalPortraits.Forward
+
+/-!
+# INJECTIVITY of `T` (Brick 4).
+
+`T` is injective on critical portraits, for every degree `d`:
+
+  `T_injOn : Set.InjOn (T (N := d*m)) {P | Portrait d m P}`
+
+uses the REAL `Portraits.T` (`= P.sup eraseMin`) and `Portraits.Portrait`.
+
+Bottom-up build (paper Part I — Uniqueness):
+  PART A  (`AbstractLaminar`)  — the TIGHTNESS / equality layer on top of `master`
+                                (`root_saturated`, `edge_tight_of_saturated`) and
+                                COLUMN-SEPARATION (`column_sep`).
+  PART B  (`CriticalPortraits`)           — geometric TIGHTNESS / column-sep at the survivor family,
+                                Lemma 2 (block-span laminarity), the BRIDGE edge core, the
+                                blocks-as-host-sets recovery, and the injectivity assembly.
+
+STATUS: FULLY SORRY-FREE.  The keystone `predIn_forced` (paper Part I, stage 1: the inductive
+forced-predecessor / Structural-Lemma dispatch — the documented all-`d` kernel) is now CLOSED for
+all `d` via the spanning-edge kernel (`spanning_edge`), built from the directional column
+separation (`column_sep_with_gap` / `column_sep_geom_dir`).  Everything is axiom-clean
+(`{propext, Classical.choice, Quot.sound}`, NO `sorryAx`, NO `native_decide`), including:
+  • PART A TIGHTNESS  (`root_saturated`, `edge_tight_of_saturated`) and COLUMN-SEPARATION
+    (`column_sep`, `column_sep_with_gap`) — degree-free, axiom-clean.
+  • PART B geometric TIGHTNESS / column-sep (`edge_tight_geom`, `column_sep_geom`,
+    `column_sep_geom_dir`), Lemma 2 (`span_laminar`), the BRIDGE edge core (`bridge_edge`).
+  • Stage 1 keystone: `predIn_forced` — PROVED (strong induction on `.val` + WLOG + the
+    spanning-edge crossing into `no_alt`).
+  • Stage 2 (component recovery): `hostSet_forced` from `predIn_forced`.
+  • The assembly `T_inj` / `T_injOn`.
+-/
+
+open Finset
+open scoped BigOperators
+
+/-! ## PART A — TIGHTNESS in `AbstractLaminar`. -/
+
+namespace AbstractLaminar
+
+variable {ι : Type*} [DecidableEq ι]
+variable (fam : Family ι)
+
+/-- **Saturation propagates to roots.** If the window `(a,b]` is saturated
+    (`N = b-a`), then every root's subtree is itself saturated. -/
+lemma root_saturated {a b : ℕ} (hsat : N fam a b = b - a) :
+    ∀ r ∈ Roots fam a b, N fam (fam.lo r) (fam.hi r) = fam.hi r - fam.lo r := by
+  -- The master chain, but tracking equality.
+  rcases Nat.lt_or_ge a b with hab | hba
+  · -- termwise bound N(lo r, hi r) ≤ hi r - lo r
+    have hterm : ∀ r ∈ Roots fam a b, N fam (fam.lo r) (fam.hi r) ≤ fam.hi r - fam.lo r := by
+      intro r _; exact master fam _ _
+    -- ∑ N(lo r, hi r) = #Sstrict (forest decomposition)
+    have hSstrict := Sstrict_card_eq_sum fam (a := a) (b := b)
+    -- N = #top + #Sstrict
+    have hNsplit := N_split fam (a := a) (b := b)
+    have htle := topEdges_card_le fam (a := a) (b := b)
+    have hwidth := roots_width_sum_le fam (a := a) (b := b)
+    -- Show ∑ N(lo r, hi r) = ∑ (hi r - lo r), then conclude pointwise.
+    have hsumeq : (∑ r ∈ Roots fam a b, N fam (fam.lo r) (fam.hi r))
+        = ∑ r ∈ Roots fam a b, (fam.hi r - fam.lo r) := by
+      -- ≤ direction is termwise.
+      have hle : (∑ r ∈ Roots fam a b, N fam (fam.lo r) (fam.hi r))
+          ≤ ∑ r ∈ Roots fam a b, (fam.hi r - fam.lo r) := Finset.sum_le_sum hterm
+      -- Now lower bound ∑ N(lo r,hi r) using the saturation.
+      rcases Finset.eq_empty_or_nonempty (topEdges fam a b) with htop | htop
+      · -- no top edge: #Sstrict = N = b - a, and ∑(hi-lo) ≤ b-a.
+        rw [htop, Finset.card_empty] at hNsplit
+        -- hNsplit : N = 0 + #Sstrict
+        have : (∑ r ∈ Roots fam a b, N fam (fam.lo r) (fam.hi r)) = b - a := by
+          rw [← hSstrict]; omega
+        omega
+      · -- top edge present: crux gives ∑(hi-lo) ≤ b-a-1, #top = 1, #Sstrict = N - 1.
+        have hcrux := crux fam hab htop
+        have htpos : 1 ≤ (topEdges fam a b).card := Finset.card_pos.mpr htop
+        have htone : (topEdges fam a b).card = 1 := le_antisymm htle htpos
+        have : (∑ r ∈ Roots fam a b, N fam (fam.lo r) (fam.hi r)) = b - a - 1 := by
+          rw [← hSstrict]; omega
+        omega
+    -- pointwise equality.
+    exact (Finset.sum_eq_sum_iff_of_le hterm).mp hsumeq
+  · -- empty window
+    intro r hr
+    obtain ⟨hrE, hra, hrb, hrs⟩ := root_self_props fam hr
+    -- if b ≤ a then there are no roots (window empty) — contradiction or vacuous.
+    have hlh := fam.lh r hrE
+    omega
+
+/-- **Every edge is tight.** If the window `(a,b]` is saturated, then every edge contained in
+    it has a saturated own-window (`N(lo e, hi e) = hi e - lo e`, i.e. `g(e) = h(e) - 1`). -/
+lemma edge_tight_of_saturated :
+    ∀ w : ℕ, ∀ a b : ℕ, b - a = w → N fam a b = b - a →
+      ∀ e ∈ contained fam a b, N fam (fam.lo e) (fam.hi e) = fam.hi e - fam.lo e := by
+  intro w
+  induction w using Nat.strong_induction_on with
+  | _ w ih =>
+    intro a b hw hsat e he
+    rw [mem_contained] at he
+    obtain ⟨heE, hea, heb⟩ := he
+    by_cases htop : fam.lo e = a ∧ fam.hi e = b
+    · -- e is the top edge: its window IS the saturated window.
+      rw [htop.1, htop.2]; rw [hsat]
+    · -- e is strict; its root is saturated, and the root window is smaller.
+      have heS : e ∈ Sstrict fam a b := by
+        rw [mem_Sstrict]
+        refine ⟨⟨heE, hea, heb⟩, ?_⟩
+        rw [not_and_or] at htop; exact htop
+      have hr := rootS_mem_Roots fam heS
+      have hrsat := root_saturated fam hsat _ hr
+      have hcont := rootS_contains fam heS
+      -- e contained in (lo r, hi r)
+      have hewin : e ∈ contained fam (fam.lo (rootS fam a b e)) (fam.hi (rootS fam a b e)) := by
+        rw [mem_contained]; exact ⟨heE, hcont.1, hcont.2⟩
+      -- root window width < w
+      have hrwidth := rootS_width_lt fam heS
+      exact ih (fam.hi (rootS fam a b e) - fam.lo (rootS fam a b e)) (by omega)
+        (fam.lo (rootS fam a b e)) (fam.hi (rootS fam a b e)) rfl hrsat e hewin
+
+/-! ### A2 — COLUMN-SEPARATION.
+
+For a saturated window `(a,b]` whose top edge `e0` exists (interval exactly `(a,b]`), every root
+`r` has `col r ≠ col e0`.  Proof by the seam scan: the gap splits roots into a left run (each
+shares the bottom `a` up to the gap; `bLeft`/`bSeam` ⇒ `col e0 < col r`) and a right run (each
+shares the top `b` down to the gap; `bRight`/`bSeam` ⇒ `col r < col e0`). -/
+
+/-- Saturated window with a top edge: the root subtree widths sum to exactly `b - a - 1`. -/
+lemma roots_width_sum_eq {a b : ℕ} (hab : a < b) (hsat : N fam a b = b - a)
+    (htop : (topEdges fam a b).Nonempty) :
+    ∑ r ∈ Roots fam a b, (fam.hi r - fam.lo r) = b - a - 1 := by
+  -- each root saturated ⇒ ∑ N(lo,hi) = ∑ widths.
+  have hrsat := root_saturated fam hsat
+  have hcongr : (∑ r ∈ Roots fam a b, N fam (fam.lo r) (fam.hi r))
+      = ∑ r ∈ Roots fam a b, (fam.hi r - fam.lo r) :=
+    Finset.sum_congr rfl (fun r hr => hrsat r hr)
+  have hSstrict := Sstrict_card_eq_sum fam (a := a) (b := b)
+  have hNsplit := N_split fam (a := a) (b := b)
+  have htone : (topEdges fam a b).card = 1 :=
+    le_antisymm (topEdges_card_le fam) (Finset.card_pos.mpr htop)
+  -- N = 1 + #Sstrict = 1 + ∑ widths; N = b - a; so ∑ widths = b - a - 1
+  rw [htone] at hNsplit
+  rw [hSstrict, hcongr] at hNsplit
+  omega
+
+/-- The root level-intervals of a saturated top-edged window miss exactly one level `g*`:
+    there is a unique `g ∈ (a,b]` covered by no root. -/
+lemma exists_gap {a b : ℕ} (hab : a < b) (hsat : N fam a b = b - a)
+    (htop : (topEdges fam a b).Nonempty) :
+    ∃ g, a < g ∧ g ≤ b ∧ (∀ r ∈ Roots fam a b, ¬ (fam.lo r < g ∧ g ≤ fam.hi r)) := by
+  -- biUnion of root Iocs has card = ∑ widths = b-a-1 < b-a = card (Ioc a b), and is a subset.
+  set B := (Roots fam a b).biUnion (fun r => Finset.Ioc (fam.lo r) (fam.hi r)) with hB
+  have hsub : B ⊆ Finset.Ioc a b := by
+    intro t ht
+    rw [hB, Finset.mem_biUnion] at ht
+    obtain ⟨r, hr, htr⟩ := ht
+    rw [Finset.mem_Ioc] at htr ⊢
+    obtain ⟨_, hra, hrb, _⟩ := root_self_props fam hr
+    omega
+  have hcardB : B.card = b - a - 1 := by
+    rw [hB, Finset.card_biUnion (roots_Ioc_disjoint fam)]
+    have : ∑ r ∈ Roots fam a b, (Finset.Ioc (fam.lo r) (fam.hi r)).card
+        = ∑ r ∈ Roots fam a b, (fam.hi r - fam.lo r) :=
+      Finset.sum_congr rfl (fun r _ => Nat.card_Ioc _ _)
+    rw [this, roots_width_sum_eq fam hab hsat htop]
+  -- so B is a proper subset of Ioc a b, missing exactly one element.
+  have hcardIoc : (Finset.Ioc a b).card = b - a := Nat.card_Ioc a b
+  have hssub : B ⊂ Finset.Ioc a b := by
+    rw [Finset.ssubset_iff_of_subset hsub]
+    by_contra hc
+    push Not at hc
+    have : Finset.Ioc a b ⊆ B := hc
+    have := Finset.card_le_card this
+    omega
+  obtain ⟨g, hgIoc, hgB⟩ := Finset.exists_of_ssubset hssub
+  rw [Finset.mem_Ioc] at hgIoc
+  refine ⟨g, hgIoc.1, hgIoc.2, ?_⟩
+  intro r hr ⟨h1, h2⟩
+  apply hgB
+  rw [hB, Finset.mem_biUnion]
+  exact ⟨r, hr, by rw [Finset.mem_Ioc]; exact ⟨h1, h2⟩⟩
+
+/-- Every level in `(a,b]` except the gap `g` (with `a < g ≤ b`) is covered by some root. -/
+lemma covered_of_ne_gap {a b g : ℕ} (htop : (topEdges fam a b).Nonempty)
+    (hsat : N fam a b = b - a) (hab : a < b)
+    (hg1 : a < g) (hg2 : g ≤ b)
+    (hgap : ∀ r ∈ Roots fam a b, ¬ (fam.lo r < g ∧ g ≤ fam.hi r))
+    {t : ℕ} (ht1 : a < t) (ht2 : t ≤ b) (htne : t ≠ g) :
+    ∃ r ∈ Roots fam a b, fam.lo r < t ∧ t ≤ fam.hi r := by
+  set B := (Roots fam a b).biUnion (fun r => Finset.Ioc (fam.lo r) (fam.hi r)) with hB
+  have hsub : B ⊆ Finset.Ioc a b := by
+    intro s hs
+    rw [hB, Finset.mem_biUnion] at hs
+    obtain ⟨r, hr, hsr⟩ := hs
+    rw [Finset.mem_Ioc] at hsr ⊢
+    obtain ⟨_, hra, hrb, _⟩ := root_self_props fam hr
+    omega
+  have hcardB : B.card = b - a - 1 := by
+    rw [hB, Finset.card_biUnion (roots_Ioc_disjoint fam)]
+    have : ∑ r ∈ Roots fam a b, (Finset.Ioc (fam.lo r) (fam.hi r)).card
+        = ∑ r ∈ Roots fam a b, (fam.hi r - fam.lo r) :=
+      Finset.sum_congr rfl (fun r _ => Nat.card_Ioc _ _)
+    rw [this, roots_width_sum_eq fam hab hsat htop]
+  have hgnotB : g ∉ B := by
+    rw [hB, Finset.mem_biUnion]; push Not
+    intro r hr
+    rw [Finset.mem_Ioc]
+    intro ⟨h1, h2⟩
+    exact hgap r hr ⟨h1, h2⟩
+  have hgIoc : g ∈ Finset.Ioc a b := by rw [Finset.mem_Ioc]; exact ⟨hg1, hg2⟩
+  -- insert g B ⊆ Ioc a b with card (b-a-1)+1 = b-a = card Ioc ⇒ insert g B = Ioc a b.
+  have hins_sub : insert g B ⊆ Finset.Ioc a b := Finset.insert_subset hgIoc hsub
+  have hins_card : (insert g B).card = b - a := by
+    rw [Finset.card_insert_of_notMem hgnotB, hcardB]
+    have hbpos : 1 ≤ b - a := by omega
+    omega
+  have heq : insert g B = Finset.Ioc a b :=
+    Finset.eq_of_subset_of_card_le hins_sub (by rw [hins_card, Nat.card_Ioc])
+  -- t ∈ Ioc a b, t ≠ g ⇒ t ∈ B
+  have htIoc : t ∈ Finset.Ioc a b := by rw [Finset.mem_Ioc]; exact ⟨ht1, ht2⟩
+  rw [← heq, Finset.mem_insert] at htIoc
+  rcases htIoc with h | h
+  · exact absurd h htne
+  · rw [hB, Finset.mem_biUnion] at h
+    obtain ⟨r, hr, htr⟩ := h
+    rw [Finset.mem_Ioc] at htr
+    exact ⟨r, hr, htr.1, htr.2⟩
+
+/-- Distinct roots covering adjacent levels seam: if `r''` covers `s` and `r` covers a level just
+    above `s` (with `lo r < s+1`), and `r'' ≠ r`, then `hi r'' = lo r`.  (Used in the seam scan.) -/
+lemma seam_of_adjacent {a b : ℕ} {r'' r : ι} (hr'' : r'' ∈ Roots fam a b) (hr : r ∈ Roots fam a b)
+    {s : ℕ} (hs1 : fam.lo r'' < s) (hs2 : s ≤ fam.hi r'')
+    (hrhi : s + 1 ≤ fam.hi r) (hadj : fam.lo r = s) : fam.hi r'' = s := by
+  -- r'' covers s, r covers s+1; if hi r'' ≥ s+1, both Iocs contain s+1 (disjoint) ⇒ contra
+  rcases roots_interval_disjoint fam hr'' hr (by
+      intro h; rw [h] at hs1 hs2; omega) with hd | hd
+  · omega
+  · omega
+
+/-- **COLUMN-SEPARATION (abstract).** For a saturated window `(a,b]` with a top edge `e0`, every
+    root has column `≠ col e0`. -/
+lemma column_sep {a b : ℕ} (hab : a < b) (hsat : N fam a b = b - a)
+    {e0 : ι} (he0E : e0 ∈ fam.E) (he0lo : fam.lo e0 = a) (he0hi : fam.hi e0 = b) :
+    ∀ r ∈ Roots fam a b, fam.col r ≠ fam.col e0 := by
+  -- top edge present
+  have htop : (topEdges fam a b).Nonempty := by
+    refine ⟨e0, ?_⟩
+    unfold topEdges; rw [Finset.mem_filter, mem_contained]
+    exact ⟨⟨he0E, by omega, by omega⟩, he0lo, he0hi⟩
+  obtain ⟨g, hg1, hg2, hgap⟩ := exists_gap fam hab hsat htop
+  -- LEFT SCAN: roots covering levels in (a, g) have col e0 < col r.
+  have scanLeft : ∀ t, a < t → t < g → ∀ r ∈ Roots fam a b,
+      fam.lo r < t → t ≤ fam.hi r → fam.col e0 < fam.col r := by
+    intro t
+    induction t using Nat.strong_induction_on with
+    | _ t ih =>
+      intro ht1 ht2 r hr hrlo hrhi
+      obtain ⟨hrE, hra, hrb, hrs⟩ := root_self_props fam hr
+      -- r is a left root: hi r < g.
+      have hrhig : fam.hi r < g := by
+        by_contra hc
+        push Not at hc  -- g ≤ hi r
+        exact hgap r hr ⟨by omega, hc⟩
+      by_cases hlo : fam.lo r = a
+      · -- bottom-most: shares bottom with e0
+        have hbl := fam.bLeft e0 he0E r hrE (by rw [he0lo, hlo]) (by rw [he0hi]; omega)
+        exact hbl
+      · -- lo r > a; find seam predecessor covering lo r
+        have hloa : a < fam.lo r := by omega
+        have hlog : fam.lo r < g := by omega
+        have hlone : fam.lo r ≠ g := by omega
+        obtain ⟨r'', hr'', hr''lo, hr''hi⟩ :=
+          covered_of_ne_gap fam htop hsat hab hg1 hg2 hgap hloa (by omega) hlone
+        have hrr : r'' ≠ r := by
+          intro h; rw [h] at hr''hi hr''lo; omega
+        have hseam : fam.hi r'' = fam.lo r :=
+          seam_of_adjacent fam hr'' hr hr''lo hr''hi (by omega) rfl
+        have hih := ih (fam.lo r) (by omega) hloa hlog r'' hr'' hr''lo hr''hi
+        have hbseam := fam.bSeam r'' (root_self_props fam hr'').1 r hrE hseam
+        omega
+  -- RIGHT SCAN: roots covering levels in (g, b] have col r < col e0. Induct on (b - t) so the
+  -- inductive step can reach the seam successor (a LARGER level).
+  have scanRight : ∀ n t, b - t = n → g < t → t ≤ b → ∀ r ∈ Roots fam a b,
+      fam.lo r < t → t ≤ fam.hi r → fam.col r < fam.col e0 := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro t hn ht1 ht2 r hr hrlo hrhi
+      obtain ⟨hrE, hra, hrb, hrs⟩ := root_self_props fam hr
+      by_cases hhi : fam.hi r = b
+      · -- top-most: shares top with e0
+        have hbr := fam.bRight e0 he0E r hrE (by rw [he0hi, hhi]) (by rw [he0lo]; omega)
+        exact hbr
+      · -- hi r < b; find seam successor covering hi r + 1
+        have hhib : fam.hi r < b := by omega
+        have hsucc1 : g < fam.hi r + 1 := by omega
+        have hsucc2 : fam.hi r + 1 ≤ b := by omega
+        have hsuccne : fam.hi r + 1 ≠ g := by omega
+        obtain ⟨r', hr', hr'lo, hr'hi⟩ :=
+          covered_of_ne_gap fam htop hsat hab hg1 hg2 hgap (by omega) hsucc2 hsuccne
+        have hrr : r' ≠ r := by
+          intro h; rw [h] at hr'lo hr'hi; omega
+        -- seam: hi r = lo r'
+        have hseam : fam.lo r' = fam.hi r := by
+          rcases roots_interval_disjoint fam hr hr' (fun h => hrr h.symm) with hd | hd
+          · -- hi r ≤ lo r'; with lo r' < hi r + 1 ⇒ lo r' = hi r
+            omega
+          · -- hi r' ≤ lo r; but hi r + 1 ≤ hi r' and lo r < t ≤ hi r ⇒ contra
+            omega
+        have hih := ih (b - (fam.hi r + 1)) (by omega) (fam.hi r + 1) rfl hsucc1 hsucc2
+          r' hr' hr'lo hr'hi
+        have hbseam := fam.bSeam r (root_self_props fam hr).1 r'
+          (root_self_props fam hr').1 hseam.symm
+        omega
+  -- conclude for every root
+  intro r hr
+  obtain ⟨hrE, hra, hrb, hrs⟩ := root_self_props fam hr
+  have hlhr := fam.lh r hrE
+  -- r does not span g
+  have hnospan : ¬ (fam.lo r < g ∧ g ≤ fam.hi r) := hgap r hr
+  rcases Nat.lt_or_ge (fam.hi r) g with hcase | hcase
+  · -- left root: covers hi r ∈ (a, g)
+    have h := scanLeft (fam.hi r) (by omega) hcase r hr (by omega) (le_refl _)
+    omega
+  · -- g ≤ hi r; since not span, g ≤ lo r; right root: covers lo r + 1 ∈ (g, b]
+    have hglo : g ≤ fam.lo r := by
+      by_contra hc; push Not at hc; exact hnospan ⟨hc, hcase⟩
+    have h := scanRight (b - (fam.lo r + 1)) (fam.lo r + 1) rfl (by omega) (by omega) r hr
+      (by omega) (by omega)
+    omega
+
+/-- **DIRECTIONAL COLUMN-SEPARATION (abstract).**  As `column_sep`, but exposes the gap `g`
+    together with the run-direction columns: left roots (top below the gap) have `col e0 < col r`,
+    right roots (bottom above the gap) have `col r < col e0`. -/
+lemma column_sep_with_gap {a b : ℕ} (hab : a < b) (hsat : N fam a b = b - a)
+    {e0 : ι} (he0E : e0 ∈ fam.E) (he0lo : fam.lo e0 = a) (he0hi : fam.hi e0 = b) :
+    ∃ g, a < g ∧ g ≤ b ∧ (∀ r ∈ Roots fam a b, ¬ (fam.lo r < g ∧ g ≤ fam.hi r)) ∧
+      (∀ r ∈ Roots fam a b, fam.hi r < g → fam.col e0 < fam.col r) ∧
+      (∀ r ∈ Roots fam a b, g ≤ fam.lo r → fam.col r < fam.col e0) := by
+  have htop : (topEdges fam a b).Nonempty := by
+    refine ⟨e0, ?_⟩
+    unfold topEdges; rw [Finset.mem_filter, mem_contained]
+    exact ⟨⟨he0E, by omega, by omega⟩, he0lo, he0hi⟩
+  obtain ⟨g, hg1, hg2, hgap⟩ := exists_gap fam hab hsat htop
+  -- LEFT SCAN (copied from column_sep).
+  have scanLeft : ∀ t, a < t → t < g → ∀ r ∈ Roots fam a b,
+      fam.lo r < t → t ≤ fam.hi r → fam.col e0 < fam.col r := by
+    intro t
+    induction t using Nat.strong_induction_on with
+    | _ t ih =>
+      intro ht1 ht2 r hr hrlo hrhi
+      obtain ⟨hrE, hra, hrb, hrs⟩ := root_self_props fam hr
+      have hrhig : fam.hi r < g := by
+        by_contra hc
+        push Not at hc
+        exact hgap r hr ⟨by omega, hc⟩
+      by_cases hlo : fam.lo r = a
+      · have hbl := fam.bLeft e0 he0E r hrE (by rw [he0lo, hlo]) (by rw [he0hi]; omega)
+        exact hbl
+      · have hloa : a < fam.lo r := by omega
+        have hlog : fam.lo r < g := by omega
+        have hlone : fam.lo r ≠ g := by omega
+        obtain ⟨r'', hr'', hr''lo, hr''hi⟩ :=
+          covered_of_ne_gap fam htop hsat hab hg1 hg2 hgap hloa (by omega) hlone
+        have hrr : r'' ≠ r := by
+          intro h; rw [h] at hr''hi hr''lo; omega
+        have hseam : fam.hi r'' = fam.lo r :=
+          seam_of_adjacent fam hr'' hr hr''lo hr''hi (by omega) rfl
+        have hih := ih (fam.lo r) (by omega) hloa hlog r'' hr'' hr''lo hr''hi
+        have hbseam := fam.bSeam r'' (root_self_props fam hr'').1 r hrE hseam
+        omega
+  -- RIGHT SCAN (copied from column_sep).
+  have scanRight : ∀ n t, b - t = n → g < t → t ≤ b → ∀ r ∈ Roots fam a b,
+      fam.lo r < t → t ≤ fam.hi r → fam.col r < fam.col e0 := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro t hn ht1 ht2 r hr hrlo hrhi
+      obtain ⟨hrE, hra, hrb, hrs⟩ := root_self_props fam hr
+      by_cases hhi : fam.hi r = b
+      · have hbr := fam.bRight e0 he0E r hrE (by rw [he0hi, hhi]) (by rw [he0lo]; omega)
+        exact hbr
+      · have hhib : fam.hi r < b := by omega
+        have hsucc1 : g < fam.hi r + 1 := by omega
+        have hsucc2 : fam.hi r + 1 ≤ b := by omega
+        have hsuccne : fam.hi r + 1 ≠ g := by omega
+        obtain ⟨r', hr', hr'lo, hr'hi⟩ :=
+          covered_of_ne_gap fam htop hsat hab hg1 hg2 hgap (by omega) hsucc2 hsuccne
+        have hrr : r' ≠ r := by
+          intro h; rw [h] at hr'lo hr'hi; omega
+        have hseam : fam.lo r' = fam.hi r := by
+          rcases roots_interval_disjoint fam hr hr' (fun h => hrr h.symm) with hd | hd
+          · omega
+          · omega
+        have hih := ih (b - (fam.hi r + 1)) (by omega) (fam.hi r + 1) rfl hsucc1 hsucc2
+          r' hr' hr'lo hr'hi
+        have hbseam := fam.bSeam r (root_self_props fam hr).1 r'
+          (root_self_props fam hr').1 hseam.symm
+        omega
+  refine ⟨g, hg1, hg2, hgap, ?_, ?_⟩
+  · intro r hr hrg
+    obtain ⟨hrE, hra, hrb, hrs⟩ := root_self_props fam hr
+    have hlhr := fam.lh r hrE
+    exact scanLeft (fam.hi r) (by omega) hrg r hr (by omega) (le_refl _)
+  · intro r hr hgr
+    obtain ⟨hrE, hra, hrb, hrs⟩ := root_self_props fam hr
+    have hlhr := fam.lh r hrE
+    exact scanRight (b - (fam.lo r + 1)) (fam.lo r + 1) rfl (by omega) (by omega) r hr
+      (by omega) (by omega)
+
+
+end AbstractLaminar
+
+/-! ## PART B — geometric layer in `CriticalPortraits`. -/
+
+namespace CriticalPortraits
+
+open Finset
+open scoped BigOperators
+
+variable {d m : ℕ}
+
+/-! ### B0. blocks = host sets: `P = image (survivor ↦ hostSet)`. -/
+
+/-- Each block of a portrait is the host set of any of its survivors.  More precisely: if
+    `x ∈ eraseMin S` and `S ∈ P` then `hostSet P x = S` (the survivor's recovered home is its
+    block, by portrait disjointness). -/
+lemma hostSet_eq_of_mem_eraseMin {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {S : Finset (ZMod (d * m))} (hS : S ∈ P) {x : ZMod (d * m)} (hxe : x ∈ eraseMin S) :
+    hostSet P x (mem_T.mpr ⟨S, hS, hxe⟩) = S := by
+  set hx : x ∈ T P := mem_T.mpr ⟨S, hS, hxe⟩ with hhx
+  by_contra hne
+  -- both S and hostSet P x hx contain x; if distinct they are disjoint — contradiction.
+  have hhost : hostSet P x hx ∈ P := hostSet_mem hx
+  have hxS : x ∈ S := eraseMin_subset S hxe
+  have hxH : x ∈ hostSet P x hx := mem_hostSet hx
+  have hdisj := hP.2.1 _ hhost _ hS (by exact fun h => hne h)
+  exact (Finset.disjoint_left.mp hdisj hxH) hxS
+
+/-- **`P` is recovered as the image of its survivors' host sets.** -/
+lemma portrait_eq_image_hostSet {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P) :
+    P = (T P).attach.image (fun x => hostSet P x.1 x.2) := by
+  apply Finset.ext
+  intro S
+  constructor
+  · -- S ∈ P ⇒ S is some hostSet
+    intro hS
+    -- S has a survivor (card ≥ 2 ⇒ eraseMin nonempty)
+    have hcard : 2 ≤ S.card := (hP.1 S hS).2
+    have hSne : S.Nonempty := Finset.card_pos.mp (by omega)
+    have hecard : (eraseMin S).card = S.card - 1 := eraseMin_card S hSne
+    have hene : (eraseMin S).Nonempty := Finset.card_pos.mp (by omega)
+    obtain ⟨x, hxe⟩ := hene
+    have hx : x ∈ T P := mem_T.mpr ⟨S, hS, hxe⟩
+    rw [Finset.mem_image]
+    refine ⟨⟨x, hx⟩, Finset.mem_attach _ _, ?_⟩
+    exact hostSet_eq_of_mem_eraseMin hP hS hxe
+  · -- image element ⇒ in P
+    intro hS
+    rw [Finset.mem_image] at hS
+    obtain ⟨x, _, hxeq⟩ := hS
+    rw [← hxeq]
+    exact hostSet_mem x.2
+
+/-! ### B1. Geometric TIGHTNESS and COLUMN-SEPARATION for the survivor family.
+
+We instantiate the abstract TIGHTNESS at the real `survivorFamily`.  The window `(0, d-1]`
+is saturated (`N = d-1`) because every survivor's level lies in `[0, d-1]` — `0 ≤ loV` and
+`hiV ≤ d-1`, so all `d-1` edges are contained, and the window width is `d-1`. -/
+
+/-- Every survivor's level is `< d` (hence `hiV x ≤ d - 1`). -/
+lemma hiV_lt_d [NeZero (d * m)] (_hm : 0 < m) (x : ZMod (d * m)) : hiV x < d := by
+  unfold hiV
+  have hval : x.val < d * m := ZMod.val_lt x
+  have hval' : x.val < m * d := lt_of_lt_of_le hval (le_of_eq (Nat.mul_comm d m))
+  exact Nat.div_lt_of_lt_mul hval'
+
+/-- The window `(0, d-1]` contains every edge of the survivor family. -/
+lemma survivorFamily_contained_eq [NeZero (d * m)] (hd : 0 < d) (hm : 0 < m)
+    {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P) :
+    AbstractLaminar.contained (survivorFamily hd hm hP) 0 (d - 1) = T P := by
+  unfold AbstractLaminar.contained
+  apply Finset.filter_true_of_mem
+  intro e he
+  refine ⟨Nat.zero_le _, ?_⟩
+  -- hi e = hiV e ≤ d - 1
+  change hiV e ≤ d - 1
+  have := hiV_lt_d (d := d) (m := m) hm e
+  omega
+
+/-- **Geometric saturation.** `N (survivorFamily) 0 (d-1) = d - 1`. -/
+lemma survivorFamily_saturated [NeZero (d * m)] (hd : 0 < d) (hm : 0 < m)
+    {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P) :
+    AbstractLaminar.N (survivorFamily hd hm hP) 0 (d - 1) = (d - 1) - 0 := by
+  unfold AbstractLaminar.N
+  rw [survivorFamily_contained_eq hd hm hP, T_card hP]
+  omega
+
+/-- **Geometric TIGHTNESS (g(e) = h(e) - 1).** Every survivor edge `e` has a saturated own
+    window: `N(loV e, hiV e) = hiV e - loV e`. -/
+theorem edge_tight_geom [NeZero (d * m)] (hd : 0 < d) (hm : 0 < m)
+    {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {e : ZMod (d * m)} (he : e ∈ T P) :
+    AbstractLaminar.N (survivorFamily hd hm hP) (loV P e) (hiV e)
+      = hiV e - loV P e := by
+  set fam := survivorFamily hd hm hP with hfam
+  have hsat := survivorFamily_saturated hd hm hP
+  have hcont : e ∈ AbstractLaminar.contained fam 0 (d - 1) := by
+    rw [survivorFamily_contained_eq hd hm hP]; exact he
+  have := AbstractLaminar.edge_tight_of_saturated fam (d - 1 - 0) 0 (d - 1) rfl hsat e hcont
+  exact this
+
+/-- **Geometric COLUMN-SEPARATION.** For a survivor edge `e` with a nondegenerate own window,
+    every maximal nested tile (root of `(loV e, hiV e]`) has column `≠ colV e`. -/
+theorem column_sep_geom [NeZero (d * m)] (hd : 0 < d) (hm : 0 < m)
+    {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {e : ZMod (d * m)} (he : e ∈ T P) (hwin : loV P e < hiV e) :
+    ∀ r ∈ AbstractLaminar.Roots (survivorFamily hd hm hP) (loV P e) (hiV e),
+      colV r ≠ colV e := by
+  set fam := survivorFamily hd hm hP with hfam
+  have hsat := edge_tight_geom hd hm hP he
+  -- `e` itself is the top edge of window (loV e, hiV e].
+  have heE : e ∈ fam.E := he
+  exact AbstractLaminar.column_sep fam hwin hsat heE rfl rfl
+
+/-- **Geometric DIRECTIONAL COLUMN-SEPARATION.**  Exposes the gap level and the run-direction
+    columns at the survivor family. -/
+theorem column_sep_geom_dir [NeZero (d * m)] (hd : 0 < d) (hm : 0 < m)
+    {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {e : ZMod (d * m)} (he : e ∈ T P) (hwin : loV P e < hiV e) :
+    ∃ g, loV P e < g ∧ g ≤ hiV e ∧
+      (∀ r ∈ AbstractLaminar.Roots (survivorFamily hd hm hP) (loV P e) (hiV e),
+        ¬ (loV P r < g ∧ g ≤ hiV r)) ∧
+      (∀ r ∈ AbstractLaminar.Roots (survivorFamily hd hm hP) (loV P e) (hiV e),
+        hiV r < g → colV e < colV r) ∧
+      (∀ r ∈ AbstractLaminar.Roots (survivorFamily hd hm hP) (loV P e) (hiV e),
+        g ≤ loV P r → colV r < colV e) := by
+  set fam := survivorFamily hd hm hP with hfam
+  have hsat := edge_tight_geom hd hm hP he
+  have heE : e ∈ fam.E := he
+  exact AbstractLaminar.column_sep_with_gap fam hwin hsat heE rfl rfl
+
+/-! ### B2. Block spans and Lemma 2 (span laminarity).
+
+`spanLo S`, `spanHi S` are the `.val` of the lowest/highest points of a block `S`.  Lemma 2
+says distinct blocks' spans are laminar (nested or disjoint), proved directly from `Unlinked`
++ the alternation witness `linked_of_lt` (structurally identical to `lemmaA`/`cross_false`). -/
+
+/-- The greatest-`.val` element of a nonempty set. -/
+noncomputable def maxVal {N : ℕ} (S : Finset (ZMod N)) (h : S.Nonempty) : ZMod N :=
+  (Finset.exists_max_image S (fun x => x.val) h).choose
+
+lemma maxVal_mem {N : ℕ} (S : Finset (ZMod N)) (h : S.Nonempty) : maxVal S h ∈ S :=
+  (Finset.exists_max_image S (fun x => x.val) h).choose_spec.1
+
+lemma maxVal_ge {N : ℕ} (S : Finset (ZMod N)) (h : S.Nonempty) :
+    ∀ x ∈ S, x.val ≤ (maxVal S h).val :=
+  (Finset.exists_max_image S (fun x => x.val) h).choose_spec.2
+
+/-- The `.val`-span of a block: `[minVal, maxVal]`. -/
+noncomputable def spanLo {N : ℕ} (S : Finset (ZMod N)) (h : S.Nonempty) : ℕ := (minVal S h).val
+/-- The greatest `.val` attained on a nonempty finset `S`. -/
+noncomputable def spanHi {N : ℕ} (S : Finset (ZMod N)) (h : S.Nonempty) : ℕ := (maxVal S h).val
+
+/-- **Lemma 2 (span laminarity).** Distinct blocks of a portrait have laminar spans: nested or
+    disjoint (no proper `.val`-overlap `spanLo A < spanLo B < spanHi A < spanHi B`). -/
+theorem span_laminar {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {A B : Finset (ZMod (d * m))} (hA : A ∈ P) (hB : B ∈ P) (hAB : A ≠ B)
+    (hAne : A.Nonempty) (hBne : B.Nonempty) :
+    ¬ (spanLo A hAne < spanLo B hBne ∧ spanLo B hBne < spanHi A hAne ∧
+       spanHi A hAne < spanHi B hBne) := by
+  rintro ⟨h1, h2, h3⟩
+  -- the four endpoints minVal A < minVal B < maxVal A < maxVal B alternate ⇒ Linked A B
+  simp only [spanLo, spanHi] at h1 h2 h3
+  have hL : Linked A B :=
+    linked_of_lt (minVal_mem A hAne) (maxVal_mem A hAne) (minVal_mem B hBne) (maxVal_mem B hBne)
+      h1 h2 h3
+  exact (hP.2.2.1 A hA B hB hAB) hL
+
+/-- **Lemma 2 (hull edge).** Every block element's `.val` lies within the span. -/
+lemma mem_span {N : ℕ} {S : Finset (ZMod N)} (h : S.Nonempty) {x : ZMod N} (hx : x ∈ S) :
+    spanLo S h ≤ x.val ∧ x.val ≤ spanHi S h :=
+  ⟨minVal_le S h x hx, maxVal_ge S h x hx⟩
+
+/-! ### B3. The BRIDGE (edge core).
+
+The algebraic heart of the Structural Lemma: a same-column edge strictly nested inside `u`'s edge
+is NOT a maximal tile (its `rootS` is a strictly-enclosing edge of a DIFFERENT column).  This is
+exactly "the c*-block `B` strictly inside `(w,u)` is enclosed by an in-gap block of column ≠ c*",
+phrased in the edge model.  Proved from `column_sep_geom` + the rootS machinery. -/
+
+/-- **BRIDGE (edge form).** If a survivor `b2` (same column as `u`) has its edge strictly nested
+    inside `u`'s edge, then there is a survivor `g` of a DIFFERENT column whose edge encloses
+    `b2`'s and is nested in `u`'s: `loV u ≤ loV g ≤ loV b2`, `hiV b2 ≤ hiV g ≤ hiV u`,
+    `colV g ≠ colV u`, and `g ≠ b2`. -/
+theorem bridge_edge [NeZero (d * m)] (hd : 0 < d) (hm : 0 < m)
+    {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {u b2 : ZMod (d * m)} (hu : u ∈ T P) (hb2 : b2 ∈ T P)
+    (hcol : colV b2 = colV u)
+    (hlo : loV P u < loV P b2) (hhi : hiV b2 < hiV u) :
+    ∃ g ∈ T P, colV g ≠ colV u ∧
+      loV P u ≤ loV P g ∧ loV P g ≤ loV P b2 ∧ hiV b2 ≤ hiV g ∧ hiV g ≤ hiV u ∧ g ≠ b2 := by
+  set fam := survivorFamily hd hm hP with hfam
+  -- window of u's edge
+  have hwin : loV P u < hiV u := by
+    change fam.lo u < fam.hi u; exact fam.lh u hu
+  -- b2 ∈ Sstrict of u's window (strictly nested: lo ≠ loV u OR hi ≠ hiV u — both hold)
+  have hb2cont : b2 ∈ AbstractLaminar.contained fam (loV P u) (hiV u) := by
+    rw [AbstractLaminar.mem_contained]
+    refine ⟨hb2, by change loV P u ≤ loV P b2; omega, by change hiV b2 ≤ hiV u; omega⟩
+  have hb2S : b2 ∈ AbstractLaminar.Sstrict fam (loV P u) (hiV u) := by
+    rw [AbstractLaminar.mem_Sstrict]
+    refine ⟨⟨hb2, by change loV P u ≤ loV P b2; omega, by change hiV b2 ≤ hiV u; omega⟩, ?_⟩
+    left; change loV P b2 ≠ loV P u; omega
+  -- g := rootS of b2 in u's window
+  set g := AbstractLaminar.rootS fam (loV P u) (hiV u) b2 with hg
+  have hgRoot : g ∈ AbstractLaminar.Roots fam (loV P u) (hiV u) :=
+    AbstractLaminar.rootS_mem_Roots fam hb2S
+  have hgE : g ∈ T P := AbstractLaminar.rootS_mem_E fam hb2S
+  have hgwin := AbstractLaminar.rootS_window fam hb2S
+  have hgcont := AbstractLaminar.rootS_contains fam hb2S
+  -- column separation: col g ≠ col u
+  have hgcol : colV g ≠ colV u := column_sep_geom hd hm hP hu hwin g hgRoot
+  -- g ≠ b2 : equal edges (same col impossible since col g ≠ col u = col b2)
+  have hgb2 : g ≠ b2 := by
+    intro h; rw [h] at hgcol; exact hgcol hcol
+  refine ⟨g, hgE, hgcol, ?_, ?_, ?_, ?_, hgb2⟩
+  · exact hgwin.1
+  · exact hgcont.1
+  · exact hgcont.2
+  · exact hgwin.2
+
+/-! ### B-keystone (stage 1): the predecessor of each survivor is FORCED by `U = T P`.
+
+This is the genuinely deep all-`d` kernel — the inductive forced-predecessor dispatch that
+consumes the now-proved `bridge_edge` / `column_sep_geom` / `edge_tight_geom` / `span_laminar`.
+It is now PROVED (no `sorry`); the stage-2 component recovery `hostSet_forced` below
+depends on it. -/
+
+/- **KEYSTONE (stage 1).**
+
+If two portraits share their survivor set `U`, each survivor's immediate predecessor agrees.
+
+Paper argument (Part I): `w = predIn P u` is the greedy maximal-`.val` same-fiber candidate
+`v < u` whose chord `(v,u)` is legal (`v ∉ U` as a committed top, and `(v,u)` crosses no
+already-committed lower edge).  The legality test references only `U` and lower (forced) edges, so
+`predIn` is a function of `U`.  Every higher candidate `v ∈ (w,u)` is illegal: used (`v ∈ U`), or
+its maximal column-`c*` block is — by the **Structural Lemma / Bridge** (`bridge_edge`) — strictly
+enclosed by an in-gap block of a different column whose edge `(a,b)` crosses `(v,u)`.
+
+Available sorry-free substrate consumed by the missing proof: `edge_tight_geom` (TIGHTNESS),
+`column_sep_geom` (COLUMN-SEP), `bridge_edge` (BRIDGE edge core), `span_laminar` (Lemma 2),
+plus Forward's `predIn_immediate` / `no_alt` / `predIn_max`. -/
+
+/-! #### Helper lemmas for `predIn_forced`. -/
+
+/-- Same-fiber `.val` comparison is the level comparison (strict). -/
+lemma level_lt_of_val_lt [NeZero (d * m)] {x y : ZMod (d * m)}
+    (hfib : x.val % m = y.val % m) (h : x.val < y.val) : x.val / m < y.val / m := by
+  rcases lt_or_eq_of_le ((val_le_iff_level_le_of_sameFiber hfib).mp h.le) with hlt | heq
+  · exact hlt
+  · exact absurd (congrArg ZMod.val (level_injOn_fiber hfib heq)) (Nat.ne_of_lt h)
+
+/-- A strict root `g` of `x`'s window (so `loV P x ≤ loV P g`, `hiV g ≤ hiV x`,
+    `colV g ≠ colV x`) has `g.val < x.val`. -/
+lemma root_val_lt [NeZero (d * m)] (hd : 0 < d) (hm : 0 < m)
+    {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {g x : ZMod (d * m)} (hg : g ∈ T P) (hx : x ∈ T P)
+    (hlo : loV P x ≤ loV P g) (hhi : hiV g ≤ hiV x) (hcol : colV g ≠ colV x) : g.val < x.val := by
+  have hgv := top_val_eq (x := g)
+  have hxv := top_val_eq (x := x)
+  rcases lt_or_eq_of_le hhi with hlt | heq
+  · have := sep_master (m := m) (p := colV g) (q := colV x) (colV_lt_m hm g) (colV_lt_m hm x) hlt
+    omega
+  · -- hiV g = hiV x.  Then loV P x < loV P g (else equal edges → g = x → colV g = colV x).
+    have hlostrict : loV P x < loV P g := by
+      rcases lt_or_eq_of_le hlo with h | h
+      · exact h
+      · exact absurd (edge_inj hd hm hP hx hg h heq.symm) (fun hxg => hcol (by rw [hxg]))
+    have hcg : colV g < colV x := lemmaB_right hd hm hP hx hg heq.symm hlostrict
+    have : colV g + hiV g * m < colV x + hiV x * m := by rw [heq]; omega
+    omega
+
+/-- **The spanning-edge kernel.**  In one portrait `P`, for a survivor `x` and a level `ℓ`
+    strictly inside `x`'s own window `(loV P x, hiV x)`, there is a survivor `b` of a different
+    column than `x` whose edge **straddles** the value `colV x + ℓ * m`:
+    `(predIn P b _).val < colV x + ℓ*m < b.val < x.val`.
+
+    This is the formalized **Structural Lemma / Bridge** content: the value `v₀ = colV x + ℓ*m`
+    (a same-fiber position strictly inside `x`'s edge) is crossed by some maximal nested tile of a
+    different column.  Proved from saturation (`edge_tight_geom`), column-separation
+    (`column_sep_geom`), and the gap/cover/seam machinery. -/
+lemma spanning_edge [NeZero (d * m)] (hd : 0 < d) (hm : 0 < m)
+    {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P) {x : ZMod (d * m)} (hx : x ∈ T P)
+    {ℓ : ℕ} (hℓ1 : loV P x < ℓ) (hℓ2 : ℓ < hiV x) :
+    ∃ b, ∃ hb : b ∈ T P, colV b ≠ colV x ∧
+      (predIn P b hb).val < colV x + ℓ * m ∧ colV x + ℓ * m < b.val ∧ b.val < x.val := by
+  set fam := survivorFamily hd hm hP with hfam
+  have hwin : loV P x < hiV x := by change fam.lo x < fam.hi x; exact fam.lh x hx
+  have hsat : AbstractLaminar.N fam (loV P x) (hiV x) = hiV x - loV P x :=
+    edge_tight_geom hd hm hP hx
+  have htop : (AbstractLaminar.topEdges fam (loV P x) (hiV x)).Nonempty := by
+    refine ⟨x, ?_⟩
+    unfold AbstractLaminar.topEdges
+    rw [Finset.mem_filter, AbstractLaminar.mem_contained]
+    exact ⟨⟨hx, le_refl _, le_refl _⟩, rfl, rfl⟩
+  have hcx := colV_lt_m hm x
+  -- gap + directional column facts.
+  obtain ⟨gp, hgp1, hgp2, hgpgap, hleft, hright⟩ := column_sep_geom_dir hd hm hP hx hwin
+  -- a generic finisher: given a root r covering value v₀ = colV x + ℓ*m in its arc, finish.
+  -- We split on ℓ < gp (use the tile covering ℓ) vs ℓ ≥ gp (use the tile covering ℓ+1).
+  rcases Nat.lt_or_ge ℓ gp with hlg | hge
+  · -- ℓ < gp : the root covering level ℓ straddles v₀.
+    obtain ⟨r, hr, hrlo0, hrhi0⟩ :=
+      AbstractLaminar.covered_of_ne_gap fam htop hsat hwin hgp1 hgp2 hgpgap
+        (show loV P x < ℓ from hℓ1) (le_of_lt hℓ2) (by omega : ℓ ≠ gp)
+    have hrlo : loV P r < ℓ := hrlo0
+    have hrhi : ℓ ≤ hiV r := hrhi0
+    obtain ⟨hrE, hra0, hrb0, _⟩ := AbstractLaminar.root_self_props fam hr
+    have hra : loV P x ≤ loV P r := hra0
+    have hrb : hiV r ≤ hiV x := hrb0
+    have hcolne : colV r ≠ colV x := column_sep_geom hd hm hP hx hwin r hr
+    have hgpgap' : ¬ (loV P r < gp ∧ gp ≤ hiV r) := hgpgap r hr
+    have hrhig : hiV r < gp := by
+      by_contra hc; push Not at hc; exact hgpgap' ⟨by omega, hc⟩
+    have hcolxr : colV x < colV r := hleft r hr hrhig
+    have hcr := colV_lt_m hm r
+    have hpr : (predIn P r hrE).val = colV r + loV P r * m := pred_val_eq hP hrE
+    have hrv : r.val = colV r + hiV r * m := top_val_eq (x := r)
+    refine ⟨r, hrE, hcolne, ?_, ?_, ?_⟩
+    · have := sep_master (m := m) (p := colV r) (q := colV x) hcr hcx hrlo
+      rw [hpr]; omega
+    · rcases lt_or_eq_of_le hrhi with hlt | heq
+      · have := sep_master (m := m) (p := colV x) (q := colV r) hcx hcr hlt
+        rw [hrv]; omega
+      · rw [hrv, ← heq]; omega
+    · exact root_val_lt hd hm hP hrE hx hra hrb hcolne
+  · -- ℓ ≥ gp : the root covering level ℓ+1 straddles v₀.
+    have hℓ1' : loV P x < ℓ + 1 := by omega
+    have hℓ2' : ℓ + 1 ≤ hiV x := by omega
+    have hne' : ℓ + 1 ≠ gp := by omega
+    obtain ⟨r, hr, hrlo0, hrhi0⟩ :=
+      AbstractLaminar.covered_of_ne_gap fam htop hsat hwin hgp1 hgp2 hgpgap hℓ1' hℓ2' hne'
+    have hrlo : loV P r < ℓ + 1 := hrlo0
+    have hrhi : ℓ + 1 ≤ hiV r := hrhi0
+    obtain ⟨hrE, hra0, hrb0, _⟩ := AbstractLaminar.root_self_props fam hr
+    have hra : loV P x ≤ loV P r := hra0
+    have hrb : hiV r ≤ hiV x := hrb0
+    have hcolne : colV r ≠ colV x := column_sep_geom hd hm hP hx hwin r hr
+    have hrlo' : loV P r ≤ ℓ := by omega
+    have hgpgap' : ¬ (loV P r < gp ∧ gp ≤ hiV r) := hgpgap r hr
+    have hgr : gp ≤ loV P r := by
+      by_contra hc; push Not at hc; exact hgpgap' ⟨hc, by omega⟩
+    have hcolrx : colV r < colV x := hright r hr hgr
+    have hcr := colV_lt_m hm r
+    have hpr : (predIn P r hrE).val = colV r + loV P r * m := pred_val_eq hP hrE
+    have hrv : r.val = colV r + hiV r * m := top_val_eq (x := r)
+    refine ⟨r, hrE, hcolne, ?_, ?_, ?_⟩
+    · rcases lt_or_eq_of_le hrlo' with hlt | heq
+      · have := sep_master (m := m) (p := colV r) (q := colV x) hcr hcx hlt
+        rw [hpr]; omega
+      · rw [hpr, heq]; omega
+    · have := sep_master (m := m) (p := colV x) (q := colV r) hcx hcr (show ℓ < hiV r by omega)
+      rw [hrv]; omega
+    · exact root_val_lt hd hm hP hrE hx hra hrb hcolne
+
+theorem predIn_forced [NeZero (d * m)] (hd : 0 < d) (hm : 0 < m)
+    {P₁ P₂ : Finset (Finset (ZMod (d * m)))} (h₁ : Portrait d m P₁) (h₂ : Portrait d m P₂)
+    (hT : T P₁ = T P₂) {x : ZMod (d * m)} (hx₁ : x ∈ T P₁) (hx₂ : x ∈ T P₂) :
+    predIn P₁ x hx₁ = predIn P₂ x hx₂ := by
+  induction hn : x.val using Nat.strong_induction_on generalizing x with
+  | _ n ih =>
+  subst hn
+  -- IH: equality for strictly-lower survivors.
+  have IH : ∀ y : ZMod (d*m), y.val < x.val → ∀ (hy₁ : y ∈ T P₁) (hy₂ : y ∈ T P₂),
+      predIn P₁ y hy₁ = predIn P₂ y hy₂ := by
+    intro y hyv hy₁ hy₂
+    exact ih y.val hyv hy₁ hy₂ rfl
+  -- one-directional WLOG, generic in the ordered pair of portraits.
+  have noLt : ∀ (Q₁ Q₂ : Finset (Finset (ZMod (d*m)))), Portrait d m Q₁ → Portrait d m Q₂ →
+      T Q₁ = T Q₂ → (∀ y : ZMod (d*m), y.val < x.val → ∀ (hy₁ : y ∈ T Q₁) (hy₂ : y ∈ T Q₂),
+        predIn Q₁ y hy₁ = predIn Q₂ y hy₂) →
+      ∀ (hq₁ : x ∈ T Q₁) (hq₂ : x ∈ T Q₂),
+        ¬ ((predIn Q₁ x hq₁).val < (predIn Q₂ x hq₂).val) := by
+    intro Q₁ Q₂ hQ₁ hQ₂ hTQ IHQ hq₁ hq₂ hlt
+    set w₁ := predIn Q₁ x hq₁ with hw₁
+    set w₂ := predIn Q₂ x hq₂ with hw₂
+    have hfib₁ : w₁.val % m = x.val % m := predIn_sameFiber hQ₁ hq₁
+    have hfib₂ : w₂.val % m = x.val % m := predIn_sameFiber hQ₂ hq₂
+    have hfib12 : w₁.val % m = w₂.val % m := by rw [hfib₁, hfib₂]
+    have hw1lt : w₁.val < x.val := predIn_val_lt hq₁
+    have hw2lt : w₂.val < x.val := predIn_val_lt hq₂
+    have hcolw₂x : colV w₂ = colV x := by unfold colV; rw [hfib₂]
+    -- levels
+    have hlevel_w1 : loV Q₁ x = w₁.val / m := loV_eq hq₁
+    have hlevel_w2 : loV Q₂ x = w₂.val / m := loV_eq hq₂
+    set ℓ := w₂.val / m with hℓdef
+    have hℓ_eq_lo2 : loV Q₂ x = ℓ := by rw [hlevel_w2]
+    have hlt_lev_12 : w₁.val / m < ℓ := level_lt_of_val_lt hfib12 hlt
+    have hℓ_gt_lo1 : loV Q₁ x < ℓ := by rw [hlevel_w1]; exact hlt_lev_12
+    have hℓ_lt_hi : ℓ < hiV x := by
+      have := level_lt_of_val_lt hfib₂ hw2lt
+      simpa [hℓdef, hiV] using this
+    have hw2val : w₂.val = colV x + ℓ * m := by
+      have h := top_val_eq (x := w₂)
+      rw [hcolw₂x] at h
+      have hhi : hiV w₂ = ℓ := rfl
+      rw [hhi] at h; exact h
+    -- The spanning edge over v₀ = colV x + ℓ*m, in Q₁.
+    obtain ⟨b, hb₁, hbcol, hbpred, hbgt, hblt⟩ :=
+      spanning_edge hd hm hQ₁ hq₁ hℓ_gt_lo1 hℓ_lt_hi
+    -- transfer b's edge to Q₂ via IH.
+    have hb₂ : b ∈ T Q₂ := hTQ ▸ hb₁
+    have hbforce : predIn Q₁ b hb₁ = predIn Q₂ b hb₂ := IHQ b hblt hb₁ hb₂
+    -- the crossing in Q₂: predIn b < w₂ < b < x.
+    have o1 : (predIn Q₂ b hb₂).val < w₂.val := by
+      rw [← hbforce, hw2val]; exact hbpred
+    have o2 : w₂.val < b.val := by rw [hw2val]; exact hbgt
+    have o3 : b.val < x.val := hblt
+    exact no_alt hQ₂ hb₂ hq₂ o1 o2 o3
+  have h12 := noLt P₁ P₂ h₁ h₂ hT IH hx₁ hx₂
+  have h21 := noLt P₂ P₁ h₂ h₁ hT.symm (fun y hyv hy₂ hy₁ => (IH y hyv hy₁ hy₂).symm) hx₂ hx₁
+  exact ZMod.val_injective _ (le_antisymm (not_lt.mp h21) (not_lt.mp h12))
+
+/-! ### B-keystone (stage 2): host blocks are forced by `U` and the forced predecessors.
+
+Stage 2 is sorry-free.  A block is recovered as the connected component of its survivors under
+the immediate-predecessor (`edgeStep`) relation, together with its unique non-survivor `minVal`
+(the "root").  Since `T P` and (by `predIn_forced`) the `predIn` map agree across `P₁, P₂`, the
+`edgeStep` relation agrees, hence components and roots agree, hence host blocks agree. -/
+
+/-- `hostSet P u` is THE block containing the survivor `u`. -/
+lemma hostSet_eq_of_mem {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {u : ZMod (d * m)} (hu : u ∈ T P) {S : Finset (ZMod (d * m))} (hSP : S ∈ P) (huS : u ∈ S) :
+    hostSet P u hu = S := by
+  by_contra hne
+  exact (Finset.disjoint_left.mp (hP.2.1 _ (hostSet_mem hu) _ hSP hne) (mem_hostSet hu)) huS
+
+/-- `minVal` only depends on the set (proof-irrelevant nonemptiness witness). -/
+lemma minVal_congr {N : ℕ} {S S' : Finset (ZMod N)} (hS : S.Nonempty) (hS' : S'.Nonempty)
+    (h : S = S') : minVal S hS = minVal S' hS' := by subst h; rfl
+
+/-- The dropped point of a block is not a survivor of `P` (blocks are disjoint). -/
+lemma minVal_host_not_mem_T {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {x : ZMod (d * m)} (hx : x ∈ T P) (hne : (hostSet P x hx).Nonempty) :
+    minVal (hostSet P x hx) hne ∉ T P := by
+  intro hmem
+  set S := hostSet P x hx with hSdef
+  set w := minVal S hne with hwdef
+  have hSP : S ∈ P := hostSet_mem hx
+  have hwS : w ∈ S := minVal_mem S hne
+  obtain ⟨S', hS'P, hwS'⟩ := mem_T.mp hmem
+  have hwS'S : w ∈ S' := eraseMin_subset S' hwS'
+  have hSS' : S = S' := by
+    by_contra hne'
+    exact (Finset.disjoint_left.mp (hP.2.1 _ hSP _ hS'P hne') hwS) hwS'S
+  rw [← hSS'] at hwS'
+  exact ((mem_eraseMin S hne w).mp hwS').2 rfl
+
+/-- The same-block immediate-predecessor step relation on survivors:
+    determined by `T P` + `predIn`. -/
+def edgeStep [NeZero (d * m)] (P : Finset (Finset (ZMod (d * m)))) (u v : ZMod (d * m)) : Prop :=
+  ∃ (hu : u ∈ T P) (hv : v ∈ T P), predIn P u hu = v ∨ predIn P v hv = u
+
+lemma edgeStep_symm [NeZero (d * m)] {P : Finset (Finset (ZMod (d * m)))}
+    {u v : ZMod (d * m)} (h : edgeStep P u v) : edgeStep P v u := by
+  obtain ⟨hu, hv, hcase⟩ := h; exact ⟨hv, hu, hcase.symm⟩
+
+lemma reach_symm [NeZero (d * m)] {P : Finset (Finset (ZMod (d * m)))}
+    {u v : ZMod (d * m)} (h : Relation.ReflTransGen (edgeStep P) u v) :
+    Relation.ReflTransGen (edgeStep P) v u := by
+  induction h with
+  | refl => exact Relation.ReflTransGen.refl
+  | @tail b c _ hbc ih => exact Relation.ReflTransGen.head (edgeStep_symm hbc) ih
+
+/-- An `edgeStep` keeps you in the same host (the predecessor lives in the same block). -/
+lemma edgeStep_sameHost [NeZero (d * m)] {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {u v : ZMod (d * m)} (hstep : edgeStep P u v) (hu : u ∈ T P) (hv : v ∈ T P) :
+    hostSet P u hu = hostSet P v hv := by
+  obtain ⟨hu', hv', hcase⟩ := hstep
+  rcases hcase with hpu | hpv
+  · have : v ∈ hostSet P u hu := by rw [← hpu]; exact predIn_mem_host hu
+    exact (hostSet_eq_of_mem hP hv (hostSet_mem hu) this).symm
+  · have : u ∈ hostSet P v hv := by rw [← hpv]; exact predIn_mem_host hv
+    exact hostSet_eq_of_mem hP hu (hostSet_mem hv) this
+
+/-- For a survivor `u` whose predecessor is itself a survivor, they share a host. -/
+lemma hostSet_predIn [NeZero (d * m)] {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {u : ZMod (d * m)} (hu : u ∈ T P) (hpu : predIn P u hu ∈ T P) :
+    hostSet P (predIn P u hu) hpu = hostSet P u hu :=
+  hostSet_eq_of_mem hP hpu (hostSet_mem hu) (predIn_mem_host hu)
+
+/-- Survivors reachable from `x` by `edgeStep` share `x`'s host. -/
+lemma reach_sameHost [NeZero (d * m)] {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {x z : ZMod (d * m)} (hx : x ∈ T P)
+    (hreach : Relation.ReflTransGen (edgeStep P) x z) (hz : z ∈ T P) :
+    hostSet P z hz = hostSet P x hx := by
+  induction hreach with
+  | refl => rfl
+  | @tail b c hxb hbc ih =>
+    obtain ⟨hb, hc', hcase⟩ := hbc
+    have hbc_host : hostSet P b hb = hostSet P c hc' :=
+      edgeStep_sameHost hP ⟨hb, hc', hcase⟩ hb hc'
+    have hzc : hostSet P c hz = hostSet P c hc' := rfl
+    rw [hzc, ← hbc_host]; exact ih hb
+
+/-- Every survivor `z` reaches the bottom survivor `q` of its block (predecessor a non-survivor). -/
+lemma reach_to_low [NeZero (d * m)] {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P) :
+    ∀ n : ℕ, ∀ z : ZMod (d*m), z.val = n → (hz : z ∈ T P) →
+      ∃ q, ∃ hq : q ∈ T P, predIn P q hq ∉ T P ∧
+        hostSet P q hq = hostSet P z hz ∧ Relation.ReflTransGen (edgeStep P) z q := by
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    intro z hzn hz
+    set p := predIn P z hz with hpdef
+    by_cases hpT : p ∈ T P
+    · have hpval : p.val < z.val := predIn_val_lt hz
+      obtain ⟨q, hq, hqpred, hqhost, hqreach⟩ := ih p.val (by omega) p rfl hpT
+      exact ⟨q, hq, hqpred, by rw [hqhost, hostSet_predIn hP hz hpT],
+        Relation.ReflTransGen.head ⟨hz, hpT, Or.inl rfl⟩ hqreach⟩
+    · exact ⟨z, hz, hpT, rfl, Relation.ReflTransGen.refl⟩
+
+/-- Two survivors in the same host reach the SAME bottom survivor; hence are mutually reachable. -/
+lemma reach_of_sameHost [NeZero (d * m)] {P : Finset (Finset (ZMod (d * m)))} (hP : Portrait d m P)
+    {x z : ZMod (d * m)} (hx : x ∈ T P) (hz : z ∈ T P)
+    (hhost : hostSet P z hz = hostSet P x hx) :
+    Relation.ReflTransGen (edgeStep P) z x := by
+  obtain ⟨qz, hqz, hqzpred, hqzhost, hqzreach⟩ := reach_to_low hP z.val z rfl hz
+  obtain ⟨qx, hqx, hqxpred, hqxhost, hqxreach⟩ := reach_to_low hP x.val x rfl hx
+  have hsamehost : hostSet P qz hqz = hostSet P qx hqx := by rw [hqzhost, hqxhost, hhost]
+  have hzne : (hostSet P qz hqz).Nonempty := ⟨qz, mem_hostSet hqz⟩
+  have hxne : (hostSet P qx hqx).Nonempty := ⟨qx, mem_hostSet hqx⟩
+  have hpqz_min : predIn P qz hqz = minVal (hostSet P qz hqz) hzne := by
+    by_contra hne
+    exact hqzpred (mem_T.mpr ⟨_, hostSet_mem hqz,
+      (mem_eraseMin _ hzne _).mpr ⟨predIn_mem_host hqz, hne⟩⟩)
+  have hpqx_min : predIn P qx hqx = minVal (hostSet P qx hqx) hxne := by
+    by_contra hne
+    exact hqxpred (mem_T.mpr ⟨_, hostSet_mem hqx,
+      (mem_eraseMin _ hxne _).mpr ⟨predIn_mem_host hqx, hne⟩⟩)
+  have hpredeq : predIn P qz hqz = predIn P qx hqx := by
+    rw [hpqz_min, hpqx_min]; exact minVal_congr hzne hxne hsamehost
+  have hqeq : qz = qx := by
+    by_contra hqne
+    have hqzlt : (predIn P qz hqz).val < qz.val := predIn_val_lt hqz
+    have hqxlt : (predIn P qx hqx).val < qx.val := predIn_val_lt hqx
+    have hqxinz : qx ∈ hostSet P qz hqz := by rw [hsamehost]; exact mem_hostSet hqx
+    have hqzinx : qz ∈ hostSet P qx hqx := by rw [← hsamehost]; exact mem_hostSet hqz
+    rcases lt_trichotomy qz.val qx.val with hlt | heq | hgt
+    · exact predIn_immediate hqx hqzinx (by rw [← hpredeq]; exact hqzlt) hlt
+    · exact hqne (ZMod.val_injective _ heq)
+    · exact predIn_immediate hqz hqxinz (by rw [hpredeq]; exact hqxlt) hgt
+  subst hqeq
+  exact hqzreach.trans (reach_symm hqxreach)
+
+/-- With forced predecessors and equal survivor sets, the `edgeStep` relations agree. -/
+lemma edgeStep_forced [NeZero (d * m)] (hd : 0 < d) (hm : 0 < m)
+    {P₁ P₂ : Finset (Finset (ZMod (d * m)))} (h₁ : Portrait d m P₁) (h₂ : Portrait d m P₂)
+    (hT : T P₁ = T P₂) {u v : ZMod (d * m)} (hstep : edgeStep P₁ u v) : edgeStep P₂ u v := by
+  obtain ⟨hu₁, hv₁, hcase⟩ := hstep
+  have hu₂ : u ∈ T P₂ := hT ▸ hu₁
+  have hv₂ : v ∈ T P₂ := hT ▸ hv₁
+  refine ⟨hu₂, hv₂, ?_⟩
+  rcases hcase with hpu | hpv
+  · left; rw [← predIn_forced hd hm h₁ h₂ hT hu₁ hu₂]; exact hpu
+  · right; rw [← predIn_forced hd hm h₁ h₂ hT hv₁ hv₂]; exact hpv
+
+/-- Reachability transfers between portraits with forced predecessors. -/
+lemma reach_forced [NeZero (d * m)] (hd : 0 < d) (hm : 0 < m)
+    {P₁ P₂ : Finset (Finset (ZMod (d * m)))} (h₁ : Portrait d m P₁) (h₂ : Portrait d m P₂)
+    (hT : T P₁ = T P₂) {u v : ZMod (d * m)}
+    (hreach : Relation.ReflTransGen (edgeStep P₁) u v) :
+    Relation.ReflTransGen (edgeStep P₂) u v := by
+  induction hreach with
+  | refl => exact Relation.ReflTransGen.refl
+  | @tail b c _ hbc ih => exact Relation.ReflTransGen.tail ih (edgeStep_forced hd hm h₁ h₂ hT hbc)
+
+/-! ### B-keystone: the host sets are forced by the survivor set `U = T P`.
+
+This is exactly Part I (Uniqueness) of the paper: a critical portrait is reconstructible from
+its survivor set.  All of the structural content (TIGHTNESS, Column-Separation, the Bridge /
+Structural Lemma, and the resulting "predecessor forced ⇒ block forced") lives here. -/
+
+/-- **KEYSTONE (Part I uniqueness) — now PROVED (sorry-free).**
+
+If two portraits have the same survivor set, then each survivor's host block is the same in both.
+This is exactly the paper's Part I ("`T` injective ↔ the portrait is reconstructible from `U`"),
+the documented open all-`d` kernel (machine-verified `d ≤ 8`; never previously mechanized for all
+`d`).  Its proof has two stages, both genuinely deep:
+
+  (1) **`predIn` forced.**  `∀ u ∈ U, predIn P₁ u = predIn P₂ u`.  By induction over `.val` order:
+      `w = predIn P u` is the GREEDY pick from `U` — the highest same-fiber `v < u` that is unused
+      and whose chord `(v,u)` crosses no already-committed (lower-`.val`) edge.  Every higher
+      candidate `v ∈ (w,u)` is illegal: either `v ∈ U` (a non-top of its block; its child is left
+      of `u`, already committed) or, by the **Structural Lemma / Bridge**, `v`'s block is not
+      maximal in `(w,u)`, so it sits in the gap of an enclosing block whose edge `(a,b)` has
+      `a < v < b < u`, crossing the committed `(a,b)`.  The Structural Lemma ("no block maximal in
+      a parent-gap `(w,u)` has its top in `fiber(u)`") is fed by the now-PROVED substrate:
+        • TIGHTNESS  : `edge_tight_geom` (`g(e) = h(e) - 1`).
+        • COLUMN-SEP : `column_sep_geom` (no maximal tile of `e` shares `e`'s column).
+        • BRIDGE     : `bridge_edge` (PROVED) — the c*-edge `eB` of a c*-block `B` strictly inside
+                       `(w,u)` is non-maximal, so `eB ≪` a maximal tile `g` with `col g ≠ c*`.
+                       Remaining glue: `span_laminar` (Lemma 2, PROVED) + chord-enclosure
+                       (`sep_master`) ⇒ `block(g)` strictly encloses `span(B)` ⇒ `B` not maximal.
+
+  (2) **Block forced from `predIn`.**  Edges `{(predIn u, u) : u ∈ U}` are then equal across
+      `P₁, P₂`; the host block of `x` is the connected component of `x` in the predecessor graph
+      (`hostSet P x = {minVal} ∪ {survivors with the same predIn-descent root}`), so equal edges
+      ⇒ equal components ⇒ equal host blocks.
+
+PROVED and available: `edge_tight_geom` (TIGHTNESS), `column_sep_geom` (COLUMN-SEP),
+`span_laminar` (Lemma 2), `bridge_edge` (BRIDGE edge core), plus all of Forward's edge model
+(`predIn_*`, `no_alt`, `lemmaA/B`, `survivorFamily`).
+
+This theorem is now SORRY-FREE: stage (2) (component recovery) is fully proved here from
+`predIn_forced` (stage 1, the single remaining `sorry`).  A block is recovered as the
+`edgeStep`-component of its survivors together with its unique non-survivor `minVal` root; both
+are forced because `T P` and the `predIn` map agree across `P₁, P₂`. -/
+theorem hostSet_forced [NeZero (d * m)] (hd : 0 < d) (hm : 0 < m)
+    {P₁ P₂ : Finset (Finset (ZMod (d * m)))} (h₁ : Portrait d m P₁) (h₂ : Portrait d m P₂)
+    (hT : T P₁ = T P₂) {x : ZMod (d * m)} (hx₁ : x ∈ T P₁) (hx₂ : x ∈ T P₂) :
+    hostSet P₁ x hx₁ = hostSet P₂ x hx₂ := by
+  -- symmetric subset argument
+  suffices H : ∀ (Q₁ Q₂ : Finset (Finset (ZMod (d*m)))), Portrait d m Q₁ → Portrait d m Q₂ →
+      T Q₁ = T Q₂ → ∀ (y : ZMod (d*m)) (hy₁ : y ∈ T Q₁) (hy₂ : y ∈ T Q₂),
+        hostSet Q₁ y hy₁ ⊆ hostSet Q₂ y hy₂ by
+    exact Finset.Subset.antisymm (H P₁ P₂ h₁ h₂ hT x hx₁ hx₂)
+      (H P₂ P₁ h₂ h₁ hT.symm x hx₂ hx₁)
+  intro Q₁ Q₂ hQ₁ hQ₂ hTQ y hy₁ hy₂ z hz
+  by_cases hzT : z ∈ T Q₁
+  · -- z survivor of y's block: reachable from y in Q₁; transfer to Q₂.
+    have hzhost : hostSet Q₁ z hzT = hostSet Q₁ y hy₁ :=
+      hostSet_eq_of_mem hQ₁ hzT (hostSet_mem hy₁) hz
+    have hreach₁ : Relation.ReflTransGen (edgeStep Q₁) z y := reach_of_sameHost hQ₁ hy₁ hzT hzhost
+    have hzT₂ : z ∈ T Q₂ := hTQ ▸ hzT
+    have hzhost₂ : hostSet Q₂ z hzT₂ = hostSet Q₂ y hy₂ :=
+      reach_sameHost hQ₂ hy₂ (reach_symm (reach_forced hd hm hQ₁ hQ₂ hTQ hreach₁)) hzT₂
+    rw [← hzhost₂]; exact mem_hostSet hzT₂
+  · -- z ∉ T Q₁: z is the root (minVal) of y's Q₁-block.
+    have hyne₁ : (hostSet Q₁ y hy₁).Nonempty := ⟨y, mem_hostSet hy₁⟩
+    have hzmin : z = minVal (hostSet Q₁ y hy₁) hyne₁ := by
+      by_contra hne
+      exact hzT (mem_T.mpr ⟨_, hostSet_mem hy₁, (mem_eraseMin _ hyne₁ z).mpr ⟨hz, hne⟩⟩)
+    obtain ⟨q, hq, hqpred, hqhost, hqreach⟩ := reach_to_low hQ₁ y.val y rfl hy₁
+    have hqne : (hostSet Q₁ q hq).Nonempty := ⟨q, mem_hostSet hq⟩
+    have hpq_min : predIn Q₁ q hq = minVal (hostSet Q₁ q hq) hqne := by
+      by_contra hne
+      exact hqpred (mem_T.mpr ⟨_, hostSet_mem hq,
+        (mem_eraseMin _ hqne _).mpr ⟨predIn_mem_host hq, hne⟩⟩)
+    have hpq_z : predIn Q₁ q hq = z := by
+      rw [hpq_min, hzmin]; exact minVal_congr hqne hyne₁ hqhost
+    have hq₂ : q ∈ T Q₂ := hTQ ▸ hq
+    have hpredeq : predIn Q₁ q hq = predIn Q₂ q hq₂ := predIn_forced hd hm hQ₁ hQ₂ hTQ hq hq₂
+    have hpq_z₂ : predIn Q₂ q hq₂ = z := by rw [← hpredeq]; exact hpq_z
+    have hqhost₂ : hostSet Q₂ q hq₂ = hostSet Q₂ y hy₂ := by
+      have hreach₁ : Relation.ReflTransGen (edgeStep Q₁) q y := reach_of_sameHost hQ₁ hy₁ hq hqhost
+      exact reach_sameHost hQ₂ hy₂ (reach_symm (reach_forced hd hm hQ₁ hQ₂ hTQ hreach₁)) hq₂
+    rw [← hqhost₂, ← hpq_z₂]; exact predIn_mem_host hq₂
+
+/-! ### B-assembly: `T` injective. -/
+
+/-- **INJECTIVITY (implication form).** Two portraits with equal survivor sets are equal. -/
+theorem T_inj (hd : 0 < d) (hm : 0 < m)
+    {P₁ P₂ : Finset (Finset (ZMod (d * m)))} (h₁ : Portrait d m P₁) (h₂ : Portrait d m P₂)
+    (hT : T P₁ = T P₂) : P₁ = P₂ := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  rw [portrait_eq_image_hostSet h₁, portrait_eq_image_hostSet h₂]
+  -- The attach sets differ (T P₁ vs T P₂), so rewrite along hT and match the functions.
+  apply Finset.ext
+  intro S
+  rw [Finset.mem_image, Finset.mem_image]
+  constructor
+  · rintro ⟨⟨x, hx₁⟩, _, hSeq⟩
+    have hx₂ : x ∈ T P₂ := hT ▸ hx₁
+    refine ⟨⟨x, hx₂⟩, Finset.mem_attach _ _, ?_⟩
+    rw [← hSeq]
+    exact (hostSet_forced hd hm h₁ h₂ hT hx₁ hx₂).symm
+  · rintro ⟨⟨x, hx₂⟩, _, hSeq⟩
+    have hx₁ : x ∈ T P₁ := hT.symm ▸ hx₂
+    refine ⟨⟨x, hx₁⟩, Finset.mem_attach _ _, ?_⟩
+    rw [← hSeq]
+    exact hostSet_forced hd hm h₁ h₂ hT hx₁ hx₂
+
+/-- **INJECTIVITY (`Set.InjOn` form, the stated target).** -/
+theorem T_injOn (hd : 0 < d) (hm : 0 < m) :
+    Set.InjOn (T (N := d*m)) {P | Portrait d m P} :=
+  fun _P₁ h₁ _P₂ h₂ hT => T_inj hd hm h₁ h₂ hT
+
+end CriticalPortraits
+
+-- Axiom audit of the fully-proved (sorry-free) results (the structural substrate).
+-- Stage-2 (component recovery) is sorry-free GIVEN the single keystone `predIn_forced`:
+-- The KEYSTONE is now closed; the final results are sorry-free:

--- a/LeanPool/CriticalPortraits/Portraits.lean
+++ b/LeanPool/CriticalPortraits/Portraits.lean
@@ -1,0 +1,314 @@
+/-
+Copyright (c) 2026 Keston Aquino-Michaels. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Keston Aquino-Michaels
+-/
+
+import LeanPool.CriticalPortraits.Core
+
+/-!
+# Geometric foundation: the critical-portrait model on `ZMod (d*m)`.
+
+A faithful, proof-friendly port of the bare-Lean verified model
+(`LamKit.CriticalCensusGeneral`; native_decide-verified `d = 3..6`).  Mathlib has cyclic
+betweenness (`Order.Circular`) but no chords/linking/laminar API, so this is built from scratch.
+
+* `IsCriticalSet`        — subset of one `σ_d`-fiber, `≥ 2` points (weight `|S| - 1`).
+* `Linked` / `Unlinked`  — convex hulls cross / don't cross on the `.val`-circle.  `Unlinked`
+                           is the negation of an alternating crossing quadruple; it agrees with
+                           the bare-Lean `hullsUnlinked` test (`cyclicRuns ≤ 1`) on every
+                           instance (verified `#eval`s match the census `5/14/12/55/22/42`).
+* `Portrait`             — pairwise vertex-disjoint, pairwise-unlinked critical sets, weight `d-1`.
+* `T`                    — delete the lowest-level (= least `.val`) point of each set, union all.
+
+API proved here (sorry-free, native_decide-free, real kernel proofs):
+* `T_card` — the weight identity `#T(P) = d - 1`.
+* `Decidable` instances throughout; an unconditional `Fintype` for the portrait subtype.
+* Downstream hooks: `sep_master` (the master separation inequality (M)), `linked_of_lt`,
+  `mem_T`, the `minVal` spec lemmas.
+
+Positions/level/fiber/`LevelCanonical` are reused from `CriticalPortraits.Core`.  The forward goal
+`LevelCanonical (T P)` is a LATER brick (3b) and is deliberately NOT stated here.
+-/
+
+namespace CriticalPortraits
+
+open Finset
+open scoped BigOperators
+
+/-! ## 1. Critical sets. -/
+
+/-- `S ⊆ Z_{d*m}` is a **critical set**: it lies in one `σ_d`-fiber (all points share a
+    column `r < m`) and has at least `2` points. Its **weight** is `S.card - 1`. -/
+def IsCriticalSet (d m : ℕ) (S : Finset (ZMod (d * m))) : Prop :=
+  (∃ r, r < m ∧ ∀ x ∈ S, x.val % m = r) ∧ 2 ≤ S.card
+
+instance (d m : ℕ) (S : Finset (ZMod (d * m))) : Decidable (IsCriticalSet d m S) := by
+  unfold IsCriticalSet; infer_instance
+
+/-! ## 2. Unlinked: convex hulls don't cross.
+
+`Linked A B` says there are two chords — `(a1, a2)` with endpoints in `A`, `(b1, b2)` with
+endpoints in `B` — that **cross** on the circle `Z_N` read by `.val`.  Geometrically the two
+crossing patterns (up to relabelling) are `a1 < b1 < a2 < b2` and `b1 < a1 < b2 < a2`
+(strict on `.val`).  This is the val-linear form of "the four points alternate cyclically
+`a, b, a, b`", which is exactly the negation of "`A` is a single cyclic run" — i.e. the
+bare-Lean `hullsUnlinked` test `cyclicRuns ≤ 1`.  `Unlinked A B := ¬ Linked A B`. -/
+/-- Two cyclic subsets `A` and `B` are linked when they interleave. -/
+def Linked {N : ℕ} (A B : Finset (ZMod N)) : Prop :=
+  ∃ a1 ∈ A, ∃ a2 ∈ A, ∃ b1 ∈ B, ∃ b2 ∈ B,
+    (a1.val < b1.val ∧ b1.val < a2.val ∧ a2.val < b2.val) ∨
+    (b1.val < a1.val ∧ a1.val < b2.val ∧ b2.val < a2.val)
+
+instance {N : ℕ} (A B : Finset (ZMod N)) : Decidable (Linked A B) := by
+  unfold Linked; infer_instance
+
+/-- `A` and `B` have unlinked convex hulls (no crossing chords). -/
+def Unlinked {N : ℕ} (A B : Finset (ZMod N)) : Prop := ¬ Linked A B
+
+instance {N : ℕ} (A B : Finset (ZMod N)) : Decidable (Unlinked A B) := by
+  unfold Unlinked; infer_instance
+
+/-- `Unlinked` is symmetric: crossing chords of `A, B` are crossing chords of `B, A`. -/
+theorem Unlinked.symm {N : ℕ} {A B : Finset (ZMod N)} (h : Unlinked A B) : Unlinked B A := by
+  intro hL
+  apply h
+  obtain ⟨b1, hb1, b2, hb2, a1, ha1, a2, ha2, hcase⟩ := hL
+  rcases hcase with ⟨h1, h2, h3⟩ | ⟨h1, h2, h3⟩
+  · exact ⟨a1, ha1, a2, ha2, b1, hb1, b2, hb2, Or.inr ⟨h1, h2, h3⟩⟩
+  · exact ⟨a1, ha1, a2, ha2, b1, hb1, b2, hb2, Or.inl ⟨h1, h2, h3⟩⟩
+
+/-- The crossing witness Lemma A / Seam / Bridge will call: a strictly-alternating quadruple
+    `a1 < b1 < a2 < b2` (linear `.val` order) with `a1,a2 ∈ A`, `b1,b2 ∈ B` contradicts
+    `Unlinked A B`. -/
+theorem not_unlinked_of_alternating {N : ℕ} {A B : Finset (ZMod N)}
+    {a1 a2 b1 b2 : ZMod N} (ha1 : a1 ∈ A) (ha2 : a2 ∈ A) (hb1 : b1 ∈ B) (hb2 : b2 ∈ B)
+    (h1 : a1.val < b1.val) (h2 : b1.val < a2.val) (h3 : a2.val < b2.val) :
+    ¬ Unlinked A B := fun h => h ⟨a1, ha1, a2, ha2, b1, hb1, b2, hb2, Or.inl ⟨h1, h2, h3⟩⟩
+
+/-! ## 3. Critical portraits. -/
+
+/-- A **critical portrait**: a family of critical sets that is pairwise vertex-disjoint,
+    pairwise unlinked, of total weight `∑ (|S| - 1) = d - 1`. -/
+def Portrait (d m : ℕ) (P : Finset (Finset (ZMod (d * m)))) : Prop :=
+  (∀ S ∈ P, IsCriticalSet d m S) ∧
+  (∀ A ∈ P, ∀ B ∈ P, A ≠ B → Disjoint A B) ∧
+  (∀ A ∈ P, ∀ B ∈ P, A ≠ B → Unlinked A B) ∧
+  (∑ S ∈ P, (S.card - 1) = d - 1)
+
+instance (d m : ℕ) (P : Finset (Finset (ZMod (d * m)))) : Decidable (Portrait d m P) := by
+  unfold Portrait; infer_instance
+
+/-! ## 4. The portrait subtype is a Fintype (unconditional, mirroring `instFiniteCanonical`). -/
+
+/-- When `d * m = 0`, no portrait exists. (`m = 0` ⇒ no fiber witness; `d = 0` ⇒ weight
+    target `0`, but every critical set has positive weight, so the family is empty.) -/
+lemma portrait_eq_empty_of_degenerate (d m : ℕ) (h0 : d * m = 0)
+    (P : Finset (Finset (ZMod (d * m)))) (hP : Portrait d m P) : P = ∅ := by
+  classical
+  obtain ⟨hcrit, _, _, hw⟩ := hP
+  rcases Nat.eq_zero_or_pos m with hm0 | hmpos
+  · -- m = 0: no fiber witness possible (r < 0 is impossible), so P has no element
+    by_contra hne
+    obtain ⟨S, hS⟩ := Finset.nonempty_of_ne_empty hne
+    obtain ⟨⟨r, hr, _⟩, _⟩ := hcrit S hS
+    omega
+  · -- m > 0 ⇒ d = 0; weight target d - 1 = 0, but each S has card ≥ 2 ⇒ weight ≥ 1
+    have hd0 : d = 0 := by
+      rcases Nat.eq_zero_or_pos d with h | h
+      · exact h
+      · exfalso; have : 0 < d * m := Nat.mul_pos h hmpos; omega
+    by_contra hne
+    obtain ⟨S, hS⟩ := Finset.nonempty_of_ne_empty hne
+    have hcardS : 2 ≤ S.card := (hcrit S hS).2
+    have hpos : 0 < ∑ T ∈ P, (T.card - 1) := by
+      apply Finset.sum_pos'
+      · intro i _; exact Nat.zero_le _
+      · exact ⟨S, hS, by omega⟩
+    rw [hw] at hpos
+    omega
+
+instance instFinitePortrait (d m : ℕ) :
+    Finite {P : Finset (Finset (ZMod (d * m))) // Portrait d m P} := by
+  rcases Nat.eq_zero_or_pos (d * m) with h0 | hpos
+  · exact Finite.of_injective (fun _ => (0 : Unit)) (by
+      intro a b _
+      exact Subtype.ext ((portrait_eq_empty_of_degenerate d m h0 a.1 a.2).trans
+        (portrait_eq_empty_of_degenerate d m h0 b.1 b.2).symm))
+  · haveI : NeZero (d * m) := ⟨hpos.ne'⟩
+    infer_instance
+
+noncomputable instance instFintypePortrait (d m : ℕ) :
+    Fintype {P : Finset (Finset (ZMod (d * m))) // Portrait d m P} :=
+  Fintype.ofFinite _
+
+/-! ## 5. The delete-min map `T`.
+
+`ZMod N` has no `LinearOrder`, so we pick the dropped point by minimising `.val` via
+`Finset.exists_min_image`.  Within a single fiber `val = level*m + col` is strictly monotone
+in level, so least-`.val` = lowest-level = exactly bare-Lean's `S.drop 1`. -/
+
+/-- The least-`.val` element of a nonempty set (the lowest-level point of a critical set). -/
+noncomputable def minVal {N : ℕ} (S : Finset (ZMod N)) (h : S.Nonempty) : ZMod N :=
+  (Finset.exists_min_image S (fun x => x.val) h).choose
+
+lemma minVal_mem {N : ℕ} (S : Finset (ZMod N)) (h : S.Nonempty) : minVal S h ∈ S :=
+  (Finset.exists_min_image S (fun x => x.val) h).choose_spec.1
+
+lemma minVal_le {N : ℕ} (S : Finset (ZMod N)) (h : S.Nonempty) :
+    ∀ x ∈ S, (minVal S h).val ≤ x.val :=
+  (Finset.exists_min_image S (fun x => x.val) h).choose_spec.2
+
+/-- Drop the lowest-level (least-`.val`) point of `S` (identity on the empty set). -/
+noncomputable def eraseMin {N : ℕ} (S : Finset (ZMod N)) : Finset (ZMod N) :=
+  if h : S.Nonempty then S.erase (minVal S h) else S
+
+lemma eraseMin_subset {N : ℕ} (S : Finset (ZMod N)) : eraseMin S ⊆ S := by
+  unfold eraseMin
+  split
+  · exact Finset.erase_subset _ _
+  · exact subset_rfl
+
+lemma eraseMin_card {N : ℕ} (S : Finset (ZMod N)) (h : S.Nonempty) :
+    (eraseMin S).card = S.card - 1 := by
+  unfold eraseMin
+  rw [dif_pos h, Finset.card_erase_of_mem (minVal_mem S h)]
+
+/-- Membership in `eraseMin`: everything of `S` except its `.val`-minimum (nonempty `S`).
+    The clean characterization the downstream membership reasoning will use. -/
+lemma mem_eraseMin {N : ℕ} (S : Finset (ZMod N)) (h : S.Nonempty) (x : ZMod N) :
+    x ∈ eraseMin S ↔ x ∈ S ∧ x ≠ minVal S h := by
+  unfold eraseMin
+  rw [dif_pos h, Finset.mem_erase]
+  tauto
+
+/-- `T(P)`: delete the lowest-level point of every set, then take the union. -/
+noncomputable def T {N : ℕ} (P : Finset (Finset (ZMod N))) : Finset (ZMod N) :=
+  P.sup eraseMin
+
+/-- The erased sets remain pairwise disjoint (erase only shrinks). -/
+lemma eraseMin_pairwiseDisjoint {d m : ℕ} (P : Finset (Finset (ZMod (d * m))))
+    (hP : Portrait d m P) : (↑P : Set (Finset (ZMod (d * m)))).PairwiseDisjoint eraseMin := by
+  intro A hA B hB hAB
+  exact (hP.2.1 A hA B hB hAB).mono (eraseMin_subset A) (eraseMin_subset B)
+
+/-! ## 6. BASIC API: the weight identity `#T = d - 1`. -/
+
+/-- **The weight identity.** For a critical portrait, `#T(P) = d - 1`. -/
+theorem T_card {d m : ℕ} {P : Finset (Finset (ZMod (d * m)))}
+    (hP : Portrait d m P) : (T P).card = d - 1 := by
+  classical
+  unfold T
+  rw [Finset.sup_eq_biUnion, Finset.card_biUnion (eraseMin_pairwiseDisjoint P hP)]
+  rw [← hP.2.2.2]
+  apply Finset.sum_congr rfl
+  intro S hS
+  have hcard : 2 ≤ S.card := (hP.1 S hS).2
+  have hne : S.Nonempty := Finset.card_pos.mp (by omega)
+  exact eraseMin_card S hne
+
+/-! ## 6b. The min-rule is the min-LEVEL rule (load-bearing for forward/surjectivity).
+
+The bare-Lean `S.drop 1` drops the lowest-LEVEL point.  `minVal` drops the least-`.val` point.
+These coincide on a critical set because within one fiber the `.val` order is the level order,
+and the level is injective on the set.  This underwrites "survivors = edge tops" and "each
+block/component has a unique non-survivor = its lowest-level vertex" (scout risk R2). -/
+
+/-- Within a single fiber (same residue mod `m`), the `.val` order equals the level order. -/
+theorem val_le_iff_level_le_of_sameFiber {N m : ℕ} {x y : ZMod N}
+    (hxy : x.val % m = y.val % m) :
+    x.val ≤ y.val ↔ x.val / m ≤ y.val / m := by
+  constructor
+  · intro h; exact Nat.div_le_div_right h
+  · intro h
+    have hx : x.val = (x.val / m) * m + x.val % m := (Nat.div_add_mod' x.val m).symm
+    have hy : y.val = (y.val / m) * m + y.val % m := (Nat.div_add_mod' y.val m).symm
+    rw [hxy] at hx
+    have : (x.val / m) * m ≤ (y.val / m) * m := Nat.mul_le_mul_right m h
+    omega
+
+/-- The level is injective on a single fiber: same fiber + same level ⇒ same `.val` ⇒
+    same element. -/
+theorem level_injOn_fiber {N m : ℕ} [NeZero N] {x y : ZMod N}
+    (hxy : x.val % m = y.val % m) (hlev : x.val / m = y.val / m) : x = y := by
+  have hx : x.val = (x.val / m) * m + x.val % m := (Nat.div_add_mod' x.val m).symm
+  have hy : y.val = (y.val / m) * m + y.val % m := (Nat.div_add_mod' y.val m).symm
+  have : x.val = y.val := by rw [hx, hy, hxy, hlev]
+  exact ZMod.val_injective _ this
+
+/-- **The min-rule is the min-LEVEL rule.** On a critical set, `minVal S` is the unique point
+    of minimum level: its level is `≤` every member's. -/
+theorem minVal_level_le {d m : ℕ} {S : Finset (ZMod (d * m))}
+    (hS : IsCriticalSet d m S) (h : S.Nonempty) :
+    ∀ x ∈ S, (minVal S h).val / m ≤ x.val / m := by
+  obtain ⟨⟨r, hr, hfib⟩, _⟩ := hS
+  intro x hx
+  have hsame : (minVal S h).val % m = x.val % m := by
+    rw [hfib _ (minVal_mem S h), hfib _ hx]
+  exact (val_le_iff_level_le_of_sameFiber hsame).mp (minVal_le S h x hx)
+
+/-- The dropped point (the minimum) is strictly below — in LEVEL — every survivor of that set.
+    This is what makes "survivors = edge tops" hold; each critical set keeps exactly its tops. -/
+theorem minVal_lt_survivor {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {S : Finset (ZMod (d * m))} (hS : IsCriticalSet d m S) (h : S.Nonempty) :
+    ∀ x ∈ eraseMin S, (minVal S h).val / m < x.val / m := by
+  haveI : NeZero (d * m) := ⟨by positivity⟩
+  obtain ⟨⟨r, hr, hfib⟩, hcard⟩ := hS
+  intro x hx
+  have hxS : x ∈ S := eraseMin_subset S hx
+  have hxne : x ≠ minVal S h := by
+    unfold eraseMin at hx
+    rw [dif_pos h] at hx
+    exact (Finset.mem_erase.mp hx).1
+  have hsame : (minVal S h).val % m = x.val % m := by
+    rw [hfib _ (minVal_mem S h), hfib _ hxS]
+  have hle : (minVal S h).val / m ≤ x.val / m :=
+    minVal_level_le ⟨⟨r, hr, hfib⟩, hcard⟩ h x hxS
+  rcases lt_or_eq_of_le hle with hlt | heq
+  · exact hlt
+  · exact absurd (level_injOn_fiber hsame heq).symm hxne
+
+/-! ## 7. Helper facts the downstream bricks will want.
+
+These pin the model to the verified one and expose the (M)-style arithmetic. -/
+
+/-- Within one fiber, `val` is strictly monotone in level: a point's `.val` equals
+    `level * m + col`.  (Used to identify least-`.val` with lowest-level.) -/
+lemma val_eq_level_mul_add_col {N : ℕ} (m : ℕ) (i : ZMod N) :
+    i.val = (i.val / m) * m + i.val % m := (Nat.div_add_mod' i.val m).symm
+
+/-- **The master separation inequality (M).** One level of separation beats any column
+    offset: for columns `p, q < m` and levels `a < c`, `p + a*m < q + c*m`. -/
+lemma sep_master {m : ℕ} {p q a c : ℕ} (hp : p < m) (_hq : q < m) (hac : a < c) :
+    p + a * m < q + c * m := by
+  have hstep : (a + 1) * m ≤ c * m := Nat.mul_le_mul_right m (by omega)
+  have : a * m + m ≤ c * m := by rw [Nat.add_mul, Nat.one_mul] at hstep; omega
+  omega
+
+/-- A crossing quadruple in strict val-order makes `A, B` linked (the (M)-witness hook). -/
+lemma linked_of_lt {N : ℕ} {A B : Finset (ZMod N)} {a1 a2 b1 b2 : ZMod N}
+    (ha1 : a1 ∈ A) (ha2 : a2 ∈ A) (hb1 : b1 ∈ B) (hb2 : b2 ∈ B)
+    (h1 : a1.val < b1.val) (h2 : b1.val < a2.val) (h3 : a2.val < b2.val) :
+    Linked A B :=
+  ⟨a1, ha1, a2, ha2, b1, hb1, b2, hb2, Or.inl ⟨h1, h2, h3⟩⟩
+
+/-- Membership in `T P`. -/
+lemma mem_T {N : ℕ} {P : Finset (Finset (ZMod N))} {x : ZMod N} :
+    x ∈ T P ↔ ∃ S ∈ P, x ∈ eraseMin S := by
+  unfold T
+  rw [Finset.mem_sup]
+
+/-! ## 8. `T P` lands in the `(d-1)`-subsets (the start of the `Tsub` packaging).
+
+`T_card` gives the cardinality; we package `T P` into the same `{S // S.card = d-1}` subtype
+the denominator counts (`Denominator.Asub`).  The remaining `LevelCanonical (T P)` clause —
+landing in the FULL `{S // S.card = d-1 ∧ LevelCanonical d m S}` subtype (`Denominator.Csub`) —
+is the FORWARD direction (brick 3b) and is deliberately NOT proved here. -/
+
+/-- `T P` packaged as a `(d-1)`-subset; the first half of the eventual `Tsub` into
+    `Denominator.Csub`. -/
+noncomputable def TsubCard {d m : ℕ} {P : Finset (Finset (ZMod (d * m)))}
+    (hP : Portrait d m P) : {S : Finset (ZMod (d * m)) // S.card = d - 1} :=
+  ⟨T P, T_card hP⟩
+
+end CriticalPortraits

--- a/LeanPool/CriticalPortraits/Surjectivity.lean
+++ b/LeanPool/CriticalPortraits/Surjectivity.lean
@@ -1,0 +1,1571 @@
+/-
+Copyright (c) 2026 Keston Aquino-Michaels. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Keston Aquino-Michaels
+-/
+
+import LeanPool.CriticalPortraits.Injectivity
+
+/-!
+# Surjectivity of `T` via the balance forest `β` (Part II of the bijection).
+
+For a level-canonical `(d-1)`-subset `U ⊆ ZMod (d*m)`, the **balance forest** `β(U)` is the
+explicit critical portrait with `T(β(U)) = U` — the discriminating section property (a wrong
+parent rule fails this).  Construction (paper Part II / bare-Lean `betaParent`):
+
+* For a survivor `u` (fiber `φ = u.val % m`, level `lu = u.val / m`) and level `k`, the
+  **deficiency** is `D(k) = S(φ+k·m, u) − (lu−k−1)` where `S(x,y) = #{t∈U : x<t.val<y}` (`Scount`).
+* `betaK U u` is the largest `k ≤ lu−1` with `D(k)=0` (`Nat.findGreatest`); `betaParent U u` is
+  the fiber-`φ` point at level `betaK`.
+* `β(U)` (`beta`) is the set of connected components (`betaBlock`) of the parent edges `(v*(u),u)`,
+  recovered via `Relation.ReflTransGen` of the adjacency relation `bAdj`.  Each block's `minVal`
+  is its non-`U` root (`betaRoot`); the survivors of each block are exactly its `U`-points.
+
+PROVED (sorry-free, axioms ⊆ {propext, Classical.choice, Quot.sound}):
+* `discrete_ivt` — discrete IVT via `Nat.findGreatest`; `exists_balance` (E) + `betaK_max` (M2).
+* `Defc_pos_after` — M2 *strict positivity* (the prefix/GPRE bound): the deficiency is `> 0`
+  strictly past the balance index (a second use of the discrete IVT, on `[j, lu-1]`).
+* `betaParent_inj` (I, parent injectivity, via the deficiency additive split + maximality).
+* **`T_beta` — `T(β(U)) = U`** (the load-bearing, discriminating spec).
+* `betaBlock_critical` (IsCriticalSet per block), `beta_pairwise_disjoint`, `beta_weight`
+  (∑(|S|−1)=d−1) — three of the four `Portrait` conjuncts.
+* `beta_unlinked` (N) is REDUCED to `beta_interval_closed` and PROVED from it.
+
+NOW FULLY PROVED (no remaining `sorry`):
+* `beta_interval_closed` — the geometric heart of N: a point of one block strictly inside another
+  block's `.val`-span forces the whole block inside.  Proved via the no-escape property `P`
+  (`noEscape`, a second discrete IVT on ψ-points anchored by the `Q` deficiency bound, with the
+  `GPRE` prefix bound and `N0` window lemma; the `ψ ≥ φ / ψ < φ` fiber split is handled by
+  `sep_master`), then the laminarity bridge (`root_ge`, `descend_cross`) turns `P` into the
+  two-sided `.val`-span containment using `betaBlock_disjoint`.  Downstream (`beta_unlinked`,
+  `beta_portrait`, `T_surjOn`) is therefore complete: SURJECTIVITY of `T` (all `d`) is proved.
+  Axioms: `{propext, Classical.choice, Quot.sound}` (no `sorryAx`, no `native_decide`).
+-/
+
+namespace CriticalPortraits
+
+open Finset
+open scoped BigOperators
+
+/-! ## Layer 0: discrete IVT via Nat.findGreatest. -/
+
+/-- **Discrete IVT.** An integer-valued sequence with `D 0 ≤ 0`, `0 ≤ D L`, and unit-bounded
+    up-steps (`D (k+1) ≤ D k + 1`) hits zero somewhere in `[0, L]`. -/
+theorem discrete_ivt (D : ℕ → ℤ) (L : ℕ) (h0 : D 0 ≤ 0) (hL : 0 ≤ D L)
+    (hstep : ∀ k, k < L → D (k + 1) ≤ D k + 1) : ∃ k ≤ L, D k = 0 := by
+  classical
+  set K := Nat.findGreatest (fun k => D k ≤ 0) L with hK
+  have hspec : D K ≤ 0 := by
+    have := Nat.findGreatest_spec (P := fun k => D k ≤ 0) (m := 0) (Nat.zero_le L) h0
+    simp only [hK]; exact this
+  have hKle : K ≤ L := Nat.findGreatest_le L
+  refine ⟨K, hKle, ?_⟩
+  rcases Nat.lt_or_ge K L with hlt | hge
+  · -- K < L: findGreatest is greatest, so ¬(D (K+1) ≤ 0), i.e. 0 < D (K+1)
+    have hnot : ¬ (D (K+1) ≤ 0) := by
+      have := Nat.findGreatest_is_greatest (P := fun k => D k ≤ 0)
+        (k := K+1) (n := L) (by simp [hK]) hlt
+      simpa using this
+    have hpos : 0 < D (K+1) := by omega
+    have := hstep K hlt
+    omega
+  · -- K ≥ L, with K ≤ L, so K = L; use hL
+    have hKeq : K = L := le_antisymm hKle hge
+    rw [hKeq] at hspec ⊢
+    omega
+
+/-! ## Layer 1: Scount and the deficiency. -/
+
+/-- `S(x,y) = #{t ∈ U : x < t.val < y}`. -/
+def Scount {d m : ℕ} (U : Finset (ZMod (d * m))) (x y : ℕ) : ℕ :=
+  (U.filter (fun t => x < t.val ∧ t.val < y)).card
+
+/-- Enlarging the lower endpoint shrinks the open interval: `Scount` is antitone in `x`. -/
+lemma Scount_antitone_left {d m : ℕ} (U : Finset (ZMod (d * m))) {x x' y : ℕ}
+    (hxx : x ≤ x') : Scount U x' y ≤ Scount U x y := by
+  unfold Scount
+  apply Finset.card_le_card
+  intro t ht
+  rw [Finset.mem_filter] at ht ⊢
+  exact ⟨ht.1, lt_of_le_of_lt hxx ht.2.1, ht.2.2⟩
+
+/-- The integer **deficiency** of survivor `u` (column `φ`, level `lu`) at index `k`:
+    `D(k) = Scount U (φ + k*m) u.val − (lu − k − 1)`. -/
+def Defc {d m : ℕ} (U : Finset (ZMod (d * m))) (φ lu uval k : ℕ) : ℤ :=
+  (Scount U (φ + k*m) uval : ℤ) - ((lu : ℤ) - (k : ℤ) - 1)
+
+/-- The deficiency has unit-bounded up-steps (the E3 step bound). -/
+lemma Defc_step {d m : ℕ} (_hm : 0 < m) (U : Finset (ZMod (d * m))) (φ lu uval k : ℕ) :
+    Defc U φ lu uval (k+1) ≤ Defc U φ lu uval k + 1 := by
+  unfold Defc
+  have hmono : Scount U (φ + (k+1)*m) uval ≤ Scount U (φ + k*m) uval := by
+    apply Scount_antitone_left
+    have : k * m ≤ (k+1) * m := Nat.mul_le_mul_right m (by omega)
+    omega
+  have h1 : (Scount U (φ + (k+1)*m) uval : ℤ) ≤ (Scount U (φ + k*m) uval : ℤ) := by
+    exact_mod_cast hmono
+  push_cast
+  omega
+
+/-- **E1 (upper boundary).** `D(lu-1) ≥ 0`: the constant `(lu - (lu-1) - 1) = 0`
+    and `Scount ≥ 0`. -/
+lemma Defc_top_nonneg {d m : ℕ} (U : Finset (ZMod (d * m))) (φ lu uval : ℕ) (hlu : 1 ≤ lu) :
+    0 ≤ Defc U φ lu uval (lu - 1) := by
+  unfold Defc
+  have hc : ((lu : ℤ) - ((lu - 1 : ℕ) : ℤ) - 1) = 0 := by
+    have : ((lu - 1 : ℕ) : ℤ) = (lu : ℤ) - 1 := by omega
+    rw [this]; ring
+  rw [hc]
+  simp only [sub_zero]
+  exact_mod_cast Nat.zero_le _
+
+/-- The scount bound from canonicity: `#{t ∈ U : φ < t.val < u.val} ≤ lu - 1`. -/
+lemma Scount_bot_le {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U)
+    {u : ZMod (d * m)} (hu : u ∈ U) :
+    Scount U (u.val % m) u.val ≤ u.val / m - 1 := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  -- key arithmetic facts about u.val
+  have hdm : u.val % m + (u.val / m) * m = u.val := Nat.mod_add_div' u.val m
+  have hφ : u.val % m < m := Nat.mod_lt _ hm
+  have hlud : u.val / m < d := by
+    have hlt : u.val < d * m := ZMod.val_lt u
+    by_contra hge
+    push Not at hge
+    have : d * m ≤ (u.val / m) * m := Nat.mul_le_mul_right m hge
+    omega
+  -- {t : φ < t.val < u.val} ⊆ filter (level ≤ lu) \ {u}
+  have hsub : U.filter (fun t => u.val % m < t.val ∧ t.val < u.val)
+      ⊆ (U.filter (fun i => i.val / m ≤ u.val / m)).erase u := by
+    intro t ht
+    rw [Finset.mem_filter] at ht
+    obtain ⟨htU, _, htlt⟩ := ht
+    rw [Finset.mem_erase, Finset.mem_filter]
+    have htlevel : t.val / m ≤ u.val / m := by
+      have hdiv : t.val / m * m ≤ t.val := Nat.div_mul_le_self t.val m
+      by_contra hgt
+      push Not at hgt
+      have : (u.val / m + 1) ≤ t.val / m := hgt
+      have h2 : (u.val / m + 1) * m ≤ (t.val / m) * m := Nat.mul_le_mul_right m this
+      rw [Nat.add_mul, Nat.one_mul] at h2
+      omega
+    refine ⟨?_, htU, htlevel⟩
+    intro htu; rw [htu] at htlt; omega
+  have humem : u ∈ U.filter (fun i => i.val / m ≤ u.val / m) := by
+    rw [Finset.mem_filter]; exact ⟨hu, le_refl _⟩
+  have hcard1 : (U.filter (fun t => u.val % m < t.val ∧ t.val < u.val)).card
+      ≤ ((U.filter (fun i => i.val / m ≤ u.val / m)).erase u).card := Finset.card_le_card hsub
+  have hcard2 : ((U.filter (fun i => i.val / m ≤ u.val / m)).erase u).card
+      = (U.filter (fun i => i.val / m ≤ u.val / m)).card - 1 :=
+    Finset.card_erase_of_mem humem
+  have hcanon_lu : (U.filter (fun i => i.val / m ≤ u.val / m)).card ≤ u.val / m :=
+    hcanon (u.val / m) hlud
+  unfold Scount
+  omega
+
+/-- **E2 (lower boundary).** `D(0) ≤ 0` from canonicity. -/
+lemma Defc_bot_nonpos {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U)
+    {u : ZMod (d * m)} (hu : u ∈ U) (hlu : 1 ≤ u.val / m) :
+    Defc U (u.val % m) (u.val / m) u.val 0 ≤ 0 := by
+  have hScount := Scount_bot_le hd hm hcanon hu
+  unfold Defc
+  simp only [Nat.zero_mul, Nat.add_zero]
+  push_cast
+  omega
+
+/-! ## Layer 2: existence of a balance index. -/
+
+/-- **Existence (E).** For a survivor `u` of a canonical `U` with level `≥ 1`, some balance index
+    `k ≤ lu-1` has deficiency `0`. -/
+lemma exists_balance {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U)
+    {u : ZMod (d * m)} (hu : u ∈ U) (hlu : 1 ≤ u.val / m) :
+    ∃ k ≤ u.val / m - 1, Defc U (u.val % m) (u.val / m) u.val k = 0 := by
+  apply discrete_ivt (fun k => Defc U (u.val % m) (u.val / m) u.val k) (u.val / m - 1)
+  · exact Defc_bot_nonpos hd hm hcanon hu hlu
+  · exact Defc_top_nonneg U (u.val % m) (u.val / m) u.val hlu
+  · intro k _
+    exact Defc_step hm U (u.val % m) (u.val / m) u.val k
+
+/-- Every position has level `< d`. -/
+lemma level_lt_d {d m : ℕ} (_hm : 0 < m) (x : ZMod (d * m)) [NeZero (d * m)] : x.val / m < d := by
+  have hlt : x.val < d * m := ZMod.val_lt x
+  have hdiv : (x.val / m) * m ≤ x.val := Nat.div_mul_le_self x.val m
+  by_contra hge
+  push Not at hge
+  have : d * m ≤ (x.val / m) * m := Nat.mul_le_mul_right m hge
+  omega
+
+/-! ## Layer 3: the balance index `betaK`, parent value and parent point. -/
+
+open Classical in
+/-- The **largest balance index** `K` of survivor `u` (the highest balance parent's level). -/
+noncomputable def betaK {d m : ℕ} (U : Finset (ZMod (d * m))) (u : ZMod (d * m)) : ℕ :=
+  Nat.findGreatest (fun k => Defc U (u.val % m) (u.val / m) u.val k = 0) (u.val / m - 1)
+
+/-- `betaK ≤ lu - 1`. -/
+lemma betaK_le {d m : ℕ} (U : Finset (ZMod (d * m))) (u : ZMod (d * m)) :
+    betaK U u ≤ u.val / m - 1 := Nat.findGreatest_le _
+
+/-- `betaK` is a balance index: deficiency `0` there. -/
+lemma betaK_spec {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U)
+    {u : ZMod (d * m)} (hu : u ∈ U) (hlu : 1 ≤ u.val / m) :
+    Defc U (u.val % m) (u.val / m) u.val (betaK U u) = 0 := by
+  classical
+  obtain ⟨k, hkle, hkdef⟩ := exists_balance hd hm hcanon hu hlu
+  have := Nat.findGreatest_spec (P := fun k => Defc U (u.val % m) (u.val / m) u.val k = 0)
+    (m := k) (n := u.val / m - 1) hkle hkdef
+  exact this
+
+/-- **Maximality (M2).** For `betaK < j ≤ lu-1`, deficiency at `j` is nonzero. -/
+lemma betaK_max {d m : ℕ} {U : Finset (ZMod (d * m))} {u : ZMod (d * m)} {j : ℕ}
+    (hj1 : betaK U u < j) (hj2 : j ≤ u.val / m - 1) :
+    Defc U (u.val % m) (u.val / m) u.val j ≠ 0 := by
+  classical
+  exact Nat.findGreatest_is_greatest (P := fun k => Defc U (u.val % m) (u.val / m) u.val k = 0)
+    hj1 hj2
+
+/-- The **parent value**: `φ + betaK*m` (same fiber as `u`, level `betaK`). -/
+noncomputable def betaParentVal {d m : ℕ} (U : Finset (ZMod (d * m))) (u : ZMod (d * m)) : ℕ :=
+  u.val % m + betaK U u * m
+
+/-- The parent value is `< d*m` (so its ZMod point round-trips). -/
+lemma betaParentVal_lt {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} {u : ZMod (d * m)} (hlu : 1 ≤ u.val / m) :
+    betaParentVal U u < d * m := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  unfold betaParentVal
+  have hφ : u.val % m < m := Nat.mod_lt _ hm
+  have hlud : u.val / m < d := by
+    have hlt : u.val < d * m := ZMod.val_lt u
+    have hdiv : (u.val / m) * m ≤ u.val := Nat.div_mul_le_self u.val m
+    by_contra hge
+    push Not at hge
+    have : d * m ≤ (u.val / m) * m := Nat.mul_le_mul_right m hge
+    omega
+  have hK : betaK U u ≤ u.val / m - 1 := betaK_le U u
+  -- betaK ≤ d - 2, so φ + betaK*m < m + (d-1)*m = d*m
+  have hKd : betaK U u ≤ d - 1 := by omega
+  have hmul : betaK U u * m ≤ (d-1) * m := Nat.mul_le_mul_right m hKd
+  have hdm : (d-1) * m + m = d * m := by
+    have : (d - 1) * m + 1 * m = (d - 1 + 1) * m := by rw [← Nat.add_mul]
+    rw [Nat.one_mul] at this
+    rw [this]
+    congr 1
+    omega
+  omega
+
+/-- The **parent point**: the ZMod element at `betaParentVal`. -/
+noncomputable def betaParent {d m : ℕ} (U : Finset (ZMod (d * m))) (u : ZMod (d * m)) :
+    ZMod (d * m) :=
+  (betaParentVal U u : ZMod (d*m))
+
+/-- `betaParent`'s `.val` is exactly `betaParentVal` (round-trips since it is `< d*m`). -/
+lemma betaParent_val {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} {u : ZMod (d * m)} (hlu : 1 ≤ u.val / m) :
+    (betaParent U u).val = betaParentVal U u := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  unfold betaParent
+  exact ZMod.val_natCast_of_lt (betaParentVal_lt hd hm hlu)
+
+/-- `betaParent` shares `u`'s fiber. -/
+lemma betaParent_fiber {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} {u : ZMod (d * m)} (hlu : 1 ≤ u.val / m) :
+    (betaParent U u).val % m = u.val % m := by
+  rw [betaParent_val hd hm hlu]
+  unfold betaParentVal
+  have hφ : u.val % m < m := Nat.mod_lt _ hm
+  rw [Nat.add_mul_mod_self_right, Nat.mod_eq_of_lt hφ]
+
+/-- `betaParent`'s level is `betaK` (strictly below `u`'s level). -/
+lemma betaParent_level {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} {u : ZMod (d * m)} (hlu : 1 ≤ u.val / m) :
+    (betaParent U u).val / m = betaK U u := by
+  rw [betaParent_val hd hm hlu]
+  unfold betaParentVal
+  have hφ : u.val % m < m := Nat.mod_lt _ hm
+  rw [Nat.add_mul_div_right _ _ hm, Nat.div_eq_of_lt hφ, Nat.zero_add]
+
+/-- `betaParent`'s level is strictly below `u`'s level. -/
+lemma betaParent_level_lt {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} {u : ZMod (d * m)} (hlu : 1 ≤ u.val / m) :
+    (betaParent U u).val / m < u.val / m := by
+  rw [betaParent_level hd hm hlu]
+  have := betaK_le U u
+  omega
+
+/-- `betaParent`'s `.val` is strictly below `u`'s `.val`. -/
+lemma betaParent_val_lt {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} {u : ZMod (d * m)} (hlu : 1 ≤ u.val / m) :
+    (betaParent U u).val < u.val := by
+  have hlev : (betaParent U u).val / m < u.val / m := betaParent_level_lt hd hm hlu
+  exact sameblock_lt (x := betaParent U u) (y := u) hm hlev
+
+/-! ## Layer 4: adjacency, reachability, and blocks as components. -/
+
+variable {d m : ℕ}
+
+/-- The (directed) **parent step**: `b` is a survivor (level ≥ 1) and `a` is its balance parent. -/
+def bEdge (U : Finset (ZMod (d * m))) (a b : ZMod (d * m)) : Prop :=
+  b ∈ U ∧ 1 ≤ b.val / m ∧ a = betaParent U b
+
+/-- The **adjacency** relation (symmetrized parent step). -/
+def bAdj (U : Finset (ZMod (d * m))) (a b : ZMod (d * m)) : Prop :=
+  bEdge U a b ∨ bEdge U b a
+
+lemma bAdj_symm {U : Finset (ZMod (d * m))} {a b : ZMod (d * m)} (h : bAdj U a b) : bAdj U b a := by
+  rcases h with h | h
+  · exact Or.inr h
+  · exact Or.inl h
+
+/-- **Reachability**: the reflexive-transitive closure of adjacency. -/
+def bReach (U : Finset (ZMod (d * m))) (a b : ZMod (d * m)) : Prop :=
+  Relation.ReflTransGen (bAdj U) a b
+
+lemma bReach_refl {U : Finset (ZMod (d * m))} (a : ZMod (d * m)) : bReach U a a :=
+  Relation.ReflTransGen.refl
+
+lemma bReach_symm {U : Finset (ZMod (d * m))} {a b : ZMod (d * m)} (h : bReach U a b) :
+    bReach U b a := by
+  unfold bReach at h ⊢
+  induction h with
+  | refl => exact Relation.ReflTransGen.refl
+  | @tail x y _ hxy ih => exact Relation.ReflTransGen.head (bAdj_symm hxy) ih
+
+lemma bReach_trans {U : Finset (ZMod (d * m))} {a b c : ZMod (d * m)}
+    (h1 : bReach U a b) (h2 : bReach U b c) : bReach U a c :=
+  Relation.ReflTransGen.trans h1 h2
+
+noncomputable instance bReachDecidable (U : Finset (ZMod (d * m))) (a b : ZMod (d * m)) :
+    Decidable (bReach U a b) := Classical.dec _
+
+/-- The active vertices of `β(U)`: the survivors and their balance parents. -/
+noncomputable def bVerts (U : Finset (ZMod (d * m))) : Finset (ZMod (d*m)) :=
+  U ∪ U.image (betaParent U)
+
+/-- The **block** of a point `x`: everything in `bVerts U` reachable from `x`. -/
+noncomputable def betaBlock (U : Finset (ZMod (d * m))) (x : ZMod (d * m)) :
+    Finset (ZMod (d * m)) :=
+  (bVerts U).filter (fun y => @decide (bReach U x y) (bReachDecidable U x y))
+
+lemma mem_betaBlock {U : Finset (ZMod (d * m))} {x y : ZMod (d * m)} :
+    y ∈ betaBlock U x ↔ y ∈ bVerts U ∧ bReach U x y := by
+  unfold betaBlock; rw [Finset.mem_filter]
+  simp only [decide_eq_true_eq]
+
+/-- **The balance forest** `β(U)`: the connected components of the parent edges. -/
+noncomputable def beta (U : Finset (ZMod (d * m))) : Finset (Finset (ZMod (d * m))) :=
+  (bVerts U).image (betaBlock U)
+
+/-! ## Layer 5: structural facts. -/
+
+/-- Canonical `U`: every survivor has level `≥ 1` (canonicity at `j = 0`). -/
+lemma survivor_level_pos {d m : ℕ} (hd : 0 < d) {U : Finset (ZMod (d * m))}
+    (hcanon : LevelCanonical d m U) {u : ZMod (d * m)} (hu : u ∈ U) : 1 ≤ u.val / m := by
+  by_contra hlt
+  push Not at hlt
+  have hlt0 : u.val / m ≤ 0 := by omega
+  have hmem : u ∈ U.filter (fun i => i.val / m ≤ 0) := by
+    rw [Finset.mem_filter]; exact ⟨hu, hlt0⟩
+  have hcanon0 : (U.filter (fun i => i.val / m ≤ 0)).card ≤ 0 := hcanon 0 hd
+  have hempty : (U.filter (fun i => i.val / m ≤ 0)).card = 0 := Nat.le_zero.mp hcanon0
+  rw [Finset.card_eq_zero] at hempty
+  rw [hempty] at hmem
+  exact absurd hmem (by simp)
+
+/-- A single adjacency step preserves the fiber. -/
+lemma bAdj_sameFiber {d m : ℕ} (hd : 0 < d) (hm : 0 < m) {U : Finset (ZMod (d * m))}
+    (_hcanon : LevelCanonical d m U) {a b : ZMod (d * m)} (h : bAdj U a b) :
+    a.val % m = b.val % m := by
+  rcases h with ⟨hbU, hblu, hab⟩ | ⟨haU, halu, hba⟩
+  · rw [hab]; exact betaParent_fiber hd hm hblu
+  · rw [hba]; exact (betaParent_fiber hd hm halu).symm
+
+/-- Reachability preserves the fiber. -/
+lemma bReach_sameFiber {d m : ℕ} (hd : 0 < d) (hm : 0 < m) {U : Finset (ZMod (d * m))}
+    (hcanon : LevelCanonical d m U) {a b : ZMod (d * m)} (h : bReach U a b) :
+    a.val % m = b.val % m := by
+  unfold bReach at h
+  induction h with
+  | refl => rfl
+  | @tail x y _ hxy ih => rw [ih]; exact bAdj_sameFiber hd hm hcanon hxy
+
+/-! ## Layer 6: Scount additivity and parent injectivity (I). -/
+
+/-- **Scount split** through an interior `U`-point `w`: if `x < w.val < y` and `w ∈ U`, then
+    `Scount U x y = Scount U x w.val + 1 + Scount U w.val y`. -/
+lemma Scount_split {d m : ℕ} [NeZero (d * m)] {U : Finset (ZMod (d * m))} {x y : ℕ}
+    {w : ZMod (d * m)}
+    (hwU : w ∈ U) (hxw : x < w.val) (hwy : w.val < y) :
+    Scount U x y = Scount U x w.val + 1 + Scount U w.val y := by
+  classical
+  unfold Scount
+  -- the filter for (x,y) splits as (x,w) ∪ {w} ∪ (w,y)
+  have hsplit : U.filter (fun t => x < t.val ∧ t.val < y)
+      = U.filter (fun t => x < t.val ∧ t.val < w.val)
+        ∪ {w}
+        ∪ U.filter (fun t => w.val < t.val ∧ t.val < y) := by
+    ext t
+    simp only [Finset.mem_filter, Finset.mem_union, Finset.mem_singleton]
+    constructor
+    · rintro ⟨htU, htx, hty⟩
+      rcases lt_trichotomy t.val w.val with hlt | heq | hgt
+      · exact Or.inl (Or.inl ⟨htU, htx, hlt⟩)
+      · exact Or.inl (Or.inr (ZMod.val_injective _ heq))
+      · exact Or.inr ⟨htU, hgt, hty⟩
+    · rintro (((⟨htU, htx, htw⟩) | rfl) | ⟨htU, htw, hty⟩)
+      · exact ⟨htU, htx, lt_trans htw hwy⟩
+      · exact ⟨hwU, hxw, hwy⟩
+      · exact ⟨htU, lt_trans hxw htw, hty⟩
+  rw [hsplit]
+  -- the three parts are pairwise disjoint
+  have hdisj1 : Disjoint (U.filter (fun t => x < t.val ∧ t.val < w.val))
+      ({w} : Finset (ZMod (d * m))) := by
+    rw [Finset.disjoint_singleton_right, Finset.mem_filter]
+    rintro ⟨_, _, hcontra⟩; omega
+  have hdisj2 : Disjoint (U.filter (fun t => x < t.val ∧ t.val < w.val) ∪ {w})
+      (U.filter (fun t => w.val < t.val ∧ t.val < y)) := by
+    rw [Finset.disjoint_union_left]
+    constructor
+    · rw [Finset.disjoint_left]
+      intro a ha hb
+      rw [Finset.mem_filter] at ha hb
+      omega
+    · rw [Finset.disjoint_singleton_left, Finset.mem_filter]
+      rintro ⟨_, hcontra, _⟩; omega
+  rw [Finset.card_union_of_disjoint hdisj2, Finset.card_union_of_disjoint hdisj1,
+    Finset.card_singleton]
+
+/-- The balance identity at `betaK`: `Scount U (betaParent).val u.val = lu - betaK - 1`. -/
+lemma betaParent_balance {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U)
+    {u : ZMod (d * m)} (hu : u ∈ U) (hlu : 1 ≤ u.val / m) :
+    (Scount U (betaParent U u).val u.val : ℤ)
+      = ((u.val / m : ℕ) : ℤ) - ((betaK U u : ℕ) : ℤ) - 1 := by
+  have hspec := betaK_spec hd hm hcanon hu hlu
+  have hpval : (betaParent U u).val = u.val % m + betaK U u * m := by
+    rw [betaParent_val hd hm hlu]; rfl
+  unfold Defc at hspec
+  rw [hpval]
+  -- hspec : (Scount U (u.val%m + betaK U u * m) u.val : ℤ) - ((u.val/m) - betaK U u - 1) = 0
+  linarith
+
+/-- **Injectivity (I).** The parent map is injective on survivors of canonical `U`. -/
+lemma betaParent_inj {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U)
+    {u1 u2 : ZMod (d * m)} (hu1 : u1 ∈ U) (hu2 : u2 ∈ U)
+    (heq : betaParent U u1 = betaParent U u2) : u1 = u2 := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  have hlu1 : 1 ≤ u1.val / m := survivor_level_pos hd hcanon hu1
+  have hlu2 : 1 ≤ u2.val / m := survivor_level_pos hd hcanon hu2
+  -- same fiber
+  have hfib : u1.val % m = u2.val % m := by
+    have h1 : (betaParent U u1).val % m = u1.val % m := betaParent_fiber hd hm hlu1
+    have h2 : (betaParent U u2).val % m = u2.val % m := betaParent_fiber hd hm hlu2
+    rw [heq] at h1; rw [← h1, h2]
+  -- WLOG handle by symmetry: prove for u1.val < u2.val a contradiction; equal vals ⇒ equal
+  by_contra hne
+  -- val inequality
+  have hvalne : u1.val ≠ u2.val := fun h => hne (ZMod.val_injective _ h)
+  -- the shared parent's val
+  have hpv : (betaParent U u1).val = (betaParent U u2).val := by rw [heq]
+  -- a symmetric core: if a.val < b.val then contradiction
+  have core : ∀ a b : ZMod (d*m), a ∈ U → b ∈ U → 1 ≤ a.val / m → 1 ≤ b.val / m →
+      a.val % m = b.val % m → (betaParent U a).val = (betaParent U b).val →
+      a.val < b.val → False := by
+    intro a b haU hbU hla hlb hfibab hpvab hab
+    -- shared parent val = φ + K*m, same K for both (since fiber same)
+    -- betaParent a level = betaK a, betaParent b level = betaK b
+    have hlevA : (betaParent U a).val / m = betaK U a := betaParent_level hd hm hla
+    have hlevB : (betaParent U b).val / m = betaK U b := betaParent_level hd hm hlb
+    have hKeq : betaK U a = betaK U b := by rw [← hlevA, ← hlevB, hpvab]
+    -- parent val < a.val (parent strictly below a)
+    have hpa_lt : (betaParent U a).val < a.val := betaParent_val_lt hd hm hla
+    have hpb_lt : (betaParent U b).val < b.val := betaParent_val_lt hd hm hlb
+    -- a.val = φ + (level a)*m, with level a > betaK a
+    have hlevAa : betaK U a < a.val / m := by
+      have hll : (betaParent U a).val / m < a.val / m := betaParent_level_lt hd hm hla
+      rw [hlevA] at hll; exact hll
+    -- a.val < b.val, same fiber ⇒ level a < level b
+    have hlevab : a.val / m < b.val / m := by
+      rcases lt_or_eq_of_le ((val_le_iff_level_le_of_sameFiber hfibab).mp hab.le) with h | h
+      · exact h
+      · exact absurd (level_injOn_fiber hfibab h) (fun heq2 => by rw [heq2] at hab; omega)
+    -- the balance identities
+    have hbalA := betaParent_balance hd hm hcanon haU hla
+    have hbalB := betaParent_balance hd hm hcanon hbU hlb
+    -- Scount split: Scount p b = Scount p a + 1 + Scount a b  (a interior, in U, p < a < b)
+    have hpab : (betaParent U b).val < a.val := by rw [← hpvab]; exact hpa_lt
+    have hsplit : Scount U (betaParent U b).val b.val
+        = Scount U (betaParent U b).val a.val + 1 + Scount U a.val b.val :=
+      Scount_split haU hpab hab
+    -- rewrite Scount p_b a using p_b = p_a
+    have hScpaa : Scount U (betaParent U b).val a.val = Scount U (betaParent U a).val a.val := by
+      rw [hpvab]
+    -- Now the deficiency of b at index (level a) is 0
+    have hDef_b_la : Defc U (b.val % m) (b.val / m) b.val (a.val / m) = 0 := by
+      unfold Defc
+      -- φ + (level a)*m = a.val
+      have haval : b.val % m + (a.val / m) * m = a.val := by
+        rw [← hfibab]
+        have := Nat.mod_add_div' a.val m; omega
+      rw [haval]
+      -- Scount a.val b.val = (lb - la - 1)
+      have hScab : (Scount U a.val b.val : ℤ)
+          = ((b.val / m : ℕ) : ℤ) - ((a.val / m : ℕ) : ℤ) - 1 := by
+        have e1 : (Scount U (betaParent U b).val b.val : ℤ)
+            = (Scount U (betaParent U a).val a.val : ℤ) + 1 + (Scount U a.val b.val : ℤ) := by
+          rw [hsplit, hScpaa]; push_cast; ring
+        rw [hbalB, hbalA, hKeq] at e1
+        linarith
+      rw [hScab]; ring
+    -- contradiction with maximality: betaK b < level a ≤ level b - 1
+    have hlt1 : betaK U b < a.val / m := by rw [← hKeq]; exact hlevAa
+    have hlt2 : a.val / m ≤ b.val / m - 1 := by omega
+    exact betaK_max hlt1 hlt2 hDef_b_la
+  rcases lt_trichotomy u1.val u2.val with h | h | h
+  · exact core u1 u2 hu1 hu2 hlu1 hlu2 hfib hpv h
+  · exact hvalne h
+  · exact core u2 u1 hu2 hu1 hlu2 hlu1 hfib.symm hpv.symm h
+
+/-! ## Layer 7: the root function (descend to the non-U sink). -/
+
+/-- One descent step: parent if a survivor (level ≥ 1), else stay. -/
+noncomputable def bStep {d m : ℕ} (U : Finset (ZMod (d * m))) (x : ZMod (d * m)) :
+    ZMod (d * m) :=
+  if _hx : x ∈ U then betaParent U x else x
+
+/-- The step strictly decreases `.val` when `x ∈ U`. -/
+lemma bStep_lt {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) {x : ZMod (d * m)} (hx : x ∈ U) :
+    (bStep U x).val < x.val := by
+  unfold bStep; rw [dif_pos hx]
+  exact betaParent_val_lt hd hm (survivor_level_pos hd hcanon hx)
+
+/-- The **root** of `x`: iterate `bStep` until a non-`U` point. Well-founded on `.val`. -/
+noncomputable def betaRoot {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) (x : ZMod (d * m)) : ZMod (d*m) :=
+  if _hx : x ∈ U then betaRoot hd hm hcanon (betaParent U x) else x
+termination_by x.val
+decreasing_by exact betaParent_val_lt hd hm (survivor_level_pos hd hcanon _hx)
+
+/-- If `x ∉ U`, the root is `x`. -/
+lemma betaRoot_of_not_mem {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) {x : ZMod (d * m)} (hx : x ∉ U) :
+    betaRoot hd hm hcanon x = x := by
+  rw [betaRoot]; rw [dif_neg hx]
+
+/-- If `x ∈ U`, the root descends to its parent's root. -/
+lemma betaRoot_of_mem {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) {x : ZMod (d * m)} (hx : x ∈ U) :
+    betaRoot hd hm hcanon x = betaRoot hd hm hcanon (betaParent U x) := by
+  rw [betaRoot]; rw [dif_pos hx]
+
+/-- The root is never in `U`. -/
+lemma betaRoot_not_mem {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) (x : ZMod (d * m)) :
+    betaRoot hd hm hcanon x ∉ U := by
+  induction hn : x.val using Nat.strong_induction_on generalizing x with
+  | _ n ih =>
+    subst hn
+    by_cases hx : x ∈ U
+    · rw [betaRoot_of_mem hd hm hcanon hx]
+      exact ih (betaParent U x).val (betaParent_val_lt hd hm (survivor_level_pos hd hcanon hx))
+        (betaParent U x) rfl
+    · rw [betaRoot_of_not_mem hd hm hcanon hx]; exact hx
+
+/-- The root's `.val` is `≤ x.val`. -/
+lemma betaRoot_le {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) (x : ZMod (d * m)) :
+    (betaRoot hd hm hcanon x).val ≤ x.val := by
+  induction hn : x.val using Nat.strong_induction_on generalizing x with
+  | _ n ih =>
+    subst hn
+    by_cases hx : x ∈ U
+    · rw [betaRoot_of_mem hd hm hcanon hx]
+      have hlt : (betaParent U x).val < x.val :=
+        betaParent_val_lt hd hm (survivor_level_pos hd hcanon hx)
+      exact le_trans (ih (betaParent U x).val hlt (betaParent U x) rfl) (le_of_lt hlt)
+    · rw [betaRoot_of_not_mem hd hm hcanon hx]
+
+/-- For `x ∈ U`, the root is strictly below `x`. -/
+lemma betaRoot_lt {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) {x : ZMod (d * m)} (hx : x ∈ U) :
+    (betaRoot hd hm hcanon x).val < x.val := by
+  rw [betaRoot_of_mem hd hm hcanon hx]
+  have hlt : (betaParent U x).val < x.val :=
+    betaParent_val_lt hd hm (survivor_level_pos hd hcanon hx)
+  exact lt_of_le_of_lt (betaRoot_le hd hm hcanon (betaParent U x)) hlt
+
+/-- `x` reaches its root. -/
+lemma bReach_betaRoot {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) (x : ZMod (d * m)) :
+    bReach U x (betaRoot hd hm hcanon x) := by
+  induction hn : x.val using Nat.strong_induction_on generalizing x with
+  | _ n ih =>
+    subst hn
+    by_cases hx : x ∈ U
+    · rw [betaRoot_of_mem hd hm hcanon hx]
+      have hlu := survivor_level_pos hd hcanon hx
+      have hstep : bAdj U x (betaParent U x) :=
+        Or.inr ⟨hx, hlu, rfl⟩
+      have hlt : (betaParent U x).val < x.val := betaParent_val_lt hd hm hlu
+      have hrec := ih (betaParent U x).val hlt (betaParent U x) rfl
+      exact bReach_trans (Relation.ReflTransGen.single hstep) hrec
+    · rw [betaRoot_of_not_mem hd hm hcanon hx]; exact bReach_refl x
+
+/-- The root is invariant under one adjacency step. -/
+lemma betaRoot_bAdj {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) {x y : ZMod (d * m)}
+    (h : bAdj U x y) : betaRoot hd hm hcanon x = betaRoot hd hm hcanon y := by
+  rcases h with ⟨hyU, _, hxy⟩ | ⟨hxU, _, hyx⟩
+  · -- bEdge U x y: y ∈ U, x = betaParent y
+    rw [hxy, ← betaRoot_of_mem hd hm hcanon hyU]
+  · -- bEdge U y x: x ∈ U, y = betaParent x
+    rw [hyx, ← betaRoot_of_mem hd hm hcanon hxU]
+
+/-- The root is invariant along reachability. -/
+lemma betaRoot_bReach {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) {x y : ZMod (d * m)}
+    (h : bReach U x y) : betaRoot hd hm hcanon x = betaRoot hd hm hcanon y := by
+  unfold bReach at h
+  induction h with
+  | refl => rfl
+  | @tail w z _ hwz ih => rw [ih]; exact betaRoot_bAdj hd hm hcanon hwz
+
+/-! ## Layer 8: block membership and the min = root. -/
+
+/-- A `U`-point is a vertex. -/
+lemma mem_bVerts_of_mem {d m : ℕ} {U : Finset (ZMod (d * m))} {x : ZMod (d * m)} (hx : x ∈ U) :
+    x ∈ bVerts U := by
+  unfold bVerts; exact Finset.mem_union_left _ hx
+
+/-- A balance parent of a `U`-point is a vertex. -/
+lemma betaParent_mem_bVerts {d m : ℕ} {U : Finset (ZMod (d * m))} {u : ZMod (d * m)} (hu : u ∈ U) :
+    betaParent U u ∈ bVerts U := by
+  unfold bVerts
+  exact Finset.mem_union_right _ (Finset.mem_image_of_mem _ hu)
+
+/-- One adjacency step from a vertex lands on a vertex. -/
+lemma bAdj_mem_bVerts {d m : ℕ} {U : Finset (ZMod (d * m))} {x y : ZMod (d * m)}
+    (h : bAdj U x y) : y ∈ bVerts U := by
+  rcases h with ⟨hyU, _, _⟩ | ⟨hxU, _, hyx⟩
+  · exact mem_bVerts_of_mem hyU
+  · rw [hyx]; exact betaParent_mem_bVerts hxU
+
+/-- Reachability from a vertex stays in `bVerts`. -/
+lemma bReach_mem_bVerts {d m : ℕ} {U : Finset (ZMod (d * m))} {x y : ZMod (d * m)}
+    (hx : x ∈ bVerts U) (h : bReach U x y) : y ∈ bVerts U := by
+  unfold bReach at h
+  induction h with
+  | refl => exact hx
+  | @tail w z _ hwz _ => exact bAdj_mem_bVerts hwz
+
+/-- The root of a vertex is a vertex. -/
+lemma betaRoot_mem_bVerts {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) {x : ZMod (d * m)}
+    (hx : x ∈ bVerts U) : betaRoot hd hm hcanon x ∈ bVerts U :=
+  bReach_mem_bVerts hx (bReach_betaRoot hd hm hcanon x)
+
+/-- The root is in the block of `x`. -/
+lemma betaRoot_mem_block {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) {x : ZMod (d * m)}
+    (hx : x ∈ bVerts U) : betaRoot hd hm hcanon x ∈ betaBlock U x := by
+  rw [mem_betaBlock]
+  exact ⟨betaRoot_mem_bVerts hd hm hcanon hx, bReach_betaRoot hd hm hcanon x⟩
+
+/-- The root is `.val`-minimal in the block. -/
+lemma betaRoot_min_in_block {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) {x y : ZMod (d * m)}
+    (hy : y ∈ betaBlock U x) : (betaRoot hd hm hcanon x).val ≤ y.val := by
+  rw [mem_betaBlock] at hy
+  obtain ⟨_, hreach⟩ := hy
+  have hroot_eq : betaRoot hd hm hcanon x = betaRoot hd hm hcanon y :=
+    betaRoot_bReach hd hm hcanon hreach
+  rw [hroot_eq]
+  exact betaRoot_le hd hm hcanon y
+
+/-- The block of a vertex is nonempty. -/
+lemma betaBlock_nonempty {d m : ℕ} {U : Finset (ZMod (d * m))} {x : ZMod (d * m)}
+    (hx : x ∈ bVerts U) : (betaBlock U x).Nonempty :=
+  ⟨x, by rw [mem_betaBlock]; exact ⟨hx, bReach_refl x⟩⟩
+
+/-- The minimum of a block is its root. -/
+lemma minVal_betaBlock {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) {x : ZMod (d * m)}
+    (hx : x ∈ bVerts U) :
+    minVal (betaBlock U x) (betaBlock_nonempty hx) = betaRoot hd hm hcanon x := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  set h := betaBlock_nonempty hx
+  -- minVal ≤ root.val and root.val ≤ minVal.val (root is min)
+  have h1 : (minVal (betaBlock U x) h).val ≤ (betaRoot hd hm hcanon x).val :=
+    minVal_le (betaBlock U x) h _ (betaRoot_mem_block hd hm hcanon hx)
+  have h2 : (betaRoot hd hm hcanon x).val ≤ (minVal (betaBlock U x) h).val :=
+    betaRoot_min_in_block hd hm hcanon (minVal_mem (betaBlock U x) h)
+  exact ZMod.val_injective _ (le_antisymm h1 h2)
+
+/-- A block member that is not the root is a survivor (`∈ U`). -/
+lemma mem_U_of_mem_block_ne_root {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) {x y : ZMod (d * m)}
+    (hy : y ∈ betaBlock U x) (hne : y ≠ betaRoot hd hm hcanon x) : y ∈ U := by
+  rw [mem_betaBlock] at hy
+  obtain ⟨hyv, hreach⟩ := hy
+  by_contra hyU
+  -- y ∉ U ⇒ betaRoot y = y; but betaRoot y = betaRoot x
+  have hself : betaRoot hd hm hcanon y = y := betaRoot_of_not_mem hd hm hcanon hyU
+  have heq : betaRoot hd hm hcanon x = betaRoot hd hm hcanon y :=
+    betaRoot_bReach hd hm hcanon hreach
+  rw [hself] at heq
+  exact hne heq.symm
+
+/-- `betaBlock U x ∈ beta U` for a vertex `x`. -/
+lemma betaBlock_mem_beta {d m : ℕ} {U : Finset (ZMod (d * m))} {x : ZMod (d * m)}
+    (hx : x ∈ bVerts U) : betaBlock U x ∈ beta U :=
+  Finset.mem_image_of_mem _ hx
+
+lemma mem_beta_iff {d m : ℕ} {U : Finset (ZMod (d * m))} {S : Finset (ZMod (d * m))} :
+    S ∈ beta U ↔ ∃ v ∈ bVerts U, betaBlock U v = S := by
+  unfold beta; rw [Finset.mem_image]
+
+/-! ## Layer 9: T(β U) = U. -/
+
+/-- **The load-bearing spec.** `T(β U) = U` for canonical `U`. -/
+theorem T_beta {d m : ℕ} (hd : 0 < d) (hm : 0 < m) {U : Finset (ZMod (d * m))}
+    (hcanon : LevelCanonical d m U) : T (beta U) = U := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  ext x
+  rw [mem_T]
+  constructor
+  · -- x ∈ eraseMin S, S = betaBlock U v ⇒ x ∈ U
+    rintro ⟨S, hS, hxS⟩
+    rw [mem_beta_iff] at hS
+    obtain ⟨v, hv, hSeq⟩ := hS
+    subst hSeq
+    have hne : (betaBlock U v).Nonempty := betaBlock_nonempty hv
+    rw [mem_eraseMin (betaBlock U v) hne] at hxS
+    obtain ⟨hxmem, hxneq⟩ := hxS
+    -- minVal = betaRoot v
+    rw [minVal_betaBlock hd hm hcanon hv] at hxneq
+    exact mem_U_of_mem_block_ne_root hd hm hcanon hxmem hxneq
+  · -- x ∈ U ⇒ x ∈ eraseMin (betaBlock U x)
+    intro hxU
+    have hxv : x ∈ bVerts U := mem_bVerts_of_mem hxU
+    refine ⟨betaBlock U x, betaBlock_mem_beta hxv, ?_⟩
+    have hne : (betaBlock U x).Nonempty := betaBlock_nonempty hxv
+    rw [mem_eraseMin (betaBlock U x) hne]
+    constructor
+    · rw [mem_betaBlock]; exact ⟨hxv, bReach_refl x⟩
+    · rw [minVal_betaBlock hd hm hcanon hxv]
+      -- x ∈ U but betaRoot x ∉ U
+      intro hcontra
+      have hroot_notmem : betaRoot hd hm hcanon x ∉ U := betaRoot_not_mem hd hm hcanon x
+      rw [← hcontra] at hroot_notmem
+      exact hroot_notmem hxU
+
+/-! ## Layer 10: β U is a Portrait — IsCriticalSet per block. -/
+
+/-- Every block member shares the vertex's fiber. -/
+lemma betaBlock_sameFiber {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) {x y : ZMod (d * m)}
+    (hy : y ∈ betaBlock U x) : y.val % m = x.val % m := by
+  rw [mem_betaBlock] at hy
+  obtain ⟨_, hreach⟩ := hy
+  exact (bReach_sameFiber hd hm hcanon hreach).symm
+
+/-- Every block contains a second point besides its root (its root has a `U`-child, or the
+    vertex itself is a `U`-point). -/
+lemma betaBlock_two_le {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) {v : ZMod (d * m)}
+    (hv : v ∈ bVerts U) : 2 ≤ (betaBlock U v).card := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  -- find a U-point u with u in the block (u = v if v ∈ U, else v = betaParent u)
+  rcases Finset.mem_union.mp hv with hvU | hvImg
+  · -- v ∈ U: block contains v and betaParent v, distinct
+    have hlu := survivor_level_pos hd hcanon hvU
+    have hp_mem : betaParent U v ∈ betaBlock U v := by
+      rw [mem_betaBlock]
+      refine ⟨betaParent_mem_bVerts hvU, ?_⟩
+      exact Relation.ReflTransGen.single (Or.inr ⟨hvU, hlu, rfl⟩)
+    have hv_mem : v ∈ betaBlock U v := by rw [mem_betaBlock]; exact ⟨hv, bReach_refl v⟩
+    have hne : betaParent U v ≠ v := by
+      intro h
+      have hlt : (betaParent U v).val < v.val := betaParent_val_lt hd hm hlu
+      rw [h] at hlt; omega
+    have hsub : ({betaParent U v, v} : Finset (ZMod (d*m))) ⊆ betaBlock U v := by
+      intro z hz
+      rw [Finset.mem_insert, Finset.mem_singleton] at hz
+      rcases hz with h | h <;> subst h
+      · exact hp_mem
+      · exact hv_mem
+    have hcard2 : ({betaParent U v, v} : Finset (ZMod (d*m))).card = 2 :=
+      Finset.card_pair_eq_two_iff.mpr hne
+    calc 2 = ({betaParent U v, v} : Finset (ZMod (d*m))).card := hcard2.symm
+      _ ≤ (betaBlock U v).card := Finset.card_le_card hsub
+  · -- v ∈ image(betaParent): v = betaParent u, u ∈ U; block contains v and u
+    rw [Finset.mem_image] at hvImg
+    obtain ⟨u, huU, hvu⟩ := hvImg
+    have hlu := survivor_level_pos hd hcanon huU
+    have hu_mem : u ∈ betaBlock U v := by
+      rw [mem_betaBlock]
+      refine ⟨mem_bVerts_of_mem huU, ?_⟩
+      -- v = betaParent u, so bAdj v u (bEdge U v u)
+      rw [← hvu]
+      exact Relation.ReflTransGen.single (Or.inl ⟨huU, hlu, rfl⟩)
+    have hv_mem : v ∈ betaBlock U v := by rw [mem_betaBlock]; exact ⟨hv, bReach_refl v⟩
+    have hne : u ≠ v := by
+      intro h
+      have hlt : (betaParent U u).val < u.val := betaParent_val_lt hd hm hlu
+      rw [hvu, h] at hlt; omega
+    have hsub : ({u, v} : Finset (ZMod (d*m))) ⊆ betaBlock U v := by
+      intro z hz
+      rw [Finset.mem_insert, Finset.mem_singleton] at hz
+      rcases hz with h | h <;> subst h
+      · exact hu_mem
+      · exact hv_mem
+    have hcard2 : ({u, v} : Finset (ZMod (d*m))).card = 2 :=
+      Finset.card_pair_eq_two_iff.mpr hne
+    calc 2 = ({u, v} : Finset (ZMod (d*m))).card := hcard2.symm
+      _ ≤ (betaBlock U v).card := Finset.card_le_card hsub
+
+/-- Each block is a critical set. -/
+lemma betaBlock_critical {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) {v : ZMod (d * m)}
+    (hv : v ∈ bVerts U) : IsCriticalSet d m (betaBlock U v) := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  refine ⟨⟨v.val % m, Nat.mod_lt _ hm, ?_⟩, betaBlock_two_le hd hm hcanon hv⟩
+  intro y hy
+  exact betaBlock_sameFiber hd hm hcanon hy
+
+/-! ## Layer 11: blocks determined by reachability; Disjoint. -/
+
+/-- Reachable vertices have the same block. -/
+lemma betaBlock_eq_of_bReach {d m : ℕ} {U : Finset (ZMod (d * m))} {v1 v2 : ZMod (d * m)}
+    (h : bReach U v1 v2) : betaBlock U v1 = betaBlock U v2 := by
+  ext z
+  rw [mem_betaBlock, mem_betaBlock]
+  constructor
+  · rintro ⟨hzv, hreach⟩; exact ⟨hzv, bReach_trans (bReach_symm h) hreach⟩
+  · rintro ⟨hzv, hreach⟩; exact ⟨hzv, bReach_trans h hreach⟩
+
+/-- Distinct blocks are vertex-disjoint. -/
+lemma betaBlock_disjoint {d m : ℕ} {U : Finset (ZMod (d * m))} {v1 v2 : ZMod (d * m)}
+    (hne : betaBlock U v1 ≠ betaBlock U v2) : Disjoint (betaBlock U v1) (betaBlock U v2) := by
+  rw [Finset.disjoint_left]
+  intro z hz1 hz2
+  rw [mem_betaBlock] at hz1 hz2
+  obtain ⟨_, hr1⟩ := hz1
+  obtain ⟨_, hr2⟩ := hz2
+  -- v1 reaches z, v2 reaches z ⇒ v1 reaches v2 ⇒ blocks equal
+  have hv12 : bReach U v1 v2 := bReach_trans hr1 (bReach_symm hr2)
+  exact hne (betaBlock_eq_of_bReach hv12)
+
+/-- Distinct blocks of `β U` are disjoint. -/
+lemma beta_pairwise_disjoint {d m : ℕ} {U : Finset (ZMod (d * m))} :
+    ∀ A ∈ beta U, ∀ B ∈ beta U, A ≠ B → Disjoint A B := by
+  intro A hA B hB hAB
+  rw [mem_beta_iff] at hA hB
+  obtain ⟨v1, _, hA1⟩ := hA
+  obtain ⟨v2, _, hB1⟩ := hB
+  subst hA1; subst hB1
+  exact betaBlock_disjoint hAB
+
+/-! ## Layer 12: the weight identity ∑(|S|-1) = d-1. -/
+
+/-- **Weight.** `∑ S ∈ β U, (|S| - 1) = d - 1` (counted via `T(β U) = U`). -/
+lemma beta_weight {d m : ℕ} (hd : 0 < d) (hm : 0 < m) {U : Finset (ZMod (d * m))}
+    (hcard : U.card = d - 1) (hcanon : LevelCanonical d m U) :
+    ∑ S ∈ beta U, (S.card - 1) = d - 1 := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  classical
+  -- pairwise disjoint eraseMin
+  have hpd : (↑(beta U) : Set (Finset (ZMod (d*m)))).PairwiseDisjoint eraseMin := by
+    intro A hA B hB hAB
+    exact (beta_pairwise_disjoint A hA B hB hAB).mono (eraseMin_subset A) (eraseMin_subset B)
+  have hTcard : (T (beta U)).card = ∑ S ∈ beta U, (S.card - 1) := by
+    unfold T
+    rw [Finset.sup_eq_biUnion, Finset.card_biUnion hpd]
+    apply Finset.sum_congr rfl
+    intro S hS
+    rw [mem_beta_iff] at hS
+    obtain ⟨v, hv, hSeq⟩ := hS
+    subst hSeq
+    exact eraseMin_card (betaBlock U v) (betaBlock_nonempty hv)
+  rw [← hTcard, T_beta hd hm hcanon, hcard]
+
+/-! ## Layer 12b: M2 strict positivity past the balance index (the prefix bound). -/
+
+/-- **M2 strict positivity.** For a survivor `u` of canonical `U` and `betaK U u < j ≤ lu-1`,
+    the deficiency at `j` is strictly positive.  If it were `≤ 0`, then since `D(lu-1) ≥ 0` (E1)
+    and up-steps are `≤ 1`, the discrete IVT on `[j, lu-1]` yields an exact zero `> K`,
+    contradicting maximality `betaK_max`. -/
+lemma Defc_pos_after {d m : ℕ} (_hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (_hcanon : LevelCanonical d m U)
+    {u : ZMod (d * m)} (_hu : u ∈ U) (hlu : 1 ≤ u.val / m) {j : ℕ}
+    (hj1 : betaK U u < j) (hj2 : j ≤ u.val / m - 1) :
+    0 < Defc U (u.val % m) (u.val / m) u.val j := by
+  classical
+  set φ := u.val % m with hφ
+  set lu := u.val / m with hludef
+  by_contra hle
+  push Not at hle
+  -- shifted sequence E i := D (j + i), defined on [0, (lu-1) - j]
+  set L := (lu - 1) - j with hLdef
+  set E : ℕ → ℤ := fun i => Defc U φ lu u.val (j + i) with hEdef
+  have hE0 : E 0 ≤ 0 := by simpa [hEdef] using hle
+  have hEL : 0 ≤ E L := by
+    have : j + L = lu - 1 := by omega
+    simp only [hEdef]
+    rw [this]
+    exact Defc_top_nonneg U φ lu u.val hlu
+  have hEstep : ∀ i, i < L → E (i+1) ≤ E i + 1 := by
+    intro i _
+    simp only [hEdef]
+    have : j + (i + 1) = (j + i) + 1 := by omega
+    rw [this]
+    exact Defc_step hm U φ lu u.val (j + i)
+  obtain ⟨i, hiL, hEi⟩ := discrete_ivt E L hE0 hEL hEstep
+  -- j + i is a zero of D, with K < j ≤ j + i ≤ lu - 1
+  have hzero : Defc U φ lu u.val (j + i) = 0 := by simpa [hEdef] using hEi
+  have hKlt : betaK U u < j + i := by omega
+  have hle_lu : j + i ≤ lu - 1 := by omega
+  exact betaK_max hKlt hle_lu hzero
+
+/-! ## Layer 12c: the no-escape property `P` and the laminarity bridge to interval-closure. -/
+
+/-- Any balance index `≤ betaK`: `betaK` is the *largest* zero of the deficiency. -/
+lemma betaK_ge {d m : ℕ} {U : Finset (ZMod (d * m))} {s : ZMod (d * m)} {k : ℕ}
+    (hk : Defc U (s.val % m) (s.val / m) s.val k = 0) (hkle : k ≤ s.val / m - 1) :
+    k ≤ betaK U s := by
+  classical
+  exact Nat.le_findGreatest hkle hk
+
+/-- Two disjoint open subintervals fit inside the whole: `Scount` is superadditive. -/
+lemma Scount_add_le {d m : ℕ} (U : Finset (ZMod (d * m))) {x y z : ℕ}
+    (hxy : x ≤ y) (hyz : y ≤ z) :
+    Scount U x y + Scount U y z ≤ Scount U x z := by
+  classical
+  unfold Scount
+  rw [← Finset.card_union_of_disjoint]
+  · apply Finset.card_le_card
+    intro t ht
+    rw [Finset.mem_union, Finset.mem_filter, Finset.mem_filter] at ht
+    rw [Finset.mem_filter]
+    rcases ht with ⟨htU, h1, h2⟩ | ⟨htU, h1, h2⟩
+    · exact ⟨htU, h1, lt_of_lt_of_le h2 hyz⟩
+    · exact ⟨htU, lt_of_le_of_lt hxy h1, h2⟩
+  · rw [Finset.disjoint_left]
+    intro t ht1 ht2
+    rw [Finset.mem_filter] at ht1 ht2
+    omega
+
+/-- **GPRE prefix bound.** For a survivor `u` of canonical `U`, with `K := betaK U u` and a
+    `φ`-column index `j` with `K < j ≤ lu`, the survivor count from `v*(u)` up to the `φ`-point at
+    level `j` is at most `j - K - 1`. -/
+lemma GPRE {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U)
+    {u : ZMod (d * m)} (hu : u ∈ U) (hlu : 1 ≤ u.val / m) {j : ℕ}
+    (hj1 : betaK U u < j) (hj2 : j ≤ u.val / m) :
+    (Scount U (betaParent U u).val (u.val % m + j * m) : ℤ) ≤ (j : ℤ) - (betaK U u : ℤ) - 1 := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  classical
+  set φ := u.val % m with hφ
+  set lu := u.val / m with hludef
+  set K := betaK U u with hKdef
+  -- v = betaParent val = φ + K*m
+  have hpval : (betaParent U u).val = φ + K * m := by
+    rw [betaParent_val hd hm hlu]; rfl
+  -- w' = φ + j*m, and v ≤ w' ≤ u.val
+  have hvw : (betaParent U u).val ≤ φ + j * m := by
+    rw [hpval]
+    have : K * m ≤ j * m := Nat.mul_le_mul_right m (le_of_lt hj1)
+    omega
+  have hwu : φ + j * m ≤ u.val := by
+    have hdm : φ + lu * m = u.val := by rw [hφ, hludef]; exact Nat.mod_add_div' u.val m
+    have : j * m ≤ lu * m := Nat.mul_le_mul_right m hj2
+    omega
+  -- additive: Scount v w' + Scount w' u ≤ Scount v u
+  have hadd := Scount_add_le U hvw hwu
+  -- balance identity: Scount v u = lu - K - 1
+  have hbal := betaParent_balance hd hm hcanon hu hlu
+  -- Scount w' u ≥ lu - j (Defc_pos_after for j<lu; trivial for j=lu)
+  have hsuf : (lu : ℤ) - (j : ℤ) ≤ (Scount U (φ + j * m) u.val : ℤ) := by
+    rcases lt_or_eq_of_le hj2 with hjlt | hjeq
+    · -- j < lu
+      have hjle : j ≤ lu - 1 := by omega
+      have hpos := Defc_pos_after hd hm hcanon hu hlu hj1 hjle
+      unfold Defc at hpos
+      -- hpos : 0 < Scount U (φ + j*m) u.val - (lu - j - 1)
+      push_cast at hpos ⊢
+      linarith
+    · -- j = lu: w' = u.val, Scount = 0
+      have hwval : φ + j * m = u.val := by
+        rw [hjeq, hφ, hludef]; exact Nat.mod_add_div' u.val m
+      rw [hwval]
+      have : Scount U u.val u.val = 0 := by
+        unfold Scount
+        rw [Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+        intro t _; omega
+      rw [this, hjeq]; push_cast; ring_nf; omega
+  -- combine
+  push_cast at hadd hbal ⊢
+  linarith
+
+/-- **N0.** No survivor lies strictly inside one column-window above an edge bottom:
+    there is no `t ∈ U` with `v*(u) < t.val < v*(u) + m`. -/
+lemma N0 {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U)
+    {u : ZMod (d * m)} (hu : u ∈ U) (hlu : 1 ≤ u.val / m)
+    {t : ZMod (d * m)} (htU : t ∈ U)
+    (hlo : (betaParent U u).val < t.val) (hhi : t.val < (betaParent U u).val + m) : False := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  classical
+  set φ := u.val % m with hφ
+  set lu := u.val / m with hludef
+  set K := betaK U u with hKdef
+  have hpval : (betaParent U u).val = φ + K * m := by
+    rw [betaParent_val hd hm hlu]; rfl
+  have hKle : K ≤ lu - 1 := betaK_le U u
+  -- GPRE at j = K+1: Scount v (φ+(K+1)*m) ≤ 0
+  have hj1 : K < K + 1 := by omega
+  have hj2 : K + 1 ≤ lu := by omega
+  have hgpre := GPRE hd hm hcanon hu hlu hj1 hj2
+  -- (φ + (K+1)*m) = v + m
+  have hwval : φ + (K + 1) * m = (betaParent U u).val + m := by
+    rw [hpval]; ring
+  rw [hwval] at hgpre
+  -- hgpre : Scount v (v+m) ≤ (K+1) - K - 1 = 0
+  have hzero : Scount U (betaParent U u).val ((betaParent U u).val + m) = 0 := by
+    have : (Scount U (betaParent U u).val ((betaParent U u).val + m) : ℤ) ≤ 0 := by
+      push_cast at hgpre; linarith
+    omega
+  -- but t is in that window
+  have htmem : t ∈ U.filter (fun w => (betaParent U u).val < w.val ∧
+      w.val < (betaParent U u).val + m) := by
+    rw [Finset.mem_filter]; exact ⟨htU, hlo, hhi⟩
+  have hpos : 0 < Scount U (betaParent U u).val ((betaParent U u).val + m) := by
+    unfold Scount
+    exact Finset.card_pos.mpr ⟨t, htmem⟩
+  omega
+
+/-- Shrinking the upper endpoint shrinks the open interval: `Scount` is monotone in `y`. -/
+lemma Scount_mono_right {d m : ℕ} (U : Finset (ZMod (d * m))) {x y y' : ℕ}
+    (hyy : y ≤ y') : Scount U x y ≤ Scount U x y' := by
+  unfold Scount
+  apply Finset.card_le_card
+  intro t ht
+  rw [Finset.mem_filter] at ht ⊢
+  exact ⟨ht.1, ht.2.1, lt_of_lt_of_le ht.2.2 hyy⟩
+
+/-- **Q (the deficiency-sign anchor).** For an edge `(v,u) = (v*(u), u)` and an interior survivor
+    `s` (fiber `ψ`), if `y = ψ + ly*m` is the `ψ`-point in `[v, v+m)`, then the deficiency of `s`
+    at level `ly` is `≤ 0`. -/
+lemma Q {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U)
+    {u s : ZMod (d * m)} (hu : u ∈ U) (hlu : 1 ≤ u.val / m) (hs : s ∈ U)
+    (hslo : (betaParent U u).val < s.val) (hshi : s.val < u.val) {ly : ℕ}
+    (hwlo : (betaParent U u).val ≤ s.val % m + ly * m)
+    (hwhi : s.val % m + ly * m < (betaParent U u).val + m) :
+    Defc U (s.val % m) (s.val / m) s.val ly ≤ 0 := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  classical
+  set φ := u.val % m with hφdef
+  set ψ := s.val % m with hψdef
+  set lu := u.val / m with hludef
+  set ls := s.val / m with hlsdef
+  set K := betaK U u with hKdef
+  have hφlt : φ < m := Nat.mod_lt _ hm
+  have hψlt : ψ < m := Nat.mod_lt _ hm
+  have hpval : (betaParent U u).val = φ + K * m := by
+    rw [betaParent_val hd hm hlu]; rfl
+  have hsval : ψ + ls * m = s.val := by rw [hψdef, hlsdef]; exact Nat.mod_add_div' s.val m
+  have huval : φ + lu * m = u.val := by rw [hφdef, hludef]; exact Nat.mod_add_div' u.val m
+  set yVal := ψ + ly * m with hyVal
+  -- window: v ≤ yVal < v + m
+  rw [hpval] at hwlo hwhi
+  -- ly ∈ {K, K+1}
+  have hlyK : K ≤ ly := by
+    by_contra hc; push Not at hc
+    have := sep_master (m := m) (p := ψ) (q := φ) hψlt hφlt hc
+    omega
+  have hlyK1 : ly ≤ K + 1 := by
+    by_contra hc; push Not at hc
+    have hlt : K + 1 < ly := by omega
+    have hsm := sep_master (m := m) (p := φ) (q := ψ) hφlt hψlt hlt
+    have he : (K + 1) * m = K * m + m := by ring
+    omega
+  -- choose w' = φ + j*m, j ∈ {ls, ls+1}
+  set j := if φ < ψ then ls + 1 else ls with hjdef
+  -- s.val ≤ w' < s.val + m
+  have hsW : s.val ≤ φ + j * m := by
+    rw [hjdef]; split
+    · rename_i h
+      have hsm := sep_master (m := m) (p := ψ) (q := φ) hψlt hφlt (show ls < ls + 1 by omega)
+      omega
+    · rename_i h
+      push Not at h
+      have hle : ψ + ls * m ≤ φ + ls * m := by omega
+      omega
+  have hWs : φ + j * m < s.val + m := by
+    rw [hjdef]; split
+    · rename_i h
+      -- φ + (ls+1)*m < ψ + ls*m + m  ↔ φ < ψ
+      have he : (ls + 1) * m = ls * m + m := by ring
+      omega
+    · rename_i h; push Not at h
+      -- ¬(φ < ψ) ⟹ ψ ≤ φ; goal φ + ls*m < ψ + ls*m + m ↔ φ < ψ + m, from φ < m
+      omega
+  -- K < j ≤ lu
+  have hKj : K < j := by
+    by_contra hc; push Not at hc
+    -- j ≤ K ⟹ φ + j*m ≤ φ + K*m = v < s.val ≤ w', contradiction
+    have h1 : φ + j * m ≤ φ + K * m := by
+      have := Nat.mul_le_mul_right m hc; omega
+    omega
+  have hjlu : j ≤ lu := by
+    by_contra hc; push Not at hc
+    have h1 : φ + (lu + 1) * m ≤ φ + j * m := by
+      have := Nat.mul_le_mul_right m (show lu + 1 ≤ j by omega); omega
+    have h2 : φ + (lu + 1) * m = u.val + m := by
+      have : φ + (lu + 1) * m = (φ + lu * m) + m := by ring
+      rw [this, huval]
+    omega
+  -- GPRE bound on Scount(v, w')
+  have hgpre := GPRE hd hm hcanon hu hlu hKj hjlu
+  rw [hpval] at hgpre
+  -- Scount(yVal, s.val) ≤ Scount(v, s.val) (antitone in lower endpoint; yVal ≥ v)
+  have hanti : Scount U yVal s.val ≤ Scount U (φ + K * m) s.val := by
+    apply Scount_antitone_left; rw [hyVal]; omega
+  -- the key Defc inequality, split on ψ = φ
+  unfold Defc
+  rw [← hyVal]
+  by_cases hψφ : ψ = φ
+  · -- ψ = φ ⟹ ly = K (window forces yVal = v) and j = ls
+    -- (φ ≤ ψ false here? φ=ψ so φ≤ψ true ⟹ j=ls+1)
+    -- recompute: with ψ=φ, w' = φ + (ls+1)*m but s.val = φ + ls*m, so s.val < w', use split anyway.
+    -- yVal: from window with ψ=φ: φ + ly*m in [φ+K*m, φ+K*m+m) ⟹ ly = K
+    have hlyEq : ly = K := by
+      rcases (lt_or_eq_of_le hlyK1) with h | h
+      · omega
+      · -- ly = K+1: yVal = ψ+(K+1)*m ≥ φ+K*m+m, contradicts hwhi (ψ=φ)
+        exfalso
+        have he : (K + 1) * m = K * m + m := by ring
+        rw [hyVal, h] at hwhi
+        omega
+    subst hlyEq
+    -- yVal = ψ + K*m = φ + K*m = v (ψ=φ); and j = ls (since ¬ φ < ψ); so w' = φ+ls*m = s.val
+    have hyv : yVal = φ + K * m := by rw [hyVal, hψφ]
+    rw [hyv]
+    have hjval : j = ls := by rw [hjdef]; rw [if_neg (by omega)]
+    have hwseq : φ + j * m = s.val := by
+      rw [hjval]; rw [← hsval, hψφ]
+    rw [hwseq, hjval] at hgpre
+    -- hgpre : Scount(v, s.val) ≤ ls - K - 1, exactly the goal (ly = K).
+    linarith
+  · -- ψ ≠ φ ⟹ s.val < w' strictly, use Scount_split for the -1, then case ly/j
+    have hsltw : s.val < φ + j * m := by
+      rcases lt_or_eq_of_le hsW with h | h
+      · exact h
+      · -- s.val = w' = φ+j*m ⟹ ψ + ls*m = φ + j*m, same fiber ⟹ ψ=φ via mod
+        exfalso
+        have : (ψ + ls * m) % m = (φ + j * m) % m := by rw [hsval, h]
+        rw [Nat.add_mul_mod_self_right, Nat.add_mul_mod_self_right,
+          Nat.mod_eq_of_lt hψlt, Nat.mod_eq_of_lt hφlt] at this
+        exact hψφ this
+    have hsplit : Scount U (φ + K * m) (φ + j * m)
+        = Scount U (φ + K * m) s.val + 1 + Scount U s.val (φ + j * m) := by
+      apply Scount_split hs
+      · rw [← hpval] at *; omega
+      · exact hsltw
+    have hsplitZ : (Scount U (φ + K * m) (φ + j * m) : ℤ)
+        = (Scount U (φ + K * m) s.val : ℤ) + 1 + (Scount U s.val (φ + j * m) : ℤ) := by
+      exact_mod_cast hsplit
+    have hge0 : (0 : ℤ) ≤ (Scount U s.val (φ + j * m) : ℤ) := by exact_mod_cast Nat.zero_le _
+    have hantiZ : (Scount U yVal s.val : ℤ) ≤ (Scount U (φ + K * m) s.val : ℤ) := by
+      exact_mod_cast hanti
+    -- pin j and ly
+    have hjcase : j = ls ∨ j = ls + 1 := by rw [hjdef]; split <;> [right; left] <;> rfl
+    -- We need: Scount(yVal, s.val) - (ls - ly - 1) ≤ 0, i.e. Scount(yVal,s.val) ≤ ls - ly - 1.
+    -- have: Scount(yVal,s) ≤ Scount(v,s); Scount(v,s)+1 ≤ Scount(v,w') ≤ j-K-1.
+    -- ⟹ Scount(yVal,s) ≤ j - K - 2. Need j+ly ≤ ls+K+1.
+    have hbound : (Scount U yVal s.val : ℤ) ≤ (j : ℤ) - K - 2 := by linarith
+    have hjly : (j : ℤ) + ly ≤ ls + K + 1 := by
+      -- enumerate ly∈{K,K+1}, j∈{ls,ls+1}; exclude (ly=K+1 ∧ j=ls+1)
+      rcases (lt_or_eq_of_le hlyK1) with hlylt | hlyeq
+      · -- ly = K
+        have : ly = K := by omega
+        subst this
+        rcases hjcase with hj | hj <;> rw [hj] <;> push_cast <;> omega
+      · -- ly = K+1 ⟹ ψ < φ (from hwhi)
+        -- hwhi : ψ + ly*m < φ + K*m + m, with ly = K+1
+        have hψφlt : ψ < φ := by
+          rw [hyVal, hlyeq] at hwhi
+          have he2 : (K + 1) * m = K * m + m := by ring
+          omega
+        -- then j = ls (else j=ls+1 ⟹ φ<ψ, contra)
+        have hjeq : j = ls := by
+          rw [hjdef]; rw [if_neg (by omega)]
+        rw [hlyeq, hjeq]; push_cast; omega
+    linarith
+
+/-- **P (no escape).** For an edge `(v,u) = (v*(u), u)` of canonical `U` and an interior survivor
+    `s` (`v < s.val < u.val`), the balance parent of `s` does not escape below `v`:
+    `v*(u).val ≤ v*(s).val`. -/
+lemma noEscape {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U)
+    {u s : ZMod (d * m)} (hu : u ∈ U) (hs : s ∈ U)
+    (hslo : (betaParent U u).val < s.val) (hshi : s.val < u.val) :
+    (betaParent U u).val ≤ (betaParent U s).val := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  classical
+  have hlu : 1 ≤ u.val / m := survivor_level_pos hd hcanon hu
+  have hls : 1 ≤ s.val / m := survivor_level_pos hd hcanon hs
+  set φ := u.val % m with hφdef
+  set ψ := s.val % m with hψdef
+  set lu := u.val / m with hludef
+  set ls := s.val / m with hlsdef
+  set K := betaK U u with hKdef
+  have hφlt : φ < m := Nat.mod_lt _ hm
+  have hψlt : ψ < m := Nat.mod_lt _ hm
+  have hpval : (betaParent U u).val = φ + K * m := by
+    rw [betaParent_val hd hm hlu]; rfl
+  have hsval : ψ + ls * m = s.val := by rw [hψdef, hlsdef]; exact Nat.mod_add_div' s.val m
+  -- ly and window
+  set ly := if ψ < φ then K + 1 else K with hlydef
+  have hwlo : (betaParent U u).val ≤ ψ + ly * m := by
+    rw [hpval, hlydef]; split
+    · rename_i h
+      have he : (K + 1) * m = K * m + m := by ring
+      omega
+    · rename_i h; push Not at h; omega
+  have hwhi : ψ + ly * m < (betaParent U u).val + m := by
+    rw [hpval, hlydef]; split
+    · rename_i h
+      have he : (K + 1) * m = K * m + m := by ring
+      omega
+    · rename_i h; push Not at h; omega
+  -- Q gives the start bound; build the shifted IVT
+  have hQ := Q hd hm hcanon hu hlu hs hslo hshi (ly := ly) hwlo hwhi
+  -- N0: s.val ≥ v + m, so ly < ls
+  have hsge : (betaParent U u).val + m ≤ s.val := by
+    by_contra hc; push Not at hc
+    exact N0 hd hm hcanon hu hlu hs hslo hc
+  have hwhi' : ψ + ly * m < φ + K * m + m := by rw [← hpval]; exact hwhi
+  have hlyls : ly < ls := by
+    -- yVal = ψ+ly*m < v+m ≤ s.val = ψ+ls*m ⟹ ly < ls
+    have h1 : ψ + ly * m < ψ + ls * m := by
+      rw [hsval]; rw [hpval] at hsge; omega
+    by_contra hc; push Not at hc
+    have : ψ + ls * m ≤ ψ + ly * m := by
+      have := Nat.mul_le_mul_right m hc; omega
+    omega
+  -- E i := Defc U ψ ls s.val (ly + i), L = (ls - 1) - ly
+  set L := (ls - 1) - ly with hLdef
+  set E : ℕ → ℤ := fun i => Defc U ψ ls s.val (ly + i) with hEdef
+  have hE0 : E 0 ≤ 0 := by
+    simp only [hEdef, Nat.add_zero]
+    rw [hψdef, hlsdef]
+    exact hQ
+  have hEL : 0 ≤ E L := by
+    have hjL : ly + L = ls - 1 := by omega
+    simp only [hEdef]
+    rw [hjL]
+    rw [hlsdef] at *
+    exact Defc_top_nonneg U ψ (s.val / m) s.val hls
+  have hEstep : ∀ i, i < L → E (i + 1) ≤ E i + 1 := by
+    intro i _
+    simp only [hEdef]
+    have : ly + (i + 1) = (ly + i) + 1 := by omega
+    rw [this]
+    rw [hlsdef] at *
+    exact Defc_step hm U ψ (s.val / m) s.val (ly + i)
+  obtain ⟨i, hiL, hEi⟩ := discrete_ivt E L hE0 hEL hEstep
+  have hzero : Defc U ψ ls s.val (ly + i) = 0 := by simpa [hEdef] using hEi
+  -- betaK s ≥ ly + i ≥ ly
+  have hkle : ly + i ≤ s.val / m - 1 := by rw [← hlsdef]; omega
+  have hge : ly + i ≤ betaK U s := by
+    apply betaK_ge (k := ly + i)
+    · rw [hψdef, hlsdef] at hzero; exact hzero
+    · exact hkle
+  have hbetaKge : ly ≤ betaK U s := by omega
+  -- (betaParent U s).val = ψ + betaK s * m ≥ ψ + ly*m ≥ v
+  have hspval : (betaParent U s).val = ψ + betaK U s * m := by
+    rw [betaParent_val hd hm hls]; rw [hψdef]; rfl
+  rw [hspval, hpval]
+  -- goal: φ + K*m ≤ ψ + betaK s * m; from φ+K*m ≤ ψ+ly*m (hwlo) and ly ≤ betaK s
+  have hmm : ψ + ly * m ≤ ψ + betaK U s * m := by
+    have := Nat.mul_le_mul_right m hbetaKge; omega
+  rw [hpval] at hwlo
+  omega
+
+/-- The **root stays above the edge bottom**: for an edge `(v,u)` and any vertex `w` strictly
+    inside its val-interval, the root of `w` has val `≥ v`. -/
+lemma root_ge {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U)
+    {u : ZMod (d * m)} (hu : u ∈ U) :
+    ∀ w : ZMod (d*m), w ∈ bVerts U →
+      (betaParent U u).val < w.val → w.val < u.val →
+      (betaParent U u).val ≤ (betaRoot hd hm hcanon w).val := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  intro w
+  induction hn : w.val using Nat.strong_induction_on generalizing w with
+  | _ n ih =>
+    subst hn
+    intro hwv h1 h2
+    by_cases hwU : w ∈ U
+    · -- survivor: noEscape ⟹ betaParent w ≥ v, and inj ⟹ strict ⟹ recurse
+      have hesc := noEscape hd hm hcanon hu hwU h1 h2
+      -- betaParent w ≠ betaParent u (else w = u, but w.val < u.val)
+      have hne : (betaParent U w).val ≠ (betaParent U u).val := by
+        intro heqv
+        have heq : betaParent U w = betaParent U u := ZMod.val_injective _ heqv
+        have := betaParent_inj hd hm hcanon hwU hu heq
+        rw [this] at h2; omega
+      have hstrict : (betaParent U u).val < (betaParent U w).val :=
+        lt_of_le_of_ne hesc (Ne.symm hne)
+      have hpw_lt : (betaParent U w).val < w.val :=
+        betaParent_val_lt hd hm (survivor_level_pos hd hcanon hwU)
+      have hpw_ltu : (betaParent U w).val < u.val := lt_trans hpw_lt h2
+      have hpwv : betaParent U w ∈ bVerts U := betaParent_mem_bVerts hwU
+      have hrec := ih (betaParent U w).val hpw_lt (betaParent U w) rfl hpwv hstrict hpw_ltu
+      rw [betaRoot_of_mem hd hm hcanon hwU]
+      exact hrec
+    · -- non-survivor: root is itself
+      rw [betaRoot_of_not_mem hd hm hcanon hwU]
+      exact le_of_lt h1
+
+/-- **Descend across a threshold.** If `w` is a vertex with `betaRoot w ≤ L < w.val`,
+    then descending
+    the parent chain crosses `L`: some survivor `b` reachable from `w` has
+    `v*(b).val ≤ L < b.val`. -/
+lemma descend_cross {d m : ℕ} (hd : 0 < d) (hm : 0 < m)
+    {U : Finset (ZMod (d * m))} (hcanon : LevelCanonical d m U) (L : ℕ) :
+    ∀ w : ZMod (d*m), (betaRoot hd hm hcanon w).val ≤ L → L < w.val →
+      ∃ b : ZMod (d*m), b ∈ U ∧ bReach U w b ∧ (betaParent U b).val ≤ L ∧ L < b.val := by
+  intro w
+  induction hn : w.val using Nat.strong_induction_on generalizing w with
+  | _ n ih =>
+    subst hn
+    intro hroot hLw
+    by_cases hwU : w ∈ U
+    · -- w is a survivor; either its parent already ≤ L (done with b=w) or recurse
+      have hlu := survivor_level_pos hd hcanon hwU
+      have hpw_lt : (betaParent U w).val < w.val := betaParent_val_lt hd hm hlu
+      by_cases hpL : (betaParent U w).val ≤ L
+      · exact ⟨w, hwU, bReach_refl w, hpL, hLw⟩
+      · push Not at hpL  -- L < (betaParent U w).val
+        have hpwv : betaParent U w ∈ bVerts U := betaParent_mem_bVerts hwU
+        have hrooteq : betaRoot hd hm hcanon (betaParent U w) = betaRoot hd hm hcanon w :=
+          (betaRoot_of_mem hd hm hcanon hwU).symm
+        have hroot' : (betaRoot hd hm hcanon (betaParent U w)).val ≤ L := by
+          rw [hrooteq]; exact hroot
+        obtain ⟨b, hbU, hbreach, hb1, hb2⟩ :=
+          ih (betaParent U w).val hpw_lt (betaParent U w) rfl hroot' hpL
+        refine ⟨b, hbU, ?_, hb1, hb2⟩
+        exact bReach_trans (Relation.ReflTransGen.single (Or.inr ⟨hwU, hlu, rfl⟩)) hbreach
+    · -- w ∉ U ⟹ betaRoot w = w ⟹ w.val ≤ L, contradicting L < w.val
+      rw [betaRoot_of_not_mem hd hm hcanon hwU] at hroot
+      omega
+
+lemma beta_interval_closed {d m : ℕ} (hd : 0 < d) (hm : 0 < m) {U : Finset (ZMod (d * m))}
+    (hcanon : LevelCanonical d m U) {x z : ZMod (d * m)}
+    (hx : x ∈ bVerts U) (hz : z ∈ bVerts U)
+    (hne : betaBlock U x ≠ betaBlock U z)
+    {p : ZMod (d * m)} (hp : p ∈ betaBlock U z)
+    (hlo : (minVal (betaBlock U x) (betaBlock_nonempty hx)).val < p.val)
+    (hhi : p.val < (maxVal (betaBlock U x) (betaBlock_nonempty hx)).val) :
+    ∀ q ∈ betaBlock U z, (minVal (betaBlock U x) (betaBlock_nonempty hx)).val ≤ q.val ∧
+      q.val ≤ (maxVal (betaBlock U x) (betaBlock_nonempty hx)).val := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  classical
+  set Xne := betaBlock_nonempty hx with hXne
+  set minX := minVal (betaBlock U x) Xne with hminX
+  set maxX := maxVal (betaBlock U x) Xne with hmaxX
+  have hdisj : Disjoint (betaBlock U x) (betaBlock U z) := betaBlock_disjoint hne
+  -- minX = betaRoot x
+  have hminroot : minX = betaRoot hd hm hcanon x := minVal_betaBlock hd hm hcanon hx
+  -- maxX ∈ block x; maxX.val is the block maximum
+  have hmaxX_mem : maxX ∈ betaBlock U x := maxVal_mem _ Xne
+  have hxreach_max : bReach U x maxX := (mem_betaBlock.mp hmaxX_mem).2
+  -- p ∈ block z, so bReach z p, betaRoot z = betaRoot p
+  have hzreach_p : bReach U z p := (mem_betaBlock.mp hp).2
+  have hrootzp : betaRoot hd hm hcanon z = betaRoot hd hm hcanon p :=
+    betaRoot_bReach hd hm hcanon hzreach_p
+  -- == Step A: enclosing X-edge of p ==
+  -- betaRoot maxX = betaRoot x = minX
+  have hroot_max : betaRoot hd hm hcanon maxX = betaRoot hd hm hcanon x :=
+    (betaRoot_bReach hd hm hcanon hxreach_max).symm
+  have hroot_max_val : (betaRoot hd hm hcanon maxX).val < p.val := by
+    rw [hroot_max, ← hminroot]; exact hlo
+  obtain ⟨cstar, hcU, hreach_max_c, hgle, hpc⟩ :=
+    descend_cross hd hm hcanon p.val maxX (le_of_lt hroot_max_val) hhi
+  -- cstar ∈ block x
+  have hxreach_c : bReach U x cstar := bReach_trans hxreach_max hreach_max_c
+  have hc_mem : cstar ∈ betaBlock U x := by
+    rw [mem_betaBlock]
+    exact ⟨bReach_mem_bVerts hx hxreach_c, hxreach_c⟩
+  have hclu : 1 ≤ cstar.val / m := survivor_level_pos hd hcanon hcU
+  -- g* = betaParent cstar ∈ block x, g*.val ≤ p.val
+  have hxreach_g : bReach U x (betaParent U cstar) :=
+    bReach_trans hxreach_c (Relation.ReflTransGen.single (Or.inr ⟨hcU, hclu, rfl⟩))
+  have hg_mem : betaParent U cstar ∈ betaBlock U x := by
+    rw [mem_betaBlock]
+    exact ⟨bReach_mem_bVerts hx hxreach_g, hxreach_g⟩
+  -- minX.val ≤ g*.val (root is block-min)
+  have hminX_le_g : minX.val ≤ (betaParent U cstar).val := by
+    rw [hminroot]; exact betaRoot_min_in_block hd hm hcanon hg_mem
+  -- g*.val < p.val (strict: else g* = p ∈ X ∩ Z)
+  have hg_lt_p : (betaParent U cstar).val < p.val := by
+    rcases lt_or_eq_of_le hgle with h | h
+    · exact h
+    · exfalso
+      have : betaParent U cstar = p := ZMod.val_injective _ h
+      have hpX : p ∈ betaBlock U x := by rw [← this]; exact hg_mem
+      exact (Finset.disjoint_left.mp hdisj hpX) hp
+  -- == Step B: lower bound. root_ge ⟹ minX.val ≤ (betaRoot p).val ==
+  have hrootp_ge : (betaParent U cstar).val ≤ (betaRoot hd hm hcanon p).val :=
+    root_ge hd hm hcanon hcU p (bReach_mem_bVerts hz hzreach_p) hg_lt_p hpc
+  have hminX_le_rootz : minX.val ≤ (betaRoot hd hm hcanon z).val := by
+    rw [hrootzp]; exact le_trans hminX_le_g hrootp_ge
+  -- == the main statement ==
+  intro q hq
+  have hqz : bReach U z q := (mem_betaBlock.mp hq).2
+  have hrootz_le_q : (betaRoot hd hm hcanon z).val ≤ q.val :=
+    betaRoot_min_in_block hd hm hcanon hq
+  refine ⟨le_trans hminX_le_rootz hrootz_le_q, ?_⟩
+  -- upper bound by contradiction
+  by_contra hqgt
+  push Not at hqgt  -- maxX.val < q.val
+  -- c*.val ≤ maxX.val
+  have hc_le_maxX : cstar.val ≤ maxX.val := maxVal_ge _ Xne _ hc_mem
+  -- (betaRoot q).val = (betaRoot z).val ≤ p.val < c*.val (root z below p, p < c*)
+  have hrootq : betaRoot hd hm hcanon q = betaRoot hd hm hcanon z :=
+    (betaRoot_bReach hd hm hcanon hqz).symm
+  have hrootz_le_p : (betaRoot hd hm hcanon z).val ≤ p.val := by
+    rw [hrootzp]; exact betaRoot_le hd hm hcanon p
+  have hrootq_le_c : (betaRoot hd hm hcanon q).val ≤ cstar.val := by
+    rw [hrootq]; exact le_trans hrootz_le_p (le_of_lt hpc)
+  have hq_gt_c : cstar.val < q.val := lt_of_le_of_lt hc_le_maxX hqgt
+  -- descend Z from q crossing c*.val
+  obtain ⟨bz, hbzU, hqreach_bz, haz_le, hc_lt_bz⟩ :=
+    descend_cross hd hm hcanon cstar.val q hrootq_le_c hq_gt_c
+  -- bz ∈ block z, a_z = betaParent bz ∈ block z
+  have hzreach_bz : bReach U z bz := bReach_trans hqz hqreach_bz
+  have hbzlu : 1 ≤ bz.val / m := survivor_level_pos hd hcanon hbzU
+  have hzreach_az : bReach U z (betaParent U bz) :=
+    bReach_trans hzreach_bz (Relation.ReflTransGen.single (Or.inr ⟨hbzU, hbzlu, rfl⟩))
+  have haz_mem : betaParent U bz ∈ betaBlock U z := by
+    rw [mem_betaBlock]
+    exact ⟨bReach_mem_bVerts hz hzreach_az, hzreach_az⟩
+  -- a_z.val < c*.val strict (else a_z = cstar ∈ X ∩ Z)
+  have haz_lt_c : (betaParent U bz).val < cstar.val := by
+    rcases lt_or_eq_of_le haz_le with h | h
+    · exact h
+    · exfalso
+      have : betaParent U bz = cstar := ZMod.val_injective _ h
+      have hcZ : cstar ∈ betaBlock U z := by rw [← this]; exact haz_mem
+      exact (Finset.disjoint_left.mp hdisj hc_mem) hcZ
+  -- root_ge: a_z.val ≤ (betaRoot cstar).val = minX.val
+  have hrootc : betaRoot hd hm hcanon cstar = betaRoot hd hm hcanon x :=
+    (betaRoot_bReach hd hm hcanon hxreach_c).symm
+  have haz_le_minX : (betaParent U bz).val ≤ minX.val := by
+    have := root_ge hd hm hcanon hbzU cstar (bReach_mem_bVerts hx hxreach_c) haz_lt_c hc_lt_bz
+    rw [hrootc, ← hminroot] at this
+    exact this
+  -- but a_z ∈ Z so a_z.val ≥ (betaRoot z).val ≥ minX.val
+  have haz_ge_minX : minX.val ≤ (betaParent U bz).val :=
+    le_trans hminX_le_rootz (betaRoot_min_in_block hd hm hcanon haz_mem)
+  have haz_eq : (betaParent U bz).val = minX.val := le_antisymm haz_le_minX haz_ge_minX
+  have haz_eq_pt : betaParent U bz = minX := ZMod.val_injective _ haz_eq
+  -- minX ∈ block x; betaParent bz ∈ block z ⟹ disjoint contradiction
+  have hminX_mem : minX ∈ betaBlock U x := by
+    rw [hminroot]; exact betaRoot_mem_block hd hm hcanon hx
+  have hminX_in_Z : minX ∈ betaBlock U z := by rw [← haz_eq_pt]; exact haz_mem
+  exact (Finset.disjoint_left.mp hdisj hminX_mem) hminX_in_Z
+
+/-- **Unlinked (N).** Distinct blocks of `β U` are unlinked. -/
+lemma beta_unlinked {d m : ℕ} (hd : 0 < d) (hm : 0 < m) {U : Finset (ZMod (d * m))}
+    (hcanon : LevelCanonical d m U) :
+    ∀ A ∈ beta U, ∀ B ∈ beta U, A ≠ B → Unlinked A B := by
+  haveI : NeZero (d*m) := ⟨by positivity⟩
+  intro A hA B hB hAB
+  rw [mem_beta_iff] at hA hB
+  obtain ⟨x, hx, hAx⟩ := hA
+  obtain ⟨z, hz, hBz⟩ := hB
+  subst hAx; subst hBz
+  intro hL
+  -- destructure the crossing quadruple
+  obtain ⟨a1, ha1, a2, ha2, b1, hb1, b2, hb2, hcase⟩ := hL
+  -- both cases are symmetric; reduce to a1<b1<a2<b2 form by relabelling
+  -- nonempty witnesses
+  have hAne := betaBlock_nonempty hx
+  have hBne := betaBlock_nonempty hz
+  -- helper: a "linked" quadruple across two distinct blocks forces equal blocks (contradiction).
+  -- symmetric in the two block-vertices.
+  have core : ∀ s t : ZMod (d*m), s ∈ bVerts U → t ∈ bVerts U →
+      betaBlock U s ≠ betaBlock U t →
+      ∀ p1 p2 q1 q2 : ZMod (d*m),
+      p1 ∈ betaBlock U s → p2 ∈ betaBlock U s → q1 ∈ betaBlock U t → q2 ∈ betaBlock U t →
+      p1.val < q1.val → q1.val < p2.val → p2.val < q2.val → False := by
+    intro s t hs ht hst p1 p2 q1 q2 hp1 hp2 hq1 hq2 ho1 ho2 ho3
+    have hSne := betaBlock_nonempty hs
+    have hTne := betaBlock_nonempty ht
+    -- q1 strictly inside S's span
+    have hminS_le_p1 : (minVal (betaBlock U s) hSne).val ≤ p1.val := minVal_le _ hSne _ hp1
+    have hp2_le_maxS : p2.val ≤ (maxVal (betaBlock U s) hSne).val := maxVal_ge _ hSne _ hp2
+    have hq1_loS : (minVal (betaBlock U s) hSne).val < q1.val := by omega
+    have hq1_hiS : q1.val < (maxVal (betaBlock U s) hSne).val := by omega
+    -- T ⊆ [minS, maxS]
+    have hTin := beta_interval_closed hd hm hcanon hs ht hst hq1 hq1_loS hq1_hiS
+    -- p2 strictly inside T's span
+    have hminT_le_q1 : (minVal (betaBlock U t) hTne).val ≤ q1.val := minVal_le _ hTne _ hq1
+    have hq2_le_maxT : q2.val ≤ (maxVal (betaBlock U t) hTne).val := maxVal_ge _ hTne _ hq2
+    have hp2_loT : (minVal (betaBlock U t) hTne).val < p2.val := by omega
+    have hp2_hiT : p2.val < (maxVal (betaBlock U t) hTne).val := by omega
+    -- S ⊆ [minT, maxT]
+    have hSin := beta_interval_closed hd hm hcanon ht hs (Ne.symm hst) hp2 hp2_loT hp2_hiT
+    have hmS_mem : minVal (betaBlock U s) hSne ∈ betaBlock U s := minVal_mem _ hSne
+    have hmT_mem : minVal (betaBlock U t) hTne ∈ betaBlock U t := minVal_mem _ hTne
+    -- T ⊆ [minS,maxS] ⇒ minS ≤ minT; S ⊆ [minT,maxT] ⇒ minT ≤ minS
+    have h1 : (minVal (betaBlock U s) hSne).val ≤ (minVal (betaBlock U t) hTne).val :=
+      (hTin _ hmT_mem).1
+    have h2 : (minVal (betaBlock U t) hTne).val ≤ (minVal (betaBlock U s) hSne).val :=
+      (hSin _ hmS_mem).1
+    have hmineq : (minVal (betaBlock U s) hSne).val = (minVal (betaBlock U t) hTne).val := by omega
+    have hmineq' : minVal (betaBlock U s) hSne = minVal (betaBlock U t) hTne :=
+      ZMod.val_injective _ hmineq
+    have hdisj := betaBlock_disjoint hst
+    have hmS_in_T : minVal (betaBlock U s) hSne ∈ betaBlock U t := by rw [hmineq']; exact hmT_mem
+    exact (Finset.disjoint_left.mp hdisj hmS_mem) hmS_in_T
+  rcases hcase with ⟨h1, h2, h3⟩ | ⟨h1, h2, h3⟩
+  · exact core x z hx hz hAB a1 a2 b1 b2 ha1 ha2 hb1 hb2 h1 h2 h3
+  · exact core z x hz hx (Ne.symm hAB) b1 b2 a1 a2 hb1 hb2 ha1 ha2 h1 h2 h3
+
+/-! ## Layer 14: β U is a Portrait, and surjectivity. -/
+
+/-- **β(U) is a valid portrait.** -/
+theorem beta_portrait {d m : ℕ} (hd : 0 < d) (hm : 0 < m) {U : Finset (ZMod (d * m))}
+    (hcard : U.card = d - 1) (hcanon : LevelCanonical d m U) : Portrait d m (beta U) := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · -- IsCriticalSet
+    intro S hS
+    rw [mem_beta_iff] at hS
+    obtain ⟨v, hv, hSeq⟩ := hS
+    subst hSeq
+    exact betaBlock_critical hd hm hcanon hv
+  · -- Disjoint
+    exact beta_pairwise_disjoint
+  · -- Unlinked
+    exact beta_unlinked hd hm hcanon
+  · -- weight
+    exact beta_weight hd hm hcard hcanon
+
+/-- **Surjectivity.** `T` is surjective onto canonical `(d-1)`-subsets. -/
+theorem T_surjOn {d m : ℕ} (hd : 0 < d) (hm : 0 < m) :
+    Set.SurjOn (T (N := d*m)) {P | Portrait d m P}
+      {U | U.card = d - 1 ∧ LevelCanonical d m U} := by
+  intro U hU
+  exact ⟨beta U, beta_portrait hd hm hU.1 hU.2, T_beta hd hm hU.2⟩
+
+end CriticalPortraits

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -3027,7 +3027,7 @@ projects:
     main_results:
       - declaration: CriticalPortraits.card_portraits
         informal: >-
-          The number of level-canonical (d-1)-subsets of ZMod (d*m) equals
+          The number of degree-d critical portraits at level m equals
           C(d*m, d-1)/d.
       - declaration: CriticalPortraits.Cycle.cycle_lemma
         informal: >-

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -3001,3 +3001,49 @@ projects:
       - commuting-probability
     msc:
       - "20P05"
+  - slug: critical-portraits
+    title: Counting Critical Portraits
+    summary: >-
+      Formalizes the census of degree-d critical portraits, modeled as
+      level-canonical (d-1)-subsets of the cyclic group ZMod (d*m), and proves
+      that their number equals C(d*m, d-1)/d for all d, via the
+      Dvoretzky-Motzkin cycle lemma together with an explicit
+      level-canonicalization bijection (injectivity and surjectivity of the
+      delete-minimum map).
+    branch: combinatorics
+    entry_module: LeanPool.CriticalPortraits
+    authors:
+      - Keston Aquino-Michaels
+    source:
+      title: "Counting critical portraits via the cycle lemma"
+      authors:
+        - Keston Aquino-Michaels
+      doi: "10.5281/zenodo.20737896"
+      github_repo: no-way-labs/lean-critical-portraits
+    status: verified
+    main_declarations:
+      - CriticalPortraits.card_portraits
+      - CriticalPortraits.Cycle.cycle_lemma
+    main_results:
+      - declaration: CriticalPortraits.card_portraits
+        informal: >-
+          The number of level-canonical (d-1)-subsets of ZMod (d*m) equals
+          C(d*m, d-1)/d.
+      - declaration: CriticalPortraits.Cycle.cycle_lemma
+        informal: >-
+          The Dvoretzky-Motzkin cycle lemma: a period-n integer sequence with
+          period-sum 1 has exactly one good cyclic shift.
+      - declaration: CriticalPortraits.T_injOn
+        informal: >-
+          The delete-minimum map is injective on critical portraits.
+      - declaration: CriticalPortraits.T_surjOn
+        informal: >-
+          The delete-minimum map surjects onto the level-canonical subsets.
+    tags:
+      - combinatorics
+      - cycle-lemma
+      - critical-portraits
+      - enumeration
+    msc:
+      - "05A15"
+      - "37F20"


### PR DESCRIPTION
Imports [no-way-labs/lean-critical-portraits](https://github.com/no-way-labs/lean-critical-portraits) (Apache-2.0), ported to Lean/Mathlib **v4.32.0-rc1**.

**Result.** The census of degree-`d` critical portraits — modeled as level-canonical `(d-1)`-subsets of `ZMod (d*m)` — equals `C(d*m, d-1)/d` for all `d`, via the Dvoretzky–Motzkin cycle lemma and an explicit level-canonicalization bijection.

**Main declarations**
- `CriticalPortraits.card_portraits` — `#{portraits} = C(d*m, d-1)/d`
- `CriticalPortraits.Cycle.cycle_lemma` — the cycle lemma (period-`n` sum-1 sequence has a unique good shift)
- `CriticalPortraits.T_injOn` / `CriticalPortraits.T_surjOn` — the bijection keystones

`sorry`-free; axioms ⊆ `{propext, Classical.choice, Quot.sound}`. All 271 upstream statements preserved. Local `lake build` / `runLinter` / `lint-style` / quality checks pass with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)