### PR TITLE
[import] Erdos367

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -484,6 +484,13 @@ import LeanPool.Erdos1196.Preliminaries
 import LeanPool.Erdos1196.PreliminariesMertens
 import LeanPool.Erdos1196.PreliminariesTailAux
 import LeanPool.Erdos1196.PrimitiveWeight
+import LeanPool.Erdos367
+import LeanPool.Erdos367.Core139
+import LeanPool.Erdos367.Core4027
+import LeanPool.Erdos367.GeneralKUpperBound
+import LeanPool.Erdos367.K3AbcUpperBound
+import LeanPool.Erdos367.PellLimsup
+import LeanPool.Erdos367.RFullLowerBound
 import LeanPool.ErdosTuzaValtr
 import LeanPool.ErdosTuzaValtr.All
 import LeanPool.ErdosTuzaValtr.Config.Default

--- a/LeanPool/Erdos367.lean
+++ b/LeanPool/Erdos367.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2026 Scott D. Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott D. Hughes
+-/
+
+import LeanPool.Erdos367.K3AbcUpperBound
+import LeanPool.Erdos367.GeneralKUpperBound
+import LeanPool.Erdos367.RFullLowerBound
+import LeanPool.Erdos367.PellLimsup
+import LeanPool.Erdos367.Core139
+import LeanPool.Erdos367.Core4027
+
+/-!
+# Erdős Problem #367
+
+Source: url:https://github.com/scottdhughes/erdos367
+Authors: Scott D. Hughes
+Status: verified
+Main declarations: `Erdos367.erdos_367_k3`, `RFullOdd.erdos367_iv`, `Erdos367.erdos367`
+Tags: number-theory, erdos-problems, powerful-numbers, abc-conjecture, pell-equations
+MSC: 11D09, 11N25, 11D45
+-/

--- a/LeanPool/Erdos367/Core139.lean
+++ b/LeanPool/Erdos367/Core139.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 Scott D. Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott D. Hughes
+-/
+
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Data.Nat.Factorization.Defs
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.IntervalCases
+import Mathlib.Tactic.LinearCombination
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Push
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Zify
+import Aesop
+
+/-!
+# The r = 3 case of the "13/9 theorem" (Erdős #367 r-full extension)
+
+This file formalizes an unconditional, elementary lower-bound construction (the `r = 3`
+case of a new lower bound for the `r`-full extension of Erdős problem #367).
+
+`rFullPart r m` is the "`r`-full part" of `m`: the product of the prime powers `p ^ v`
+occurring in the factorization of `m` for which `r ≤ v_p(m)`. We write `B₃ m := rFullPart 3 m`.
+
+The construction fixes a prime `s ≠ 3`, a "seed" `t₀` with `1 ≤ t₀ ≤ s^3` such that
+`s^3 ∣ g t₀`, and sets `t := t₀ + s^3`, `n := (t^3 - 1)^3`. The three main results are:
+
+* `T1` : `B₃ n = n`;
+* `T2` : `t^3 * s^3 ∣ B₃ (n+1)`;
+* `T3` : `512 * (B₃ n * B₃ (n+1))^9 > n^13`, the integer form of `B₃ n · B₃ (n+1) > n^{13/9}/2`.
+
+The "prime supply" (the existence of infinitely many suitable pairs `(s, t₀)`) is kept as a
+hypothesis and is *not* part of this development.
+-/
+
+open scoped BigOperators
+
+namespace Core139
+
+/-- The `r`-full part of `m`: the product of prime powers `p ^ v_p(m)` with `r ≤ v_p(m)`. -/
+def rFullPart (r m : ℕ) : ℕ :=
+  (m.factorization.filter (fun p => r ≤ m.factorization p)).prod (fun p v => p ^ v)
+
+/-- The auxiliary polynomial `g t = t^6 - 3 t^3 + 3` (with natural-number subtraction). -/
+def g (t : ℕ) : ℕ := t ^ 6 - 3 * t ^ 3 + 3
+
+/-! ## Generic facts about `rFullPart` -/
+
+/-- `rFullPart` is always positive (it is a product of prime powers, each `≥ 1`). -/
+lemma rFullPart_pos (r M : ℕ) : 1 ≤ rFullPart r M := by
+  by_contra! h_contra
+  simp_all +decide [rFullPart]
+
+/-- For `m ≥ 1`, the `r`-full part of `m ^ r` is `m ^ r` itself: every prime dividing `m ^ r`
+has multiplicity `r * v_p(m) ≥ r`, so the filter keeps the entire factorization. -/
+lemma rFullPart_pow (r m : ℕ) (hm : 1 ≤ m) :
+    rFullPart r (m ^ r) = m ^ r := by
+  unfold rFullPart
+  convert Nat.prod_factorization_pow_eq_self (pow_ne_zero r (ne_bot_of_gt hm)) using 2
+  ext p
+  by_cases hp : p ∈ (m ^ r).primeFactors
+  · suffices r * m.factorization p < r → r = 0 ∨ m.factorization p = 0 by
+      simpa +decide [Finsupp.filter_apply] using this
+    exact fun _ => Or.inr (by nlinarith)
+  · suffices r * m.factorization p < r → r = 0 ∨ m.factorization p = 0 by
+      simpa +decide [Finsupp.filter_apply] using this
+    exact fun _ => Or.inr (Nat.eq_zero_of_not_pos fun h' => by nlinarith)
+
+/-- The factorization of `rFullPart r M` is the filtered factorization. -/
+lemma factorization_rFullPart (r M : ℕ) :
+    (rFullPart r M).factorization = M.factorization.filter (fun p => r ≤ M.factorization p) := by
+  unfold rFullPart
+  apply Nat.prod_pow_factorization_eq_self
+  intro p hp
+  have hp' : p ∈ M.factorization.support := Finset.mem_of_mem_filter p hp
+  rw [Nat.support_factorization] at hp'
+  exact Nat.prime_of_mem_primeFactors hp'
+
+/-- If `d ≥ 1` and `d ^ r ∣ M` then `d ^ r ∣ rFullPart r M`: each prime `p ∣ d` has
+`v_p(M) ≥ r * v_p(d) ≥ r`, so it survives the filter and `v_p(rFullPart r M) = v_p(M)`. -/
+lemma pow_dvd_rFullPart (r d M : ℕ) (hd : 1 ≤ d) (hM : M ≠ 0)
+    (h : d ^ r ∣ M) : d ^ r ∣ rFullPart r M := by
+  rw [← Nat.factorization_le_iff_dvd] at *
+  · rw [factorization_rFullPart _ _]
+    intro p
+    by_cases hp : r ≤ M.factorization p <;> simp_all +decide
+    · simpa using h p
+    · exact Or.inr (Nat.eq_zero_of_le_zero (by have := h p; norm_num at this; nlinarith))
+  · positivity
+  · assumption
+  · positivity
+  · exact Nat.ne_of_gt (rFullPart_pos r M)
+
+/-! ## Arithmetic facts about `g` -/
+
+/-- For `t ≥ 2`, the natural subtraction in `g` is exact: `g t + 3 t^3 = t^6 + 3`. -/
+lemma g_add (t : ℕ) (ht : 2 ≤ t) : g t + 3 * t ^ 3 = t ^ 6 + 3 := by
+  unfold g
+  linarith [Nat.sub_add_cancel
+    (show 3 * t ^ 3 ≤ t ^ 6 by nlinarith [Nat.pow_le_pow_left ht 3, Nat.pow_le_pow_left ht 6])]
+
+/-- Casting `g` to any commutative ring (for `t ≥ 2`): `(g t : R) = t^6 - 3 t^3 + 3`. -/
+lemma g_cast {R : Type*} [CommRing R] (t : ℕ) (ht : 2 ≤ t) :
+    (g t : R) = (t : R) ^ 6 - 3 * (t : R) ^ 3 + 3 := by
+  have h_cast : (g t : R) + 3 * (t : R) ^ 3 = (t : R) ^ 6 + 3 := by
+    exact mod_cast (g_add t ht) ▸ rfl
+  linear_combination h_cast
+
+/-! ## The construction -/
+
+/-- The shifted seed `t = t₀ + s^3`. -/
+def tval (s t₀ : ℕ) : ℕ := t₀ + s ^ 3
+
+/-- The constructed integer `n = (t^3 - 1)^3`. -/
+def nval (s t₀ : ℕ) : ℕ := (tval s t₀ ^ 3 - 1) ^ 3
+
+section Construction
+
+/-- Basic bound: `t = t₀ + s^3 ≥ 9` (since `s ≥ 2` so `s^3 ≥ 8`, and `t₀ ≥ 1`). -/
+lemma tval_ge (s t₀ : ℕ) (hs : s.Prime) (ht₀ : 1 ≤ t₀ ∧ t₀ ≤ s ^ 3) :
+    9 ≤ tval s t₀ := by
+  unfold tval
+  nlinarith [Nat.pow_le_pow_left hs.two_le 3]
+
+/-- Key identity: `n + 1 = t^3 * g t`, i.e. `(t^3 - 1)^3 + 1 = t^3 (t^6 - 3 t^3 + 3)`. -/
+lemma key_identity (s t₀ : ℕ) (hs : s.Prime) (ht₀ : 1 ≤ t₀ ∧ t₀ ≤ s ^ 3) :
+    nval s t₀ + 1 = tval s t₀ ^ 3 * g (tval s t₀) := by
+  convert Nat.cast_injective (R := ℤ) _
+  have ht_ge_2 : 2 ≤ tval s t₀ := le_trans (by decide) (tval_ge s t₀ hs ht₀)
+  simp only [g_cast, ht_ge_2, Nat.cast_add, Nat.cast_one, Nat.cast_mul, Nat.cast_pow]
+  unfold nval
+  norm_num [Nat.cast_sub (show 1 ≤ tval s t₀ ^ 3 from Nat.one_le_pow _ _ (by linarith))]
+  ring
+
+/-- Congruence step: `s^3 ∣ g t`. Since `t ≡ t₀ (mod s^3)` and `g` is a polynomial,
+`g t ≡ g t₀ ≡ 0 (mod s^3)`. -/
+lemma s3_dvd_g_t (s t₀ : ℕ) (hs : s.Prime) (ht₀ : 1 ≤ t₀ ∧ t₀ ≤ s ^ 3)
+    (hroot : s ^ 3 ∣ g t₀) : s ^ 3 ∣ g (tval s t₀) := by
+  have h_cast : (g (tval s t₀) : ZMod (s ^ 3)) = (g t₀ : ZMod (s ^ 3)) := by
+    rw [g_cast, g_cast]
+    · simp +decide [tval]
+    · contrapose! hroot
+      interval_cases t₀ <;> norm_num [g] at *
+      exact Nat.not_dvd_of_pos_of_lt (by norm_num) (by nlinarith [hs.two_le, pow_succ s 2])
+    · exact le_trans (by decide) (tval_ge s t₀ hs ht₀)
+  simp_all +decide [← ZMod.natCast_eq_zero_iff]
+
+/-- `s` does not divide `t`: otherwise `s ∣ g t` together with `s ∣ t^6`, `s ∣ 3 t^3` would
+force `s ∣ 3`, hence `s = 3`, contradicting `hs3`. -/
+lemma s_not_dvd_t (s t₀ : ℕ) (hs : s.Prime) (hs3 : s ≠ 3) (ht₀ : 1 ≤ t₀ ∧ t₀ ≤ s ^ 3)
+    (hroot : s ^ 3 ∣ g t₀) : ¬ s ∣ tval s t₀ := by
+  intro hdiv
+  have hdiv_gt : s ∣ g (tval s t₀) :=
+    dvd_trans (dvd_pow_self _ (by decide)) (s3_dvd_g_t s t₀ hs ht₀ hroot)
+  have hdiv_t3 : s ∣ tval s t₀ ^ 3 := dvd_pow hdiv three_ne_zero
+  have hdiv_t6 : s ∣ tval s t₀ ^ 6 := dvd_trans hdiv (dvd_pow_self _ (by decide))
+  have hdiv_3t3 : s ∣ 3 * tval s t₀ ^ 3 := dvd_mul_of_dvd_right hdiv_t3 _
+  have hdiv_3 : s ∣ 3 := by
+    convert Nat.dvd_sub (hdiv_gt.add hdiv_3t3) hdiv_t6 using 1
+    exact eq_tsub_of_add_eq
+      (by linarith [g_add (tval s t₀) (by linarith [tval_ge s t₀ hs ht₀])])
+  have := Nat.le_of_dvd (by decide) hdiv_3
+  interval_cases s <;> trivial
+
+/-! ## The three theorems -/
+
+/-- (T1) The `3`-full part of `n` is `n`. Since `n = (t^3-1)^3` is a perfect cube with
+`t^3 - 1 ≥ 1`, this is `rFullPart_pow`.
+
+(The hypotheses `hs3` and `hroot` are part of the construction's hypothesis structure but
+turn out to be unnecessary for this particular statement.) -/
+theorem T1 (s t₀ : ℕ) (hs : s.Prime) (_hs3 : s ≠ 3) (ht₀ : 1 ≤ t₀ ∧ t₀ ≤ s ^ 3)
+    (_hroot : s ^ 3 ∣ g t₀) : rFullPart 3 (nval s t₀) = nval s t₀ := by
+  have hm : 1 ≤ tval s t₀ ^ 3 - 1 :=
+    Nat.le_sub_one_of_lt (one_lt_pow₀ (by linarith [tval_ge s t₀ hs ht₀]) (by norm_num))
+  unfold nval
+  exact rFullPart_pow 3 (tval s t₀ ^ 3 - 1) hm
+
+/-- (T2) `t^3 * s^3` divides the `3`-full part of `n + 1`. Both `t^3` and `s^3` divide `n+1`
+(via `n+1 = t^3 g t` and `s^3 ∣ g t`), each survives into `B₃` by `pow_dvd_rFullPart`, and
+they are coprime since `s ∤ t`. -/
+theorem T2 (s t₀ : ℕ) (hs : s.Prime) (hs3 : s ≠ 3) (ht₀ : 1 ≤ t₀ ∧ t₀ ≤ s ^ 3)
+    (hroot : s ^ 3 ∣ g t₀) : tval s t₀ ^ 3 * s ^ 3 ∣ rFullPart 3 (nval s t₀ + 1) := by
+  apply Nat.Coprime.mul_dvd_of_dvd_of_dvd
+  · exact Nat.Coprime.pow _ _ <| Nat.Coprime.symm <|
+      hs.coprime_iff_not_dvd.mpr <| s_not_dvd_t s t₀ hs hs3 ht₀ hroot
+  · convert pow_dvd_rFullPart 3 (tval s t₀) (nval s t₀ + 1)
+      (by linarith [tval_ge s t₀ hs ht₀]) (Nat.succ_ne_zero _) _ using 1
+    exact key_identity s t₀ hs ht₀ ▸ dvd_mul_right _ _
+  · convert pow_dvd_rFullPart 3 s (nval s t₀ + 1)
+      (Nat.Prime.pos hs) (Nat.succ_ne_zero _) _ using 1
+    exact dvd_trans (s3_dvd_g_t s t₀ hs ht₀ hroot) (key_identity s t₀ hs ht₀ ▸ dvd_mul_left _ _)
+
+/-- (T3) The integer form of `B₃(n) B₃(n+1) > n^{13/9} / 2`:
+`512 * (B₃ n * B₃ (n+1))^9 > n^13`.
+
+Proof chain: `B₃ n = n` and `t^3 s^3 ≤ B₃ (n+1)`, with `t ≤ 2 s^3` giving
+`2 (B₃ n · B₃ (n+1)) ≥ n t^4`; raising to the `9`-th power and using `t^9 > n` (so
+`t^36 > n^4`) yields `512 (B₃ n · B₃ (n+1))^9 ≥ n^9 t^36 > n^13`. -/
+theorem T3 (s t₀ : ℕ) (hs : s.Prime) (hs3 : s ≠ 3) (ht₀ : 1 ≤ t₀ ∧ t₀ ≤ s ^ 3)
+    (hroot : s ^ 3 ∣ g t₀) :
+    512 * (rFullPart 3 (nval s t₀) * rFullPart 3 (nval s t₀ + 1)) ^ 9
+    > nval s t₀ ^ 13 := by
+  have hB0 : rFullPart 3 (nval s t₀) = nval s t₀ := T1 s t₀ hs hs3 ht₀ hroot
+  have hB1 : tval s t₀ ^ 3 * s ^ 3 ∣ rFullPart 3 (nval s t₀ + 1) := T2 s t₀ hs hs3 ht₀ hroot
+  have hB1pos : 0 < rFullPart 3 (nval s t₀ + 1) := rFullPart_pos _ _
+  have hts_le : tval s t₀ ^ 3 * s ^ 3 ≤ rFullPart 3 (nval s t₀ + 1) := Nat.le_of_dvd hB1pos hB1
+  have ht9 : 9 ≤ tval s t₀ := tval_ge s t₀ hs ht₀
+  have ht_le : tval s t₀ ≤ 2 * s ^ 3 := by unfold tval; linarith
+  have hn_pos : 0 < nval s t₀ :=
+    pow_pos (Nat.sub_pos_of_lt (one_lt_pow₀ (by linarith) (by linarith))) _
+  have ht9n : tval s t₀ ^ 9 > nval s t₀ := by
+    unfold nval; zify
+    rw [Nat.cast_sub] <;> push_cast <;>
+      nlinarith only [ht9, pow_pos (by linarith : 0 < tval s t₀) 3,
+        pow_pos (by linarith : 0 < tval s t₀) 6]
+  -- `2 * (B₃ n · B₃ (n+1)) ≥ n * t^4`
+  have h2BB_ge_nt4 :
+      2 * (nval s t₀ * rFullPart 3 (nval s t₀ + 1)) ≥ nval s t₀ * tval s t₀ ^ 4 := by
+    nlinarith [Nat.mul_le_mul_left (nval s t₀) hts_le, Nat.mul_le_mul_left (nval s t₀) ht_le]
+  -- `512 * (B₃ n · B₃ (n+1))^9 ≥ n^9 * t^36`
+  have h512BB_ge_nt36 :
+      512 * (nval s t₀ * rFullPart 3 (nval s t₀ + 1)) ^ 9 ≥ nval s t₀ ^ 9 * tval s t₀ ^ 36 := by
+    have := Nat.pow_le_pow_left h2BB_ge_nt4 9
+    ring_nf at *
+    aesop
+  simp_all +decide only [gt_iff_lt]
+  exact lt_of_lt_of_le
+    (by nlinarith [pow_pos hn_pos 9, pow_pos hn_pos 4,
+      pow_lt_pow_left₀ ht9n (by positivity) (by positivity : (4 : ℕ) ≠ 0)])
+    h512BB_ge_nt36
+
+end Construction
+
+end Core139

--- a/LeanPool/Erdos367/Core4027.lean
+++ b/LeanPool/Erdos367/Core4027.lean
@@ -1,0 +1,406 @@
+/-
+Copyright (c) 2026 Scott D. Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott D. Hughes
+-/
+
+import Mathlib.Algebra.Order.BigOperators.GroupWithZero.Finset
+import Mathlib.Algebra.Ring.GrindInstances
+import Mathlib.Data.Nat.Factorization.Defs
+import Mathlib.Data.Nat.ModEq
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.IntervalCases
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Ring
+import Aesop
+
+/-! ## Definitions -/
+
+open scoped BigOperators
+
+namespace Core4027
+
+/-- The `r`-full part of `m`: the product of `p ^ v_p(m)` over primes `p` with `v_p(m) ≥ r`. -/
+def rFullPart (r m : ℕ) : ℕ :=
+  (m.factorization.filter (fun p => r ≤ m.factorization p)).prod (fun p v => p ^ v)
+
+/-- The constant `N = 2^14 * 3^4`. -/
+def N : ℕ := 1327104
+
+/-- `C(t) = t^4 + 42 t^2 + 72 t + 333`. -/
+def Cpoly (t : ℕ) : ℕ := t^4 + 42*t^2 + 72*t + 333
+
+/-- `G(t)`. -/
+def Gpoly (t : ℕ) : ℕ :=
+  t^9 + 108*t^7 + 216*t^6 + 4374*t^5 + 13608*t^4 + 99468*t^3 + 215784*t^2 + 998001*t + 1474200
+
+/-- `H(t)`. -/
+def Hpoly (t : ℕ) : ℕ :=
+  t^15 + 198*t^13 + 432*t^12 + 16875*t^11 + 65448*t^10 + 893700*t^9 + 3965760*t^8
+    + 32798439*t^7 + 132802416*t^6 + 770808150*t^5 + 2699107920*t^4 + 10666416717*t^3
+    + 28403408808*t^2 + 78874347456*t + 150060252672
+
+/-- `n = (G(t)/N)^3`. -/
+def nn (t : ℕ) : ℕ := (Gpoly t / N) ^ 3
+
+/-! ## The `rFullPart` factorization theory -/
+
+theorem rFullPart_ne_zero (r M : ℕ) : rFullPart r M ≠ 0 := by
+  unfold rFullPart
+  apply Finsupp.prod_ne_zero_iff.mpr
+  intro p hp
+  have hsupp : p ∈ M.factorization.support := by
+    have h := Finsupp.support_filter (p := fun p => r ≤ M.factorization p) (f := M.factorization)
+    rw [h] at hp
+    exact Finset.mem_of_mem_filter p hp
+  have hp2 : p.Prime := Nat.prime_of_mem_primeFactors (by rwa [Nat.support_factorization] at hsupp)
+  exact pow_ne_zero _ hp2.pos.ne'
+
+/-- A perfect cube of a positive number is `3`-full: its `rFullPart 3` is itself. -/
+theorem rFullPart_cube_eq (a : ℕ) (ha : 1 ≤ a) : rFullPart 3 (a^3) = a^3 := by
+  unfold rFullPart
+  have hne : a^3 ≠ 0 := by positivity
+  have hfilter : (a^3).factorization.filter (fun p => 3 ≤ (a^3).factorization p)
+      = (a^3).factorization := by
+    apply Finsupp.ext
+    intro p
+    rw [Finsupp.filter_apply]
+    by_cases hp : (a^3).factorization p = 0
+    · simp
+    · rw [if_pos]
+      rw [Nat.factorization_pow] at hp ⊢
+      simp only [Finsupp.smul_apply, smul_eq_mul] at hp ⊢
+      omega
+  rw [hfilter]
+  exact Nat.prod_factorization_pow_eq_self hne
+
+/-
+The factorization of `rFullPart r M` at a prime `q`.
+-/
+theorem rFullPart_factorization (r M : ℕ) (q : ℕ) :
+    (rFullPart r M).factorization q
+      = if r ≤ M.factorization q then M.factorization q else 0 := by
+  unfold rFullPart
+  rw [Nat.prod_pow_factorization_eq_self]
+  · rw [Finsupp.filter_apply]
+  · intro p hp
+    have hp_support : p ∈ M.factorization.support := Finset.mem_of_mem_filter p hp
+    exact Nat.prime_of_mem_primeFactors (by
+      rwa [Nat.support_factorization] at hp_support)
+
+/-
+If `d ^ 3 ∣ M` (and `M > 0`), then `d ^ 3 ∣ rFullPart 3 M`.
+-/
+theorem pow_dvd_rFullPart (M d : ℕ) (hM : 0 < M) (hd : d ^ 3 ∣ M) :
+    d ^ 3 ∣ rFullPart 3 M := by
+  rw [ ← Nat.factorization_le_iff_dvd ] at *;
+  · intro q; by_cases hq : Nat.Prime q <;> simp_all +decide ;
+    have := hd q; simp_all +decide [ rFullPart_factorization ] ;
+    grind;
+  · aesop;
+  · positivity;
+  · aesop;
+  · exact rFullPart_ne_zero 3 M
+
+/-! ## The key algebraic identity -/
+
+theorem IDENT (t : ℕ) : Gpoly t ^ 3 + N ^ 3 = Hpoly t * Cpoly t ^ 3 := by
+  unfold Gpoly Hpoly Cpoly N
+  ring
+
+/-! ## Polynomial congruence transfer -/
+
+theorem Cpoly_modEq {a b M : ℕ} (h : a ≡ b [MOD M]) : Cpoly a ≡ Cpoly b [MOD M] := by
+  unfold Cpoly; gcongr
+
+theorem Gpoly_modEq {a b M : ℕ} (h : a ≡ b [MOD M]) : Gpoly a ≡ Gpoly b [MOD M] := by
+  unfold Gpoly; gcongr
+
+theorem Hpoly_modEq {a b M : ℕ} (h : a ≡ b [MOD M]) : Hpoly a ≡ Hpoly b [MOD M] := by
+  unfold Hpoly; gcongr
+
+/-! ## Concrete constant facts -/
+
+theorem Gpoly_const_modN : Gpoly 23016 ≡ 0 [MOD N] := by
+  unfold Gpoly N Nat.ModEq; norm_num
+
+theorem Cpoly_const_mod2 : Cpoly 23016 % 2 = 1 := by
+  unfold Cpoly; norm_num
+
+theorem Cpoly_const_mod27 : Cpoly 23016 % 27 = 9 := by
+  unfold Cpoly; norm_num
+
+/-! ## Pure polynomial bounds -/
+
+theorem Cpoly_gt (t : ℕ) : t^4 < Cpoly t := by
+  exact lt_add_of_le_of_pos
+    (Nat.le_add_right _ _ |> Nat.le_trans (Nat.le_add_right _ _))
+    (by norm_num [ Cpoly ])
+
+theorem Cpoly_cube_gt (t : ℕ) : t^12 < Cpoly t ^ 3 := by
+  convert Nat.pow_lt_pow_left ( Cpoly_gt t ) three_ne_zero using 1; ring
+
+theorem Gpoly_ge_const (t : ℕ) : 1474200 ≤ Gpoly t := by
+  exact le_add_of_nonneg_left ( Nat.zero_le _ )
+
+theorem Gpoly_div_pos (t : ℕ) : 1 ≤ Gpoly t / N := by
+  exact Nat.div_pos
+    (show N ≤ Gpoly t by exact le_trans ( by decide ) ( Gpoly_ge_const t ))
+    (by decide)
+
+theorem Gpoly_upper (t : ℕ) (ht : 1676 ≤ t) : Gpoly t ≤ 2 * t^9 := by
+  unfold Gpoly
+  nlinarith [Nat.pow_le_pow_left ht 2, Nat.pow_le_pow_left ht 3,
+    Nat.pow_le_pow_left ht 4, Nat.pow_le_pow_left ht 5, Nat.pow_le_pow_left ht 6,
+    Nat.pow_le_pow_left ht 7]
+
+theorem Gpoly_cube_le (t : ℕ) (ht : 1676 ≤ t) : Gpoly t ^ 3 ≤ 8 * t^27 := by
+  convert Nat.pow_le_pow_left ( Gpoly_upper t ht ) 3 using 1; ring
+
+/-! ## T1 : `n` is `3`-full -/
+
+theorem T1 (t : ℕ) : rFullPart 3 (nn t) = nn t := by
+  unfold nn
+  exact rFullPart_cube_eq _ (Gpoly_div_pos t)
+
+/-! ## Main section: the prime-supply hypotheses -/
+
+section
+variable (s t₀ t : ℕ)
+variable (hs : s.Prime) (hs6 : ¬ s ∣ 6)
+variable (ht₀ : 1 ≤ t₀ ∧ t₀ ≤ N * s ^ 3)
+variable (hcong : t₀ % N = 23016 % N)
+variable (hH : s ^ 3 ∣ Hpoly t₀) (hC : ¬ s ∣ Cpoly t₀)
+variable (ht : t = t₀ + N * s ^ 3)
+
+include hcong ht in
+theorem t_mod_N : t ≡ 23016 [MOD N] := by
+  simp +decide [ *, Nat.ModEq, Nat.add_mod ]
+
+include ht in
+theorem t_mod_s3 : t ≡ t₀ [MOD s^3] := by
+  norm_num [ ht, Nat.ModEq, Nat.add_mod, Nat.mul_mod ]
+
+include ht in
+theorem t_mod_s : t ≡ t₀ [MOD s] := by
+  norm_num [ ht, Nat.ModEq, Nat.add_mod, Nat.mul_mod, Nat.pow_mod ]
+
+include hH ht in
+theorem hHt : s ^ 3 ∣ Hpoly t := by
+  rw [ ← Nat.modEq_zero_iff_dvd ] at *; simp_all +decide [ ← ZMod.natCast_eq_natCast_iff ] ;
+  simp_all +decide [ Hpoly ]
+
+include hC ht in
+theorem hCt : ¬ s ∣ Cpoly t := by
+  rw [← ZMod.natCast_eq_zero_iff] at hC ⊢
+  rw [ht]
+  unfold Cpoly at *; simp_all +decide [ pow_succ, mul_assoc ]
+
+include hcong ht in
+theorem L1 : N ∣ Gpoly t := by
+  have h_gt_mod : Gpoly t ≡ Gpoly 23016 [MOD N] :=
+    Gpoly_modEq (t_mod_N s t₀ t hcong ht)
+  exact (Nat.modEq_zero_iff_dvd).mp (h_gt_mod.trans Gpoly_const_modN)
+
+include hcong ht in
+theorem L2 : Cpoly t % 2 = 1 := by
+  exact Cpoly_modEq (show t ≡ 23016 [MOD 2] by
+    exact Nat.ModEq.of_dvd (by decide) (t_mod_N s t₀ t hcong ht))
+
+include hcong ht in
+theorem L3mod : Cpoly t % 27 = 9 := by
+  rw [ ← Cpoly_const_mod27 ];
+  rw [ ← Nat.mod_add_div t 27, ← Nat.mod_add_div 23016 27 ];
+  norm_num [ Nat.add_mod, Nat.mul_mod, Nat.pow_mod, Cpoly ]; ring_nf;
+  rw [ ht ]; norm_num [ Nat.add_mod, Nat.mul_mod, Nat.pow_mod, hcong ];
+  rw [ ← Nat.mod_mod_of_dvd t₀ ( by decide : 27 ∣ N ), hcong ]; norm_num [ N ];
+
+include hcong ht in
+theorem L3a : 9 ∣ Cpoly t := by
+  have := L3mod s t₀ t hcong ht; omega;
+
+include hcong ht in
+theorem L3b : ¬ 27 ∣ Cpoly t := by
+  rw [ Nat.dvd_iff_mod_eq_zero, L3mod s t₀ t hcong ht ]
+  norm_num
+
+include hs hs6 in
+theorem hs_ge5 : 5 ≤ s := by
+  contrapose! hs6; interval_cases s <;> trivial;
+
+include ht in
+theorem Ns3_le_t : N * s^3 ≤ t := by
+  linarith
+
+include ht ht₀ in
+theorem t_le_2Ns3 : t ≤ 2 * (N * s ^ 3) := by
+  linarith
+
+include ht hs hs6 in
+theorem t_big : 1676 ≤ t := by
+  exact ht.symm ▸
+    le_add_of_nonneg_of_le (Nat.zero_le _) (by
+      exact le_trans (by decide)
+        (Nat.mul_le_mul_left _
+          (pow_le_pow_left' (show s ≥ 5 by
+            contrapose! hs6
+            interval_cases s <;> trivial) 3)))
+
+include hcong ht in
+theorem N3_mul_nn : N ^ 3 * nn t = Gpoly t ^ 3 := by
+  rw [ nn ];
+  rw [ ← mul_pow, Nat.mul_div_cancel' ( L1 s t₀ t hcong ht ) ]
+
+include hcong ht in
+theorem T0 : N ^ 3 * (nn t + 1) = Hpoly t * Cpoly t ^ 3 := by
+  rw [ ← IDENT t, mul_add, mul_one ];
+  rw [ ← N3_mul_nn ];
+  exacts [ s, t₀, hcong, ht ]
+
+include hcong ht in
+theorem T0_div : nn t + 1 = Hpoly t * Cpoly t ^ 3 / N ^ 3 := by
+  exact Eq.symm ( Nat.div_eq_of_eq_mul_left ( by decide ) ( by linarith [ T0 s t₀ t hcong ht ] ) )
+
+include hcong ht in
+theorem Ctil_eq : Cpoly t = 9 * (Cpoly t / 9) := by
+  rw [ Nat.mul_div_cancel' ( show 9 ∣ Cpoly t from ?_ ) ];
+  convert L3a s t₀ t hcong ht using 1
+
+include hcong ht in
+theorem Ctil_coprime6 : Nat.Coprime (Cpoly t / 9) 6 := by
+  refine Nat.Coprime.symm ?_;
+  refine Nat.coprime_of_dvd' ?_;
+  intro k hk hk' hk''
+  have := Nat.le_of_dvd ( by decide ) hk';
+  interval_cases k <;> norm_num at *;
+  · have := L2 ( s := s ) ( t₀ := t₀ ) ( t := t ) ( hcong := hcong ) ( ht := ht );
+    exact absurd
+      (Nat.mod_eq_zero_of_dvd
+        (dvd_trans hk'' (Nat.div_dvd_of_dvd (show 9 ∣ Cpoly t from
+          L3a (s := s) (t₀ := t₀) (t := t) (hcong := hcong) (ht := ht)))))
+      (by omega)
+  · exact absurd hk'' (by
+      rw [Nat.dvd_div_iff_mul_dvd
+        (show 9 ∣ Cpoly t from dvd_trans (by decide) (L3a s t₀ t hcong ht))]
+      exact fun h => L3b s t₀ t hcong ht (dvd_trans (by decide) h))
+  · exact (by decide : ¬ Nat.Prime 6) hk
+
+include hC ht hs hcong in
+theorem Ctil_coprime_s : Nat.Coprime (Cpoly t / 9) s := by
+  -- By definition of $Ctil$, we know that $Ctil = Cpoly t / 9$.
+  set Ctil := Cpoly t / 9 with hCtil_def
+  have hCtil_dvd : Ctil ∣ Cpoly t := by
+    exact Nat.div_dvd_of_dvd <| L3a _ _ t hcong ht
+  have hCtil_not_dvd : ¬ s ∣ Ctil := by
+    have := hCt s t₀ t hC ht; ( contrapose! this; );
+    exact dvd_trans this hCtil_dvd
+  have hCtil_coprime : Nat.Coprime s Ctil := by
+    exact hs.coprime_iff_not_dvd.mpr hCtil_not_dvd
+  exact hCtil_coprime.symm
+
+include hs hs6 hcong ht hH hC in
+theorem T2_dvd : ((Cpoly t / 9) * s)^3 ∣ nn t + 1 := by
+  have h_div : (Cpoly t / 9)^3 ∣ nn t + 1 := by
+    have h_div : (Cpoly t / 9)^3 ∣ N ^ 3 * (nn t + 1) := by
+      rw [ show N ^ 3 * ( nn t + 1 ) = Hpoly t * Cpoly t ^ 3 from
+        T0 s t₀ t hcong ht ];
+      exact dvd_mul_of_dvd_right
+        (pow_dvd_pow_of_dvd
+          (Nat.div_dvd_of_dvd (show 9 ∣ Cpoly t from L3a s t₀ t hcong ht)) _)
+        _;
+    refine Nat.Coprime.dvd_of_dvd_mul_left ?_ h_div;
+    apply_rules [ Nat.Coprime.pow, Nat.Coprime.symm ];
+    have h_coprime : Nat.Coprime 6 (Cpoly t / 9) := by
+      convert Ctil_coprime6 s t₀ t hcong ht |> Nat.Coprime.symm using 1;
+    exact Nat.Coprime.mul_left
+      (show Nat.Coprime ( 2 ^ 14 ) ( Cpoly t / 9 ) from
+        Nat.Coprime.pow_left _ <| Nat.prime_two.coprime_iff_not_dvd.mpr fun h => by
+          have := Nat.dvd_gcd ( by decide : 2 ∣ 6 ) h; simp_all +decide)
+      (show Nat.Coprime ( 3 ^ 4 ) ( Cpoly t / 9 ) from
+        Nat.Coprime.pow_left _ <| Nat.prime_three.coprime_iff_not_dvd.mpr fun h => by
+          have := Nat.dvd_gcd ( by decide : 3 ∣ 6 ) h; simp_all +decide);
+  have h_div_s : s ^ 3 ∣ nn t + 1 := by
+    have h_div_s : s ^ 3 ∣ N ^ 3 * (nn t + 1) := by
+      convert T0 s t₀ t hcong ht ▸ dvd_mul_of_dvd_left ( hHt s t₀ t hH ht ) _ using 1;
+    refine Nat.Coprime.dvd_of_dvd_mul_left ?_ h_div_s;
+    suffices ¬ s ∣ N by
+      simpa +decide only [Nat.ofNat_pos, Nat.coprime_pow_right_iff,
+        Nat.coprime_pow_left_iff] using
+        hs.coprime_iff_not_dvd.mpr this
+    rw [ show N = 2 ^ 14 * 3 ^ 4 by rfl ]
+    exact fun h => hs6 <| by
+      have := Nat.Prime.dvd_mul hs |>.1 h
+      rcases this with (h | h) <;>
+        have := Nat.Prime.dvd_of_dvd_pow hs h <;>
+        (have := Nat.le_of_dvd ( by decide ) this; interval_cases s <;> trivial)
+  convert Nat.Coprime.mul_dvd_of_dvd_of_dvd _ h_div h_div_s using 1;
+  · ring;
+  · apply_mod_cast Nat.Coprime.pow;
+    exact Ctil_coprime_s (s := s) (t₀ := t₀) (t := t) (hs := hs)
+      (hcong := hcong) (hC := hC) (ht := ht)
+
+include hs hs6 hcong ht hH hC in
+theorem T2 : ((Cpoly t / 9) * s)^3 ∣ rFullPart 3 (nn t + 1) := by
+  apply pow_dvd_rFullPart;
+  · positivity;
+  · apply_rules [ T2_dvd ]
+
+include hs hs6 hcong ht hH hC in
+theorem B1_ge : ((Cpoly t / 9) * s)^3 ≤ rFullPart 3 (nn t + 1) := by
+  refine Nat.le_of_dvd ?_ ?_;
+  · exact Nat.pos_of_ne_zero ( rFullPart_ne_zero _ _ );
+  · apply_rules [ T2 ]
+
+include hs hs6 ht₀ hcong ht hH hC in
+theorem T3 :
+    8^13 * (1458 * N * (rFullPart 3 (nn t) * rFullPart 3 (nn t + 1)))^27
+      > N^39 * (nn t)^40 := by
+  -- From Fact (C), we have $P > n t^{13}$.
+  have hP_gt : 1458 * N * ((nn t) * rFullPart 3 (nn t + 1)) > (nn t) * t^13 := by
+    -- From Fact (C), we have $P > n t^{13}$. This follows from the bounds on $C'^3$ and $s^3$.
+    have hP_gt : 729 * (Cpoly t / 9)^3 * (2 * N * s^3) ≥ t^13 + 1 := by
+      have hP_gt : 729 * (Cpoly t / 9)^3 ≥ t^12 + 1 := by
+        have hP_gt : 729 * (Cpoly t / 9)^3 = Cpoly t^3 := by
+          rw [ ← Nat.mul_div_cancel' ( show 9 ∣ Cpoly t from L3a s t₀ t hcong ht ) ]; ring_nf;
+          norm_num;
+        exact hP_gt.symm ▸ Nat.succ_le_of_lt ( Cpoly_cube_gt t );
+      nlinarith [ pow_pos
+        (show 0 < t by
+          linarith [show 0 < N * s ^ 3 by
+            exact mul_pos ( by decide ) ( pow_pos hs.pos _ )])
+        12 ];
+    -- By Fact (B1_ge), we have $(Cpoly t / 9)^3 * s^3 \leq rFullPart 3 (nn t + 1)$.
+    have h_B1_ge : (Cpoly t / 9)^3 * s^3 ≤ rFullPart 3 (nn t + 1) := by
+      have h_B1_ge : (Cpoly t / 9 * s)^3 ≤ rFullPart 3 (nn t + 1) := by
+        apply_rules [ B1_ge ];
+      simpa only [ mul_pow ] using h_B1_ge;
+    -- By combining the results from hP_gt and h_B1_ge, we get the desired inequality.
+    have h_combined :
+        1458 * N * (nn t * rFullPart 3 (nn t + 1)) ≥
+          729 * (Cpoly t / 9)^3 * (2 * N * s^3) * nn t := by
+      nlinarith [ show 0 ≤ N * nn t by positivity ];
+    nlinarith [ show 0 < nn t from pow_pos ( Gpoly_div_pos t ) 3 ];
+  -- From Fact (D), we have $N^3 n \leq 8 t^{27}$.
+  have hN3n_le : N^3 * (nn t) ≤ 8 * t^27 := by
+    -- By definition of $nn$, we know that $N^3 * nn t = Gpoly t ^ 3$.
+    have hN3n_eq : N^3 * (nn t) = Gpoly t ^ 3 := by
+      exact N3_mul_nn s t₀ t hcong ht
+    exact hN3n_eq.symm ▸ Gpoly_cube_le t ( t_big s t₀ t hs hs6 ht );
+  -- From Fact (C), we have $8^{13} P^{27} > 8^{13} (n t^{13})^{27}$.
+  have h8P27_gt :
+      8 ^ 13 * (1458 * N * ((nn t) * rFullPart 3 (nn t + 1))) ^ 27 >
+        8 ^ 13 * ((nn t) * t ^ 13) ^ 27 := by
+    gcongr;
+  -- From Fact (D), we have $8^{13} (n t^{13})^{27} \geq n^{27} (N^3 n)^{13}$.
+  have h8P27_ge : 8 ^ 13 * ((nn t) * t ^ 13) ^ 27 ≥ (nn t) ^ 27 * (N ^ 3 * (nn t)) ^ 13 := by
+    have h8P27_ge : 8 ^ 13 * ((nn t) * t ^ 13) ^ 27 ≥ (nn t) ^ 27 * (8 * t ^ 27) ^ 13 := by
+      ring_nf; norm_num;
+    exact le_trans ( Nat.mul_le_mul_left _ ( Nat.pow_le_pow_left hN3n_le _ ) ) h8P27_ge;
+  rw [ show rFullPart 3 ( nn t ) = nn t from T1 t ]; ring_nf at *; linarith;
+
+end
+
+end Core4027

--- a/LeanPool/Erdos367/GeneralKUpperBound.lean
+++ b/LeanPool/Erdos367/GeneralKUpperBound.lean
@@ -1,0 +1,205 @@
+/-
+Copyright (c) 2026 Scott D. Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott D. Hughes
+-/
+
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Data.Nat.Factorization.Defs
+import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Push
+import Mathlib.Tactic.Ring
+
+/-!
+# Conditional upper bound on B₂ via a radical lower bound (Erdős #367)
+
+We formalize the "Langevin route" for the general-k upper bound in Erdős #367,
+taking the deep unproven ingredient — a radical lower bound for products of
+consecutive integers — as an **explicit hypothesis** (`RadLB`).
+
+## Definitions
+
+* `rad m` — the radical (squarefree kernel) of `m`: product of its distinct prime factors.
+* `B2 m` — the powerful (2-full) part of `m`: ∏_{p : v_p(m) ≥ 2} p^{v_p(m)}.
+* `F k n` — the product of `k` consecutive integers starting at `n`.
+
+## Main results
+
+* `lemma_star` (unconditional): `rad m ^ 2 * B2 m ≤ m ^ 2`.
+* `B2_upper_bound` (conditional on `RadLB`): for every `ε > 0` there is `C' > 0` with
+  `B2 (F k n) ≤ C' * n ^ (2 + ε)` for all `n ≥ 1`.
+-/
+
+namespace GeneralK
+
+open scoped BigOperators
+open Finset
+
+noncomputable section
+
+/-! ### Definitions -/
+
+/-- The radical of `m`: product of its distinct prime factors. rad(0) = rad(1) = 1 by convention. -/
+def rad (m : ℕ) : ℕ := ∏ p ∈ m.factorization.support, p
+
+/-- The 2-full (powerful) part of `m`: product of p^{a_p} over primes with a_p ≥ 2. -/
+def B2 (m : ℕ) : ℕ :=
+  ∏ p ∈ m.factorization.support.filter (fun p => 2 ≤ m.factorization p), p ^ m.factorization p
+
+/-- Product of k consecutive integers starting at n. -/
+def F (k n : ℕ) : ℕ := ∏ i ∈ Finset.range k, (n + i)
+
+/-! ### Auxiliary lemmas -/
+
+/-- Every element of the factorization support is a prime. -/
+lemma prime_of_mem_factorization_support {m p : ℕ} (hp : p ∈ m.factorization.support) :
+    Nat.Prime p := by
+  rw [Nat.support_factorization, Nat.mem_primeFactors] at hp
+  exact hp.1
+
+/-
+rad(m) ≥ 1 for all m.
+-/
+lemma rad_pos (m : ℕ) : 1 ≤ rad m := by
+  exact Finset.prod_pos fun p hp => Nat.Prime.pos ( prime_of_mem_factorization_support hp )
+
+/-
+F(k, n) ≥ 1 when n ≥ 1.
+-/
+lemma F_pos {k n : ℕ} (hn : 1 ≤ n) : 1 ≤ F k n := by
+  exact Nat.one_le_iff_ne_zero.mpr <| Finset.prod_ne_zero_iff.mpr fun i hi => by linarith;
+
+/-
+F(k, n) ≠ 0 when n ≥ 1.
+-/
+lemma F_ne_zero {k n : ℕ} (hn : 1 ≤ n) : F k n ≠ 0 := by
+  exact Finset.prod_ne_zero_iff.mpr fun _ _ => by positivity;
+
+/-
+Each factor n + i ≤ k * n for i < k, when n ≥ 1 and k ≥ 1.
+-/
+lemma factor_le_mul {k n i : ℕ} (_hk : 1 ≤ k) (hn : 1 ≤ n) (hi : i < k) :
+    n + i ≤ k * n := by
+  nlinarith
+
+/-
+F(k, n) ≤ (k * n) ^ k for n ≥ 1, k ≥ 1.
+-/
+lemma F_le_pow {k n : ℕ} (hk : 1 ≤ k) (hn : 1 ≤ n) : F k n ≤ (k * n) ^ k := by
+  exact le_trans
+    (Finset.prod_le_prod' fun _ _ => factor_le_mul hk hn (Finset.mem_range.mp ‹_›))
+    (by norm_num)
+
+/-! ### LEMMA STAR -/
+
+/-
+**Lemma Star** (unconditional): rad(m)² · B₂(m) ≤ m² for all m.
+
+Proof idea: express both sides as products over the prime factorization support.
+For each prime p with exponent a_p:
+- If a_p = 1: LHS contributes p², RHS contributes p² (equal).
+- If a_p ≥ 2: LHS contributes p^{2+a_p}, RHS contributes p^{2a_p}, and 2+a_p ≤ 2a_p.
+-/
+theorem lemma_star (m : ℕ) (hm : m ≠ 0) : rad m ^ 2 * B2 m ≤ m ^ 2 := by
+  -- Express m^2 using the prime factorization of m.
+  have h_factorization :
+      m ^ 2 = ∏ p ∈ (Nat.factorization m).support,
+        p ^ (2 * (Nat.factorization m p)) := by
+    conv_lhs => rw [ ← Nat.prod_factorization_pow_eq_self hm ];
+    simp +decide [ pow_mul', Finset.prod_pow ];
+    rfl;
+  -- Express rad(m)^2 * B2(m) using the prime factorization of m.
+  have h_rad_B2 :
+      rad m ^ 2 * B2 m =
+        (∏ p ∈ (Nat.factorization m).support,
+          p ^ (if 2 ≤ (Nat.factorization m p) then
+            2 + (Nat.factorization m p)
+          else
+            2)) := by
+    unfold rad B2;
+    rw [ ← Finset.prod_pow ]; rw [ Finset.prod_filter ];
+    rw [ ← Finset.prod_mul_distrib ]; congr; ext; split_ifs <;> ring;
+  rw [ h_factorization, h_rad_B2 ];
+  exact Finset.prod_le_prod' fun p hp =>
+    Nat.pow_le_pow_right (Nat.pos_of_mem_primeFactors hp) (by
+      split_ifs <;> linarith [Nat.pos_of_ne_zero (Finsupp.mem_support_iff.mp hp)])
+
+/-! ### Bridge to ℝ -/
+
+/-
+Cast of lemma_star to ℝ: B₂(m) ≤ m²/rad(m)².
+-/
+lemma B2_le_sq_div_rad_sq (m : ℕ) (hm : m ≠ 0) :
+    (B2 m : ℝ) ≤ (m : ℝ) ^ 2 / (rad m : ℝ) ^ 2 := by
+  rw [ le_div_iff₀ ] <;> norm_cast;
+  · linarith [ lemma_star m hm ];
+  · exact pow_pos ( rad_pos m ) 2
+
+/-
+rad(m) cast to ℝ is positive for m ≠ 0. Actually rad is always ≥ 1.
+-/
+lemma rad_cast_pos (m : ℕ) : (0 : ℝ) < (rad m : ℝ) := by
+  exact_mod_cast rad_pos m
+
+/-! ### RadLB hypothesis and conditional theorem -/
+
+/-- The "Langevin route" radical lower bound, taken as a hypothesis.
+For every ε > 0 there is C > 0 such that rad(F(k,n)) ≥ C · n^{k-1-ε} for all n ≥ 1. -/
+def RadLB (k : ℕ) : Prop :=
+  ∀ ε : ℝ, 0 < ε → ∃ C : ℝ, 0 < C ∧
+    ∀ n : ℕ, 1 ≤ n →
+      (rad (F k n) : ℝ) ≥ C * (n : ℝ) ^ ((k : ℝ) - 1 - ε)
+
+/-
+**Conditional theorem**: assuming RadLB, for every ε > 0 there is C' > 0 with
+B₂(F(k,n)) ≤ C' · n^{2+ε} for all n ≥ 1.
+
+This isolates the logical core of the proposed "Langevin route" argument for the
+general-k upper bound in Erdős #367.
+-/
+theorem B2_upper_bound (k : ℕ) (hk : 1 ≤ k) (hRadLB : RadLB k) :
+    ∀ ε : ℝ, 0 < ε → ∃ C' : ℝ, 0 < C' ∧
+      ∀ n : ℕ, 1 ≤ n → (B2 (F k n) : ℝ) ≤ C' * (n : ℝ) ^ ((2 : ℝ) + ε) := by
+  intro ε hε_pos
+  obtain ⟨C, hC_pos, hC⟩ :
+      ∃ C : ℝ, 0 < C ∧
+        ∀ n : ℕ, 1 ≤ n →
+          (rad (F k n) : ℝ) ≥ C * (n : ℝ) ^ ((k : ℝ) - 1 - ε / 2) := by
+    exact hRadLB ( ε / 2 ) ( half_pos hε_pos )
+  use ((k : ℝ) ^ (2 * k)) / C ^ 2
+  constructor
+  · positivity
+  · intro n hn
+    -- By B2_le_sq_div_rad_sq (using F_ne_zero for F k n ≠ 0):
+    have h_B2_le :
+        (B2 (F k n) : ℝ) ≤
+          ((k : ℝ) * (n : ℝ)) ^ (2 * k) /
+            (C * (n : ℝ) ^ ((k : ℝ) - 1 - ε / 2)) ^ 2 := by
+      refine le_trans ( B2_le_sq_div_rad_sq _ <| F_ne_zero hn ) ?_;
+      gcongr;
+      · exact_mod_cast by
+          rw [ pow_mul' ]
+          exact pow_le_pow_left₀ (Nat.cast_nonneg _) (F_le_pow hk hn) _
+      · exact hC n hn;
+    convert h_B2_le using 1; ring;
+    norm_num [ sq, mul_assoc, ← Real.rpow_add ( by positivity : 0 < ( n : ℝ ) ),
+      ← Real.rpow_neg ( by positivity : 0 ≤ ( n : ℝ ) ) ]; ring;
+    exact Or.inl (by
+      rw [← Real.rpow_natCast, ← Real.rpow_add (by positivity)]
+      push_cast
+      ring)
+
+-- Remark (not part of the proof):
+-- ∏_{i=0}^{k-1} B₂(n+i) ≤ B₂(F(n)) up to a factor depending only on k
+-- (the only shared primes among the n+i are ≤ k), so the theorem also bounds
+-- the Erdős #367 product ∏ B₂(n+i) ≪ n^{2+ε}.
+-- For k=3 the hypothesis RadLB is a THEOREM under abc (via the identity
+-- (n+1)² = n(n+2)+1); for k ≥ 4 whether RadLB holds is open.
+
+end
+
+end GeneralK

--- a/LeanPool/Erdos367/K3AbcUpperBound.lean
+++ b/LeanPool/Erdos367/K3AbcUpperBound.lean
@@ -1,0 +1,397 @@
+/-
+Copyright (c) 2026 Scott D. Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott D. Hughes
+-/
+
+import Mathlib.Algebra.Order.Ring.Nat
+import Mathlib.Algebra.Order.BigOperators.GroupWithZero.Finset
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Data.Nat.Factorization.Defs
+import Mathlib.Data.Nat.PrimeFin
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic.Convert
+import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.IntervalCases
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Ring
+
+/-!
+# Erdős Problem #367 (k = 3 case), conditional on abc
+
+We formalize:
+  1. rad(m)  — the radical (squarefree kernel) of m
+  2. B₂(m)  — the powerful (2-full) part of m
+  3. LEMMA STAR:  rad(m)² · B₂(m) ≤ m²
+  4. Submultiplicativity of rad
+  5. The abc conjecture (as a hypothesis)
+  6. The main theorem:  B₂(n) · B₂(n+1) · B₂(n+2) ≤ C'_ε · n^{2+ε}
+-/
+
+open Finset BigOperators Nat
+
+noncomputable section
+
+namespace Erdos367
+
+/-! ## Definitions -/
+
+/-- The radical (squarefree kernel) of n: the product of distinct prime factors. -/
+def Nat.rad (n : ℕ) : ℕ := n.primeFactors.prod id
+
+/-- The powerful (2-full) part of n: ∏_{p : v_p(n) ≥ 2} p^{v_p(n)}. -/
+def Nat.powerfulPart (n : ℕ) : ℕ :=
+  (n.primeFactors.filter (fun p => 2 ≤ n.factorization p)).prod
+    (fun p => p ^ n.factorization p)
+
+/-! ## Basic properties of rad -/
+
+@[simp] theorem Nat.rad_zero : Nat.rad 0 = 1 := by simp [Nat.rad]
+
+@[simp] theorem Nat.rad_one : Nat.rad 1 = 1 := by simp [Nat.rad]
+
+theorem Nat.rad_pos (n : ℕ) (_hn : 0 < n) : 0 < Nat.rad n := by
+  exact Finset.prod_pos fun p hp => Nat.pos_of_mem_primeFactors hp
+
+/-! ## Basic properties of powerfulPart -/
+
+@[simp] theorem Nat.powerfulPart_zero : Nat.powerfulPart 0 = 1 := by
+  simp [Nat.powerfulPart]
+
+@[simp] theorem Nat.powerfulPart_one : Nat.powerfulPart 1 = 1 := by
+  simp [Nat.powerfulPart]
+
+theorem Nat.powerfulPart_pos (n : ℕ) (_hn : 0 < n) : 0 < Nat.powerfulPart n := by
+  exact Finset.prod_pos fun p hp =>
+    pow_pos (Nat.pos_of_mem_primeFactors (Finset.mem_filter.mp hp |>.1)) _
+
+/-! ## LEMMA STAR: rad(m)² · B₂(m) ≤ m²
+
+The key integer-arithmetic lemma. For every m > 0,
+  rad(m)² * powerfulPart(m) ≤ m².
+
+Proof sketch: Write m = ∏ p^{a_p}. Then
+  rad(m)² * B₂(m) = ∏_{a_p=1} p² · ∏_{a_p≥2} p^{2+a_p}
+  m²              = ∏ p^{2a_p}
+Compare primewise: for a_p = 1, 2 ≤ 2; for a_p ≥ 2, 2+a_p ≤ 2a_p.
+-/
+
+theorem lemma_star (m : ℕ) (hm : 0 < m) :
+    Nat.rad m ^ 2 * Nat.powerfulPart m ≤ m ^ 2 := by
+  -- We need to compare rad(m)² * powerfulPart(m) and m² term by term.
+  have h_term_by_term :
+      (Nat.primeFactors m).prod
+          (fun p => p ^ 2 * if 2 ≤ m.factorization p then p ^ m.factorization p else 1) ≤
+        (Nat.primeFactors m).prod (fun p => p ^ (2 * m.factorization p)) := by
+    refine Finset.prod_le_prod' ?_
+    intro p hp
+    split_ifs with h_factorization
+    · rw [← pow_add]
+      exact Nat.pow_le_pow_right (Nat.prime_of_mem_primeFactors hp).one_lt.le (by
+        nlinarith)
+    · interval_cases _ : m.factorization p <;> simp_all +decide [Nat.pow_succ']
+      simp_all +decide [ Nat.factorization_eq_zero_iff ];
+  -- By definition of $rad$ and $powerfulPart$, we can rewrite the left-hand side of the inequality.
+  simp only [Nat.rad, Nat.powerfulPart, ge_iff_le] at *
+  convert h_term_by_term using 1
+  · simp +decide [Finset.prod_ite, Finset.prod_mul_distrib, Finset.prod_pow]
+    ring_nf
+    rw [← Finset.prod_filter_mul_prod_filter_not m.primeFactors
+      (fun x => 2 ≤ m.factorization x)]
+    ring_nf
+    grind
+  · conv_lhs => rw [← Nat.prod_factorization_pow_eq_self hm.ne']
+    simp +decide [pow_mul', Finset.prod_pow, Finsupp.prod]
+
+/-! ## Submultiplicativity of rad
+
+rad(a * b) ≤ rad(a) * rad(b) for positive a, b.
+This follows because primeFactors(ab) = primeFactors(a) ∪ primeFactors(b),
+and the product over a union is ≤ the product of products (intersection terms ≥ 1).
+-/
+
+theorem Nat.rad_mul_le (a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
+    Nat.rad (a * b) ≤ Nat.rad a * Nat.rad b := by
+  unfold Nat.rad
+  rw [Nat.primeFactors_mul ha hb]
+  simp only [id_eq]
+  rw [← Finset.prod_union_inter]
+  exact le_mul_of_one_le_right (Nat.zero_le _)
+    (Finset.prod_pos fun p hp =>
+      Nat.pos_of_mem_primeFactors (Finset.mem_inter.mp hp |>.1))
+
+/-! ## The abc conjecture (stated as a hypothesis) -/
+
+/-- The abc conjecture: for every ε > 0, there exists C > 0 such that for all
+coprime positive integers a, b with a + b = c, we have c ≤ C · rad(abc)^{1+ε}. -/
+def ABCConjecture : Prop :=
+  ∀ ε : ℝ, 0 < ε → ∃ C : ℝ, 0 < C ∧
+    ∀ a b c : ℕ, 0 < a → 0 < b → 0 < c → a + b = c → Nat.Coprime a b →
+      (c : ℝ) ≤ C * ((Nat.rad (a * b * c) : ℕ) : ℝ) ^ (1 + ε)
+
+/-! ## Key identity and the abc application step -/
+
+/-- (n+1)² = n(n+2) + 1, the "squaring trick" identity. -/
+theorem squaring_trick (n : ℕ) : (n + 1) ^ 2 = n * (n + 2) + 1 := by ring
+
+/-
+rad(n(n+1)²(n+2)) = rad(n(n+1)(n+2)) since rad ignores exponents.
+-/
+theorem rad_ignore_sq (n : ℕ) (hn : 0 < n) :
+    Nat.rad (n * (n + 1) ^ 2 * (n + 2)) = Nat.rad (n * (n + 1) * (n + 2)) := by
+  unfold Nat.rad;
+  norm_num [ Nat.primeFactors_mul, hn.ne', Nat.primeFactors_pow ]
+
+/-! ## Main theorem: Erdős #367 (k=3), conditional on abc
+
+**Theorem.** Assume abc. For every ε > 0, there exists C' > 0 such that for all n ≥ 1,
+  B₂(n) · B₂(n+1) · B₂(n+2) ≤ C' · n^{2+ε}.
+
+The proof proceeds in two stages:
+  (1) *Integer core*: Use the squaring trick + abc to get
+        (n+1)² ≤ C_ε · rad(n(n+1)(n+2))^{1+ε},
+      then apply rad submultiplicativity and LEMMA STAR to bound the radical
+      in terms of n and the powerful parts.
+  (2) *Real-analytic rearrangement*: Rearrange the resulting inequality
+      using real-valued exponents to isolate B₂(n)B₂(n+1)B₂(n+2) ≤ C'·n^{2+ε}.
+-/
+
+/-
+The integer core: from abc, we get
+  (n+1)² ≤ C_ε · [n(n+1)(n+2) / (B₂(n)B₂(n+1)B₂(n+2))^{1/2}]^{1+ε}.
+  Stated as: (n+1)^2 * P^{(1+ε)/2} ≤ C_ε * (n(n+1)(n+2))^{1+ε},
+  where P = B₂(n)·B₂(n+1)·B₂(n+2).
+-/
+theorem integer_core_ineq (habc : ABCConjecture) (ε : ℝ) (hε : 0 < ε) :
+    ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 0 < n →
+      ((n + 1 : ℕ) : ℝ) ^ 2 ≤ C *
+        ((Nat.rad n : ℝ) * (Nat.rad (n + 1) : ℝ) *
+          (Nat.rad (n + 2) : ℝ)) ^ (1 + ε) := by
+  obtain ⟨C, hC_pos, hC⟩ := habc ε hε
+  use C
+  refine ⟨hC_pos, fun n hn ↦ ?_⟩
+  have hC_applied :=
+    hC (n * (n + 2)) 1 ((n + 1) ^ 2) (by positivity) (by norm_num)
+      (by positivity) (by ring) (by simp)
+  norm_num [mul_assoc] at hC_applied ⊢
+  refine le_trans hC_applied ?_
+  gcongr
+  -- `Nat.rad_mul_le` gives the radical bound; `rad_ignore_sq` removes the square.
+  have h_rad_mul :
+      Nat.rad (n * (n + 2) * (n + 1) ^ 2) ≤
+        Nat.rad n * Nat.rad (n + 2) * Nat.rad ((n + 1) ^ 2) := by
+    convert
+      Nat.rad_mul_le (n * (n + 2)) ((n + 1) ^ 2) (by positivity) (by positivity)
+        |> le_trans <|
+          Nat.mul_le_mul (Nat.rad_mul_le n (n + 2) (by positivity) (by positivity))
+            le_rfl
+      using 1
+  -- Since rad((n + 1)^2) = rad(n + 1), we can simplify the inequality.
+  have h_rad_sq : Nat.rad ((n + 1) ^ 2) = Nat.rad (n + 1) := by
+    unfold Nat.rad; simp +decide [ Nat.primeFactors_pow ] ;
+  rw [h_rad_sq] at h_rad_mul
+  have h_rad_mul' :
+      Nat.rad (n * ((n + 2) * (n + 1) ^ 2)) ≤
+        Nat.rad n * (Nat.rad (n + 1) * Nat.rad (n + 2)) := by
+    convert h_rad_mul using 1 <;> ring
+  exact_mod_cast h_rad_mul'
+
+/-! ## Helper: product of three LEMMA STAR instances (pure ℕ) -/
+
+/-
+Multiplying three instances of LEMMA STAR: if R = rad(n)·rad(n+1)·rad(n+2)
+and P = B₂(n)·B₂(n+1)·B₂(n+2), then R² · P ≤ (n(n+1)(n+2))².
+-/
+theorem triple_lemma_star (n : ℕ) (hn : 0 < n) :
+    (Nat.rad n * Nat.rad (n + 1) * Nat.rad (n + 2)) ^ 2 *
+      (Nat.powerfulPart n * Nat.powerfulPart (n + 1) *
+        Nat.powerfulPart (n + 2)) ≤
+    (n * (n + 1) * (n + 2)) ^ 2 := by
+  convert
+    Nat.mul_le_mul
+      (Nat.mul_le_mul (lemma_star n hn) (lemma_star (n + 1) (by linarith)))
+      (lemma_star (n + 2) (by linarith))
+    using 1
+  all_goals ring
+
+/-
+**Real-analytic rearrangement lemma** (clearly marked).
+Given the bound from the integer core and LEMMA STAR applied to each of
+n, n+1, n+2, the real-exponent bookkeeping yields
+  B₂(n)·B₂(n+1)·B₂(n+2) ≤ C'·n^{2+ε}.
+
+The key steps are:
+  1. rad(n+i) ≤ (n+i) / B₂(n+i)^{1/2}  (from LEMMA STAR)
+  2. Substituting into the abc bound and using n(n+1)(n+2) ≤ 27n³
+  3. Rearranging to isolate the product of powerful parts
+  4. The resulting exponent 6 - 4/(1+ε) = 2 + 4ε/(1+ε) ≤ 2 + 4ε,
+     then relabeling ε' = ε/4.
+-/
+theorem real_analytic_rearrangement (habc : ABCConjecture) (ε : ℝ) (hε : 0 < ε) :
+    ∃ C' : ℝ, 0 < C' ∧ ∀ n : ℕ, 0 < n →
+      ((Nat.powerfulPart n * Nat.powerfulPart (n + 1) *
+        Nat.powerfulPart (n + 2) : ℕ) : ℝ) ≤
+        C' * (n : ℝ) ^ (2 + ε) := by
+  obtain ⟨ C₁, hC₁, hC₁' ⟩ := integer_core_ineq habc ( ε / 4 ) ( by positivity );
+  -- From triple_lemma_star, we have `R^2 * P ≤ (n(n+1)(n+2))^2`.
+  have h_triple_lemma_star :
+      ∀ n : ℕ, 0 < n →
+        ((Nat.rad n : ℝ) * (Nat.rad (n + 1) : ℝ) *
+          (Nat.rad (n + 2) : ℝ)) ^ 2 *
+          (Nat.powerfulPart n * Nat.powerfulPart (n + 1) *
+            Nat.powerfulPart (n + 2)) ≤
+          (n * (n + 1) * (n + 2)) ^ 2 := by
+    exact fun n hn => mod_cast triple_lemma_star n hn
+  -- So `P^((1+ε/4)/2) ≤ C * (n(n+1)(n+2))^(1+ε/4) / (n+1)^2`.
+  have h_bound :
+      ∀ n : ℕ, 0 < n →
+        ((Nat.powerfulPart n * Nat.powerfulPart (n + 1) *
+          Nat.powerfulPart (n + 2)) : ℝ) ^ ((1 + ε / 4) / 2) ≤
+          C₁ * ((n * (n + 1) * (n + 2)) ^ (1 + ε / 4)) / ((n + 1) ^ 2) := by
+    intro n hn
+    have h_powerful_pos :
+        0 < Nat.powerfulPart n * Nat.powerfulPart (n + 1) *
+          Nat.powerfulPart (n + 2) := by
+      exact
+        mul_pos
+          (mul_pos (Nat.powerfulPart_pos _ hn)
+            (Nat.powerfulPart_pos _ (Nat.succ_pos _)))
+          (Nat.powerfulPart_pos _ (Nat.succ_pos _))
+    have h_powerful_pos_real :
+        0 < (Nat.powerfulPart n : ℝ) * (Nat.powerfulPart (n + 1) : ℝ) *
+          (Nat.powerfulPart (n + 2) : ℝ) := by
+      exact
+        mul_pos
+          (mul_pos (Nat.cast_pos.mpr (Nat.powerfulPart_pos _ hn))
+            (Nat.cast_pos.mpr (Nat.powerfulPart_pos _ (Nat.succ_pos _))))
+          (Nat.cast_pos.mpr (Nat.powerfulPart_pos _ (Nat.succ_pos _)))
+    have h_bound_step :
+        ((Nat.rad n : ℝ) * (Nat.rad (n + 1) : ℝ) *
+          (Nat.rad (n + 2) : ℝ)) ^ (1 + ε / 4) ≤
+          ((n * (n + 1) * (n + 2)) ^ (1 + ε / 4)) /
+            ((Nat.powerfulPart n * Nat.powerfulPart (n + 1) *
+              Nat.powerfulPart (n + 2)) : ℝ) ^ ((1 + ε / 4) / 2) := by
+      have h_bound_step :
+          ((Nat.rad n : ℝ) * (Nat.rad (n + 1) : ℝ) *
+            (Nat.rad (n + 2) : ℝ)) ^ 2 ≤
+            ((n * (n + 1) * (n + 2)) ^ 2) /
+              ((Nat.powerfulPart n * Nat.powerfulPart (n + 1) *
+                Nat.powerfulPart (n + 2)) : ℝ) := by
+        rw [le_div_iff₀]
+        · norm_cast at *
+          simp_all +decide only [CanonicallyOrderedAdd.mul_pos]
+        · exact h_powerful_pos_real
+      convert
+        Real.rpow_le_rpow (by positivity) h_bound_step
+          (show 0 ≤ (1 + ε / 4) / 2 by positivity)
+        using 1
+      · rw [← Real.rpow_natCast _ 2, ← Real.rpow_mul (by positivity)]
+        ring
+      · rw [Real.div_rpow (by positivity) (by positivity), ← Real.rpow_natCast,
+          ← Real.rpow_mul (by positivity)]
+        ring
+    rw [le_div_iff₀] at *
+    · norm_cast at *
+      simp_all +decide only [cast_mul, cast_pow, cast_add, cast_one, cast_ofNat]
+      refine le_trans ?_ (mul_le_mul_of_nonneg_left h_bound_step hC₁.le)
+      convert
+        mul_le_mul_of_nonneg_right (hC₁' n hn)
+          (Real.rpow_nonneg
+            (show 0 ≤
+              (Nat.powerfulPart n *
+                (Nat.powerfulPart (n + 1) * Nat.powerfulPart (n + 2)) : ℝ) by
+              positivity)
+            ((1 + ε / 4) / 2))
+        using 1
+      · ring
+      · ring
+    · exact
+        Real.rpow_pos_of_pos h_powerful_pos_real _
+    · positivity
+  -- So `P^((1+ε/4)/2) ≤ C * 27^(1+ε/4) * n^(1+3ε/4)`.
+  have h_bound_simplified :
+      ∀ n : ℕ, 0 < n →
+        ((Nat.powerfulPart n * Nat.powerfulPart (n + 1) *
+          Nat.powerfulPart (n + 2)) : ℝ) ^ ((1 + ε / 4) / 2) ≤
+          C₁ * (27 ^ (1 + ε / 4)) * (n ^ (1 + 3 * ε / 4)) := by
+    intros n hn_pos
+    specialize h_bound n hn_pos
+    have h_bound_simplified_step :
+        ((n * (n + 1) * (n + 2)) : ℝ) ^ (1 + ε / 4) ≤
+          (27 : ℝ) ^ (1 + ε / 4) * (n ^ (3 * (1 + ε / 4))) := by
+      have h_bound_simplified_step :
+          ((n * (n + 1) * (n + 2)) : ℝ) ≤ (27 : ℝ) * (n ^ 3) := by
+        norm_cast
+        nlinarith [pow_pos hn_pos 2]
+      exact
+        le_trans
+          (Real.rpow_le_rpow (by positivity) h_bound_simplified_step (by positivity))
+          (by
+            rw [Real.mul_rpow (by positivity) (by positivity), ← Real.rpow_natCast,
+              ← Real.rpow_mul (by positivity)]
+            ring_nf
+            norm_num)
+    refine le_trans h_bound ?_
+    rw [div_le_iff₀ (by positivity)]
+    refine le_trans (mul_le_mul_of_nonneg_left h_bound_simplified_step <| by positivity) ?_
+    rw [show (3 * (1 + ε / 4) : ℝ) = (1 + 3 * ε / 4) + 2 by ring,
+      Real.rpow_add] <;> norm_num
+    ring_nf
+    norm_num [hn_pos]
+    rw [show (3 + ε * (3 / 4) : ℝ) = (1 + ε * (3 / 4)) + 2 by ring,
+      Real.rpow_add]
+    · norm_num
+      ring_nf
+      norm_num [hn_pos]
+      positivity
+    · positivity
+  -- So `P ≤ [C * 27^(1+ε/4)]^(2/(1+ε/4)) * n^(2(1+3ε/4)/(1+ε/4))`.
+  have h_bound_final :
+      ∀ n : ℕ, 0 < n →
+        ((Nat.powerfulPart n * Nat.powerfulPart (n + 1) *
+          Nat.powerfulPart (n + 2)) : ℝ) ≤
+          (C₁ * (27 ^ (1 + ε / 4))) ^ (2 / (1 + ε / 4)) *
+            (n ^ (2 * (1 + 3 * ε / 4) / (1 + ε / 4))) := by
+    intro n hn
+    specialize h_bound_simplified n hn
+    have :
+        ((Nat.powerfulPart n * Nat.powerfulPart (n + 1) *
+          Nat.powerfulPart (n + 2)) : ℝ) ≤
+          ((C₁ * (27 ^ (1 + ε / 4))) * (n ^ (1 + 3 * ε / 4))) ^
+            (2 / (1 + ε / 4)) := by
+      exact
+        le_trans
+          (by
+            rw [← Real.rpow_mul (by positivity), div_mul_div_cancel₀ (by positivity),
+              div_self (by positivity), Real.rpow_one])
+          (Real.rpow_le_rpow (by positivity) h_bound_simplified (by positivity))
+    convert this using 1
+    rw [Real.mul_rpow (by positivity) (by positivity), ← Real.rpow_mul (by positivity)]
+    ring
+    rw [Real.mul_rpow (by positivity) (by positivity),
+      Real.mul_rpow (by positivity) (by positivity), ← Real.rpow_mul (by positivity),
+      ← Real.rpow_mul (by positivity)]
+    ring
+  refine
+    ⟨(C₁ * 27 ^ (1 + ε / 4)) ^ (2 / (1 + ε / 4)), by positivity, fun n hn => ?_⟩
+  exact
+    le_trans (mod_cast h_bound_final n hn)
+      (mul_le_mul_of_nonneg_left
+        (Real.rpow_le_rpow_of_exponent_le (mod_cast hn) (by
+          rw [div_le_iff₀] <;> nlinarith))
+        (by positivity))
+
+/-- **Main theorem (Erdős #367, k=3 case, conditional on abc).**
+For every ε > 0, there exists C' > 0 such that for all n ≥ 1,
+  B₂(n) · B₂(n+1) · B₂(n+2) ≤ C' · n^{2+ε}. -/
+theorem erdos_367_k3 (habc : ABCConjecture) (ε : ℝ) (hε : 0 < ε) :
+    ∃ C' : ℝ, 0 < C' ∧ ∀ n : ℕ, 0 < n →
+      ((Nat.powerfulPart n * Nat.powerfulPart (n+1) * Nat.powerfulPart (n+2) : ℕ) : ℝ) ≤
+        C' * (n : ℝ) ^ (2 + ε) :=
+  real_analytic_rearrangement habc ε hε
+
+end Erdos367
+
+end

--- a/LeanPool/Erdos367/PellLimsup.lean
+++ b/LeanPool/Erdos367/PellLimsup.lean
@@ -1,0 +1,888 @@
+/-
+Copyright (c) 2026 Scott D. Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott D. Hughes
+-/
+
+import Mathlib.NumberTheory.LSeries.PrimesInAP
+import Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol
+import Mathlib.NumberTheory.Zsqrtd.Basic
+import Mathlib.Tactic.Convert
+import Mathlib.Tactic.Cases
+import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.IntervalCases
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Push
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Zify
+import Aesop
+
+/-!
+# Erdős Problem #367: Consecutive Powerful Parts
+
+We prove that `limsup_{n→∞} B₂(n)·B₂(n+1)·B₂(n+2) / (n²·log n) = ∞`,
+where `B₂(m) = ∏_{p^e ∥ m, e≥2} p^e` is the powerful (2-full) part of `m`.
+
+Equivalently: `∀ M : ℝ, ∃ n : ℕ, B₂(n) * B₂(n+1) * B₂(n+2) > M * n² * log n`.
+
+## Strategy
+
+We use the Pell equation `x² - 8y² = 1` (fundamental solution `(3,1)`) to produce triples
+`(n, n+1, n+2)` where `n = 8y²` is powerful, `n+1 = x²` is powerful, and `n+2 = x²+1`
+has a large powerful part thanks to the algebraic structure of `ℤ[√2]`.
+
+## What is proved
+
+All lemmas and theorems are fully proved with no `sorry` statements.
+The final `#print axioms erdos367` shows only the standard axioms:
+`propext`, `Classical.choice`, `Lean.ofReduceBool`, `Lean.trustCompiler`, `Quot.sound`.
+-/
+
+noncomputable section
+
+namespace Erdos367
+
+open Finsupp Nat
+
+/-! ## Powerful part -/
+
+/-- The powerful (2-full) part of `m`: `∏_{p^e ∥ m, e ≥ 2} p^e`. -/
+def powerfulPart (m : ℕ) : ℕ :=
+  m.factorization.prod (fun p e => if e ≥ 2 then p ^ e else 1)
+
+/-- A number is *powerful* if every prime factor has exponent ≥ 2. -/
+def IsPowerful (m : ℕ) : Prop :=
+  ∀ p : ℕ, p.Prime → p ∣ m → 2 ≤ m.factorization p
+
+lemma powerfulPart_of_powerful {m : ℕ} (hm : m ≠ 0)
+    (h : IsPowerful m) : powerfulPart m = m := by
+  unfold powerfulPart
+  conv_rhs => rw [← Nat.prod_factorization_pow_eq_self hm]
+  apply Finsupp.prod_congr
+  intro p hp
+  rw [Nat.support_factorization] at hp
+  simp only [Nat.mem_primeFactors] at hp
+  simp only [ge_iff_le, h p hp.1 hp.2.1, ite_true]
+
+lemma isPowerful_sq {k : ℕ} (hk : k ≠ 0) : IsPowerful (k ^ 2) := by
+  intro p hp hd
+  rw [Nat.factorization_pow, Finsupp.coe_nsmul, Pi.smul_apply, smul_eq_mul]
+  have hmem : k.factorization p ≠ 0 := by
+    rw [← Finsupp.mem_support_iff, Nat.support_factorization, Nat.mem_primeFactors]
+    exact ⟨hp, hp.dvd_of_dvd_pow hd, hk⟩
+  omega
+
+lemma powerfulPart_sq {k : ℕ} (hk : k ≠ 0) : powerfulPart (k ^ 2) = k ^ 2 :=
+  powerfulPart_of_powerful (by positivity) (isPowerful_sq hk)
+
+private lemma eight_factorization_ne_two (p : ℕ) (hp2 : p ≠ 2) :
+    (8 : ℕ).factorization p = 0 := by
+  rw [show (8 : ℕ) = 2 ^ 3 from by norm_num, Nat.factorization_pow, Finsupp.coe_nsmul,
+      Pi.smul_apply, smul_eq_mul, Nat.prime_two.factorization, Finsupp.single_apply,
+      if_neg (Ne.symm hp2), mul_zero]
+
+lemma isPowerful_eight_mul_sq {y : ℕ} (hy : y ≠ 0) : IsPowerful (8 * y ^ 2) := by
+  intro p hp hd
+  rw [Nat.factorization_mul (by norm_num) (by positivity : y ^ 2 ≠ 0),
+      Finsupp.coe_add, Pi.add_apply]
+  by_cases hp2 : p = 2
+  · subst hp2
+    have : (8 : ℕ).factorization 2 = 3 := by
+      rw [show (8:ℕ) = 2^3 by norm_num, Nat.Prime.factorization_pow Nat.prime_two]; simp
+    rw [this]; omega
+  · rw [eight_factorization_ne_two p hp2, zero_add, Nat.factorization_pow,
+        Finsupp.coe_nsmul, Pi.smul_apply, smul_eq_mul]
+    have hpy : p ∣ y := by
+      have hpy2 : p ∣ y ^ 2 := by
+        rcases hp.dvd_mul.mp hd with h | h
+        · exfalso
+          have h8 : p ∣ 2 ^ 3 := by norm_num at h ⊢; exact h
+          have h2 : p ∣ 2 := hp.dvd_of_dvd_pow h8
+          rcases Nat.prime_two.eq_one_or_self_of_dvd p h2 with h | h
+          · exact hp.one_lt.ne' h
+          · exact hp2 h
+        · exact h
+      exact hp.dvd_of_dvd_pow hpy2
+    have hmem : y.factorization p ≠ 0 := by
+      rw [← Finsupp.mem_support_iff, Nat.support_factorization, Nat.mem_primeFactors]
+      exact ⟨hp, hpy, hy⟩
+    omega
+
+lemma powerfulPart_eight_mul_sq {y : ℕ} (hy : y ≠ 0) :
+    powerfulPart (8 * y ^ 2) = 8 * y ^ 2 :=
+  powerfulPart_of_powerful (by positivity) (isPowerful_eight_mul_sq hy)
+
+/-
+If `p` is prime and `p² ∣ m` (with `m ≠ 0`), then `p²` divides `powerfulPart m`.
+-/
+lemma powerfulPart_ge_of_prime_sq_dvd {m p : ℕ} (hm : m ≠ 0) (hp : p.Prime)
+    (hd : p ^ 2 ∣ m) : p ^ 2 ∣ powerfulPart m := by
+  unfold powerfulPart
+  rw [Finsupp.prod, Nat.support_factorization]
+  refine dvd_trans ?_
+    (Finset.dvd_prod_of_mem _
+      (Nat.mem_primeFactors.mpr ⟨hp, by
+        have hp_dvd_sq : p ∣ p ^ 2 := by
+          rw [pow_two]
+          exact dvd_mul_right p p
+        exact dvd_trans hp_dvd_sq hd, hm⟩))
+  have hfactor : 2 ≤ m.factorization p := by
+    have hle := (Nat.factorization_le_iff_dvd (pow_ne_zero 2 hp.ne_zero) hm).2 hd
+    have := hle p
+    simpa [Nat.Prime.factorization_pow hp] using this
+  simp only [ge_iff_le, hfactor, ite_true]
+  exact pow_dvd_pow p hfactor
+
+/-! ## Pell sequence for x² - 8y² = 1 -/
+
+/-- Joint recurrence for Pell solutions `(X_j, Y_j)` with `X_j² - 8·Y_j² = 1`. -/
+def pellXY : ℕ → ℤ × ℤ
+  | 0 => (1, 0)
+  | j + 1 => let (x, y) := pellXY j; (3 * x + 8 * y, x + 3 * y)
+
+/-- X component of Pell solutions for `x² - 8y² = 1`. -/
+def pellX (j : ℕ) : ℤ := (pellXY j).1
+
+/-- Y component of Pell solutions for `x² - 8y² = 1`. -/
+def pellY (j : ℕ) : ℤ := (pellXY j).2
+
+@[simp] lemma pellX_zero : pellX 0 = 1 := rfl
+@[simp] lemma pellY_zero : pellY 0 = 0 := rfl
+
+@[simp] lemma pellX_succ (j : ℕ) : pellX (j + 1) = 3 * pellX j + 8 * pellY j := by
+  simp [pellX, pellY, pellXY]
+
+@[simp] lemma pellY_succ (j : ℕ) : pellY (j + 1) = pellX j + 3 * pellY j := by
+  simp [pellX, pellY, pellXY]
+
+private theorem pellXY_pos_nonneg (j : ℕ) : 0 < pellX j ∧ 0 ≤ pellY j := by
+  induction j with
+  | zero => constructor <;> simp [pellX, pellY, pellXY]
+  | succ n ih =>
+    exact ⟨by simp; linarith [ih.1, ih.2], by simp; linarith [ih.1, ih.2]⟩
+
+theorem pellX_pos (j : ℕ) : 0 < pellX j := (pellXY_pos_nonneg j).1
+theorem pellY_nonneg (j : ℕ) : 0 ≤ pellY j := (pellXY_pos_nonneg j).2
+
+theorem pellY_pos {j : ℕ} (hj : 0 < j) : 0 < pellY j := by
+  cases j with
+  | zero => omega
+  | succ n => simp; linarith [pellX_pos n, pellY_nonneg n]
+
+/-- **Pell identity.** `X_j² - 8·Y_j² = 1`. -/
+theorem pell_identity (j : ℕ) : pellX j ^ 2 - 8 * pellY j ^ 2 = 1 := by
+  induction j with
+  | zero => simp
+  | succ n ih => simp only [pellX_succ, pellY_succ]; nlinarith
+
+/-- `pellY j ≤ pellX j` for all `j`. -/
+theorem pellY_le_pellX (j : ℕ) : pellY j ≤ pellX j := by
+  induction j with
+  | zero => simp
+  | succ n ih =>
+    simp only [pellX_succ, pellY_succ]
+    linarith [pellY_nonneg n, pellX_pos n]
+
+/-- Upper bound: `pellX j ≤ 11 ^ j`. -/
+theorem pellX_le_pow (j : ℕ) : pellX j ≤ 11 ^ j := by
+  induction j with
+  | zero => simp
+  | succ n ih =>
+    simp only [pellX_succ]
+    calc 3 * pellX n + 8 * pellY n ≤ 3 * pellX n + 8 * pellX n := by
+          linarith [pellY_le_pellX n]
+      _ = 11 * pellX n := by ring
+      _ ≤ 11 * 11 ^ n := by linarith
+      _ = 11 ^ (n + 1) := by ring
+
+/-! ## The triple (n_j, n_j + 1, n_j + 2) -/
+
+/-- `n_j = 8 · Y_j²`, a powerful number for `j ≥ 1`. -/
+def pellN (j : ℕ) : ℕ := (8 * pellY j ^ 2).toNat
+
+lemma pellN_eq (j : ℕ) : (pellN j : ℤ) = 8 * pellY j ^ 2 := by
+  unfold pellN
+  rw [Int.toNat_of_nonneg]
+  positivity [pellY_nonneg j]
+
+lemma pellN_pos {j : ℕ} (hj : 0 < j) : 0 < pellN j := by
+  have h : (0 : ℤ) < 8 * pellY j ^ 2 := by positivity [pellY_pos hj]
+  have := pellN_eq j; omega
+
+/-- **L0.** `n_j + 1 = X_j²` (as natural numbers). -/
+theorem L0 (j : ℕ) : pellN j + 1 = (pellX j).toNat ^ 2 := by
+  have hx := pellX_pos j
+  zify
+  rw [pellN_eq, Int.toNat_of_nonneg (le_of_lt hx)]
+  linarith [pell_identity j]
+
+/-- **L1.** `B₂(n_j) = n_j` for `j ≥ 1`: `n_j = 8·Y_j²` is powerful. -/
+theorem L1 {j : ℕ} (hj : 0 < j) : powerfulPart (pellN j) = pellN j := by
+  have hypos : (0 : ℤ) < pellY j := pellY_pos hj
+  have heq : pellN j = 8 * (pellY j).toNat ^ 2 := by
+    have := pellN_eq j
+    zify [Int.toNat_of_nonneg (le_of_lt hypos)]
+    linarith
+  rw [heq]
+  exact powerfulPart_eight_mul_sq (by omega)
+
+/-- **L2.** `B₂(n_j + 1) = n_j + 1`: `n_j + 1 = X_j²` is a perfect square. -/
+theorem L2 (j : ℕ) : powerfulPart (pellN j + 1) = pellN j + 1 := by
+  rw [L0]
+  exact powerfulPart_sq (by have := pellX_pos j; omega)
+
+/-- **L3.** `n_j + 2 = X_j² + 1`. -/
+theorem L3 (j : ℕ) : pellN j + 2 = (pellX j).toNat ^ 2 + 1 := by
+  have := L0 j; omega
+
+/-- For `j ≥ 1`, the triple product simplifies using L1 and L2. -/
+theorem product_lower_bound {j : ℕ} (hj : 0 < j) :
+    powerfulPart (pellN j) * powerfulPart (pellN j + 1) * powerfulPart (pellN j + 2) =
+    pellN j * (pellN j + 1) * powerfulPart (pellN j + 2) := by
+  rw [L1 hj, L2]
+
+/-! ## The algebraic BOOST
+
+For a prime `p ≡ 5 mod 8`, the fundamental unit `α = 3 + √8` of `ℤ[√8]` satisfies
+`α^{(p+1)/2·p} ≡ -1 mod p²` in `ℤ[√8]`. In concrete terms: with `L = (p+1)/2 · p`,
+`pellX L ≡ -1 (mod p²)` and `pellY L ≡ 0 (mod p²)`.
+
+**Proof sketch:** Since `p ≡ 5 mod 8`, `(2/p) = -1` (Legendre symbol), so `p` is inert
+in `ℤ[√2]`. The Frobenius on `ℤ[√2]/p ≅ 𝔽_{p²}` sends `√2 ↦ -√2`, giving
+`(1+√2)^p ≡ 1-√2 = -(1+√2)^{-1} (mod p)`, hence `α^{(p+1)/2} ≡ -1 (mod p)`.
+Hensel lifting (via the structure of `(ℤ[√2]/p^a)×`) gives `α^{(p+1)/2·p} ≡ -1 (mod p²)`.
+-/
+
+-- === Step 1: α^j = ⟨pellX j, 2 * pellY j⟩ in ℤ√2 ===
+lemma alpha_pow (j : ℕ) : (⟨3, 2⟩ : ℤ√2) ^ j = ⟨pellX j, 2 * pellY j⟩ := by
+  induction j with
+  | zero => simp [pellX, pellY, pellXY]; rfl
+  | succ j ih =>
+    simp only [pow_succ]
+    rw [ih]
+    ext <;> simp [pellX, pellY, pellXY, Zsqrtd.re_mul, Zsqrtd.im_mul] <;> ring
+
+-- === Step 2: ε² = α ===
+lemma eps_sq : (⟨1, 1⟩ : ℤ√2) ^ 2 = (⟨3, 2⟩ : ℤ√2) := by decide
+
+/-
+=== Step 3a: sqrtd^(2k+1) = ⟨0, 2^k⟩ ===
+-/
+lemma sqrtd_pow_odd (k : ℕ) :
+    (Zsqrtd.sqrtd : ℤ√2) ^ (2 * k + 1) = ⟨0, (2 : ℤ) ^ k⟩ := by
+  induction k <;> simp_all +decide only [Nat.mul_succ, pow_succ, pow_mul]
+  ext <;> simp +decide
+  ring
+
+/-
+=== Step 3b: Euler criterion for 2 mod p ===
+When p ≡ 5 (mod 8), 2 is a QNR, so 2^(p/2) ≡ -1 (mod p)
+-/
+lemma euler_two_mod (p : ℕ) (hp : p.Prime) (hp5 : p % 8 = 5) :
+    (p : ℤ) ∣ (2 : ℤ) ^ (p / 2) + 1 := by
+  -- Use Legendre symbol to get $(2/p) = -1$.
+  have h_legendre : (jacobiSym 2 p) = -1 := by
+    have hp_odd : Odd p := hp.odd_of_ne_two <| by
+      rintro rfl
+      norm_num at hp5
+    rw [jacobiSym.at_two hp_odd, ZMod.χ₈_nat_eq_if_mod_eight]
+    have hp2 : p % 2 = 1 := Nat.odd_iff.mp hp_odd
+    simp [hp2, hp5]
+  -- By Euler's criterion, we have $2^{p/2} \equiv jacobiSym 2 p \pmod p$.
+  have h_euler : 2 ^ (p / 2) ≡ jacobiSym 2 p [ZMOD p] := by
+    haveI := Fact.mk hp; simp +decide [ ← ZMod.intCast_eq_intCast_iff, jacobiSym ] ;
+    simp +decide [ Nat.primeFactorsList_prime hp, legendreSym.eq_pow ];
+  simpa [ h_legendre ] using h_euler.symm.dvd
+
+/-
+=== Step 4: Frobenius - ε^p ≡ ⟨1, -1⟩ (mod p) componentwise ===
+Uses freshman's dream: (1 + sqrtd)^p = 1 + sqrtd^p + p*(stuff)
+and sqrtd^p = ⟨0, 2^(p/2)⟩ for odd p, and 2^(p/2) ≡ -1 (mod p)
+-/
+lemma frobenius_eps (p : ℕ) (hp : p.Prime) (hp5 : p % 8 = 5) :
+    (p : ℤ) ∣ ((⟨1, 1⟩ : ℤ√2) ^ p).re - 1 ∧
+    (p : ℤ) ∣ ((⟨1, 1⟩ : ℤ√2) ^ p).im + 1 := by
+  -- By added_pow_prime_eq, we have ε^p = 1^p + sqrtd^p + p * 1 * sqrtd * S
+  have h_eps_p : (Zsqrtd.mk 1 1 : ℤ√2) ^ p = 1 ^ p +
+      (Zsqrtd.sqrtd : ℤ√2) ^ p +
+      (p : ℤ) * (1 : ℤ√2) * (Zsqrtd.sqrtd : ℤ√2) *
+        (∑ k ∈ Finset.Ioo 0 p,
+          1 ^ (k - 1) * (Zsqrtd.sqrtd : ℤ√2) ^ (p - k - 1) *
+            (((Nat.choose p k / p : ℕ) : ℤ) : ℤ√2)) := by
+    rw [show (Zsqrtd.mk 1 1 : ℤ√2) = 1 + (Zsqrtd.sqrtd : ℤ√2) by
+      ext <;> simp [Zsqrtd.sqrtd]]
+    exact add_pow_prime_eq hp (1 : ℤ√2) (Zsqrtd.sqrtd : ℤ√2)
+  -- By sqrtd_pow_odd, we have sqrtd^p = ⟨0, 2^(p/2)⟩
+  have h_sqrtd_p : (Zsqrtd.sqrtd : ℤ√2) ^ p = ⟨0, 2 ^ (p / 2)⟩ := by
+    convert sqrtd_pow_odd ( p / 2 );
+    omega;
+  -- By euler_two_mod, we have p ∣ 2^(p/2) + 1
+  have h_euler : (p : ℤ) ∣ 2 ^ (p / 2) + 1 := by
+    convert euler_two_mod p hp hp5 using 1;
+  simp_all +decide [ ← ZMod.intCast_zmod_eq_zero_iff_dvd ]
+
+/-
+=== Step 5: ε^(p+1) ≡ ⟨-1, 0⟩ (mod p) ===
+ε^(p+1) = ε^p * ε, and ⟨1,-1⟩ * ⟨1,1⟩ = ⟨-1, 0⟩ in ℤ√2
+-/
+lemma eps_succ_mod (p : ℕ) (hp : p.Prime) (hp5 : p % 8 = 5) :
+    (p : ℤ) ∣ ((⟨1, 1⟩ : ℤ√2) ^ (p + 1)).re + 1 ∧
+    (p : ℤ) ∣ ((⟨1, 1⟩ : ℤ√2) ^ (p + 1)).im := by
+  -- Use Frobenius to get the two components modulo `p`.
+  obtain ⟨hr, hi⟩ :
+      (p : ℤ) ∣ ((⟨1, 1⟩ : ℤ√2) ^ p).re - 1 ∧
+        (p : ℤ) ∣ ((⟨1, 1⟩ : ℤ√2) ^ p).im + 1 := by
+    convert frobenius_eps p hp hp5 using 1;
+  simp only [pow_succ, Zsqrtd.re_mul, Zsqrtd.im_mul]
+  constructor
+  · rw [show ((⟨1, 1⟩ : ℤ√2) ^ p).re * 1 +
+          2 * ((⟨1, 1⟩ : ℤ√2) ^ p).im * 1 + 1 =
+        ((⟨1, 1⟩ : ℤ√2) ^ p).re - 1 +
+          2 * (((⟨1, 1⟩ : ℤ√2) ^ p).im + 1) by ring]
+    exact dvd_add hr (hi.mul_left 2)
+  · rw [show ((⟨1, 1⟩ : ℤ√2) ^ p).re * 1 +
+          ((⟨1, 1⟩ : ℤ√2) ^ p).im * 1 =
+        ((⟨1, 1⟩ : ℤ√2) ^ p).re - 1 +
+          (((⟨1, 1⟩ : ℤ√2) ^ p).im + 1) by ring]
+    exact dvd_add hr hi
+
+/-
+=== Step 6: Hensel lift from mod p to mod p² ===
+If z ≡ -1 (mod p) in ℤ√2 componentwise, then z^p ≡ -1 (mod p²)
+Uses: z = -1 + (z+1), apply add_pow_prime_eq,
+(-1)^p = -1 for odd p, and (z+1)^p, p*(z+1)*stuff have components div by p²
+-/
+lemma hensel_lift (p : ℕ) (hp : p.Prime) (hp2 : p ≠ 2) (z : ℤ√2)
+    (hre : (p : ℤ) ∣ z.re + 1) (him : (p : ℤ) ∣ z.im) :
+    ((p : ℤ) ^ 2 ∣ (z ^ p).re + 1) ∧ ((p : ℤ) ^ 2 ∣ (z ^ p).im) := by
+  obtain ⟨k₁, hk₁⟩ := hre
+  obtain ⟨k₂, hk₂⟩ := him
+  have hz_re : z.re = -1 + p * k₁ := by linarith
+  have hz_im : z.im = p * k₂ := by linarith
+  -- Write $z = -1 + p \cdot w$ where $w = k₁ + k₂ \cdot \sqrt{2}$
+  obtain ⟨w, hw⟩ : ∃ w : ℤ√2, z = -1 + (p : ℤ√2) * w := by
+    exact ⟨⟨k₁, k₂⟩, by ext <;> simp [hz_re, hz_im]⟩
+  -- Expand $(-1 + pw)^p$ using the binomial theorem.
+  have h_expand :
+      (-1 + (p : ℤ√2) * w) ^ p =
+        (-1 : ℤ√2) ^ p + p * (-1 : ℤ√2) ^ (p - 1) * (p : ℤ√2) * w +
+          ∑ k ∈ Finset.Icc 2 p,
+            Nat.choose p k * (-1 : ℤ√2) ^ (p - k) * (p : ℤ√2) ^ k * w ^ k := by
+    rw [add_comm, add_pow]
+    erw [Finset.sum_Ico_eq_sub _]
+    · norm_num [Finset.sum_range_succ]
+      ring
+    · linarith [hp.two_le]
+  -- Since $p$ is odd, $(-1)^p = -1$ and $(-1)^{p-1} = 1$.
+  have h_odd : (-1 : ℤ√2) ^ p = -1 ∧ (-1 : ℤ√2) ^ (p - 1) = 1 := by
+    rcases hp.eq_two_or_odd' with rfl | ⟨m, rfl⟩
+    · contradiction
+    · constructor
+      · simp [pow_succ, pow_mul]
+      · simp [pow_mul]
+  have h_sum_div :
+      (p : ℤ√2) ^ 2 ∣
+        ∑ k ∈ Finset.Icc 2 p,
+          Nat.choose p k * (-1 : ℤ√2) ^ (p - k) * (p : ℤ√2) ^ k * w ^ k := by
+    exact Finset.dvd_sum fun x hx =>
+      dvd_mul_of_dvd_left
+        (dvd_mul_of_dvd_right (pow_dvd_pow _ <| Finset.mem_Icc.mp hx |>.1) _)
+        _
+  obtain ⟨a, ha⟩ := h_sum_div
+  simp_all +decide only [pow_succ, mul_assoc, mul_left_comm]
+  exact ⟨⟨w.re + a.re, by simp; ring_nf⟩, ⟨w.im + a.im, by simp; ring_nf⟩⟩
+
+/-
+=== Main theorem ===
+-/
+lemma pell_boost (p : ℕ) (hp : p.Prime) (hp5 : p % 8 = 5) :
+    let L := (p + 1) / 2 * p
+    (p : ℤ) ^ 2 ∣ pellX L + 1 ∧ (p : ℤ) ^ 2 ∣ pellY L := by
+  -- Let $L = (p+1)/2 * p$.
+  set L := (p + 1) / 2 * p with hL;
+  have h_div :
+      (p : ℤ) ^ 2 ∣ ((⟨1, 1⟩ : ℤ√2) ^ (2 * L)).re + 1 ∧
+        (p : ℤ) ^ 2 ∣ ((⟨1, 1⟩ : ℤ√2) ^ (2 * L)).im := by
+    convert hensel_lift p hp ( by
+      rintro rfl
+      norm_num at hp5 ) ( ⟨ 1, 1 ⟩ ^ ( p + 1 ) ) _ _ using 1;
+    · rw [← pow_mul, show 2 * L = (p + 1) * p by
+        nlinarith [Nat.div_mul_cancel
+          (show 2 ∣ p + 1 from Nat.dvd_of_mod_eq_zero (by omega))]]
+    · rw [← pow_mul, show 2 * L = (p + 1) * p by
+        nlinarith [Nat.div_mul_cancel
+          (show 2 ∣ p + 1 from even_iff_two_dvd.mp (by
+            simpa [parity_simps] using hp.eq_two_or_odd'.resolve_left (by
+              rintro rfl
+              norm_num at hp5)))]]
+    · exact eps_succ_mod p hp hp5 |>.1;
+    · exact eps_succ_mod p hp hp5 |>.2;
+  -- By alpha_pow, α^L = ⟨pellX L, 2*pellY L⟩.
+  have h_alpha_pow : (⟨1, 1⟩ : ℤ√2) ^ (2 * L) = ⟨pellX L, 2 * pellY L⟩ := by
+    convert alpha_pow L using 1;
+    rw [ pow_mul ]; aesop;
+  rw [h_alpha_pow] at h_div
+  constructor
+  · exact h_div.1
+  refine Int.dvd_of_dvd_mul_right_of_gcd_one h_div.2 ?_
+  exact_mod_cast Nat.Coprime.pow_left 2 (hp.coprime_iff_not_dvd.mpr fun h => by
+    have := Nat.le_of_dvd (by decide) h
+    interval_cases p <;> trivial)
+
+/-! ## From BOOST to divisibility of n_j + 2 -/
+
+/-- If `pellX L ≡ -1 (mod m)` and `pellY L ≡ 0 (mod m)` with `L` odd, then
+`m ∣ 4·((pellX ((L+1)/2))² + 1)`. This uses the doubling formula for Pell sequences. -/
+lemma pell_sq_plus_one_div (L : ℕ) (m : ℤ) (_hm : 0 < m)
+    (hx : m ∣ pellX L + 1) (hy : m ∣ pellY L)
+    (hL_odd : L % 2 = 1) :
+    m ∣ 4 * (pellX ((L + 1) / 2) ^ 2 + 1) := by
+  have h_double : pellX ((L + 1) / 2 * 2) = 2 * pellX ((L + 1) / 2) ^ 2 - 1 := by
+    have h_double : ∀ j : ℕ, pellX (2 * j) = 2 * pellX j ^ 2 - 1 := by
+      intro j
+      induction j with
+      | zero => simp
+      | succ j ih =>
+        have h_ind : ∀ j : ℕ, pellX (2 * j) = 2 * pellX j ^ 2 - 1 ∧
+            pellY (2 * j) = 2 * pellX j * pellY j := by
+          intro j; induction j with
+          | zero => simp
+          | succ j ih₂ =>
+            simp only [Nat.mul_succ, pellX_succ, pellY_succ]
+            constructor <;> [rw [ih₂.2]; rw [ih₂.2]] <;> nlinarith [pell_identity j]
+        simp only [Nat.mul_succ, pellX_succ, pellY_succ]
+        rw [h_ind j |>.2]; nlinarith [pell_identity j]
+    rw [mul_comm, h_double]
+  rw [show (L + 1) / 2 * 2 = L + 1 by omega] at h_double
+  -- Now: 4*(pellX((L+1)/2)² + 1) = 2*(pellX(L+1) + 3) = 6*(pellX L + 1) + 16*pellY L
+  have htarget :
+      4 * (pellX ((L + 1) / 2) ^ 2 + 1) = 6 * (pellX L + 1) + 16 * pellY L := by
+    rw [pellX_succ] at h_double
+    linarith
+  rw [htarget]
+  exact dvd_add (hx.mul_left 6) (hy.mul_left 16)
+
+/-
+For a prime `p ≡ 5 mod 8`, setting `j = ((p+1)/2·p + 1) / 2`, we have
+`p² ∣ pellN j + 2` (as integers).
+-/
+lemma prime_sq_dvd_pellN_plus2 (p : ℕ) (hp : p.Prime) (hp5 : p % 8 = 5) :
+    let L := (p + 1) / 2 * p
+    let j := (L + 1) / 2
+    (p : ℤ) ^ 2 ∣ (pellN j + 2 : ℤ) := by
+  obtain ⟨L, hL⟩ :
+      ∃ L : ℕ, L = (p + 1) / 2 * p ∧
+        (p : ℤ) ^ 2 ∣ pellX L + 1 ∧ (p : ℤ) ^ 2 ∣ pellY L := by
+    exact ⟨ _, rfl, pell_boost p hp hp5 ⟩;
+  obtain ⟨j, hj⟩ :
+      ∃ j : ℕ, j = (L + 1) / 2 ∧ (p : ℤ) ^ 2 ∣ pellX j ^ 2 + 1 := by
+    obtain ⟨j, hj⟩ :
+        ∃ j : ℕ, j = (L + 1) / 2 ∧
+          (p : ℤ) ^ 2 ∣ 4 * (pellX j ^ 2 + 1) := by
+      refine ⟨_, rfl, ?_⟩
+      exact pell_sq_plus_one_div L _ (sq_pos_of_pos (Nat.cast_pos.mpr hp.pos))
+        hL.2.1 hL.2.2 (by
+          norm_num [hL.1, Nat.add_mod, Nat.mul_mod, Nat.pow_mod, hp5]
+          norm_num [← Nat.mod_mod_of_dvd p (by decide : 2 ∣ 8), hp5]
+          omega)
+    refine ⟨j, hj.1, ?_⟩
+    refine Int.dvd_of_dvd_mul_right_of_gcd_one hj.2 ?_
+    exact_mod_cast Nat.Coprime.pow_left 2 (hp.coprime_iff_not_dvd.mpr fun h => by
+      have := Nat.le_of_dvd (by decide) h
+      interval_cases p <;> trivial)
+  -- Transfer divisibility from `pellX j ^ 2 + 1` to `pellN j + 2`.
+  have h_div : (p : ℤ) ^ 2 ∣ pellN j + 2 := by
+    convert hj.2 using 1;
+    rw [pellN_eq, show pellX j ^ 2 = 8 * pellY j ^ 2 + 1 by
+      linarith [pell_identity j]]
+    ring
+  aesop
+
+/-! ## Key lemma and main theorem
+
+### Assembly + Divergence (combined in `erdos367_key`)
+
+Given a finite set `S` of primes `≡ 5 mod 8`, form
+`L = lcm_{p∈S}((p+1)/2 · p)` (odd), set `j = (L+1)/2`. By a generalized BOOST
+(extending `pell_boost` to odd multiples via `α^{kL₀} = (α^{L₀})^k ≡ (-1)^k`),
+`p² ∣ n_j + 2` for each `p ∈ S`. Since the `p²` are coprime,
+`B₂(n_j+2) ≥ ∏_{p∈S} p²`.
+
+The ratio `∏ p² / log(n_j)` grows as `(1/log α) · ∏ 2p/(p+1) → ∞`,
+since each factor `2p/(p+1) > 1` and there are infinitely many such primes
+(Dirichlet: `Nat.setOf_prime_and_eq_mod_infinite` in Mathlib).
+-/
+
+/-! ### Helper lemmas for erdos367_key -/
+
+/-
+K1a: If `m ∣ z.re - 1` and `m ∣ z.im`, then for all `k`,
+`m ∣ (z ^ k).re - 1` and `m ∣ (z ^ k).im`.
+-/
+lemma zsqrt2_pow_cong_one (m : ℤ) (z : ℤ√2) (k : ℕ)
+    (hre : m ∣ z.re - 1) (him : m ∣ z.im) :
+    m ∣ (z ^ k).re - 1 ∧ m ∣ (z ^ k).im := by
+  induction k with
+  | zero =>
+    norm_num
+  | succ k ih =>
+    simp only [pow_succ, Zsqrtd.re_mul, Zsqrtd.im_mul]
+    constructor
+    · rw [show (z ^ k).re * z.re + 2 * (z ^ k).im * z.im - 1 =
+          ((z ^ k).re - 1) * z.re + (z ^ k).im * (2 * z.im) + (z.re - 1) by
+        ring]
+      exact dvd_add
+        (dvd_add (dvd_mul_of_dvd_left ih.1 z.re) (dvd_mul_of_dvd_left ih.2 (2 * z.im)))
+        hre
+    · rw [show (z ^ k).re * z.im + (z ^ k).im * z.re =
+          ((z ^ k).re - 1) * z.im + (z ^ k).im * z.re + z.im by
+        ring]
+      exact dvd_add
+        (dvd_add (dvd_mul_of_dvd_left ih.1 z.im) (dvd_mul_of_dvd_left ih.2 z.re))
+        him
+
+/-
+K1b: If `m ∣ z.re + 1` and `m ∣ z.im` in `ℤ√2`,
+and `t` is odd, then `m ∣ (z ^ t).re + 1` and `m ∣ (z ^ t).im`.
+-/
+lemma zsqrt2_odd_pow_neg_one (m : ℤ) (z : ℤ√2) (t : ℕ)
+    (hre : m ∣ z.re + 1) (him : m ∣ z.im) (ht : t % 2 = 1) :
+    m ∣ (z ^ t).re + 1 ∧ m ∣ (z ^ t).im := by
+  rcases Nat.even_or_odd' t with ⟨k, rfl | rfl⟩
+  · omega
+  · simp only [pow_succ, pow_mul, pow_zero, one_mul, Zsqrtd.re_mul, Zsqrtd.im_mul]
+    have hsq_re : m ∣ (z * z).re - 1 := by
+      simp only [Zsqrtd.re_mul]
+      rw [show z.re * z.re + 2 * z.im * z.im - 1 =
+          (z.re + 1) * (z.re - 1) + z.im * (2 * z.im) by
+        ring]
+      exact dvd_add (dvd_mul_of_dvd_left hre (z.re - 1))
+        (dvd_mul_of_dvd_left him (2 * z.im))
+    have hsq_im : m ∣ (z * z).im := by
+      simp only [Zsqrtd.im_mul]
+      rw [show z.re * z.im + z.im * z.re = z.im * (2 * z.re) by ring]
+      exact dvd_mul_of_dvd_left him (2 * z.re)
+    have hpow := zsqrt2_pow_cong_one m (z * z) k hsq_re hsq_im
+    constructor
+    · rw [show ((z * z) ^ k).re * z.re + 2 * ((z * z) ^ k).im * z.im + 1 =
+          (((z * z) ^ k).re - 1) * z.re + ((z * z) ^ k).im * (2 * z.im) +
+            (z.re + 1) by
+        ring]
+      exact dvd_add
+        (dvd_add (dvd_mul_of_dvd_left hpow.1 z.re)
+          (dvd_mul_of_dvd_left hpow.2 (2 * z.im)))
+        hre
+    · exact dvd_add (dvd_mul_of_dvd_right him (((z * z) ^ k).re))
+        (dvd_mul_of_dvd_left hpow.2 z.re)
+
+/-
+Generalized boost: for prime `p ≡ 5 mod 8`, if `M_p ∣ L` and `L` is odd,
+then `p² ∣ pellN ((L+1)/2) + 2`.
+-/
+lemma generalized_boost_pellN (p : ℕ) (hp : p.Prime) (hp5 : p % 8 = 5)
+    (L : ℕ) (hL_dvd : (p + 1) / 2 * p ∣ L) (hL_odd : L % 2 = 1) :
+    p ^ 2 ∣ pellN ((L + 1) / 2) + 2 := by
+  -- Let $M = (p + 1) / 2 * p$.
+  set M := (p + 1) / 2 * p;
+  -- Since $M \mid L$, we have $L = M * t$ for some integer $t$.
+  obtain ⟨t, ht⟩ : ∃ t : ℕ, L = M * t := hL_dvd;
+  -- By pell_boost, $(p : ℤ)^2 | pellX M + 1$ and $(p : ℤ)^2 | pellY M$.
+  have h_boost : (p : ℤ)^2 ∣ pellX M + 1 ∧ (p : ℤ)^2 ∣ pellY M := by
+    convert pell_boost p hp hp5 using 1;
+  -- By zsqrt2_odd_pow_neg_one, $(p : ℤ)^2 | pellX L + 1$ and $(p : ℤ)^2 | pellY L$.
+  have h_odd_pow : (p : ℤ)^2 ∣ pellX L + 1 ∧ (p : ℤ)^2 ∣ pellY L := by
+    convert zsqrt2_odd_pow_neg_one
+        (p ^ 2 : ℤ) (⟨3, 2⟩ ^ M) t _ _ _ using 1 <;>
+      norm_num [ht]
+    · rw [ ← pow_mul, alpha_pow ];
+    · rw [ ← pow_mul, alpha_pow ]; norm_num [ pellX, pellY ];
+      exact ⟨
+        fun h => dvd_mul_of_dvd_right h _,
+        fun h => by
+          exact Int.dvd_of_dvd_mul_right_of_gcd_one h <| by
+            exact_mod_cast Nat.Coprime.pow_left 2 <|
+              hp.coprime_iff_not_dvd.mpr fun h => by
+                have := Nat.le_of_dvd (by norm_num) h
+                interval_cases p <;> trivial⟩
+    · convert h_boost.1 using 1;
+      exact congr_arg₂ _ ( congr_arg Zsqrtd.re ( alpha_pow M ) ) rfl;
+    · rw [show ((⟨3, 2⟩ : ℤ√2) ^ M).im = 2 * pellY M
+        from congr_arg Zsqrtd.im (alpha_pow M)]
+      exact h_boost.2.mul_left 2
+    · cases Nat.mod_two_eq_zero_or_one t <;> simp_all +decide [ Nat.mul_mod ];
+  -- By pell_sq_plus_one_div, $(p : ℤ)^2 | 4 * (pellX ((L + 1) / 2)^2 + 1)$.
+  have h_div : (p : ℤ)^2 ∣ 4 * (pellX ((L + 1) / 2)^2 + 1) := by
+    convert pell_sq_plus_one_div L (p ^ 2) (pow_pos (Nat.cast_pos.mpr hp.pos) 2)
+      h_odd_pow.1 h_odd_pow.2 hL_odd using 1
+  -- Since $p$ is odd, we have $(p : ℤ)^2 \mid pellX ((L + 1) / 2)^2 + 1$.
+  have h_div_odd : (p : ℤ)^2 ∣ pellX ((L + 1) / 2)^2 + 1 := by
+    refine Int.dvd_of_dvd_mul_right_of_gcd_one h_div ?_
+    exact_mod_cast Nat.Coprime.pow_left 2 (hp.coprime_iff_not_dvd.mpr fun h => by
+      have := Nat.le_of_dvd (by decide) h
+      interval_cases p <;> trivial)
+  convert h_div_odd using 1;
+  rw [ ← Int.natCast_dvd_natCast ]; norm_num [ L3 ];
+  rw [ max_eq_left ( pellX_pos _ |> le_of_lt ) ]
+
+/-- Infinitely many primes are ≡ 5 mod 8. -/
+lemma infinite_primes_5_mod_8 : Set.Infinite {p : ℕ | p.Prime ∧ p % 8 = 5} := by
+  have hinf : Set.Infinite {p : ℕ | p.Prime ∧ (p : ZMod 8) = 5} :=
+    Nat.infinite_setOf_prime_and_eq_mod (by decide)
+  apply hinf.mono
+  intro p ⟨hp, hp5⟩
+  refine ⟨hp, ?_⟩
+  have : (p : ZMod 8) = ((5 : ℕ) : ZMod 8) := by exact_mod_cast hp5
+  rw [ZMod.natCast_eq_natCast_iff'] at this
+  omega
+
+/-
+From an infinite set, extract a finset of any desired cardinality.
+-/
+lemma exists_finset_of_infinite {α : Type*} {S : Set α} (hS : S.Infinite) (n : ℕ) :
+    ∃ T : Finset α, n ≤ T.card ∧ ∀ x ∈ T, x ∈ S := by
+  rcases hS.exists_subset_card_eq n with ⟨ T, hT ⟩; aesop
+
+/-
+For a finset of distinct primes, if each `p^2 ∣ m`, then `∏ p^2 ∣ m`.
+-/
+lemma finset_coprime_sq_dvd (S : Finset ℕ) (m : ℕ)
+    (hS : ∀ p ∈ S, p.Prime) (hdvd : ∀ p ∈ S, p ^ 2 ∣ m) :
+    S.prod (fun p => p ^ 2) ∣ m := by
+  induction S using Finset.induction with
+  | empty => simp
+  | insert p S hpS ih =>
+      rw [Finset.prod_insert hpS]
+      apply Nat.Coprime.mul_dvd_of_dvd_of_dvd
+      · exact Nat.Coprime.prod_right fun x hx =>
+          Nat.Coprime.pow _ _ <|
+            (hS p (Finset.mem_insert_self p S)).coprime_iff_not_dvd.mpr fun hpx_dvd =>
+              hpS <| by
+                have hpx := (Nat.prime_dvd_prime_iff_eq
+                  (hS p (Finset.mem_insert_self p S))
+                  (hS x (Finset.mem_insert_of_mem hx))).mp hpx_dvd
+                simpa [hpx] using hx
+      · exact hdvd p (Finset.mem_insert_self p S)
+      · exact ih
+          (fun q hq => hS q (Finset.mem_insert_of_mem hq))
+          (fun q hq => hdvd q (Finset.mem_insert_of_mem hq))
+
+/-
+Upper bound: `pellN j < 11 ^ (2 * j)` for `j ≥ 1`.
+-/
+lemma pellN_lt_eleven_pow (j : ℕ) (_hj : 0 < j) : pellN j < 11 ^ (2 * j) := by
+  rw [ pow_mul' ];
+  rw [ show pellN j = ( pellX j |> Int.toNat ) ^ 2 - 1 from ?_ ];
+  · rw [ tsub_lt_iff_left ];
+    · exact lt_add_of_pos_of_le zero_lt_one
+        (Nat.pow_le_pow_left (by
+          linarith [pellX_le_pow j,
+            Int.toNat_of_nonneg (show 0 ≤ pellX j from le_of_lt (pellX_pos j))]) 2)
+    · exact Nat.one_le_pow _ _ (by
+        linarith [pellX_pos j, Int.toNat_of_nonneg (le_of_lt (pellX_pos j))])
+  · exact eq_tsub_of_add_eq ( L0 j )
+
+/-
+Product of `(p+1)/2 * p` is odd when all `p ≡ 5 mod 8`.
+-/
+lemma prod_Mp_odd (S : Finset ℕ) (hS : ∀ p ∈ S, p % 8 = 5) :
+    S.prod (fun p => (p + 1) / 2 * p) % 2 = 1 := by
+  rw [Finset.prod_nat_mod, Finset.prod_eq_one] <;> norm_num
+  intro p hp
+  rw [← Nat.mod_add_div p 8, hS p hp]
+  norm_num [Nat.add_mod, Nat.mul_mod]
+  omega
+
+/-
+Product of `(p+1)/2 * p` is positive when `S` is nonempty and elements are primes ≡ 5 mod 8.
+-/
+lemma prod_Mp_pos (S : Finset ℕ) (hS : ∀ p ∈ S, p.Prime ∧ p % 8 = 5) (_hne : S.Nonempty) :
+    0 < S.prod (fun p => (p + 1) / 2 * p) := by
+  exact Finset.prod_pos fun p hp =>
+    mul_pos
+      (Nat.div_pos (by linarith [Nat.Prime.two_le (hS p hp |>.1)]) zero_lt_two)
+      (Nat.Prime.pos (hS p hp |>.1))
+
+/-
+For `p ≥ 5`, `3 * p ^ 2 ≥ 5 * ((p + 1) / 2 * p)`.
+-/
+lemma ratio_bound_per_prime (p : ℕ) (hp : 5 ≤ p) (_hp_odd : p % 2 = 1) :
+    5 * ((p + 1) / 2 * p) ≤ 3 * p ^ 2 := by
+  nlinarith [ Nat.div_mul_le_self ( p + 1 ) 2 ]
+
+/-
+Product ratio bound: `(5/3)^|S| * ∏ M_p ≤ ∏ p²` ∈ ℕ,
+or equivalently `5^|S| * ∏ M_p ≤ 3^|S| * ∏ p²`.
+-/
+lemma prod_ratio_bound_nat (S : Finset ℕ) (hS : ∀ p ∈ S, 5 ≤ p ∧ p % 2 = 1) :
+    5 ^ S.card * S.prod (fun p => (p + 1) / 2 * p) ≤
+    3 ^ S.card * S.prod (fun p => p ^ 2) := by
+  induction S using Finset.induction with
+  | empty => simp
+  | insert p S hpS ih =>
+      rw [Finset.card_insert_of_notMem hpS, Finset.prod_insert hpS, Finset.prod_insert hpS]
+      simp only [pow_succ]
+      convert Nat.mul_le_mul
+        (ratio_bound_per_prime _ (hS p (Finset.mem_insert_self p S)).1
+          (hS p (Finset.mem_insert_self p S)).2)
+        (ih (fun q hq => hS q (Finset.mem_insert_of_mem hq))) using 1 <;> ring
+
+/-
+**Key lemma.** For every `N`, there exists `j ≥ 1` such that
+`powerfulPart(n_j + 2) > N · log(n_j)`.
+-/
+lemma erdos367_key :
+    ∀ N : ℝ, ∃ j : ℕ, 0 < j ∧
+      (powerfulPart (pellN j + 2) : ℝ) > N * Real.log (pellN j : ℝ) := by
+  intro N
+  by_cases hN : N ≤ 0;
+  · use 1
+    refine ⟨by norm_num, lt_of_le_of_lt
+      (mul_nonpos_of_nonpos_of_nonneg hN (by positivity)) ?_⟩
+    exact_mod_cast (by
+      unfold powerfulPart
+      apply Finset.prod_pos
+      intro p hp
+      simp only [Nat.support_factorization, Nat.mem_primeFactors] at hp
+      simp only [ge_iff_le]
+      split_ifs with h
+      · exact pow_pos hp.1.pos _
+      · exact Nat.one_pos :
+        0 < powerfulPart (pellN 1 + 2))
+  · -- Choose s with (5/3:ℝ)^s > max 1 (2 * N * Real.log 11) using pow_unbounded_of_one_lt.
+    obtain ⟨s, hs⟩ : ∃ s : ℕ, (5 / 3 : ℝ) ^ s > max 1 (2 * N * Real.log 11) := by
+      exact pow_unbounded_of_one_lt _ <| by norm_num;
+    -- Extract a finite set of primes `p ≡ 5 mod 8`.
+    obtain ⟨S, hS_card, hS⟩ :
+        ∃ S : Finset ℕ, s ≤ S.card ∧ ∀ p ∈ S, p.Prime ∧ p % 8 = 5 := by
+      exact Exists.elim (exists_finset_of_infinite infinite_primes_5_mod_8 s) fun S hS =>
+        ⟨S, hS.1, fun p hp => hS.2 p hp⟩
+    -- Set L := S.prod (fun p => (p + 1) / 2 * p) and j := (L + 1) / 2.
+    set L := S.prod (fun p => (p + 1) / 2 * p)
+    set j := (L + 1) / 2;
+    -- Show L is odd and L > 0.
+    have hL_odd : L % 2 = 1 := by
+      exact prod_Mp_odd S fun p hp => hS p hp |>.2
+    have hL_pos : 0 < L := by
+      exact Finset.prod_pos fun p hp =>
+        mul_pos
+          (Nat.div_pos (by linarith [Nat.Prime.two_le (hS p hp |>.1)]) zero_lt_two)
+          (Nat.Prime.pos (hS p hp |>.1))
+    have hj_pos : 0 < j := by
+      exact Nat.div_pos ( by linarith ) zero_lt_two
+    have h_prod_sq_dvd : S.prod (fun p => p ^ 2) ∣ powerfulPart (pellN j + 2) := by
+      apply finset_coprime_sq_dvd;
+      · exact fun p hp => hS p hp |>.1;
+      · intro p hp
+        have h_div : p ^ 2 ∣ pellN j + 2 := by
+          apply generalized_boost_pellN p (hS p hp).left (hS p hp).right L
+            (Finset.dvd_prod_of_mem _ hp) hL_odd
+        exact powerfulPart_ge_of_prime_sq_dvd (by linarith [pellN_pos hj_pos])
+          (hS p hp |>.1) h_div
+    have h_prod_sq_ge : (S.prod (fun p => p ^ 2) : ℝ) ≥ (5 / 3 : ℝ) ^ s * L := by
+      have h_prod_sq_ge : (S.prod (fun p => p ^ 2) : ℝ) ≥
+          (5 / 3 : ℝ) ^ S.card * L := by
+        have h_prod_sq_ge :
+            ∀ p ∈ S, (p ^ 2 : ℝ) ≥ (5 / 3 : ℝ) * (((p : ℝ) + 1) / 2 * p) := by
+          intro p hp
+          nlinarith only [show (p : ℝ) ≥ 5 by
+            exact_mod_cast le_of_not_gt fun h => by
+              have := hS p hp
+              interval_cases p <;> trivial]
+        have h_lower_nonneg :
+            ∀ p ∈ S, 0 ≤ (5 / 3 : ℝ) * (((p : ℝ) + 1) / 2 * p) := by
+          intro p hp
+          positivity
+        have h_lower_le_sq :
+            (∏ p ∈ S, (5 / 3 : ℝ) * (((p : ℝ) + 1) / 2 * p)) ≤
+              ∏ p ∈ S, (p : ℝ) ^ 2 :=
+          Finset.prod_le_prod h_lower_nonneg h_prod_sq_ge
+        have hL_le :
+            (L : ℝ) ≤ ∏ p ∈ S, (((p : ℝ) + 1) / 2 * p) := by
+          change ((S.prod (fun p => (p + 1) / 2 * p) : ℕ) : ℝ) ≤
+            ∏ p ∈ S, (((p : ℝ) + 1) / 2 * p)
+          rw [Nat.cast_prod]
+          exact Finset.prod_le_prod (fun p hp => by positivity) fun p hp => by
+            rw [Nat.cast_mul]
+            have hdiv : (((p + 1) / 2 : ℕ) : ℝ) ≤ ((p : ℝ) + 1) / 2 := by
+              rw [le_div_iff₀ (by positivity : (0 : ℝ) < 2)]
+              norm_cast
+              exact Nat.div_mul_le_self (p + 1) 2
+            exact mul_le_mul_of_nonneg_right hdiv (Nat.cast_nonneg p)
+        have h_first :
+            (5 / 3 : ℝ) ^ S.card * L ≤
+              ∏ p ∈ S, (5 / 3 : ℝ) * (((p : ℝ) + 1) / 2 * p) := by
+          rw [Finset.prod_mul_distrib, Finset.prod_const]
+          exact mul_le_mul_of_nonneg_left hL_le (by positivity)
+        exact le_trans h_first h_lower_le_sq
+      exact le_trans
+          (mul_le_mul_of_nonneg_right
+            (pow_le_pow_right₀ (by norm_num) hS_card)
+            (Nat.cast_nonneg _))
+          h_prod_sq_ge
+    have h_log_bound : Real.log (pellN j) < (L + 1) * Real.log 11 := by
+      have h_log_bound : Real.log (pellN j) < Real.log (11 ^ (2 * j)) := by
+        exact Real.log_lt_log (Nat.cast_pos.mpr <| pellN_pos hj_pos) <|
+            mod_cast pellN_lt_eleven_pow j hj_pos
+      norm_num at *
+      exact h_log_bound.trans_le
+          (mul_le_mul_of_nonneg_right
+            (by norm_cast; omega)
+            (Real.log_nonneg (by norm_num)))
+    have h_final_bound : (S.prod (fun p => p ^ 2) : ℝ) > 2 * N * Real.log 11 * L := by
+      exact lt_of_lt_of_le
+          (mul_lt_mul_of_pos_right
+            (lt_of_le_of_lt (le_max_right _ _) hs)
+            (Nat.cast_pos.mpr hL_pos))
+          h_prod_sq_ge
+    have h_final_ineq :
+        (powerfulPart (pellN j + 2) : ℝ) > N * Real.log (pellN j) := by
+      have h_final_ineq :
+          (powerfulPart (pellN j + 2) : ℝ) ≥ (S.prod (fun p => p ^ 2) : ℝ) := by
+        norm_cast
+        refine Nat.le_of_dvd ?_ h_prod_sq_dvd
+        exact Nat.pos_of_ne_zero (by
+            exact Finsupp.prod_ne_zero_iff.mpr fun p hp => by aesop)
+      nlinarith [
+          show (L : ℝ) ≥ 1 by exact_mod_cast hL_pos,
+          show (Real.log 11 : ℝ) > 0 by positivity,
+          show (N : ℝ) > 0 by exact_mod_cast lt_of_not_ge hN,
+          mul_le_mul_of_nonneg_left
+            (show (L : ℝ) ≥ 1 by exact_mod_cast hL_pos)
+            (show (0 : ℝ) ≤ N by exact_mod_cast le_of_not_ge hN)]
+    use j, hj_pos, h_final_ineq
+
+/-- **Main theorem (Erdős #367).** For every `M : ℝ`, there exists `n : ℕ` such that
+`B₂(n) · B₂(n+1) · B₂(n+2) > M · n² · log(n)`.
+
+This captures `limsup_{n→∞} B₂(n)·B₂(n+1)·B₂(n+2) / (n²·log n) = ∞`. -/
+theorem erdos367 :
+    ∀ M : ℝ, ∃ n : ℕ,
+      (powerfulPart n * powerfulPart (n + 1) * powerfulPart (n + 2) : ℝ) >
+        M * (n : ℝ) ^ 2 * Real.log (n : ℝ) := by
+  intro M
+  obtain ⟨j, hj, hbig⟩ := erdos367_key M
+  refine ⟨pellN j, ?_⟩
+  rw [show pellN j + 1 + 1 = pellN j + 2 from by ring, L1 hj, L2]
+  have hnj_pos : (0 : ℝ) < pellN j := Nat.cast_pos.mpr (pellN_pos hj)
+  have hcast : (↑(pellN j + 1) : ℝ) = ↑(pellN j) + 1 := by push_cast; ring
+  rw [hcast]
+  by_cases hM : 0 ≤ M * Real.log ↑(pellN j)
+  · calc ↑(pellN j) * (↑(pellN j) + 1) * (↑(powerfulPart (pellN j + 2)) : ℝ)
+        > ↑(pellN j) * (↑(pellN j) + 1) * (M * Real.log ↑(pellN j)) :=
+          mul_lt_mul_of_pos_left hbig (by positivity)
+      _ ≥ ↑(pellN j) ^ 2 * (M * Real.log ↑(pellN j)) := by
+          nlinarith [sq_nonneg (↑(pellN j) : ℝ)]
+      _ = M * ↑(pellN j) ^ 2 * Real.log ↑(pellN j) := by ring
+  · push Not at hM
+    have h1 : M * ↑(pellN j) ^ 2 * Real.log ↑(pellN j) < 0 := by
+      have : (↑(pellN j) : ℝ) ^ 2 > 0 := by positivity
+      nlinarith
+    linarith [show (0 : ℝ) ≤ ↑(pellN j) * (↑(pellN j) + 1) *
+      ↑(powerfulPart (pellN j + 2)) from by positivity]
+
+
+end Erdos367
+
+end

--- a/LeanPool/Erdos367/PellLimsup.lean
+++ b/LeanPool/Erdos367/PellLimsup.lean
@@ -25,7 +25,9 @@ import Aesop
 We prove that `limsup_{n→∞} B₂(n)·B₂(n+1)·B₂(n+2) / (n²·log n) = ∞`,
 where `B₂(m) = ∏_{p^e ∥ m, e≥2} p^e` is the powerful (2-full) part of `m`.
 
-Equivalently: `∀ M : ℝ, ∃ n : ℕ, B₂(n) * B₂(n+1) * B₂(n+2) > M * n² * log n`.
+Equivalently (the cofinal form, which is what makes it a `limsup` rather than a
+mere `sup`): `∀ M : ℝ, ∀ N : ℕ, ∃ n ≥ N, B₂(n) * B₂(n+1) * B₂(n+2) > M * n² * log n`,
+i.e. the ratio exceeds every `M` for arbitrarily large `n`.
 
 ## Strategy
 
@@ -36,8 +38,8 @@ has a large powerful part thanks to the algebraic structure of `ℤ[√2]`.
 ## What is proved
 
 All lemmas and theorems are fully proved with no `sorry` statements.
-The final `#print axioms erdos367` shows only the standard axioms:
-`propext`, `Classical.choice`, `Lean.ofReduceBool`, `Lean.trustCompiler`, `Quot.sound`.
+`#print axioms erdos367` shows only the three standard axioms:
+`propext`, `Classical.choice`, `Quot.sound`.
 -/
 
 noncomputable section
@@ -185,6 +187,15 @@ theorem pellY_le_pellX (j : ℕ) : pellY j ≤ pellX j := by
     simp only [pellX_succ, pellY_succ]
     linarith [pellY_nonneg n, pellX_pos n]
 
+/-- Lower bound: `j ≤ Y_j`. The Pell `Y`-sequence grows at least linearly, so the
+witness index `j` can be pushed arbitrarily large. -/
+theorem pellY_ge_self (j : ℕ) : (j : ℤ) ≤ pellY j := by
+  induction j with
+  | zero => simp
+  | succ n ih =>
+    simp only [pellY_succ, Nat.cast_succ]
+    linarith [pellX_pos n]
+
 /-- Upper bound: `pellX j ≤ 11 ^ j`. -/
 theorem pellX_le_pow (j : ℕ) : pellX j ≤ 11 ^ j := by
   induction j with
@@ -210,6 +221,15 @@ lemma pellN_eq (j : ℕ) : (pellN j : ℤ) = 8 * pellY j ^ 2 := by
 lemma pellN_pos {j : ℕ} (hj : 0 < j) : 0 < pellN j := by
   have h : (0 : ℤ) < 8 * pellY j ^ 2 := by positivity [pellY_pos hj]
   have := pellN_eq j; omega
+
+/-- Lower bound: `j ≤ n_j`. Since `n_j = 8·Y_j²` and `j ≤ Y_j`, the witness `n_j`
+grows at least linearly, so it exceeds any prescribed threshold. -/
+theorem pellN_ge_self (j : ℕ) : j ≤ pellN j := by
+  have hY : (j : ℤ) ≤ pellY j := pellY_ge_self j
+  have hYnn : (0 : ℤ) ≤ pellY j := pellY_nonneg j
+  have heq := pellN_eq j
+  have : (j : ℤ) ≤ pellN j := by nlinarith [sq_nonneg ((pellY j) - j)]
+  exact_mod_cast this
 
 /-- **L0.** `n_j + 1 = X_j²` (as natural numbers). -/
 theorem L0 (j : ℕ) : pellN j + 1 = (pellX j).toNat ^ 2 := by
@@ -729,17 +749,22 @@ lemma prod_ratio_bound_nat (S : Finset ℕ) (hS : ∀ p ∈ S, 5 ≤ p ∧ p % 2
         (ih (fun q hq => hS q (Finset.mem_insert_of_mem hq))) using 1 <;> ring
 
 /-
-**Key lemma.** For every `N`, there exists `j ≥ 1` such that
-`powerfulPart(n_j + 2) > N · log(n_j)`.
+**Key lemma.** For every threshold `j₀` and every `N`, there exists `j ≥ j₀` (with
+`j ≥ 1`) such that `powerfulPart(n_j + 2) > N · log(n_j)`. The lower bound `j₀`
+lets the caller push the witness index — and hence `n_j` — arbitrarily large,
+which is what turns the bound into a genuine `limsup = ∞` statement.
 -/
-lemma erdos367_key :
-    ∀ N : ℝ, ∃ j : ℕ, 0 < j ∧
+lemma erdos367_key (j₀ : ℕ) :
+    ∀ N : ℝ, ∃ j : ℕ, j₀ ≤ j ∧ 0 < j ∧
       (powerfulPart (pellN j + 2) : ℝ) > N * Real.log (pellN j : ℝ) := by
   intro N
   by_cases hN : N ≤ 0;
-  · use 1
-    refine ⟨by norm_num, lt_of_le_of_lt
-      (mul_nonpos_of_nonpos_of_nonneg hN (by positivity)) ?_⟩
+  · refine ⟨max 1 j₀, le_max_right _ _, lt_of_lt_of_le one_pos (le_max_left _ _), ?_⟩
+    have hjpos : 0 < max 1 j₀ := lt_of_lt_of_le one_pos (le_max_left _ _)
+    have hlog : 0 ≤ Real.log (pellN (max 1 j₀) : ℝ) :=
+      Real.log_nonneg (by exact_mod_cast pellN_pos hjpos)
+    refine lt_of_le_of_lt
+      (mul_nonpos_of_nonpos_of_nonneg hN hlog) ?_
     exact_mod_cast (by
       unfold powerfulPart
       apply Finset.prod_pos
@@ -749,18 +774,40 @@ lemma erdos367_key :
       split_ifs with h
       · exact pow_pos hp.1.pos _
       · exact Nat.one_pos :
-        0 < powerfulPart (pellN 1 + 2))
+        0 < powerfulPart (pellN (max 1 j₀) + 2))
   · -- Choose s with (5/3:ℝ)^s > max 1 (2 * N * Real.log 11) using pow_unbounded_of_one_lt.
     obtain ⟨s, hs⟩ : ∃ s : ℕ, (5 / 3 : ℝ) ^ s > max 1 (2 * N * Real.log 11) := by
       exact pow_unbounded_of_one_lt _ <| by norm_num;
-    -- Extract a finite set of primes `p ≡ 5 mod 8`.
-    obtain ⟨S, hS_card, hS⟩ :
-        ∃ S : Finset ℕ, s ≤ S.card ∧ ∀ p ∈ S, p.Prime ∧ p % 8 = 5 := by
-      exact Exists.elim (exists_finset_of_infinite infinite_primes_5_mod_8 s) fun S hS =>
-        ⟨S, hS.1, fun p hp => hS.2 p hp⟩
+    -- Extract a finite set of primes `p ≡ 5 mod 8`, large enough to also force
+    -- the witness index `j ≥ j₀` (we request `max s (2 * j₀)` of them).
+    obtain ⟨S, hS_card_max, hS⟩ :
+        ∃ S : Finset ℕ, max s (2 * j₀) ≤ S.card ∧ ∀ p ∈ S, p.Prime ∧ p % 8 = 5 := by
+      exact Exists.elim (exists_finset_of_infinite infinite_primes_5_mod_8 (max s (2 * j₀)))
+        fun S hS => ⟨S, hS.1, fun p hp => hS.2 p hp⟩
+    have hS_card : s ≤ S.card := le_trans (le_max_left _ _) hS_card_max
+    have hS_card_j : 2 * j₀ ≤ S.card := le_trans (le_max_right _ _) hS_card_max
     -- Set L := S.prod (fun p => (p + 1) / 2 * p) and j := (L + 1) / 2.
-    set L := S.prod (fun p => (p + 1) / 2 * p)
-    set j := (L + 1) / 2;
+    set L := S.prod (fun p => (p + 1) / 2 * p) with hL_def
+    set j := (L + 1) / 2 with hj_def
+    -- Each prime factor contributes a factor ≥ 2, so `L ≥ 2 ^ |S| ≥ |S| ≥ 2·j₀`,
+    -- hence `j = (L + 1) / 2 ≥ j₀`.
+    have hj0_le : j₀ ≤ j := by
+      have hfac : ∀ p ∈ S, 2 ≤ (p + 1) / 2 * p := by
+        intro p hp
+        have hp5 := (hS p hp).2
+        have hp5le : 5 ≤ p := by
+          rcases Nat.lt_or_ge p 5 with h | h
+          · interval_cases p <;> omega
+          · exact h
+        have h1 : 3 ≤ (p + 1) / 2 := by omega
+        calc 2 ≤ 3 * 5 := by norm_num
+          _ ≤ (p + 1) / 2 * p := Nat.mul_le_mul h1 hp5le
+      have h2card : 2 ^ S.card ≤ L := by
+        calc 2 ^ S.card = ∏ _p ∈ S, 2 := by rw [Finset.prod_const]
+          _ ≤ L := Finset.prod_le_prod' hfac
+      have hcard_le : S.card ≤ 2 ^ S.card := Nat.lt_two_pow_self.le
+      have hj0_le_L : 2 * j₀ ≤ L := le_trans hS_card_j (le_trans hcard_le h2card)
+      omega
     -- Show L is odd and L > 0.
     have hL_odd : L % 2 = 1 := by
       exact prod_Mp_odd S fun p hp => hS p hp |>.2
@@ -851,19 +898,21 @@ lemma erdos367_key :
           mul_le_mul_of_nonneg_left
             (show (L : ℝ) ≥ 1 by exact_mod_cast hL_pos)
             (show (0 : ℝ) ≤ N by exact_mod_cast le_of_not_ge hN)]
-    use j, hj_pos, h_final_ineq
+    use j, hj0_le, hj_pos, h_final_ineq
 
-/-- **Main theorem (Erdős #367).** For every `M : ℝ`, there exists `n : ℕ` such that
-`B₂(n) · B₂(n+1) · B₂(n+2) > M · n² · log(n)`.
+/-- **Main theorem (Erdős #367).** For every `M : ℝ` and every threshold `N : ℕ`,
+there exists `n ≥ N` such that `B₂(n) · B₂(n+1) · B₂(n+2) > M · n² · log(n)`.
 
-This captures `limsup_{n→∞} B₂(n)·B₂(n+1)·B₂(n+2) / (n²·log n) = ∞`. -/
+Because the bound holds for arbitrarily large `n`, this is the genuine
+`limsup_{n→∞} B₂(n)·B₂(n+1)·B₂(n+2) / (n²·log n) = ∞`, not merely a supremum:
+the ratio exceeds every `M` cofinally often. -/
 theorem erdos367 :
-    ∀ M : ℝ, ∃ n : ℕ,
+    ∀ M : ℝ, ∀ N : ℕ, ∃ n : ℕ, N ≤ n ∧
       (powerfulPart n * powerfulPart (n + 1) * powerfulPart (n + 2) : ℝ) >
         M * (n : ℝ) ^ 2 * Real.log (n : ℝ) := by
-  intro M
-  obtain ⟨j, hj, hbig⟩ := erdos367_key M
-  refine ⟨pellN j, ?_⟩
+  intro M N
+  obtain ⟨j, hj0, hj, hbig⟩ := erdos367_key N M
+  refine ⟨pellN j, le_trans hj0 (pellN_ge_self j), ?_⟩
   rw [show pellN j + 1 + 1 = pellN j + 2 from by ring, L1 hj, L2]
   have hnj_pos : (0 : ℝ) < pellN j := Nat.cast_pos.mpr (pellN_pos hj)
   have hcast : (↑(pellN j + 1) : ℝ) = ↑(pellN j) + 1 := by push_cast; ring

--- a/LeanPool/Erdos367/RFullLowerBound.lean
+++ b/LeanPool/Erdos367/RFullLowerBound.lean
@@ -1,0 +1,201 @@
+/-
+Copyright (c) 2026 Scott D. Hughes. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott D. Hughes
+-/
+
+import Mathlib.Algebra.Order.BigOperators.GroupWithZero.Finset
+import Mathlib.Algebra.Ring.GeomSum
+import Mathlib.Data.Finsupp.SMul
+import Mathlib.Data.Nat.Factorization.Defs
+import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.IntervalCases
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Push
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Zify
+import Aesop
+
+/-!
+# Erdős #367: r-full part and the odd-r extension
+
+For a positive integer m with prime factorization m = ∏ p^{a_p}, and r ≥ 1,
+the r-full part is B_r(m) = ∏_{p : a_p ≥ r} p^{a_p}.
+
+Main theorem: for odd r ≥ 1 and q ≥ 2, with n = (q^r - 1)^r,
+  (i)   B_r(n) = n,
+  (ii)  q^r ∣ n + 1,
+  (iii) B_r(n) · B_r(n+1) ≥ n · q^r,
+  (iv)  (B_r(n) · B_r(n+1))^r > n^{r+1}.
+-/
+
+namespace RFullOdd
+
+open Finset Finsupp Nat
+
+/-! ## Definition of the r-full part -/
+
+/-- The r-full part of m: the product of prime-power components p^{a_p} of m
+    for which the exponent a_p ≥ r. -/
+noncomputable def rFullPart (r m : ℕ) : ℕ :=
+  (m.factorization.filter (fun p => r ≤ m.factorization p)).prod (fun p v => p ^ v)
+
+/-! ## Factorization of rFullPart -/
+
+/-
+The factorization of rFullPart r m equals the filtered factorization of m.
+-/
+lemma rFullPart_factorization (r m : ℕ) (_hm : m ≠ 0) :
+    (rFullPart r m).factorization =
+      m.factorization.filter (fun p => r ≤ m.factorization p) := by
+  unfold rFullPart
+  apply Nat.prod_pow_factorization_eq_self
+  intro p hp
+  have hp_support : p ∈ m.factorization.support := by
+    rw [Finsupp.support_filter] at hp
+    exact Finset.mem_of_mem_filter p hp
+  exact Nat.prime_of_mem_primeFactors (by simpa [Nat.support_factorization] using hp_support)
+
+/-
+rFullPart r m is nonzero when m is nonzero.
+-/
+lemma rFullPart_pos (r m : ℕ) (_hm : m ≠ 0) : 0 < rFullPart r m := by
+  exact Finset.prod_pos fun p hp =>
+    pow_pos (Nat.pos_of_mem_primeFactors (Finset.mem_filter.mp hp |>.1)) _
+
+/-! ## Key properties of rFullPart -/
+
+/-
+B_r(m) divides m.
+-/
+lemma rFullPart_dvd (r m : ℕ) (hm : m ≠ 0) : rFullPart r m ∣ m := by
+  have h_factorization :
+      rFullPart r m =
+        ∏ p ∈ Nat.primeFactors m,
+          p ^ (if r ≤ m.factorization p then m.factorization p else 0) := by
+    unfold rFullPart
+    simpa [Finsupp.prod, Finset.prod_ite] using
+      (Finset.prod_congr rfl fun x hx => by
+        rw [Finsupp.filter_apply]
+        aesop)
+  conv_rhs => rw [← Nat.prod_factorization_pow_eq_self hm]
+  exact h_factorization.symm ▸
+    Finset.prod_dvd_prod_of_dvd _ _ fun p hp => by
+      split_ifs <;> simp +decide [*]
+
+/-
+L1: A perfect r-th power is r-full: B_r(m^r) = m^r for m ≥ 1 and r ≥ 1.
+-/
+lemma rFullPart_pow (r m : ℕ) (hm : m ≠ 0) (hr : r ≠ 0) :
+    rFullPart r (m ^ r) = m ^ r := by
+  apply Nat.factorization_inj
+  · exact Nat.ne_of_gt ( rFullPart_pos _ _ ( pow_ne_zero _ hm ) );
+  · aesop;
+  · ext p
+    by_cases hp : p.Prime
+    · rw [rFullPart_factorization _ _ (pow_ne_zero _ hm)]
+      by_cases h : r ≤ r * m.factorization p
+      · simp only [Nat.factorization_pow, Finsupp.coe_smul, Pi.smul_apply,
+          smul_eq_mul, Finsupp.filter_smul, mul_eq_mul_left_iff,
+          Finsupp.filter_apply, h]
+        left
+        rfl
+      · simp only [Nat.factorization_pow, Finsupp.coe_smul, Pi.smul_apply,
+          smul_eq_mul, Finsupp.filter_smul, mul_eq_mul_left_iff,
+          Finsupp.filter_apply, h]
+        left
+        cases hv : m.factorization p with
+        | zero => rfl
+        | succ v =>
+            exfalso
+            apply h
+            rw [hv]
+            exact Nat.le_mul_of_pos_right r (Nat.succ_pos v)
+    · simp_all +decide [rFullPart_factorization]
+
+/-
+If d^r ∣ m and m ≠ 0, then d^r ∣ B_r(m).
+-/
+lemma pow_dvd_rFullPart (r m d : ℕ) (hm : m ≠ 0) (hdvd : d ^ r ∣ m) :
+    d ^ r ∣ rFullPart r m := by
+  by_cases hr : r = 0
+  · simp [hr]
+  rw [ ← Nat.factorization_le_iff_dvd ];
+  · intro p
+    have := Nat.factorization_le_iff_dvd
+      (show d ^ r ≠ 0 from by aesop)
+      (show m ≠ 0 from hm) |>.2 hdvd
+    simp_all +decide [Finsupp.le_def]
+    by_cases h : r ≤ m.factorization p <;> simp_all +decide [ rFullPart_factorization ];
+    nlinarith [ this p ];
+  · aesop;
+  · exact Nat.ne_of_gt ( rFullPart_pos r m hm )
+
+/-- If d^r ∣ m and m ≠ 0, then d^r ≤ B_r(m). -/
+lemma pow_le_rFullPart (r m d : ℕ) (hm : m ≠ 0) (hdvd : d ^ r ∣ m) :
+    d ^ r ≤ rFullPart r m :=
+  Nat.le_of_dvd (rFullPart_pos r m hm) (pow_dvd_rFullPart r m d hm hdvd)
+
+/-! ## L2: Odd-power divisibility -/
+
+/-
+For odd r and a ≥ 1, (a + 1) ∣ (a^r + 1).
+    Proof: a ≡ -1 (mod a+1), so a^r ≡ (-1)^r = -1 (mod a+1).
+-/
+lemma odd_pow_add_one_dvd (r a : ℕ) (hr : Odd r) :
+    (a + 1) ∣ (a ^ r + 1) := by
+  simpa using hr.nat_add_dvd_pow_add_pow a 1
+
+/-! ## Main theorem: the odd-r case -/
+
+variable {r q : ℕ}
+
+/-- (i) B_r(n) = n where n = (q^r - 1)^r. -/
+theorem erdos367_i (hr : 0 < r) (hq : 2 ≤ q) :
+    rFullPart r ((q ^ r - 1) ^ r) = (q ^ r - 1) ^ r := by
+  apply rFullPart_pow
+  · have : 2 ≤ q ^ r := le_trans hq (Nat.le_self_pow hr.ne' q)
+    omega
+  · exact hr.ne'
+
+/-
+(ii) q^r ∣ (q^r - 1)^r + 1.
+-/
+theorem erdos367_ii (hr : Odd r) (hq : 2 ≤ q) :
+    q ^ r ∣ (q ^ r - 1) ^ r + 1 := by
+  convert odd_pow_add_one_dvd r ( q ^ r - 1 ) hr using 1;
+  rw [ Nat.sub_add_cancel ( Nat.one_le_pow _ _ ( by linarith ) ) ]
+
+/-- B_r(n+1) ≥ q^r. -/
+theorem erdos367_Br_succ_ge (hr_odd : Odd r) (_hr : 0 < r) (hq : 2 ≤ q) :
+    q ^ r ≤ rFullPart r ((q ^ r - 1) ^ r + 1) := by
+  apply pow_le_rFullPart r _ q
+  · positivity
+  · exact erdos367_ii hr_odd hq
+
+/-- (iii) B_r(n) · B_r(n+1) ≥ n · q^r. -/
+theorem erdos367_iii (hr_odd : Odd r) (hr : 0 < r) (hq : 2 ≤ q) :
+    (q ^ r - 1) ^ r * q ^ r ≤
+      rFullPart r ((q ^ r - 1) ^ r) * rFullPart r ((q ^ r - 1) ^ r + 1) := by
+  rw [erdos367_i hr hq]
+  exact Nat.mul_le_mul_left _ (erdos367_Br_succ_ge hr_odd hr hq)
+
+/-
+(iv) (B_r(n) · B_r(n+1))^r > n^(r+1).
+-/
+theorem erdos367_iv (hr_odd : Odd r) (hr : 0 < r) (hq : 2 ≤ q) :
+    ((q ^ r - 1) ^ r) ^ (r + 1) <
+      (rFullPart r ((q ^ r - 1) ^ r) * rFullPart r ((q ^ r - 1) ^ r + 1)) ^ r := by
+  refine lt_of_lt_of_le ?_ (Nat.pow_le_pow_left (erdos367_iii hr_odd hr hq) r)
+  rw [mul_pow, pow_succ]
+  gcongr
+  · exact pow_pos
+      (pow_pos (Nat.sub_pos_of_lt (one_lt_pow₀ (by linarith) (by linarith))) _)
+      _
+  · exact Nat.sub_lt (by positivity) (by positivity)
+
+/-! ## Axiom verification -/
+
+end RFullOdd

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -3001,3 +3001,46 @@ projects:
       - commuting-probability
     msc:
       - "20P05"
+  - slug: erdos367
+    title: "Erdős Problem #367"
+    summary: Formalizes upper and lower bound results for powerful parts of products of consecutive integers, including abc-conditional upper bounds, an unconditional odd r-full lower bound, a Pell-style limsup theorem, and polynomial arithmetic cores.
+    branch: number theory
+    entry_module: LeanPool.Erdos367
+    authors:
+      - Scott D. Hughes
+    source:
+      title: Powerful parts of consecutive integers and Davenport-Zannier polynomials
+      authors:
+        - Scott D. Hughes
+      url: https://github.com/scottdhughes/erdos367
+      github_repo: scottdhughes/erdos367
+    status: verified
+    main_declarations:
+      - Erdos367.erdos_367_k3
+      - RFullOdd.erdos367_iv
+      - Erdos367.erdos367
+    main_results:
+      - declaration: Erdos367.erdos_367_k3
+        informal: Proves an abc-conditional k = 3 upper bound for the product of square-full parts of three consecutive integers.
+      - declaration: GeneralK.B2_upper_bound
+        informal: Proves a general-k upper bound for the square-full part of a product of consecutive integers from an explicit radical lower-bound hypothesis.
+      - declaration: RFullOdd.erdos367_iv
+        informal: Gives an unconditional odd r construction where the product of r-full parts of two consecutive integers is larger than the stated power of n.
+      - declaration: Erdos367.erdos367
+        informal: Proves an unconditional limsup form showing that the product of square-full parts of three consecutive integers exceeds any fixed multiple of n squared times log n.
+      - declaration: Core139.T3
+        informal: Proves the integer-form arithmetic core yielding the E3 at least 13/9 lower-bound construction under explicit prime-supply data.
+      - declaration: Core4027.IDENT
+        informal: Verifies the degree-27 polynomial identity used in the Davenport-Zannier construction.
+      - declaration: Core4027.T3
+        informal: Proves the integer-form arithmetic core yielding the E3 at least 40/27 lower-bound construction under explicit prime-supply data.
+    tags:
+      - number-theory
+      - erdos-problems
+      - powerful-numbers
+      - abc-conjecture
+      - pell-equations
+    msc:
+      - "11D09"
+      - "11N25"
+      - "11D45"

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -3014,6 +3014,7 @@ projects:
         - Scott D. Hughes
       url: https://github.com/scottdhughes/erdos367
       github_repo: scottdhughes/erdos367
+    license: Apache-2.0
     status: verified
     main_declarations:
       - Erdos367.erdos_367_k3


### PR DESCRIPTION
## Summary
- Import `scottdhughes/erdos367` into `LeanPool/Erdos367`.
- Register the project in `LeanPool/projects.yml` and regenerate `LeanPool.lean`.
- Omit upstream `AxiomAudit.lean`, which only contained diagnostic `#print axioms` commands.

Source: https://github.com/scottdhughes/erdos367 at `6666c2f1bf7be45a2b91e70a24b1f1a2ab8b672b`.

## Validation
- `LAKE_JOBS=1 lake build LeanPool.Erdos367`
- `lake exe mk_all --check`
- `LAKE_JOBS=1 lake exe runLinter LeanPool.Erdos367`
- `lake exe lint-style LeanPool/Erdos367 LeanPool/Erdos367.lean`
- `LAKE_JOBS=1 lake build LeanPool`
- `cd python && uv run python -m lean_pool.quality --repo ..`
