### PR TITLE
[import] frontiermath-hypergraphs — extremal hypergraph Ramsey lower bounds

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -629,6 +629,16 @@ import LeanPool.FriezePatterns
 import LeanPool.FriezePatterns.Chapter1
 import LeanPool.FriezePatterns.Chapter2
 import LeanPool.FriezePatterns.Chapter3
+import LeanPool.FrontierMathOpenHypergraphs
+import LeanPool.FrontierMathOpenHypergraphs.Basic
+import LeanPool.FrontierMathOpenHypergraphs.Lubell
+import LeanPool.FrontierMathOpenHypergraphs.Substitution
+import LeanPool.FrontierMathOpenHypergraphs.Uniform
+import LeanPool.FrontierMathOpenHypergraphs.Uniform.FrameBoosters
+import LeanPool.FrontierMathOpenHypergraphs.Uniform.FrameDefs
+import LeanPool.FrontierMathOpenHypergraphs.Uniform.FrameExact
+import LeanPool.FrontierMathOpenHypergraphs.Uniform.FrameResidues
+import LeanPool.FrontierMathOpenHypergraphs.Uniform.Frames
 import LeanPool.GrothendieckVanishing
 import LeanPool.GrothendieckVanishing.ClosedImmersion
 import LeanPool.GrothendieckVanishing.ClosedImmersionCohomology

--- a/LeanPool/FrontierMathOpenHypergraphs.lean
+++ b/LeanPool/FrontierMathOpenHypergraphs.lean
@@ -1,0 +1,21 @@
+/-
+Copyright (c) 2026 Dean Cureton. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dean Cureton
+-/
+
+import LeanPool.FrontierMathOpenHypergraphs.Basic
+import LeanPool.FrontierMathOpenHypergraphs.Substitution
+import LeanPool.FrontierMathOpenHypergraphs.Uniform
+import LeanPool.FrontierMathOpenHypergraphs.Lubell
+
+/-!
+# FrontierMath Ramsey Hypergraphs
+
+Source: arxiv:1908.10914, doi:10.1016/j.ejc.2021.103349
+Authors: Dean Cureton
+Status: verified
+Main declarations: `HypergraphLowerBound.thm_main_H_lower_bound`
+Tags: combinatorics, hypergraphs, ramsey-theory, extremal-combinatorics, frontiermath
+MSC: 05C65, 05D10, 03E02
+-/

--- a/LeanPool/FrontierMathOpenHypergraphs/Basic.lean
+++ b/LeanPool/FrontierMathOpenHypergraphs/Basic.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 Dean Cureton. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dean Cureton
+-/
+
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Finset.Union
+import Mathlib.Data.Nat.Basic
+import Mathlib.Order.Lattice.Nat
+
+/-!
+# Basic definitions for the hypergraph lower bound
+
+Basic definitions and the substitution theorem for the hypergraph lower bound.
+-/
+
+open Finset
+
+namespace HypergraphLowerBound
+
+/-! ## Hypergraph definitions -/
+
+/-- A finite hypergraph on `V`, encoded by its finite edge family. -/
+abbrev Hypergraph (V : Type*) := Finset (Finset V)
+
+/-- A family of hypergraphs indexed by `ι`. -/
+abbrev HypergraphFamily (ι : Type*) (V : Type*) := ι → Hypergraph V
+
+/-- The vertex set of a hypergraph given by its edge set: the union of all edges. -/
+noncomputable def vertexSet {V : Type*} [DecidableEq V]
+    (edges : Hypergraph V) : Finset V :=
+  edges.biUnion id
+
+/-- The unique coverage count: the number of vertices belonging to exactly one edge in P. -/
+noncomputable def uniqueCoverage {V : Type*} [DecidableEq V]
+    (edges : Hypergraph V) (P : Hypergraph V) : ℕ :=
+  (vertexSet edges).filter (fun v => (P.filter (fun e => v ∈ e)).card = 1) |>.card
+
+/-- A hypergraph contains no partition of size greater than n. -/
+def NoLargePartition {V : Type*} [DecidableEq V]
+    (edges : Hypergraph V) (n : ℕ) : Prop :=
+  ∀ P : Hypergraph V, P ⊆ edges → uniqueCoverage edges P ≤ n
+
+/-- `H n` is the largest number of vertices of a finite hypergraph with no isolated
+    vertices and no partition of size greater than `n`.
+
+    In this development hypergraphs are encoded by their edge sets, so "no isolated
+    vertices" is reflected by taking the vertex set to be the union of the edges. -/
+noncomputable def H (n : ℕ) : ℕ :=
+  sSup {k : ℕ | ∃ (edges : Hypergraph ℕ),
+    (vertexSet edges).card = k ∧ NoLargePartition edges n}
+
+/-! ## The benchmark sequence k_n -/
+
+/-- The benchmark sequence k(n) defined by k(1) = 1 and
+    k(n) = ⌊n/2⌋ + k(⌊n/2⌋) + k(⌊(n+1)/2⌋) for n ≥ 2. -/
+def k : ℕ → ℕ
+  | 0 => 0
+  | 1 => 1
+  | n + 2 =>
+    let half := (n + 2) / 2
+    let halfUp := (n + 3) / 2
+    half + k half + k halfUp
+termination_by n => n
+
+/-- The partition problem is equivalent to bounding unique coverage. -/
+theorem partition_iff_uniqueCoverage {V : Type*} [DecidableEq V]
+    (edges : Hypergraph V) (n : ℕ) :
+    NoLargePartition edges n ↔
+    ∀ P : Hypergraph V, P ⊆ edges → uniqueCoverage edges P ≤ n :=
+  Iff.rfl
+
+end HypergraphLowerBound

--- a/LeanPool/FrontierMathOpenHypergraphs/Lubell.lean
+++ b/LeanPool/FrontierMathOpenHypergraphs/Lubell.lean
@@ -1,0 +1,2068 @@
+/-
+Copyright (c) 2026 Dean Cureton. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dean Cureton
+-/
+
+import Batteries.Tactic.OpenPrivate
+import Mathlib.Algebra.GCDMonoid.Finset
+import Mathlib.Algebra.Order.Group.Multiset
+import Mathlib.Analysis.Convex.Jensen
+import Mathlib.Analysis.SpecialFunctions.Log.NegMulLog
+import Mathlib.Data.Fintype.Fin
+import Mathlib.Data.Nat.Cast.Field
+import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Nat.Choose.Basic
+import Mathlib.Data.Nat.Choose.Cast
+import Mathlib.Data.Nat.Choose.Sum
+import Mathlib.Data.Nat.Log
+import Mathlib.Data.Finset.Powerset
+import Mathlib.Data.Multiset.Replicate
+import Mathlib.NumberTheory.Harmonic.Defs
+import Mathlib.NumberTheory.Harmonic.Bounds
+import Mathlib.Order.Filter.AtTopBot.Basic
+import Mathlib.Order.Filter.AtTopBot.Tendsto
+import Mathlib.Analysis.SpecialFunctions.Log.Base
+import Mathlib.Topology.Order.LiminfLimsup
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Order
+import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Ring
+import LeanPool.FrontierMathOpenHypergraphs.Basic
+import LeanPool.FrontierMathOpenHypergraphs.Substitution
+import LeanPool.FrontierMathOpenHypergraphs.Uniform
+
+/-!
+# Lubell frames and asymptotic context
+-/
+
+namespace HypergraphLowerBound
+
+open private WitnessStrong WitnessStrong.toWitnessData apply_frameData ws_singleton
+  exists_cover_subset_card_le_of_noLargePartition
+  from LeanPool.FrontierMathOpenHypergraphs.Uniform
+
+/-! ## The Lubell frame -/
+
+/-- M_t = lcm { C(t-1, r) : 1 ≤ r ≤ t-1 }. -/
+noncomputable def M (t : ℕ) : ℕ :=
+  (Finset.Icc 1 (t - 1)).lcm (fun r => Nat.choose (t - 1) r)
+
+/-- The multiplicity attached to each `j`-subset in the Lubell family. -/
+noncomputable def lubellMultiplicity (t j : ℕ) : ℕ :=
+  M t / Nat.choose (t - 1) (j - 1)
+
+/-- The constant capacity vector of the Lubell frame. -/
+noncomputable def lubellCap (t : ℕ) : Fin t → ℕ := Function.const (Fin t) (M t)
+
+/-- Embed a `j`-subset of `[t]` into the type of support patterns. -/
+private def supportPatternEmbedding {t j : ℕ} (hj : 2 ≤ j) :
+    {S // S ∈ (((Finset.univ : Finset (Fin t)).powersetCard j).val)} ↪ SupportPattern t where
+  toFun := fun S =>
+    ⟨S.1, by
+      have hmem : S.1 ∈ (Finset.univ : Finset (Fin t)).powersetCard j := by
+        simp
+      have hcard : S.1.card = j := (Finset.mem_powersetCard.mp hmem).2
+      omega
+    ⟩
+  inj' := by
+    intro a b h
+    exact Subtype.ext <| congrArg (fun x : SupportPattern t => x.1) h
+
+/-- All support patterns of size `j` on `[t]`, each occurring once. -/
+noncomputable def supportPatternsOfCard (t j : ℕ) : Multiset (SupportPattern t) :=
+  if hj : 2 ≤ j then
+    ((((Finset.univ : Finset (Fin t)).powersetCard j).val.attach).map
+      (supportPatternEmbedding (t := t) (j := j) hj))
+  else
+    0
+
+/-- The `j`-subsets in the Lubell multiset, each with the prescribed multiplicity. -/
+noncomputable def lubellLayer (t j : ℕ) : Multiset (SupportPattern t) :=
+  (supportPatternsOfCard t j).bind fun S =>
+    Multiset.replicate (lubellMultiplicity t j) S
+
+/-- The Lubell support multiset on `[t]`. -/
+noncomputable def lubellFrame (t : ℕ) : Multiset (SupportPattern t) :=
+  (Finset.Icc 2 t).val.bind (lubellLayer t)
+
+/-- The explicit cardinality expression for the Lubell frame. -/
+noncomputable def lubellCardSum (t : ℕ) : ℕ :=
+  (Finset.Icc 2 t).sum (fun j => Nat.choose t j * lubellMultiplicity t j)
+
+private lemma supportPatternsOfCard_card (t j : ℕ) (hj : 2 ≤ j) :
+    (supportPatternsOfCard t j).card = Nat.choose t j := by
+  simp only [supportPatternsOfCard, hj, dite_true]
+  rw [Multiset.card_map, Multiset.card_attach]
+  simp [Finset.card_powersetCard, Fintype.card_fin]
+
+private lemma lubellLayer_card (t j : ℕ) (hj : 2 ≤ j) :
+    (lubellLayer t j).card = Nat.choose t j * lubellMultiplicity t j := by
+  simp only [lubellLayer]
+  rw [Multiset.card_bind]
+  simp only [Function.comp, Multiset.card_replicate, Multiset.map_const',
+    Multiset.sum_replicate, Nat.nsmul_eq_mul, supportPatternsOfCard_card t j hj]
+
+/-- The omegaCount of a multiset is bounded by the count of elements satisfying
+    the predicate times the maximum multiplicity. This is proved at the level of
+    list indexing used in omegaCount. -/
+private lemma omegaCount_le_card_filter {t : ℕ}
+    (F : Multiset (SupportPattern t)) (T I : Finset (Fin t)) :
+    omegaCount F T I ≤ F.card := by
+  change ((Finset.univ : Finset (Fin F.card)).filter fun s =>
+      (supportPatternAt F s).1 ⊆ T ∧ ((supportPatternAt F s).1 ∩ I).card = 1).card ≤ F.card
+  calc ((Finset.univ.filter _).card : ℕ) ≤ Finset.univ.card := Finset.card_filter_le _ _
+    _ = F.card := by simp [Fintype.card_fin]
+
+/-! ### Vandermonde-Chu identity for the frame bound -/
+
+/-- The divisibility property of M: C(t-1, r) divides M(t) for 1 ≤ r ≤ t-1. -/
+private lemma M_dvd (t : ℕ) (r : ℕ) (hr1 : 1 ≤ r) (hr2 : r ≤ t - 1) :
+    Nat.choose (t - 1) r ∣ M t :=
+  Finset.dvd_lcm (Finset.mem_Icc.mpr ⟨hr1, hr2⟩)
+
+/-- When I ⊆ T ⊆ Fin t, no support pattern S ⊆ T with |S| ≥ 2 has |S ∩ T| = 1
+    when T = I (so T \ I = ∅). -/
+private lemma omegaCount_eq_zero_of_sdiff_empty {t : ℕ}
+    (F : Multiset (SupportPattern t)) (T I : Finset (Fin t))
+    (hIT : I ⊆ T) (hTI : T \ I = ∅) :
+    omegaCount F T I = 0 := by
+  have hTeqI : T = I := by
+    ext x; constructor
+    · intro hx
+      by_contra hxI
+      exact Finset.notMem_empty x (hTI ▸ Finset.mem_sdiff.mpr ⟨hx, hxI⟩)
+    · exact fun hx => hIT hx
+  unfold omegaCount
+  apply Finset.card_eq_zero.mpr
+  apply Finset.filter_eq_empty_iff.mpr
+  intro s _
+  push Not
+  intro hST
+  -- S ⊆ T = I, so S ∩ I = S, and |S| ≥ 2
+  have hSI : supportSetAt F s ∩ I = supportSetAt F s :=
+    Finset.inter_eq_left.mpr <| hTeqI ▸ hST
+  rw [hSI]
+  have h2 : 2 ≤ (supportSetAt F s).card := (supportPatternAt F s).2
+  omega
+
+/-! ### Infrastructure for the frame bound -/
+
+/-- Counting list indices satisfying a predicate equals list countP. -/
+private lemma list_filter_fin_eq_countP {α : Type*} (L : List α)
+    (P : α → Prop) [DecidablePred P] :
+    ((Finset.univ : Finset (Fin L.length)).filter (fun i => P (L.get i))).card =
+    L.countP (fun b => decide (P b)) :=
+  card_filter_univ_get_eq_countP_prop L P
+
+/-- Index-based counting on a multiset equals filter cardinality. -/
+private lemma multiset_index_filter_eq {α : Type*} (F : Multiset α)
+    (P : α → Prop) [DecidablePred P] :
+    ((Finset.univ : Finset (Fin F.card)).filter
+      (fun i => P (F.toList.get ⟨i.val, by rw [Multiset.length_toList]; exact i.isLt⟩))).card =
+    (Multiset.filter P F).card := by
+  set L := F.toList
+  have hlen : L.length = F.card := Multiset.length_toList F
+  have rhs : (Multiset.filter P F).card = L.countP (fun b => decide (P b)) := by
+    have : F = (L : Multiset α) := (Multiset.coe_toList F).symm
+    rw [this, Multiset.filter_coe, Multiset.coe_card, List.countP_eq_length_filter]
+  rw [rhs]
+  exact card_filter_univ_multiset_toList_eq_countP_prop F P
+
+/-- omegaCount equals the cardinality of the filtered multiset. -/
+private lemma oc_eq_filter_card {t : ℕ} (F : Multiset (SupportPattern t))
+    (T I : Finset (Fin t)) :
+    omegaCount F T I =
+      (F.filter (fun S : SupportPattern t => S.1 ⊆ T ∧ (S.1 ∩ I).card = 1)).card := by
+  unfold omegaCount supportSetAt
+  exact multiset_index_filter_eq F (fun S : SupportPattern t => S.1 ⊆ T ∧ (S.1 ∩ I).card = 1)
+
+/-- Filter of replicate gives conditional replicate. -/
+private lemma filter_replicate_eq {α : Type*} (P : α → Prop) [DecidablePred P]
+    (n : ℕ) (a : α) :
+    Multiset.filter P (Multiset.replicate n a) =
+      if P a then Multiset.replicate n a else 0 := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [Multiset.replicate_succ, Multiset.filter_cons]
+    simp only [ih]
+    split <;> simp
+
+/-! ### Vandermonde-Chu identity ingredients -/
+
+/-- Hockey-stick identity, reindexed: Σ_{r=0}^{z} C(n-r, z-r) = C(n+1, z). -/
+private lemma sum_choose_antidiag (n z : ℕ) (hz : z ≤ n) :
+    (Finset.range (z + 1)).sum (fun r => Nat.choose (n - r) (z - r)) =
+      Nat.choose (n + 1) z := by
+  have step1 : ∀ r ∈ Finset.range (z + 1),
+      Nat.choose (n - r) (z - r) = Nat.choose (n - r) (n - z) := by
+    intro r hr; rw [Finset.mem_range] at hr
+    have : n - r - (n - z) = z - r := by omega
+    rw [← this]; exact Nat.choose_symm (by omega)
+  rw [Finset.sum_congr rfl step1]
+  have hockey := Nat.sum_Icc_choose n (n - z)
+  have hchoose_eq : Nat.choose (n + 1) (n - z + 1) = Nat.choose (n + 1) z := by
+    rw [← show n + 1 - z = n - z + 1 from by omega, Nat.choose_symm (by omega : z ≤ n + 1)]
+  rw [hchoose_eq] at hockey; rw [← hockey]
+  apply Finset.sum_nbij (fun r => n - r)
+  · intro r hr
+    have : r ≤ z := by simp [Finset.mem_range] at hr; omega
+    exact Finset.mem_Icc.mpr ⟨by omega, by omega⟩
+  · intro r₁ hr₁ r₂ hr₂ h
+    have h1 : r₁ ≤ z := by simp at hr₁; omega
+    have h2 : r₂ ≤ z := by simp at hr₂; omega
+    dsimp at h; omega
+  · intro m hm
+    simp only [Set.mem_image, Finset.mem_coe]
+    have hm' := hm; rw [Finset.mem_coe, Finset.mem_Icc] at hm'
+    exact ⟨n - m, Finset.mem_range.mpr (by omega), by omega⟩
+  · intros; rfl
+
+/-- Binomial identity: C(t,z) * (t-z) = t * C(t-1,z) for 1 ≤ z ≤ t. -/
+private lemma choose_mul_sub (t z : ℕ) (hz : z ≤ t) (hz1 : 1 ≤ z) :
+    Nat.choose t z * (t - z) = t * Nat.choose (t - 1) z := by
+  cases t with
+  | zero => omega
+  | succ t =>
+    cases z with
+    | zero => omega
+    | succ z =>
+      simp only [Nat.succ_sub_succ_eq_sub]
+      have hpascal := Nat.choose_succ_succ t z
+      have habsorb := Nat.choose_succ_right_eq t z
+      calc Nat.choose (t + 1) (z + 1) * (t - z)
+          = (Nat.choose t z + Nat.choose t (z + 1)) * (t - z) := by rw [hpascal]
+        _ = Nat.choose t z * (t - z) + Nat.choose t (z + 1) * (t - z) := by ring
+        _ = Nat.choose t (z + 1) * (z + 1) + Nat.choose t (z + 1) * (t - z) := by rw [habsorb]
+        _ = Nat.choose t (z + 1) * (z + 1 + (t - z)) := by ring
+        _ = Nat.choose t (z + 1) * (t + 1) := by congr 1; omega
+        _ = (t + 1) * Nat.choose t (z + 1) := by ring
+
+/-- Term identity: C(z,r) * (M/C(n,r)) * C(n,z) = M * C(n-r,z-r). -/
+private lemma term_identity (n z r M : ℕ) (hr : r ≤ z)
+    (hdvd : Nat.choose n r ∣ M) :
+    Nat.choose z r * (M / Nat.choose n r) * Nat.choose n z =
+    M * Nat.choose (n - r) (z - r) := by
+  have hcm := @Nat.choose_mul (n := n) (k := z) (s := r) hr
+  calc Nat.choose z r * (M / Nat.choose n r) * Nat.choose n z
+      = (M / Nat.choose n r) * (Nat.choose n z * Nat.choose z r) := by ring
+    _ = (M / Nat.choose n r) * (Nat.choose n r * Nat.choose (n - r) (z - r)) := by rw [hcm]
+    _ = (M / Nat.choose n r * Nat.choose n r) * Nat.choose (n - r) (z - r) := by ring
+    _ = (Nat.choose n r * (M / Nat.choose n r)) * Nat.choose (n - r) (z - r) := by ring
+    _ = M * Nat.choose (n - r) (z - r) := by rw [Nat.mul_div_cancel' hdvd]
+
+/-- Sum identity: [Σ_{r=0}^{z} C(z,r)*(M/C(n,r))] * C(n,z) = M * C(n+1,z). -/
+private lemma sum_mul_choose_identity (n z M : ℕ) (hz : z ≤ n)
+    (hdvd : ∀ r, r ≤ z → Nat.choose n r ∣ M) :
+    (Finset.range (z + 1)).sum (fun r => Nat.choose z r * (M / Nat.choose n r)) *
+      Nat.choose n z = M * Nat.choose (n + 1) z := by
+  rw [Finset.sum_mul]
+  have h1 : ∀ r ∈ Finset.range (z + 1),
+      Nat.choose z r * (M / Nat.choose n r) * Nat.choose n z =
+      M * Nat.choose (n - r) (z - r) := by
+    intro r hr; rw [Finset.mem_range] at hr
+    exact term_identity n z r M (by omega) (hdvd r (by omega))
+  rw [Finset.sum_congr rfl h1, ← Finset.mul_sum, sum_choose_antidiag n z hz]
+
+/-- Product identity: [Σ_{r=0}^{z} C(z,r)*(M/C(n,r))] * (n+1-z) = M*(n+1)
+    when C(n,z) > 0, using the sum identity and C(n+1,z)*(n+1-z) = (n+1)*C(n,z). -/
+private lemma full_sum_product_identity (n z M : ℕ) (hz : 1 ≤ z) (hzn : z ≤ n)
+    (hdvd : ∀ r, r ≤ z → Nat.choose n r ∣ M) :
+    (Finset.range (z + 1)).sum (fun r => Nat.choose z r * (M / Nat.choose n r)) *
+      (n + 1 - z) = M * (n + 1) := by
+  have hcnz_pos : 0 < Nat.choose n z := Nat.choose_pos hzn
+  have hsum := sum_mul_choose_identity n z M hzn hdvd
+  -- hsum: Σ * C(n,z) = M * C(n+1,z)
+  have hcms := choose_mul_sub (n + 1) z (by omega) hz
+  -- hcms: C(n+1,z) * (n+1-z) = (n+1) * C(n,z)
+  -- We need: Σ * (n+1-z) = M * (n+1)
+  -- From hsum: Σ * C(n,z) = M * C(n+1,z)
+  -- Multiply by (n+1-z): Σ * C(n,z) * (n+1-z) = M * C(n+1,z) * (n+1-z) = M * (n+1) * C(n,z)
+  -- Cancel C(n,z): Σ * (n+1-z) = M * (n+1)
+  have h1 : (Finset.range (z + 1)).sum (fun r => Nat.choose z r * (M / Nat.choose n r)) *
+      (n + 1 - z) * Nat.choose n z = M * (n + 1) * Nat.choose n z := by
+    calc _ = (Finset.range (z + 1)).sum (fun r => Nat.choose z r * (M / Nat.choose n r)) *
+            Nat.choose n z * (n + 1 - z) := by ring
+      _ = M * Nat.choose (n + 1) z * (n + 1 - z) := by rw [hsum]
+      _ = M * (Nat.choose (n + 1) z * (n + 1 - z)) := by ring
+      _ = M * ((n + 1) * Nat.choose n z) := by
+            rw [show (n + 1 - 1 : ℕ) = n from by omega] at hcms; rw [hcms]
+      _ = M * (n + 1) * Nat.choose n z := by ring
+  exact Nat.eq_of_mul_eq_mul_right hcnz_pos h1
+
+/-- Counting bound: the number of j-subsets of T that intersect I in exactly 1 element
+    is at most I.card * C(|T\I|, j-1). -/
+private lemma good_subsets_le {t : ℕ} (j : ℕ)
+    (T I : Finset (Fin t)) (_hIT : I ⊆ T) :
+    ((T.powersetCard j).filter (fun S => (S ∩ I).card = 1)).card ≤
+      I.card * Nat.choose ((T \ I).card) (j - 1) := by
+  set goodSet := (T.powersetCard j).filter (fun S => (S ∩ I).card = 1) with hgood_def
+  -- Cover goodSet by fibers indexed by elements of I
+  have h_sub : goodSet ⊆ I.biUnion fun i => goodSet.filter fun S => i ∈ S := by
+    intro S hS
+    have hSmem := Finset.mem_filter.mp hS
+    have hSI := hSmem.2
+    have hne : (S ∩ I).Nonempty := Finset.card_pos.mp (by omega)
+    obtain ⟨x, hx⟩ := hne
+    rw [Finset.mem_biUnion]
+    exact ⟨x, (Finset.mem_inter.mp hx).2,
+      Finset.mem_filter.mpr ⟨hS, (Finset.mem_inter.mp hx).1⟩⟩
+  -- Each fiber has card ≤ C(|T\I|, j-1) via injection S ↦ S.erase i
+  have h_fib : ∀ i ∈ I,
+      (goodSet.filter fun S => i ∈ S).card ≤ Nat.choose ((T \ I).card) (j - 1) := by
+    intro i hi
+    rw [show Nat.choose ((T \ I).card) (j - 1) =
+        ((T \ I).powersetCard (j - 1)).card from
+        (Finset.card_powersetCard (j - 1) (T \ I)).symm]
+    apply Finset.card_le_card_of_injOn (Finset.erase · i)
+    · -- MapsTo: S.erase i ∈ (T\I).powersetCard (j-1)
+      intro S hS
+      rw [Finset.mem_coe] at hS
+      have hSmem := Finset.mem_filter.mp hS
+      have hiS := hSmem.2
+      have hSgood := Finset.mem_filter.mp hSmem.1
+      have hSpow := Finset.mem_powersetCard.mp hSgood.1
+      have hST := hSpow.1
+      have hScard := hSpow.2
+      have hSI := hSgood.2
+      -- S ∩ I = {i}
+      have hSI_eq : S ∩ I = {i} := by
+        obtain ⟨a, ha⟩ := Finset.card_eq_one.mp hSI
+        have : i ∈ ({a} : Finset (Fin t)) := ha ▸ Finset.mem_inter.mpr ⟨hiS, hi⟩
+        rw [Finset.mem_singleton] at this; subst this; exact ha
+      rw [Finset.mem_coe, Finset.mem_powersetCard]
+      constructor
+      · -- S.erase i ⊆ T \ I
+        intro v hv
+        rw [Finset.mem_sdiff]
+        constructor
+        · exact hST (Finset.mem_of_mem_erase hv)
+        · intro hvI
+          have : v ∈ S ∩ I := Finset.mem_inter.mpr ⟨Finset.mem_of_mem_erase hv, hvI⟩
+          rw [hSI_eq, Finset.mem_singleton] at this
+          exact absurd this (Finset.ne_of_mem_erase hv)
+      · -- |S.erase i| = j - 1
+        rw [Finset.card_erase_of_mem hiS, hScard]
+    · -- InjOn: S₁.erase i = S₂.erase i → S₁ = S₂
+      intro S₁ hS₁ S₂ hS₂ heq
+      rw [Finset.mem_coe] at hS₁ hS₂
+      have h1 := (Finset.mem_filter.mp hS₁).2
+      have h2 := (Finset.mem_filter.mp hS₂).2
+      dsimp at heq
+      rw [← Finset.insert_erase h1, ← Finset.insert_erase h2, heq]
+  -- Combine
+  calc goodSet.card
+      ≤ (I.biUnion fun i => goodSet.filter fun S => i ∈ S).card := Finset.card_le_card h_sub
+    _ ≤ I.card * Nat.choose ((T \ I).card) (j - 1) :=
+        Finset.card_biUnion_le_card_mul I _ _ h_fib
+
+/-- Sum of (if P then c else 0) over a multiset = c * (filter P).card. -/
+private lemma sum_ite_eq_mul_filter_card {α : Type*} (m : Multiset α)
+    (P : α → Prop) [DecidablePred P] (c : ℕ) :
+    (m.map (fun a => if P a then c else 0)).sum = c * (m.filter P).card := by
+  rw [← Multiset.countP_eq_card_filter]
+  induction m using Multiset.induction with
+  | empty => simp
+  | cons a m ih =>
+    simp only [Multiset.map_cons, Multiset.sum_cons, Multiset.countP_cons, ih]
+    split <;> ring
+
+/-- Filter cardinality of supportPatternsOfCard equals filter cardinality of powersetCard. -/
+private lemma spoc_filter_card {t j : ℕ} (hj : 2 ≤ j)
+    (Q : Finset (Fin t) → Prop) [DecidablePred Q] :
+    ((supportPatternsOfCard t j).filter (fun S : SupportPattern t => Q S.1)).card =
+      ((Finset.univ.powersetCard j).filter Q).card := by
+  simp only [supportPatternsOfCard, hj, dite_true]
+  rw [Multiset.filter_map, Multiset.card_map]
+  set s := (Finset.univ : Finset (Fin t)).powersetCard j
+  -- Both sides equal (s.val.filter Q).card
+  have lhs : (Multiset.filter (((fun S : SupportPattern t => Q S.1) ∘
+      ⇑(supportPatternEmbedding hj))) s.val.attach).card = (s.val.filter Q).card := by
+    rw [← Multiset.countP_eq_card_filter, ← Multiset.countP_eq_card_filter]
+    exact (Multiset.countP_congr rfl (fun x _ => rfl)).trans (Multiset.countP_attach Q s.val)
+  exact lhs
+
+/-- Splitting a range sum: (range (n+1)).sum f = f 0 + (range n).sum (fun i => f (i+1)). -/
+private lemma sum_range_shift (f : ℕ → ℕ) (n : ℕ) :
+    (Finset.range (n + 1)).sum f = f 0 + (Finset.range n).sum (fun i => f (i + 1)) := by
+  induction n with
+  | zero => simp
+  | succ k ih => rw [Finset.sum_range_succ, ih, Finset.sum_range_succ]; ring
+
+/-- Per-layer bound: the filtered card of a Lubell layer is bounded. -/
+private lemma layer_filter_card_bound {t : ℕ} (j : ℕ) (hj : 2 ≤ j)
+    (T I : Finset (Fin t)) (hIT : I ⊆ T) :
+    ((lubellLayer t j).filter
+      (fun S : SupportPattern t => S.1 ⊆ T ∧ (S.1 ∩ I).card = 1)).card ≤
+      I.card * Nat.choose ((T \ I).card) (j - 1) * (M t / Nat.choose (t - 1) (j - 1)) := by
+  set c := M t / Nat.choose (t - 1) (j - 1) with hc_def
+  set Q : Finset (Fin t) → Prop := fun S => S ⊆ T ∧ (S ∩ I).card = 1 with hQ_def
+  change ((lubellLayer t j).filter (fun S : SupportPattern t => Q S.1)).card ≤ _
+  simp only [lubellLayer]
+  rw [Multiset.filter_bind]
+  -- Fold c back into the goal
+  change ((supportPatternsOfCard t j).bind fun a =>
+    Multiset.filter (fun S : SupportPattern t => Q S.1) (Multiset.replicate c a)).card ≤ _
+  simp_rw [filter_replicate_eq (fun S : SupportPattern t => Q S.1) c]
+  rw [Multiset.card_bind]
+  simp only [Function.comp, apply_ite Multiset.card, Multiset.card_replicate,
+    Multiset.card_zero]
+  rw [sum_ite_eq_mul_filter_card (supportPatternsOfCard t j)
+    (fun S : SupportPattern t => Q S.1) c]
+  rw [spoc_filter_card hj Q]
+  have h_sub : ((Finset.univ.powersetCard j).filter Q) ⊆
+      (T.powersetCard j).filter (fun S => (S ∩ I).card = 1) := by
+    intro S hS
+    simp only [Finset.mem_filter, Finset.mem_powersetCard, hQ_def] at hS ⊢
+    exact ⟨⟨hS.2.1, hS.1.2⟩, hS.2.2⟩
+  calc c * ((Finset.univ.powersetCard j).filter Q).card
+      ≤ c * ((T.powersetCard j).filter (fun S => (S ∩ I).card = 1)).card :=
+        Nat.mul_le_mul_left c (Finset.card_le_card h_sub)
+    _ ≤ c * (I.card * Nat.choose ((T \ I).card) (j - 1)) :=
+        Nat.mul_le_mul_left c (good_subsets_le j T I hIT)
+    _ = I.card * Nat.choose ((T \ I).card) (j - 1) * c := by ring
+
+/-- The omegaCount of the Lubell frame is bounded by |T\I| * M(t).
+    This is the core combinatorial lemma, using the Vandermonde-Chu identity
+    ∑_{r=0}^{z} C(z,r)/C(n,r) = (n+1)/(n+1-z)
+    to show ω_{L_t}(T,I) = |I| · M_t · z/(t-z) ≤ z · M_t. -/
+private lemma lubell_omega_bound (t : ℕ) (ht : 2 ≤ t)
+    (T I : Finset (Fin t)) (hIT : I ⊆ T) :
+    omegaCount (lubellFrame t) T I ≤ (T \ I).card * M t := by
+  -- Handle the case T \ I = ∅
+  by_cases hTI : T \ I = ∅
+  · rw [Finset.card_eq_zero.mpr hTI, Nat.zero_mul]
+    exact Nat.le_of_eq (omegaCount_eq_zero_of_sdiff_empty _ T I hIT hTI)
+  -- Now T \ I ≠ ∅, so z = |T\I| ≥ 1
+  set z := (T \ I).card with hz_def
+  have hz_pos : 1 ≤ z := by
+    rw [hz_def]; exact Finset.one_le_card.mpr (Finset.nonempty_of_ne_empty hTI)
+  -- z ≤ t - 1 (since T ⊆ Fin t and I is nonempty or not, but T\I ⊊ T ⊆ Fin t)
+  have hzt : z ≤ t := by
+    exact card_finset_fin_le (T \ I)
+  -- |I| + z = |T|, so |I| ≤ t - z
+  have hIz : I.card + z = T.card := by
+    rw [hz_def]; have := Finset.card_sdiff_add_card_eq_card hIT; omega
+  have hI_le : I.card ≤ t - z := by
+    have hT_le : T.card ≤ t := by
+      exact card_finset_fin_le T
+    omega
+  -- Case split: I empty or not
+  by_cases hIcard : I.card = 0
+  · -- I empty → omegaCount = 0
+    suffices omegaCount (lubellFrame t) T I = 0 by omega
+    rw [oc_eq_filter_card, Multiset.card_eq_zero, Multiset.filter_eq_nil]
+    intro S _ ⟨_, hSI⟩
+    rw [Finset.card_eq_zero.mp hIcard, Finset.inter_empty, Finset.card_empty] at hSI
+    exact absurd hSI (by omega)
+  · -- I nonempty: z ≤ t - 1
+    have hzt1 : z ≤ t - 1 := by omega
+    -- Divisibility for the Vandermonde identity
+    have hdvd : ∀ r, r ≤ z → Nat.choose (t - 1) r ∣ M t := by
+      intro r hr
+      by_cases hr0 : r = 0; · simp [hr0]
+      simpa [hr0] using M_dvd t r (by omega) (by omega)
+    -- Define f and tail_sum
+    set f : ℕ → ℕ := fun r => Nat.choose z r * (M t / Nat.choose (t - 1) r) with hf_def
+    have hf0 : f 0 = M t := by simp [hf_def]
+    set tail_sum := (Finset.range z).sum (fun i => f (i + 1)) with hts_def
+    -- Vandermonde identity: (range (z+1)).sum f * (t - z) = M t * t
+    have hfull := full_sum_product_identity (t - 1) z (M t) hz_pos hzt1 hdvd
+    rw [show t - 1 + 1 = t from by omega] at hfull
+    -- Split the sum: (range (z+1)).sum f = M t + tail_sum
+    have hsplit : (Finset.range (z + 1)).sum f = M t + tail_sum := by
+      simpa [hf0] using sum_range_shift f z
+    -- Key identity: tail_sum * (t - z) = z * M t
+    have hkey : (t - z) * tail_sum = z * M t := by
+      rw [hsplit, Nat.add_mul] at hfull
+      have h2 : M t * t = M t * (t - z) + M t * z := by
+        rw [← Nat.mul_add]; congr 1; omega
+      lia
+    -- omegaCount ≤ I.card * tail_sum (layer decomposition + per-layer bounds)
+    have hoc_le : omegaCount (lubellFrame t) T I ≤ I.card * tail_sum := by
+      rw [oc_eq_filter_card]
+      show ((lubellFrame t).filter
+        (fun S : SupportPattern t => S.1 ⊆ T ∧ (S.1 ∩ I).card = 1)).card ≤ _
+      simp only [lubellFrame]
+      rw [Multiset.filter_bind, Multiset.card_bind]
+      -- Per-layer bound function
+      set bound := fun j : ℕ =>
+        I.card * Nat.choose z (j - 1) * (M t / Nat.choose (t - 1) (j - 1))
+      -- Step 1: pointwise per-layer bounds
+      apply le_trans
+      · simpa using Multiset.sum_map_le_sum_map _ bound (fun j hj =>
+          layer_filter_card_bound j ((Finset.mem_Icc.mp hj).1) T I hIT)
+      -- Step 2: factor out I.card and identify f
+      change ((Finset.Icc 2 t).val.map bound).sum ≤ I.card * tail_sum
+      have h_bound_eq : ∀ j, bound j = I.card * f (j - 1) := by
+        intro j; simp only [bound, hf_def]; ring
+      simp_rw [h_bound_eq]
+      rw [show (Multiset.map (fun j => I.card * f (j - 1)) (Finset.Icc 2 t).val).sum =
+          (Finset.Icc 2 t).sum (fun j => I.card * f (j - 1)) from rfl,
+        ← Finset.mul_sum]
+      -- Step 3: (Icc 2 t).sum (fun j => f(j-1)) = tail_sum (reindexing)
+      suffices h_eq : (Finset.Icc 2 t).sum (fun j => f (j - 1)) = tail_sum by
+        rw [h_eq]
+      rw [hts_def]
+      -- Vanishing terms: f r = 0 for r > z
+      have h_vanish : ∀ r : ℕ, z < r → f r = 0 := by
+        intro r hr; simp only [hf_def, Nat.choose_eq_zero_of_lt hr, Nat.zero_mul]
+      -- Reduce Icc 2 t to Icc 2 (z+1) by Finset.sum_subset (extra terms vanish)
+      have h_sub : Finset.Icc 2 (z + 1) ⊆ Finset.Icc 2 t := by
+        intro x hx; simp only [Finset.mem_Icc] at *; omega
+      rw [← Finset.sum_subset h_sub (fun j hj1 hj2 => by
+        apply h_vanish; simp only [Finset.mem_Icc] at hj1 hj2; omega)]
+      -- Reindex: (Icc 2 (z+1)).sum (fun j => f(j-1)) = (range z).sum (fun i => f(i+1))
+      -- Use Finset.sum_map with embedding (· + 2)
+      have h_map : Finset.Icc 2 (z + 1) =
+          (Finset.range z).map ⟨(· + 2), fun a b h => Nat.add_right_cancel h⟩ := by
+        ext j; simp only [Finset.mem_map, Finset.mem_range, Finset.mem_Icc,
+          Function.Embedding.coeFn_mk]
+        constructor
+        · intro ⟨h1, h2⟩; exact ⟨j - 2, by omega, by omega⟩
+        · rintro ⟨i, hi, rfl⟩; omega
+      rw [h_map, Finset.sum_map]
+      assumption
+    -- Final calc
+    calc omegaCount (lubellFrame t) T I
+        ≤ I.card * tail_sum := hoc_le
+      _ ≤ (t - z) * tail_sum := Nat.mul_le_mul_right _ hI_le
+      _ = z * M t := hkey
+
+/-- The Lubell multiset L_t is an (M_t, ..., M_t)-frame with
+    |L_t| = M_t * t * (h_t - 1). -/
+theorem lubell_is_frame (t : ℕ) (ht : 2 ≤ t) :
+    IsFrame (lubellFrame t) (lubellCap t) ∧
+    (lubellFrame t).card = lubellCardSum t := by
+  constructor
+  · -- Frame property: IsFrame (lubellFrame t) (lubellCap t)
+    intro T I hIT
+    simpa [lubellCap, Finset.sum_const, smul_eq_mul] using
+      lubell_omega_bound t ht T I hIT
+  · -- Cardinality
+    change Multiset.card ((Finset.Icc 2 t).val.bind (lubellLayer t)) = lubellCardSum t
+    rw [lubellCardSum]
+    rw [Multiset.card_bind]
+    congr 1
+    apply Multiset.map_congr rfl
+    intro j hj
+    have hj2 : 2 ≤ j := (Finset.mem_Icc.mp hj).1
+    exact lubellLayer_card t j hj2
+
+/-! ## Digit sum formula for k_n -/
+
+/-- Sum of binary digits of m. -/
+def s2 : ℕ → ℕ
+  | 0 => 0
+  | n + 1 => (n + 1) % 2 + s2 ((n + 1) / 2)
+termination_by n => n
+decreasing_by simp_all; omega
+
+/-- The prefix sum of binary digit counts appearing in the formula for `k n`. -/
+def digitSumPrefix (n : ℕ) : ℕ :=
+  (Finset.range n).sum s2
+
+private lemma s2_two_mul (m : ℕ) : s2 (2 * m) = s2 m := by
+  cases m with
+  | zero => rfl
+  | succ n =>
+    have h : 2 * (n + 1) = (2 * n + 1) + 1 := by omega
+    conv_lhs => rw [h]; unfold s2
+    have hmod : (2 * n + 2) % 2 = 0 := by omega
+    have hdiv : (2 * n + 2) / 2 = n + 1 := by omega
+    rw [hmod, hdiv]
+    simp
+
+private lemma s2_two_mul_add_one (m : ℕ) : s2 (2 * m + 1) = 1 + s2 m := by
+  conv_lhs => unfold s2
+  have hmod : (2 * m + 1) % 2 = 1 := by omega
+  have hdiv : (2 * m + 1) / 2 = m := by omega
+  rw [hmod, hdiv]
+
+private lemma k_two_mul (m : ℕ) (hm : 1 ≤ m) : k (2 * m) = m + 2 * k m := by
+  cases m with
+  | zero => omega
+  | succ n =>
+    have h : 2 * (n + 1) = 2 * n + 2 := by ring
+    conv_lhs => rw [h]; unfold k
+    have hdiv1 : (2 * n + 2) / 2 = n + 1 := by omega
+    have hdiv2 : (2 * n + 3) / 2 = n + 1 := by omega
+    rw [hdiv1, hdiv2]
+    simp [two_mul, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
+
+private lemma k_two_mul_add_one (m : ℕ) (hm : 1 ≤ m) :
+    k (2 * m + 1) = m + k m + k (m + 1) := by
+  cases m with
+  | zero => omega
+  | succ n =>
+    have h : 2 * (n + 1) + 1 = (2 * n + 1) + 2 := by omega
+    conv_lhs => rw [h]; unfold k
+    have hdiv1 : (2 * n + 3) / 2 = n + 1 := by omega
+    have hdiv2 : (2 * n + 4) / 2 = n + 2 := by omega
+    rw [hdiv1, hdiv2]
+
+-- Helper to avoid .sum vs ∑ notation mismatch
+private lemma sum_range_succ' (f : ℕ → ℕ) (n : ℕ) :
+    (Finset.range (n + 1)).sum f = (Finset.range n).sum f + f n :=
+  @Finset.sum_range_succ ℕ _ f n
+
+private lemma sum_s2_double (m : ℕ) :
+    (Finset.range (2 * m)).sum s2 = m + 2 * (Finset.range m).sum s2 := by
+  induction m with
+  | zero => simp
+  | succ n ih =>
+    rw [show 2 * (n + 1) = (2 * n + 1) + 1 from by omega,
+        sum_range_succ', s2_two_mul_add_one,
+        show 2 * n + 1 = (2 * n) + 1 from by omega,
+        sum_range_succ', ih, s2_two_mul, sum_range_succ']
+    omega
+
+/-- k_n = n + Σ_{j=0}^{n-1} s_2(j), and k_n / (n log_2 n) → 1/2. -/
+theorem digit_sum_formula (n : ℕ) (hn : 1 ≤ n) :
+    k n = n + digitSumPrefix n := by
+  induction n using Nat.strongRecOn with
+  | ind n ih =>
+    by_cases h1 : n = 1
+    · subst h1
+      simp [k, digitSumPrefix, s2]
+    · have hn2 : 2 ≤ n := by omega
+      rcases Nat.even_or_odd n with ⟨m, hm⟩ | ⟨m, hm⟩
+      · -- Even: n = m + m
+        have hm2 : n = 2 * m := by omega
+        subst hm2
+        have hprefix : digitSumPrefix (2 * m) = m + 2 * digitSumPrefix m := by
+          simpa [digitSumPrefix] using sum_s2_double m
+        rw [k_two_mul m (by omega), ih m (by omega) (by omega), hprefix]
+        omega
+      · -- Odd: n = 2 * m + 1
+        have hm2 : n = 2 * m + 1 := by omega
+        subst hm2
+        have hm_pos : 1 ≤ m := by omega
+        rw [k_two_mul_add_one m hm_pos, ih m (by omega) (by omega),
+            ih (m + 1) (by omega) (by omega)]
+        have h_sum : digitSumPrefix (2 * m + 1) =
+            m + 2 * digitSumPrefix m + s2 m := by
+          rw [digitSumPrefix, sum_range_succ', sum_s2_double, s2_two_mul]
+          simp [digitSumPrefix]
+        rw [h_sum,
+          show digitSumPrefix (m + 1) = digitSumPrefix m + s2 m by
+            simp [digitSumPrefix, sum_range_succ']]
+        omega
+
+/-- The asymptotic coefficient `(h_t - 1) / log_2 t` appearing in the fixed-`t` bound. -/
+noncomputable def fixedTCoeff (t : ℕ) : ℝ :=
+  (((harmonic t : ℚ) : ℝ) - 1) / Real.logb 2 (t : ℝ)
+
+private lemma IsFrame.mono {t : ℕ} {F : Multiset (SupportPattern t)}
+    {cap₁ cap₂ : Fin t → ℕ} (hF : IsFrame F cap₁) (hcap : ∀ i, cap₁ i ≤ cap₂ i) :
+    IsFrame F cap₂ := by
+  intro T I hIT
+  exact le_trans (hF T I hIT) <| Finset.sum_le_sum fun i _ => hcap i
+
+private lemma omegaCount_nsmul {t : ℕ} (q : ℕ) (F : Multiset (SupportPattern t))
+    (T I : Finset (Fin t)) :
+    omegaCount (q • F) T I = q * omegaCount F T I := by
+  rw [oc_eq_filter_card, Multiset.filter_nsmul, Multiset.card_nsmul, oc_eq_filter_card]
+
+private lemma IsFrame.nsmul {t : ℕ} (q : ℕ)
+    {F : Multiset (SupportPattern t)} {cap : Fin t → ℕ}
+    (hF : IsFrame F cap) :
+    IsFrame (q • F) (fun i => q * cap i) := by
+  intro T I hIT
+  rw [omegaCount_nsmul]
+  calc
+    q * omegaCount F T I ≤ q * (T \ I).sum cap := Nat.mul_le_mul_left q (hF T I hIT)
+    _ = (T \ I).sum (fun i => q * cap i) := by rw [Finset.mul_sum]
+
+private def exactWitnessSet (n : ℕ) : Set ℕ := {v : ℕ | WitnessStrong n v}
+
+private noncomputable def exactWitnessSup (n : ℕ) : ℕ := sSup (exactWitnessSet n)
+
+private theorem witnessStrong_le_H {n v : ℕ} (hw : WitnessStrong n v) : v ≤ H n := by
+  let w : Witness n v := Classical.choose hw
+  unfold H
+  exact le_csSup (H_set_bddAbove n) ⟨w.edges, w.vertexCard, w.noLargePartition⟩
+
+private theorem exactWitnessSet_bddAbove (n : ℕ) :
+    BddAbove (exactWitnessSet n) := by
+  refine ⟨H n, ?_⟩
+  intro v hv
+  exact witnessStrong_le_H hv
+
+private theorem exactWitnessSup_spec (n : ℕ) (hn : 1 ≤ n) :
+    WitnessStrong n (exactWitnessSup n) :=
+  Nat.sSup_mem ⟨n, ws_singleton n hn⟩ (exactWitnessSet_bddAbove n)
+
+private theorem exactWitnessSup_ge {n v : ℕ} (hw : WitnessStrong n v) :
+    v ≤ exactWitnessSup n := by
+  exact le_csSup (exactWitnessSet_bddAbove n) hw
+
+private theorem exactWitnessSup_le_H (n : ℕ) (hn : 1 ≤ n) :
+    exactWitnessSup n ≤ H n :=
+  csSup_le ⟨n, ws_singleton n hn⟩ fun _ hv => witnessStrong_le_H hv
+
+private theorem exactWitnessSup_singleton_lower (n : ℕ) (hn : 1 ≤ n) :
+    n ≤ exactWitnessSup n :=
+  exactWitnessSup_ge (ws_singleton n hn)
+
+private lemma harmonic_sub_one_eq_sum_Icc (t : ℕ) (ht : 2 ≤ t) :
+    (((harmonic t : ℚ) : ℝ) - 1) = ∑ j ∈ Finset.Icc 2 t, (j : ℝ)⁻¹ := by
+  have hIcc : Finset.Icc 1 t = insert 1 (Finset.Icc 2 t) := by
+    ext j
+    simp [Finset.mem_Icc]
+    omega
+  calc
+    (((harmonic t : ℚ) : ℝ) - 1)
+        = (∑ j ∈ Finset.Icc 1 t, (j : ℝ)⁻¹) - 1 := by
+            rw [harmonic_eq_sum_Icc, Rat.cast_sum]
+            simp_rw [Rat.cast_inv, Rat.cast_natCast]
+    _ = (1 : ℝ) + ∑ j ∈ Finset.Icc 2 t, (j : ℝ)⁻¹ - 1 := by
+            rw [hIcc, Finset.sum_insert]
+            · simp
+            · simp
+    _ = ∑ j ∈ Finset.Icc 2 t, (j : ℝ)⁻¹ := by ring
+
+private lemma M_ne_zero (t : ℕ) (_ht : 2 ≤ t) : M t ≠ 0 := by
+  intro hM
+  rw [M, Finset.lcm_eq_zero_iff] at hM
+  rcases hM with ⟨r, hr, hr0⟩
+  exact (Nat.choose_pos (Finset.mem_Icc.mp hr).2).ne' hr0
+
+private lemma M_pos (t : ℕ) (ht : 2 ≤ t) : 0 < M t :=
+  Nat.pos_of_ne_zero (M_ne_zero t ht)
+
+private lemma lubellCard_real (t : ℕ) (ht : 2 ≤ t) :
+    (((lubellFrame t).card : ℕ) : ℝ) =
+      (M t : ℝ) * (t : ℝ) * ((((harmonic t : ℚ) : ℝ) - 1)) := by
+  have hcardNat : (lubellFrame t).card = lubellCardSum t := (lubell_is_frame t ht).2
+  calc
+    (((lubellFrame t).card : ℕ) : ℝ) = (lubellCardSum t : ℝ) := by exact_mod_cast hcardNat
+    _ = ∑ j ∈ Finset.Icc 2 t, ((Nat.choose t j * lubellMultiplicity t j : ℕ) : ℝ) := by
+          rw [lubellCardSum, Nat.cast_sum]
+    _ = ∑ j ∈ Finset.Icc 2 t, (M t : ℝ) * (t : ℝ) / j := by
+          refine Finset.sum_congr rfl ?_
+          intro j hj
+          rcases Finset.mem_Icc.mp hj with ⟨hj2, hjt⟩
+          have hdvd : Nat.choose (t - 1) (j - 1) ∣ M t := M_dvd t (j - 1) (by omega) (by omega)
+          have hchoose_pos : 0 < Nat.choose (t - 1) (j - 1) := by
+            exact Nat.choose_pos (by omega)
+          have hden_ne : (((Nat.choose (t - 1) (j - 1) : ℕ) : ℝ)) ≠ 0 := by
+            exact_mod_cast hchoose_pos.ne'
+          have hj_ne : (j : ℝ) ≠ 0 := by positivity
+          have hratio :
+              (Nat.choose t j : ℝ) / Nat.choose (t - 1) (j - 1) = (t : ℝ) / j := by
+              have hchoose_nat :
+                  t * Nat.choose (t - 1) (j - 1) = Nat.choose t j * j := by
+                have h := Nat.add_one_mul_choose_eq (t - 1) (j - 1)
+                have ht_sub : t - 1 + 1 = t := by omega
+                have hj_sub : j - 1 + 1 = j := by omega
+                simpa [ht_sub, hj_sub] using h
+              have hchoose :
+                  (t : ℝ) * (Nat.choose (t - 1) (j - 1) : ℝ) =
+                    (Nat.choose t j : ℝ) * j := by
+                exact_mod_cast hchoose_nat
+              exact (div_eq_div_iff hden_ne hj_ne).mpr (id (Eq.symm hchoose))
+          calc
+            ((Nat.choose t j * lubellMultiplicity t j : ℕ) : ℝ)
+                = (Nat.choose t j : ℝ) * (lubellMultiplicity t j : ℝ) := by norm_num
+            _ = (Nat.choose t j : ℝ) * ((M t : ℝ) / Nat.choose (t - 1) (j - 1)) := by
+                  rw [lubellMultiplicity, Nat.cast_div_charZero hdvd]
+            _ = (M t : ℝ) * ((Nat.choose t j : ℝ) / Nat.choose (t - 1) (j - 1)) := by ring
+            _ = (M t : ℝ) * ((t : ℝ) / j) := by rw [hratio]
+            _ = (M t : ℝ) * (t : ℝ) / j := by ring
+    _ = (M t : ℝ) * (t : ℝ) * ∑ j ∈ Finset.Icc 2 t, (j : ℝ)⁻¹ := by
+          simp_rw [div_eq_mul_inv]
+          rw [← Finset.mul_sum]
+    _ = (M t : ℝ) * (t : ℝ) * ((((harmonic t : ℚ) : ℝ) - 1)) := by
+          rw [harmonic_sub_one_eq_sum_Icc t ht]
+
+private lemma fixedTCoeff_eq_log_ratio (t : ℕ) (ht : 2 ≤ t) :
+    fixedTCoeff t =
+      Real.log 2 * ((((harmonic t : ℚ) : ℝ) - 1)) / Real.log (t : ℝ) := by
+  have hlog2_ne : Real.log (2 : ℝ) ≠ 0 :=
+    Real.log_ne_zero_of_pos_of_ne_one (by positivity) (by norm_num)
+  have ht_ne_one_nat : t ≠ 1 := by omega
+  have ht_ne_one : (t : ℝ) ≠ 1 := by exact_mod_cast ht_ne_one_nat
+  have hlogt_ne : Real.log (t : ℝ) ≠ 0 :=
+    Real.log_ne_zero_of_pos_of_ne_one (by positivity) ht_ne_one
+  rw [fixedTCoeff, Real.logb]
+  calc
+    ((((harmonic t : ℚ) : ℝ) - 1) / (Real.log (t : ℝ) / Real.log 2))
+        = ((((harmonic t : ℚ) : ℝ) - 1) * Real.log 2) / Real.log (t : ℝ) := by
+            field_simp [hlog2_ne, hlogt_ne]
+    _ = Real.log 2 * ((((harmonic t : ℚ) : ℝ) - 1)) / Real.log (t : ℝ) := by ring
+
+private lemma fixedTCoeff_mul_logb_eq (t : ℕ) (ht : 2 ≤ t) (x : ℕ) :
+    fixedTCoeff t * (x : ℝ) * Real.logb 2 (x : ℝ) =
+      ((((harmonic t : ℚ) : ℝ) - 1) / Real.log (t : ℝ)) * (x : ℝ) * Real.log (x : ℝ) := by
+  have hlog2_ne : Real.log (2 : ℝ) ≠ 0 :=
+    Real.log_ne_zero_of_pos_of_ne_one (by positivity) (by norm_num)
+  have ht_ne_one_nat : t ≠ 1 := by omega
+  have ht_ne_one : (t : ℝ) ≠ 1 := by exact_mod_cast ht_ne_one_nat
+  have hlogt_ne : Real.log (t : ℝ) ≠ 0 :=
+    Real.log_ne_zero_of_pos_of_ne_one (by positivity) ht_ne_one
+  rw [fixedTCoeff_eq_log_ratio t ht, Real.logb]
+  field_simp [hlog2_ne, hlogt_ne]
+
+private lemma fixedTCoeff_nonneg (t : ℕ) (ht : 2 ≤ t) : 0 ≤ fixedTCoeff t := by
+  rw [fixedTCoeff_eq_log_ratio t ht]
+  have hlogt_pos : 0 < Real.log (t : ℝ) := Real.log_pos (by exact_mod_cast ht)
+  rw [harmonic_sub_one_eq_sum_Icc t ht]
+  positivity
+
+private lemma log_le_harmonic (t : ℕ) (ht : 2 ≤ t) :
+    Real.log (t : ℝ) ≤ ((harmonic t : ℚ) : ℝ) := by
+  have hmain :
+      Real.log (t : ℝ) ≤ ((harmonic (t - 1) : ℚ) : ℝ) := by
+    have h := log_add_one_le_harmonic (t - 1)
+    have ht' : t - 1 + 1 = t := by omega
+    rw [ht'] at h
+    exact h
+  have hsucc :
+      ((harmonic t : ℚ) : ℝ) = ((harmonic (t - 1) : ℚ) : ℝ) + (t : ℝ)⁻¹ := by
+    have hsuccq : harmonic t = harmonic (t - 1) + (↑t : ℚ)⁻¹ := by
+      have h := harmonic_succ (t - 1)
+      have ht' : t - 1 + 1 = t := by omega
+      rw [ht'] at h
+      exact h
+    simpa [Rat.cast_add, Rat.cast_inv, Rat.cast_natCast] using
+      congrArg (fun q : ℚ => (q : ℝ)) hsuccq
+  have hnonneg : 0 ≤ (t : ℝ)⁻¹ := by positivity
+  calc
+    Real.log (t : ℝ) ≤ ((harmonic (t - 1) : ℚ) : ℝ) := hmain
+    _ ≤ ((harmonic (t - 1) : ℚ) : ℝ) + (t : ℝ)⁻¹ := by linarith
+    _ = ((harmonic t : ℚ) : ℝ) := by rw [hsucc]
+
+private lemma fixedTCoeff_lower (t : ℕ) (ht : 2 ≤ t) :
+    Real.log 2 * (1 - 1 / Real.log (t : ℝ)) ≤ fixedTCoeff t := by
+  have hlogt_pos : 0 < Real.log (t : ℝ) := Real.log_pos (by exact_mod_cast ht)
+  have hlogt_ne : Real.log (t : ℝ) ≠ 0 := hlogt_pos.ne'
+  have hlog2_pos : 0 < Real.log (2 : ℝ) := Real.log_pos one_lt_two
+  have hnum_lower : Real.log (t : ℝ) - 1 ≤ (((harmonic t : ℚ) : ℝ) - 1) := by
+    have hlog_le_harmonic :
+        Real.log (t : ℝ) ≤ ((harmonic t : ℚ) : ℝ) :=
+      log_le_harmonic t ht
+    linarith
+  calc
+    Real.log 2 * (1 - 1 / Real.log (t : ℝ))
+        = Real.log 2 * (Real.log (t : ℝ) - 1) / Real.log (t : ℝ) := by
+            field_simp [hlogt_ne]
+    _ ≤ Real.log 2 * ((((harmonic t : ℚ) : ℝ) - 1)) / Real.log (t : ℝ) := by
+          have hmul :
+              Real.log 2 * (Real.log (t : ℝ) - 1) ≤
+                Real.log 2 * ((((harmonic t : ℚ) : ℝ) - 1)) :=
+            mul_le_mul_of_nonneg_left hnum_lower hlog2_pos.le
+          exact (div_le_div_of_nonneg_right hmul hlogt_pos.le)
+    _ = fixedTCoeff t := (fixedTCoeff_eq_log_ratio t ht).symm
+
+private noncomputable def lubellQ (t n : ℕ) : ℕ := n / (t * M t)
+
+private noncomputable def lubellR (t n : ℕ) : ℕ := n % (t * M t)
+
+private noncomputable def lubellRem (t n : ℕ) (i : Fin t) : ℕ :=
+  lubellR t n / t + if i.1 < lubellR t n % t then 1 else 0
+
+private noncomputable def lubellPart (t n : ℕ) (i : Fin t) : ℕ :=
+  lubellQ t n * M t + lubellRem t n i
+
+private lemma lubell_decomp (t n : ℕ) :
+    n = t * (lubellQ t n * M t) + lubellR t n := by
+  unfold lubellQ lubellR
+  calc
+    n = n % (t * M t) + (t * M t) * (n / (t * M t)) := by
+          symm
+          exact Nat.mod_add_div n (t * M t)
+    _ = n % (t * M t) + t * (n / (t * M t) * M t) := by ring
+    _ = t * (n / (t * M t) * M t) + n % (t * M t) := by ring
+
+private lemma lubellRem_sum (t n : ℕ) (ht : 2 ≤ t) :
+    ((Finset.univ : Finset (Fin t)).sum (lubellRem t n)) = lubellR t n := by
+  have ht_pos : 0 < t := by omega
+  have hcount :
+      ((Finset.univ : Finset (Fin t)).filter fun i => i.1 < lubellR t n % t).card =
+        lubellR t n % t := by
+    simpa [min_eq_right (Nat.mod_lt _ ht_pos).le] using
+      (Fin.card_filter_val_lt (n := t) (m := lubellR t n % t))
+  have hsum_ite :
+      ((Finset.univ : Finset (Fin t)).sum fun i => if i.1 < lubellR t n % t then 1 else 0) =
+        lubellR t n % t := by
+    simp [hcount]
+  calc
+    ((Finset.univ : Finset (Fin t)).sum (lubellRem t n))
+        = ((Finset.univ : Finset (Fin t)).sum fun _ => lubellR t n / t) +
+            ((Finset.univ : Finset (Fin t)).sum
+              fun i => if i.1 < lubellR t n % t then 1 else 0) := by
+              simp [lubellRem, Finset.sum_add_distrib]
+    _ = t * (lubellR t n / t) + lubellR t n % t := by
+          rw [hsum_ite]
+          simp [Finset.sum_const, Fintype.card_fin]
+    _ = lubellR t n := by
+          exact Nat.div_add_mod (lubellR t n) t
+
+private lemma lubellPart_sum (t n : ℕ) (ht : 2 ≤ t) :
+    ((Finset.univ : Finset (Fin t)).sum (lubellPart t n)) = n := by
+  calc
+    ((Finset.univ : Finset (Fin t)).sum (lubellPart t n))
+        = t * (lubellQ t n * M t) + ((Finset.univ : Finset (Fin t)).sum (lubellRem t n)) := by
+            simp [lubellPart, Finset.sum_add_distrib, Finset.sum_const, Fintype.card_fin]
+    _ = t * (lubellQ t n * M t) + lubellR t n := by rw [lubellRem_sum t n ht]
+    _ = n := by exact (lubell_decomp t n).symm
+
+private lemma lubellPart_ge_qM (t n : ℕ) (i : Fin t) :
+    lubellQ t n * M t ≤ lubellPart t n i := by
+  simp [lubellPart, lubellRem]
+
+private lemma lubellQ_pos (t n : ℕ) (ht : 2 ≤ t) (hn : t * M t ≤ n) :
+    1 ≤ lubellQ t n := by
+  unfold lubellQ
+  exact
+    (Nat.le_div_iff_mul_le (Nat.mul_pos (by omega) (M_pos t ht))).2
+      (by simpa [one_mul] using hn)
+
+private lemma lubellRem_le_M (t n : ℕ) (ht : 2 ≤ t) (i : Fin t) :
+    lubellRem t n i ≤ M t := by
+  have ht_pos : 0 < t := by omega
+  have hM_pos : 0 < M t := M_pos t ht
+  have hr_lt : lubellR t n < t * M t := by
+    unfold lubellR
+    exact Nat.mod_lt _ (Nat.mul_pos ht_pos hM_pos)
+  have hdiv_lt : lubellR t n / t < M t := by
+    exact
+      (Nat.div_lt_iff_lt_mul ht_pos).2
+        (by simpa [Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using hr_lt)
+  by_cases hi : i.1 < lubellR t n % t
+  · simp only [lubellRem, hi, ↓reduceIte, ge_iff_le]
+    exact Nat.succ_le_of_lt hdiv_lt
+  · simp [lubellRem, hi, le_of_lt hdiv_lt]
+
+private lemma lubellPart_pos (t n : ℕ) (ht : 2 ≤ t) (hq : 1 ≤ lubellQ t n) (i : Fin t) :
+    1 ≤ lubellPart t n i := by
+  have hM_pos : 0 < M t := M_pos t ht
+  calc
+    1 ≤ lubellQ t n * M t := by
+          exact Nat.succ_le_of_lt (Nat.mul_pos (by omega) hM_pos)
+    _ ≤ lubellPart t n i := lubellPart_ge_qM t n i
+
+private lemma lubellPart_lt (t n : ℕ) (ht : 2 ≤ t) (hn : t * M t ≤ n)
+    (i : Fin t) : lubellPart t n i < n := by
+  have hq : 1 ≤ lubellQ t n := lubellQ_pos t n ht hn
+  have hqM_pos : 0 < lubellQ t n * M t := Nat.mul_pos (by omega) (M_pos t ht)
+  have hqM_ge_M : M t ≤ lubellQ t n * M t := by
+    simpa using Nat.mul_le_mul_right (M t) hq
+  by_cases hr0 : lubellR t n = 0
+  · have hrem0 : lubellRem t n i = 0 := by simp [lubellRem, hr0]
+    have hdecomp : n = t * (lubellQ t n * M t) := by simpa [hr0] using lubell_decomp t n
+    set x := lubellQ t n * M t
+    have hx_pos : 0 < x := by simpa [x] using hqM_pos
+    have hlt : x < n := by
+      have hxt : x < x * t := by
+        exact (Nat.lt_mul_iff_one_lt_right hx_pos).2 (by omega)
+      lia
+    simpa [lubellPart, hrem0, x] using hlt
+  · have hpart_le : lubellPart t n i ≤ lubellQ t n * M t + M t := by
+      simpa [lubellPart] using Nat.add_le_add_left (lubellRem_le_M t n ht i) (lubellQ t n * M t)
+    have htwo_le : lubellQ t n * M t + M t ≤ t * (lubellQ t n * M t) := by
+      have h2 :
+          lubellQ t n * M t + M t ≤
+            lubellQ t n * M t + lubellQ t n * M t :=
+        Nat.add_le_add_left hqM_ge_M _
+      have h3 :
+          lubellQ t n * M t + lubellQ t n * M t = 2 * (lubellQ t n * M t) := by ring
+      have h4 : 2 * (lubellQ t n * M t) ≤ t * (lubellQ t n * M t) := by
+        exact Nat.mul_le_mul_right _ ht
+      exact le_trans (h3 ▸ h2) h4
+    have htx_lt_n : t * (lubellQ t n * M t) < n := by
+      have hr_pos : 0 < lubellR t n := Nat.pos_of_ne_zero hr0
+      have hdecomp := lubell_decomp t n
+      omega
+    exact lt_of_le_of_lt (le_trans hpart_le htwo_le) htx_lt_n
+
+private lemma lubellPart_sum_mul_log (t n : ℕ) (ht : 2 ≤ t) (hn : 1 ≤ n) :
+    (n : ℝ) * Real.log ((n : ℝ) / t) ≤
+      ((Finset.univ : Finset (Fin t)).sum
+        fun i => (lubellPart t n i : ℝ) * Real.log (lubellPart t n i : ℝ)) := by
+  have ht_pos : 0 < (t : ℝ) := by positivity
+  have ht_ne : (t : ℝ) ≠ 0 := ht_pos.ne'
+  have hsumParts :
+      (∑ i ∈ (Finset.univ : Finset (Fin t)), (lubellPart t n i : ℝ)) = n := by
+    exact_mod_cast lubellPart_sum t n ht
+  have hJensen :=
+    Real.convexOn_mul_log.map_sum_le
+      (t := (Finset.univ : Finset (Fin t)))
+      (w := fun _ => (1 : ℝ) / t)
+      (p := fun i => (lubellPart t n i : ℝ))
+      (by
+        exact fun i a => Nat.one_div_cast_nonneg t)
+      (by
+        rw [Finset.sum_const, nsmul_eq_mul]
+        have h : (t : ℝ) * (1 / t) = 1 := by
+          field_simp [ht_ne]
+        simpa using h)
+      (by
+        intro i hi
+        change 0 ≤ (lubellPart t n i : ℝ)
+        positivity)
+  have havg :
+      (∑ i ∈ (Finset.univ : Finset (Fin t)), (1 : ℝ) / t * (lubellPart t n i : ℝ)) =
+        (n : ℝ) / t := by
+    rw [← Finset.mul_sum, hsumParts]
+    ring
+  have hJensen' :
+      ((n : ℝ) / t) * Real.log ((n : ℝ) / t) ≤
+        ∑ i ∈ (Finset.univ : Finset (Fin t)),
+          (1 : ℝ) / t * ((lubellPart t n i : ℝ) * Real.log (lubellPart t n i : ℝ)) := by
+    have hJensen'' :
+        (∑ i ∈ (Finset.univ : Finset (Fin t)),
+            (1 : ℝ) / t * (lubellPart t n i : ℝ)) *
+            Real.log (∑ i ∈ (Finset.univ : Finset (Fin t)),
+              (1 : ℝ) / t * (lubellPart t n i : ℝ)) ≤
+          ∑ i ∈ (Finset.univ : Finset (Fin t)),
+            (1 : ℝ) / t * ((lubellPart t n i : ℝ) * Real.log (lubellPart t n i : ℝ)) := by
+      simpa [smul_eq_mul, div_eq_mul_inv, mul_assoc, mul_left_comm, mul_comm] using hJensen
+    lia
+  calc
+    (n : ℝ) * Real.log ((n : ℝ) / t)
+        = (t : ℝ) * (((n : ℝ) / t) * Real.log ((n : ℝ) / t)) := by
+            field_simp [ht_ne]
+    _ ≤ (t : ℝ) *
+          ∑ i ∈ (Finset.univ : Finset (Fin t)),
+            (1 : ℝ) / t * ((lubellPart t n i : ℝ) * Real.log (lubellPart t n i : ℝ)) := by
+            exact mul_le_mul_of_nonneg_left hJensen' ht_pos.le
+    _ = ((Finset.univ : Finset (Fin t)).sum
+          fun i => (lubellPart t n i : ℝ) * Real.log (lubellPart t n i : ℝ)) := by
+          rw [Finset.mul_sum]
+          apply Finset.sum_congr rfl
+          intro i hi
+          field_simp [ht_ne]
+
+private lemma lubell_bonus_lower (t n : ℕ) (ht : 2 ≤ t) :
+    (lubellQ t n : ℝ) * ((((lubellFrame t).card : ℕ) : ℝ)) ≥
+      (n : ℝ) * ((((harmonic t : ℚ) : ℝ) - 1)) - ((((lubellFrame t).card : ℕ) : ℝ)) := by
+  let b : ℝ := (((harmonic t : ℚ) : ℝ) - 1)
+  have hcard :
+      ((((lubellFrame t).card : ℕ) : ℝ)) = ((t * M t : ℕ) : ℝ) * b := by
+    dsimp [b]
+    simpa [Nat.cast_mul, mul_assoc, mul_left_comm, mul_comm] using lubellCard_real t ht
+  have hdecomp :
+      (n : ℝ) * b =
+        (lubellQ t n : ℝ) * (((t * M t : ℕ) : ℝ) * b) + (lubellR t n : ℝ) * b := by
+    have hnat : (n : ℝ) = (t * (lubellQ t n * M t) : ℕ) + lubellR t n := by
+      exact_mod_cast lubell_decomp t n
+    rw [hnat]
+    norm_num
+    ring
+  have hrle :
+      (lubellR t n : ℝ) * b ≤ ((t * M t : ℕ) : ℝ) * b := by
+    have hb_nonneg : 0 ≤ b := by
+      dsimp [b]
+      rw [harmonic_sub_one_eq_sum_Icc t ht]
+      positivity
+    gcongr
+    exact_mod_cast (Nat.mod_lt n (Nat.mul_pos (by omega) (M_pos t ht))).le
+  have hmain :
+      (n : ℝ) * b ≤
+        (lubellQ t n : ℝ) * ((((lubellFrame t).card : ℕ) : ℝ)) +
+          ((((lubellFrame t).card : ℕ) : ℝ)) := by
+    calc
+      (n : ℝ) * b
+          = (lubellQ t n : ℝ) * (((t * M t : ℕ) : ℝ) * b) +
+              (lubellR t n : ℝ) * b := hdecomp
+      _ = (lubellQ t n : ℝ) * ((((lubellFrame t).card : ℕ) : ℝ)) +
+            (lubellR t n : ℝ) * b := by rw [← hcard]
+      _ ≤ (lubellQ t n : ℝ) * ((((lubellFrame t).card : ℕ) : ℝ)) +
+            ((((lubellFrame t).card : ℕ) : ℝ)) := by
+            linarith
+  linarith
+
+private theorem exactWitnessSup_lubell_step (t n : ℕ) (ht : 2 ≤ t) (hn : t * M t ≤ n) :
+    exactWitnessSup n ≥
+      ((Finset.univ : Finset (Fin t)).sum fun i => exactWitnessSup (lubellPart t n i)) +
+        lubellQ t n * (lubellFrame t).card := by
+  classical
+  have hq : 1 ≤ lubellQ t n := lubellQ_pos t n ht hn
+  have hw : ∀ i, WitnessStrong (lubellPart t n i) (exactWitnessSup (lubellPart t n i)) :=
+    fun i => exactWitnessSup_spec (lubellPart t n i) (lubellPart_pos t n ht hq i)
+  have hframe0 : IsFrame (lubellFrame t) (lubellCap t) := (lubell_is_frame t ht).1
+  have hframeQ : IsFrame (lubellQ t n • lubellFrame t) (fun _ => lubellQ t n * M t) := by
+    simpa [lubellCap, smul_eq_mul] using IsFrame.nsmul (q := lubellQ t n) hframe0
+  have hframePart : IsFrame (lubellQ t n • lubellFrame t) (lubellPart t n) :=
+    IsFrame.mono hframeQ (lubellPart_ge_qM t n)
+  have happly :=
+    apply_frameData (lubellQ t n • lubellFrame t) (lubellPart t n)
+      (fun i => exactWitnessSup (lubellPart t n i))
+      (lubellQ t n * (lubellFrame t).card)
+      (Multiset.card_nsmul (lubellFrame t) (lubellQ t n))
+      hframePart hw
+  have hwit :
+      WitnessStrong n
+        (((Finset.univ : Finset (Fin t)).sum fun i => exactWitnessSup (lubellPart t n i)) +
+          lubellQ t n * (lubellFrame t).card) := by
+    simpa [lubellPart_sum t n ht] using happly
+  exact exactWitnessSup_ge hwit
+
+private theorem fixed_t_bound_exact (t : ℕ) (ht : 2 ≤ t) :
+    ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 1 ≤ n →
+      (exactWitnessSup n : ℝ) ≥
+        fixedTCoeff t * (n : ℝ) * Real.logb 2 (n : ℝ) - C * ((n : ℝ) - 1) := by
+  let N : ℕ := t * M t
+  let B : ℝ := (((lubellFrame t).card : ℕ) : ℝ)
+  let C : ℝ := fixedTCoeff t * (N : ℝ) * Real.logb 2 (N : ℝ) + B + 1
+  have hcoeff_nonneg : 0 ≤ fixedTCoeff t := fixedTCoeff_nonneg t ht
+  have hN_two : 2 ≤ N := by
+    have hM_one : 1 ≤ M t := Nat.succ_le_of_lt (M_pos t ht)
+    exact le_mul_of_le_of_one_le ht hM_one
+  have hN_one : 1 ≤ N := by omega
+  have hlogN_nonneg : 0 ≤ Real.logb 2 (N : ℝ) :=
+    Real.logb_nonneg one_lt_two (by exact_mod_cast hN_one)
+  have hB_nonneg : 0 ≤ B := by
+    positivity
+  have hcoeff_term_nonneg : 0 ≤ fixedTCoeff t * (N : ℝ) * Real.logb 2 (N : ℝ) := by
+    positivity
+  have hC_pos : 0 < C := by
+    positivity
+  refine ⟨C, hC_pos, ?_⟩
+  intro n
+  induction n using Nat.strongRecOn with
+  | ind n ih =>
+      intro hn
+      by_cases hsmall : n < N
+      · by_cases hn1 : n = 1
+        · subst hn1
+          norm_num [Real.logb]
+        · have hW : (n : ℝ) ≤ exactWitnessSup n := by
+            exact_mod_cast exactWitnessSup_singleton_lower n hn
+          have hlog_le :
+              Real.logb 2 (n : ℝ) ≤ Real.logb 2 (N : ℝ) := by
+            apply Real.logb_le_logb_of_le one_lt_two
+            · positivity
+            · exact_mod_cast (Nat.le_of_lt hsmall)
+          have hn_nat_le : n ≤ N * (n - 1) := by
+            have hn2 : 2 ≤ n := by omega
+            have hN_ge_n1 : n + 1 ≤ N := by omega
+            calc
+              n = n * 1 := by ring
+              _ ≤ n * (n - 1) := Nat.mul_le_mul_left n (by omega)
+              _ ≤ (n + 1) * (n - 1) := Nat.mul_le_mul_right (n - 1) (by omega)
+              _ ≤ N * (n - 1) := Nat.mul_le_mul_right (n - 1) hN_ge_n1
+          have hn_le : (n : ℝ) ≤ (N : ℝ) * ((n : ℝ) - 1) := by
+            exact_mod_cast hn_nat_le
+          have hstep1 :
+              fixedTCoeff t * (n : ℝ) * Real.logb 2 (n : ℝ) ≤
+                fixedTCoeff t * (n : ℝ) * Real.logb 2 (N : ℝ) := by
+            gcongr
+          have hstep2 :
+              fixedTCoeff t * (n : ℝ) * Real.logb 2 (N : ℝ) ≤
+                fixedTCoeff t * ((N : ℝ) * ((n : ℝ) - 1)) * Real.logb 2 (N : ℝ) := by
+            gcongr
+          have hcoef_le :
+              fixedTCoeff t * (N : ℝ) * Real.logb 2 (N : ℝ) ≤ C := by
+            dsimp [C]
+            nlinarith [hB_nonneg]
+          have hbase :
+              fixedTCoeff t * (n : ℝ) * Real.logb 2 (n : ℝ) ≤ C * ((n : ℝ) - 1) := by
+            have htmp :
+                fixedTCoeff t * (n : ℝ) * Real.logb 2 (n : ℝ) ≤
+                  (fixedTCoeff t * (N : ℝ) * Real.logb 2 (N : ℝ)) * ((n : ℝ) - 1) := by
+              calc
+                fixedTCoeff t * (n : ℝ) * Real.logb 2 (n : ℝ)
+                    ≤ fixedTCoeff t * (n : ℝ) * Real.logb 2 (N : ℝ) := hstep1
+                _ ≤ fixedTCoeff t * ((N : ℝ) * ((n : ℝ) - 1)) *
+                    Real.logb 2 (N : ℝ) := hstep2
+                _ = (fixedTCoeff t * (N : ℝ) * Real.logb 2 (N : ℝ)) * ((n : ℝ) - 1) := by
+                      ring
+            have hn1_nonneg : 0 ≤ (n : ℝ) - 1 := sub_nonneg.mpr (by exact_mod_cast hn)
+            exact le_mul_of_le_mul_of_nonneg_right htmp hcoef_le hn1_nonneg
+          linarith
+      · have hlarge : N ≤ n := by omega
+        have hstep_nat := exactWitnessSup_lubell_step t n ht hlarge
+        have hstep :
+            (exactWitnessSup n : ℝ) ≥
+              ((Finset.univ : Finset (Fin t)).sum
+                fun i => (exactWitnessSup (lubellPart t n i) : ℝ)) +
+                (lubellQ t n : ℝ) * B := by
+          have hstep' :
+              (exactWitnessSup n : ℝ) ≥
+                ((Finset.univ : Finset (Fin t)).sum
+                  fun i => (exactWitnessSup (lubellPart t n i) : ℝ)) +
+                  (lubellQ t n : ℝ) * ((((lubellFrame t).card : ℕ) : ℝ)) := by
+            exact_mod_cast hstep_nat
+          simpa [B] using hstep'
+        have hterm :
+            ∀ i : Fin t,
+              (exactWitnessSup (lubellPart t n i) : ℝ) ≥
+                ((((harmonic t : ℚ) : ℝ) - 1) / Real.log (t : ℝ)) *
+                    (lubellPart t n i : ℝ) * Real.log (lubellPart t n i : ℝ) -
+                  C * ((lubellPart t n i : ℝ) - 1) := by
+          intro i
+          have hih := ih (lubellPart t n i) (lubellPart_lt t n ht hlarge i)
+            (lubellPart_pos t n ht (lubellQ_pos t n ht hlarge) i)
+          rwa [fixedTCoeff_mul_logb_eq t ht (lubellPart t n i)] at hih
+        set S : ℝ :=
+          ((Finset.univ : Finset (Fin t)).sum
+            fun i => (lubellPart t n i : ℝ) * Real.log (lubellPart t n i : ℝ))
+        have hsumIH :
+            ((Finset.univ : Finset (Fin t)).sum fun i => (exactWitnessSup (lubellPart t n i) : ℝ))
+              ≥ ((((harmonic t : ℚ) : ℝ) - 1) / Real.log (t : ℝ)) * S -
+                C * ((n : ℝ) - t) := by
+          let A : Fin t → ℝ := fun i =>
+            ((((harmonic t : ℚ) : ℝ) - 1) / Real.log (t : ℝ)) *
+              (lubellPart t n i : ℝ) * Real.log (lubellPart t n i : ℝ) -
+                C * ((lubellPart t n i : ℝ) - 1)
+          have hsum :
+              (∑ i : Fin t, A i) ≤
+                (∑ i : Fin t,
+                  (exactWitnessSup (lubellPart t n i) : ℝ)) :=
+            Finset.sum_le_sum fun i _ => hterm i
+          rw [Finset.sum_sub_distrib] at hsum
+          have hsumA :
+              (∑ i : Fin t,
+                  ((((harmonic t : ℚ) : ℝ) - 1) / Real.log (t : ℝ)) *
+                    (lubellPart t n i : ℝ) * Real.log (lubellPart t n i : ℝ)) =
+                ((((harmonic t : ℚ) : ℝ) - 1) / Real.log (t : ℝ)) * S := by
+            let a : ℝ := (((harmonic t : ℚ) : ℝ) - 1) / Real.log (t : ℝ)
+            have ha :
+                (∑ i : Fin t,
+                    a * ((lubellPart t n i : ℝ) *
+                      Real.log (lubellPart t n i : ℝ))) = a * S := by
+              exact Eq.symm
+                (Finset.mul_sum Finset.univ
+                  (fun i => ↑(lubellPart t n i) * Real.log ↑(lubellPart t n i)) a)
+            simpa [a, mul_assoc] using ha
+          have hsumParts :
+              (∑ i : Fin t, (lubellPart t n i : ℝ)) = n := by
+            exact_mod_cast lubellPart_sum t n ht
+          have hsumC :
+              (∑ i : Fin t,
+                  C * ((lubellPart t n i : ℝ) - 1)) = C * ((n : ℝ) - t) := by
+            have hsumSub :
+                (∑ i : Fin t, ((lubellPart t n i : ℝ) - 1)) = (n : ℝ) - t := by
+              rw [Finset.sum_sub_distrib, hsumParts]
+              simp [Finset.sum_const, Fintype.card_fin]
+            rw [← Finset.mul_sum, hsumSub]
+          lia
+        have hcoeff_natlog_nonneg :
+            0 ≤ ((((harmonic t : ℚ) : ℝ) - 1) / Real.log (t : ℝ)) := by
+          rw [harmonic_sub_one_eq_sum_Icc t ht]
+          positivity
+        have hJ := lubellPart_sum_mul_log t n ht hn
+        have hscaled :
+            ((((harmonic t : ℚ) : ℝ) - 1) / Real.log (t : ℝ)) * S ≥
+              fixedTCoeff t * (n : ℝ) * Real.logb 2 (n : ℝ) -
+                (n : ℝ) * ((((harmonic t : ℚ) : ℝ) - 1)) := by
+          have hmul := mul_le_mul_of_nonneg_left hJ hcoeff_natlog_nonneg
+          have hrewrite :
+              ((((harmonic t : ℚ) : ℝ) - 1) / Real.log (t : ℝ)) *
+                  ((n : ℝ) * Real.log ((n : ℝ) / t)) =
+                fixedTCoeff t * (n : ℝ) * Real.logb 2 (n : ℝ) -
+                  (n : ℝ) * ((((harmonic t : ℚ) : ℝ) - 1)) := by
+            have hlogdiv :
+                Real.log ((n : ℝ) / t) = Real.log (n : ℝ) - Real.log (t : ℝ) := by
+              rw [Real.log_div (by positivity) (by positivity)]
+            have hdist :
+                (n : ℝ) * (Real.log (n : ℝ) - Real.log (t : ℝ)) =
+                  (n : ℝ) * Real.log (n : ℝ) - (n : ℝ) * Real.log (t : ℝ) := by
+              ring
+            have hlogt_pos : 0 < Real.log (t : ℝ) := Real.log_pos (by exact_mod_cast ht)
+            have hlogt_ne : Real.log (t : ℝ) ≠ 0 := hlogt_pos.ne'
+            rw [hlogdiv, hdist]
+            calc
+              ((((harmonic t : ℚ) : ℝ) - 1) / Real.log (t : ℝ)) *
+                  ((n : ℝ) * Real.log (n : ℝ) - (n : ℝ) * Real.log (t : ℝ))
+                  = ((((harmonic t : ℚ) : ℝ) - 1) / Real.log (t : ℝ)) *
+                      ((n : ℝ) * Real.log (n : ℝ)) -
+                    (n : ℝ) * ((((harmonic t : ℚ) : ℝ) - 1)) := by
+                        field_simp [hlogt_ne]
+              _ = fixedTCoeff t * (n : ℝ) * Real.logb 2 (n : ℝ) -
+                    (n : ℝ) * ((((harmonic t : ℚ) : ℝ) - 1)) := by
+                        rw [fixedTCoeff_mul_logb_eq t ht n]
+                        ring
+          exact le_of_eq_of_le (id (Eq.symm hrewrite)) hmul
+        have hbonus := lubell_bonus_lower t n ht
+        have hC_ge_B : B ≤ C := by
+          dsimp [C]
+          nlinarith [hcoeff_term_nonneg]
+        have hCt : B ≤ C * ((t : ℝ) - 1) := by
+          have hC_nonneg : 0 ≤ C := hC_pos.le
+          have ht1 : (1 : ℝ) ≤ (t : ℝ) - 1 := by
+            have ht' : (2 : ℝ) ≤ t := by exact_mod_cast ht
+            linarith
+          calc
+            B ≤ C := hC_ge_B
+            _ ≤ C * ((t : ℝ) - 1) := by nlinarith
+        linarith
+
+/-! ## The fixed-t lower bound -/
+
+/-- For fixed t ≥ 2, H(n) ≥ (h_t - 1) / log_2(t) · n log_2(n) - C_t · n. -/
+theorem fixed_t_bound (t : ℕ) (ht : 2 ≤ t) :
+    ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 1 ≤ n →
+      (H n : ℝ) ≥
+        fixedTCoeff t *
+          (n : ℝ) * Real.logb 2 (n : ℝ) - C * (n : ℝ) := by
+  rcases fixed_t_bound_exact t ht with ⟨C, hC_pos, hC⟩
+  refine ⟨C, hC_pos, ?_⟩
+  intro n hn
+  have hsup : (exactWitnessSup n : ℝ) ≤ H n := by exact_mod_cast exactWitnessSup_le_H n hn
+  calc
+    (H n : ℝ) ≥ exactWitnessSup n := hsup
+    _ ≥ fixedTCoeff t * (n : ℝ) * Real.logb 2 (n : ℝ) - C * ((n : ℝ) - 1) := hC n hn
+    _ ≥ fixedTCoeff t * (n : ℝ) * Real.logb 2 (n : ℝ) - C * (n : ℝ) := by
+          nlinarith [hC_pos]
+
+private lemma s2_add_pow_two (k m : ℕ) (hm : m < 2 ^ k) :
+    s2 (2 ^ k + m) = 1 + s2 m := by
+  induction k generalizing m with
+  | zero =>
+      have hm0 : m = 0 := by omega
+      subst hm0
+      norm_num [s2]
+  | succ k ih =>
+      rcases Nat.even_or_odd m with ⟨r, hr_even⟩ | ⟨r, hr_odd⟩
+      · have hm_even : m = 2 * r := by omega
+        have hr : r < 2 ^ k := by omega
+        rw [hm_even]
+        have hrewrite : 2 ^ (k + 1) + 2 * r = 2 * (2 ^ k + r) := by
+          lia
+        calc
+          s2 (2 ^ (k + 1) + 2 * r) = s2 (2 * (2 ^ k + r)) := by rw [hrewrite]
+          _ = s2 (2 ^ k + r) := by rw [s2_two_mul]
+          _ = 1 + s2 r := ih r hr
+          _ = 1 + s2 (2 * r) := by rw [s2_two_mul]
+      · have hm_odd : m = 2 * r + 1 := by omega
+        have hr : r < 2 ^ k := by omega
+        rw [hm_odd]
+        have hrewrite : 2 ^ (k + 1) + (2 * r + 1) = 2 * (2 ^ k + r) + 1 := by
+          lia
+        calc
+          s2 (2 ^ (k + 1) + (2 * r + 1)) = s2 (2 * (2 ^ k + r) + 1) := by rw [hrewrite]
+          _ = 1 + s2 (2 ^ k + r) := by rw [s2_two_mul_add_one]
+          _ = 1 + (1 + s2 r) := by rw [ih r hr]
+          _ = 1 + s2 (2 * r + 1) := by rw [s2_two_mul_add_one]
+
+private lemma digitSumPrefix_add_pow_two (k m : ℕ) (hm : m ≤ 2 ^ k) :
+    digitSumPrefix (2 ^ k + m) =
+      digitSumPrefix (2 ^ k) + m + digitSumPrefix m := by
+  calc
+    digitSumPrefix (2 ^ k + m)
+        = digitSumPrefix (2 ^ k) + ∑ x ∈ Finset.range m, s2 (2 ^ k + x) := by
+            rw [digitSumPrefix, Finset.sum_range_add, digitSumPrefix]
+    _ = digitSumPrefix (2 ^ k) + ∑ x ∈ Finset.range m, (1 + s2 x) := by
+          congr 1
+          apply Finset.sum_congr rfl
+          intro x hx
+          rw [s2_add_pow_two k x]
+          exact lt_of_lt_of_le (Finset.mem_range.mp hx) hm
+    _ = digitSumPrefix (2 ^ k) + (m + digitSumPrefix m) := by
+          rw [Finset.sum_add_distrib]
+          simp [digitSumPrefix]
+    _ = digitSumPrefix (2 ^ k) + m + digitSumPrefix m := by
+          omega
+
+private lemma digitSumPrefix_pow_two_succ (k : ℕ) :
+    digitSumPrefix (2 ^ (k + 1)) =
+      2 ^ k + 2 * digitSumPrefix (2 ^ k) := by
+  simpa [Nat.pow_succ, Nat.mul_comm, two_mul, add_assoc, add_left_comm, add_comm] using
+    digitSumPrefix_add_pow_two k (2 ^ k) le_rfl
+
+private lemma digitSumPrefix_pow_two_exact (k : ℕ) :
+    digitSumPrefix (2 ^ (k + 1)) = (k + 1) * 2 ^ k := by
+  induction k with
+  | zero =>
+      rw [digitSumPrefix]
+      norm_num [s2, Finset.sum_range_succ]
+  | succ k ih =>
+      rw [digitSumPrefix_pow_two_succ (k + 1), ih]
+      ring_nf
+
+private lemma digitSumPrefix_pow_two_exact' {k : ℕ} (hk : 1 ≤ k) :
+    digitSumPrefix (2 ^ k) = k * 2 ^ (k - 1) := by
+  rcases Nat.exists_eq_add_of_le hk with ⟨m, rfl⟩
+  simpa [Nat.add_comm] using digitSumPrefix_pow_two_exact m
+
+private lemma digitSumPrefix_pow_two_real {k : ℕ} (hk : 1 ≤ k) :
+    (digitSumPrefix (2 ^ k) : ℝ) = (2 ^ k : ℝ) * ((k : ℝ) / 2) := by
+  have hnat : digitSumPrefix (2 ^ k) = k * 2 ^ (k - 1) := digitSumPrefix_pow_two_exact' hk
+  have hk_sub_add : k - 1 + 1 = k := Nat.sub_add_cancel hk
+  have hpow : (2 ^ k : ℝ) = (2 ^ (k - 1) : ℝ) * 2 := by
+    lia
+  calc
+    (digitSumPrefix (2 ^ k) : ℝ) = (k : ℝ) * (2 ^ (k - 1) : ℝ) := by exact_mod_cast hnat
+    _ = (2 ^ k : ℝ) * ((k : ℝ) / 2) := by
+          rw [hpow]
+          ring
+
+private theorem digitSumPrefix_upper (n : ℕ) (hn : 1 ≤ n) :
+    (digitSumPrefix n : ℝ) ≤ (n : ℝ) * (((Nat.log 2 n : ℕ) : ℝ) / 2 + 1) := by
+  induction n using Nat.strongRecOn with
+  | ind n ih =>
+      by_cases hn1 : n = 1
+      · subst hn1
+        simp [digitSumPrefix, s2]
+      · have hn2 : 2 ≤ n := by omega
+        let k : ℕ := Nat.log 2 n
+        let r : ℕ := n - 2 ^ k
+        have hk_pos : 1 ≤ k := by
+          dsimp [k]
+          exact Nat.le_log_of_pow_le one_lt_two (by simpa using hn2)
+        have hn0 : n ≠ 0 := by omega
+        have hk_pow_le : 2 ^ k ≤ n := by
+          exact Nat.pow_log_le_self 2 hn0
+        have hr_eq : n = 2 ^ k + r := by
+          exact Eq.symm (Nat.add_sub_of_le hk_pow_le)
+        have hr_lt_pow : r < 2 ^ k := by
+          have hlt : n < 2 ^ (k + 1) := by
+            dsimp [k]
+            exact Nat.lt_pow_succ_log_self one_lt_two n
+          lia
+        have hr_le_pow : r ≤ 2 ^ k := hr_lt_pow.le
+        have hsmall :
+            (digitSumPrefix r : ℝ) ≤
+              (r : ℝ) * (((k - 1 : ℕ) : ℝ) / 2 + 1) := by
+          by_cases hr0 : r = 0
+          · simp [hr0]
+          · have hr_pos : 1 ≤ r := Nat.succ_le_of_lt (Nat.pos_of_ne_zero hr0)
+            have hr_lt_n : r < n := by
+              exact Nat.lt_of_lt_of_le hr_lt_pow hk_pow_le
+            have hlog_r_lt : Nat.log 2 r < k :=
+              Nat.log_lt_of_lt_pow (by omega : r ≠ 0) (by simpa using hr_lt_pow)
+            have hlog_r_le : Nat.log 2 r ≤ k - 1 := by omega
+            calc
+              (digitSumPrefix r : ℝ) ≤ (r : ℝ) * (((Nat.log 2 r : ℕ) : ℝ) / 2 + 1) :=
+                ih r hr_lt_n hr_pos
+              _ ≤ (r : ℝ) * (((k - 1 : ℕ) : ℝ) / 2 + 1) := by
+                    gcongr
+        have hk_sub : (((k - 1 : ℕ) : ℝ)) = (k : ℝ) - 1 := by
+          rw [Nat.cast_pred hk_pos]
+        have hdecomp :
+            digitSumPrefix n = digitSumPrefix (2 ^ k) + r + digitSumPrefix r := by
+          rw [hr_eq, digitSumPrefix_add_pow_two k r hr_le_pow]
+        calc
+          (digitSumPrefix n : ℝ)
+              = (digitSumPrefix (2 ^ k) : ℝ) + (r : ℝ) + (digitSumPrefix r : ℝ) := by
+                  exact_mod_cast hdecomp
+          _ ≤ (digitSumPrefix (2 ^ k) : ℝ) + (r : ℝ) +
+                (r : ℝ) * (((k - 1 : ℕ) : ℝ) / 2 + 1) := by
+                  gcongr
+          _ = (2 ^ k : ℝ) * ((k : ℝ) / 2) + (r : ℝ) +
+                (r : ℝ) * (((k - 1 : ℕ) : ℝ) / 2 + 1) := by
+                  rw [digitSumPrefix_pow_two_real hk_pos]
+          _ ≤ (n : ℝ) * ((k : ℝ) / 2 + 1) := by
+                rw [hk_sub]
+                have hnr : (n : ℝ) = (2 ^ k : ℝ) + (r : ℝ) := by exact_mod_cast hr_eq
+                have hr_cast_le : (r : ℝ) ≤ (2 ^ k : ℝ) := by exact_mod_cast hr_le_pow
+                rw [hnr]
+                nlinarith
+          _ = (n : ℝ) * (((Nat.log 2 n : ℕ) : ℝ) / 2 + 1) := by
+                dsimp [k]
+
+private theorem k_upper_bound (n : ℕ) (hn : 1 ≤ n) :
+    (k n : ℝ) ≤ (n : ℝ) * (Real.logb 2 (n : ℝ) / 2 + 2) := by
+  have hdigits : (digitSumPrefix n : ℝ) ≤ (n : ℝ) * (((Nat.log 2 n : ℕ) : ℝ) / 2 + 1) :=
+    digitSumPrefix_upper n hn
+  have hlog : (((Nat.log 2 n : ℕ) : ℝ)) ≤ Real.logb 2 (n : ℝ) := by
+    simpa using (Real.natLog_le_logb n 2)
+  calc
+    (k n : ℝ) = (n : ℝ) + (digitSumPrefix n : ℝ) := by
+                  exact_mod_cast digit_sum_formula n hn
+    _ ≤ (n : ℝ) + (n : ℝ) * ((((Nat.log 2 n : ℕ) : ℝ) / 2) + 1) := by
+          gcongr
+    _ = (n : ℝ) * ((((Nat.log 2 n : ℕ) : ℝ) / 2) + 2) := by ring
+    _ ≤ (n : ℝ) * (Real.logb 2 (n : ℝ) / 2 + 2) := by
+          gcongr
+
+section HarmonicUpper
+
+open Finset
+
+/-- The number of edges in `edges` containing the vertex `v`. -/
+noncomputable def degree (edges : Finset (Finset ℕ)) (v : ℕ) : ℕ :=
+  (edges.filter fun e => v ∈ e).card
+
+private lemma card_degreeOneSubsets_eq
+    (edges : Finset (Finset ℕ)) (r v : ℕ) (hr : 1 ≤ r) :
+    (((edges.powersetCard r).filter fun A => degree A v = 1).card : ℕ) =
+      (edges.filter fun e => v ∈ e).card *
+        ((edges.filter fun e => v ∉ e).powersetCard (r - 1)).card := by
+  classical
+  let inc : Finset (Finset ℕ) := edges.filter fun e => v ∈ e
+  let non : Finset (Finset ℕ) := edges.filter fun e => v ∉ e
+  let pieces : Finset (Finset (Finset ℕ)) :=
+    inc.biUnion fun e => ((non.powersetCard (r - 1)).image (insert e))
+  have hpieces : pieces = (edges.powersetCard r).filter fun A => degree A v = 1 := by
+    ext A
+    constructor
+    · intro hA
+      rcases mem_biUnion.mp hA with ⟨e, he, hAe⟩
+      rw [mem_image] at hAe
+      rcases hAe with ⟨B, hB, rfl⟩
+      refine mem_filter.mpr ?_
+      refine ⟨?_, ?_⟩
+      · refine mem_powersetCard.mpr ?_
+        refine ⟨?_, ?_⟩
+        · intro x hx
+          rcases mem_insert.mp hx with rfl | hx
+          · exact (mem_filter.mp he).1
+          · exact (mem_filter.mp ((mem_powersetCard.mp hB).1 hx)).1
+        · have he_not_mem : e ∉ B := by
+            intro heB
+            exact (mem_filter.mp ((mem_powersetCard.mp hB).1 heB)).2 ((mem_filter.mp he).2)
+          have hBcard : B.card = r - 1 := (mem_powersetCard.mp hB).2
+          have : r - 1 + 1 = r := by omega
+          simp [he_not_mem, hBcard, this]
+      · have hfilter_insert : (insert e B).filter (fun e' => v ∈ e') = {e} := by
+          ext x
+          constructor
+          · intro hx
+            rcases mem_insert.mp (mem_filter.mp hx).1 with rfl | hxB
+            · simp
+            · exact False.elim
+                ((mem_filter.mp ((mem_powersetCard.mp hB).1 hxB)).2 (mem_filter.mp hx).2)
+          · intro hx
+            rw [mem_singleton] at hx
+            subst hx
+            exact mem_filter.mpr ⟨mem_insert_self _ _, (mem_filter.mp he).2⟩
+        rw [degree, hfilter_insert]
+        simp
+    · intro hA
+      rcases mem_filter.mp hA with ⟨hAcard, hdeg⟩
+      have hincident_card : (A.filter fun e => v ∈ e).card = 1 := by
+        simpa [degree] using hdeg
+      rcases Finset.card_eq_one.mp hincident_card with ⟨e, he_singleton⟩
+      have he_mem_filter : e ∈ A.filter fun e => v ∈ e := by simp [he_singleton]
+      have heA : e ∈ A := (mem_filter.mp he_mem_filter).1
+      have hev : v ∈ e := (mem_filter.mp he_mem_filter).2
+      have hBsub_non : A.erase e ⊆ non := by
+        intro x hx
+        refine mem_filter.mpr ⟨?_, ?_⟩
+        · exact (mem_powersetCard.mp hAcard).1 ((mem_erase.mp hx).2)
+        · intro hvx
+          have hx_filter : x ∈ A.filter fun e => v ∈ e :=
+            mem_filter.mpr ⟨(mem_erase.mp hx).2, hvx⟩
+          rw [he_singleton] at hx_filter
+          exact (mem_erase.mp hx).1 (by simpa using hx_filter)
+      have hBcard : (A.erase e).card = r - 1 := by
+        have hAcard' : A.card = r := (mem_powersetCard.mp hAcard).2
+        rw [Finset.card_erase_of_mem heA, hAcard']
+      have hinsert : insert e (A.erase e) = A := insert_erase heA
+      refine mem_biUnion.mpr ⟨e, ?_, ?_⟩
+      · exact mem_filter.mpr ⟨(mem_powersetCard.mp hAcard).1 heA, hev⟩
+      · exact mem_image.mpr ⟨A.erase e, mem_powersetCard.mpr ⟨hBsub_non, hBcard⟩, hinsert⟩
+  rw [← hpieces]
+  rw [card_biUnion]
+  · calc
+      ∑ e ∈ inc, #(image (insert e) (powersetCard (r - 1) non))
+          = ∑ e ∈ inc, #(non.powersetCard (r - 1)) := by
+              refine sum_congr rfl ?_
+              intro e he
+              symm
+              refine Finset.card_bij (fun B hB => insert e B) ?_ ?_ ?_
+              · intro B hB
+                exact mem_image.mpr ⟨B, hB, rfl⟩
+              · intro B1 hB1 B2 hB2 hEq
+                have he_not_mem1 : e ∉ B1 := fun heB =>
+                  (mem_filter.mp ((mem_powersetCard.mp hB1).1 heB)).2 ((mem_filter.mp he).2)
+                have he_not_mem2 : e ∉ B2 := fun heB =>
+                  (mem_filter.mp ((mem_powersetCard.mp hB2).1 heB)).2 ((mem_filter.mp he).2)
+                simpa [he_not_mem1, he_not_mem2] using congrArg (fun s => s.erase e) hEq
+              · intro C hC
+                rcases mem_image.mp hC with ⟨B, hB, rfl⟩
+                exact ⟨B, hB, rfl⟩
+      _ = inc.card * (non.powersetCard (r - 1)).card := by
+              rw [Finset.sum_const_nat (m := (non.powersetCard (r - 1)).card) (fun _ _ => rfl)]
+      _ = (edges.filter fun e => v ∈ e).card *
+            ((edges.filter fun e => v ∉ e).powersetCard (r - 1)).card := by
+              simp [inc, non]
+  · intro e1 he1 e2 he2 hne
+    refine disjoint_left.2 ?_
+    intro A hA1 hA2
+    rw [mem_image] at hA1 hA2
+    rcases hA1 with ⟨B1, hB1, rfl⟩
+    rcases hA2 with ⟨B2, hB2, hEq⟩
+    have hv1 : v ∈ e1 := (mem_filter.mp he1).2
+    have he1_not_B2 : e1 ∉ B2 := fun he => (mem_filter.mp ((mem_powersetCard.mp hB2).1 he)).2 hv1
+    have : e1 = e2 := by
+      have he1_mem : e1 ∈ insert e2 B2 := by simp [hEq]
+      rcases mem_insert.mp he1_mem with h | h
+      · exact h
+      · exact False.elim (he1_not_B2 h)
+    exact hne this
+
+private lemma degree_pos_of_mem_vertexSet {edges : Finset (Finset ℕ)} {v : ℕ}
+    (hv : v ∈ vertexSet edges) : 1 ≤ degree edges v := by
+  rw [degree]
+  rcases Finset.mem_biUnion.mp hv with ⟨e, he, hvE⟩
+  exact Finset.card_pos.mpr ⟨e, Finset.mem_filter.mpr ⟨he, hvE⟩⟩
+
+private lemma degree_le_card_edges (edges : Finset (Finset ℕ)) (v : ℕ) :
+    degree edges v ≤ edges.card :=
+  Finset.card_filter_le _ _
+
+private lemma choose_cross_identity (m k r : ℕ)
+    (hk : 1 ≤ k) (hkm : k ≤ m) (hr : 1 ≤ r) (hrm : r ≤ m) :
+    (Nat.choose (m - 1) (r - 1) : ℚ) * Nat.choose (m - r) (k - 1)
+      = Nat.choose (m - 1) (k - 1) * Nat.choose (m - k) (r - 1) := by
+  by_cases hbig : k + r ≤ m + 1
+  · let t := r + k - 2
+    have hrt : r - 1 ≤ t := by
+      lia
+    have hkt : k - 1 ≤ t := by
+      lia
+    have h1 := Nat.choose_mul (n := m - 1) (k := t) (s := r - 1) hrt
+    have h2 := Nat.choose_mul (n := m - 1) (k := t) (s := k - 1) hkt
+    have ht_eq : t = (r - 1) + (k - 1) := by
+      lia
+    have hsymm : Nat.choose t (r - 1) = Nat.choose t (k - 1) := by
+      exact Nat.choose_symm_of_eq_add ht_eq
+    have hmr : m - 1 - (r - 1) = m - r := by omega
+    have hmk : m - 1 - (k - 1) = m - k := by omega
+    have htr : t - (r - 1) = k - 1 := by
+      exact (Nat.sub_eq_iff_eq_add' hrt).mpr ht_eq
+    have htk : t - (k - 1) = r - 1 := by
+      exact (Nat.sub_eq_iff_eq_add hkt).mpr ht_eq
+    have h1' : Nat.choose (m - 1) t * Nat.choose t (r - 1)
+        = Nat.choose (m - 1) (r - 1) * Nat.choose (m - r) (k - 1) := by
+      simpa [hmr, htr] using h1
+    have h2' : Nat.choose (m - 1) t * Nat.choose t (k - 1)
+        = Nat.choose (m - 1) (k - 1) * Nat.choose (m - k) (r - 1) := by
+      simpa [hmk, htk] using h2
+    have h1q : ((Nat.choose (m - 1) t : ℚ) * Nat.choose t (r - 1))
+        = Nat.choose (m - 1) (r - 1) * Nat.choose (m - r) (k - 1) := by
+      exact_mod_cast h1'
+    have h2q : ((Nat.choose (m - 1) t : ℚ) * Nat.choose t (k - 1))
+        = Nat.choose (m - 1) (k - 1) * Nat.choose (m - k) (r - 1) := by
+      exact_mod_cast h2'
+    rw [← h1q, hsymm, h2q]
+  · have hrbig : m - k < r - 1 := by omega
+    have hkbig : m - r < k - 1 := by omega
+    simp [Nat.choose_eq_zero_of_lt hrbig, Nat.choose_eq_zero_of_lt hkbig]
+
+private lemma degree_weighted_sum (m k : ℕ) (hm : 1 ≤ m) (hk : 1 ≤ k) (hkm : k ≤ m) :
+    ∑ r ∈ Icc 1 m,
+      (((k : ℚ) * Nat.choose (m - k) (r - 1)) / Nat.choose (m - 1) (r - 1)) = m := by
+  have hden_nat : 0 < Nat.choose (m - 1) (k - 1) := Nat.choose_pos (by omega : k - 1 ≤ m - 1)
+  have hden : (Nat.choose (m - 1) (k - 1) : ℚ) ≠ 0 := by
+    exact_mod_cast hden_nat.ne'
+  have hterm : ∀ r ∈ Icc 1 m,
+      (((k : ℚ) * Nat.choose (m - k) (r - 1)) / Nat.choose (m - 1) (r - 1))
+        = ((k : ℚ) / Nat.choose (m - 1) (k - 1)) * Nat.choose (m - r) (k - 1) := by
+    intro r hr
+    have hr1 : 1 ≤ r := (mem_Icc.mp hr).1
+    have hrm : r ≤ m := (mem_Icc.mp hr).2
+    have hrden_nat : 0 < Nat.choose (m - 1) (r - 1) := Nat.choose_pos (by omega : r - 1 ≤ m - 1)
+    have hrden : (Nat.choose (m - 1) (r - 1) : ℚ) ≠ 0 := by exact_mod_cast hrden_nat.ne'
+    have hcross := choose_cross_identity m k r hk hkm hr1 hrm
+    field_simp [hden, hrden]
+    ring_nf
+    simpa [mul_comm, mul_left_comm, mul_assoc] using hcross.symm
+  calc
+    ∑ r ∈ Icc 1 m,
+        (((k : ℚ) * Nat.choose (m - k) (r - 1)) / Nat.choose (m - 1) (r - 1))
+      = ∑ r ∈ Icc 1 m,
+          (((k : ℚ) / Nat.choose (m - 1) (k - 1)) * Nat.choose (m - r) (k - 1)) := by
+            refine sum_congr rfl hterm
+    _ = ((k : ℚ) / Nat.choose (m - 1) (k - 1)) *
+          ∑ r ∈ Icc 1 m, (Nat.choose (m - r) (k - 1) : ℚ) := by
+          rw [← mul_sum]
+    _ = ((k : ℚ) / Nat.choose (m - 1) (k - 1)) * Nat.choose m k := by
+          congr 1
+          have hsum1 :
+              ∑ r ∈ Icc 1 m, (Nat.choose (m - r) (k - 1) : ℚ)
+                = ∑ j ∈ range m, (Nat.choose ((m - 1) - j) (k - 1) : ℚ) := by
+              rw [← Ico_add_one_right_eq_Icc, Finset.sum_Ico_eq_sum_range]
+              lia
+          rw [hsum1]
+          have hreflect :
+              ∑ j ∈ range m, (Nat.choose ((m - 1) - j) (k - 1) : ℚ)
+                = ∑ j ∈ range m, (Nat.choose j (k - 1) : ℚ) := by
+              simpa using (Finset.sum_range_reflect (f := fun j => (Nat.choose j (k - 1) : ℚ)) m)
+          rw [hreflect]
+          have hsplit :=
+            Finset.sum_range_add_sum_Ico
+              (fun j => (Nat.choose j (k - 1) : ℚ)) (by omega : k - 1 ≤ m)
+          have hzero : ∑ j ∈ range (k - 1), (Nat.choose j (k - 1) : ℚ) = 0 := by
+            refine sum_eq_zero ?_
+            intro j hj
+            have hjlt : j < k - 1 := by simpa using hj
+            simp [Nat.choose_eq_zero_of_lt hjlt]
+          have hIco :
+              ∑ j ∈ Ico (k - 1) m, (Nat.choose j (k - 1) : ℚ)
+                = ∑ i ∈ range (m - k + 1), (Nat.choose (i + (k - 1)) (k - 1) : ℚ) := by
+              rw [Finset.sum_Ico_eq_sum_range]
+              have hlen : m - (k - 1) = m - k + 1 := by omega
+              simp [hlen, Nat.add_comm]
+          have hshift :
+              ∑ i ∈ range (m - k + 1),
+                (Nat.choose (i + (k - 1)) (k - 1) : ℚ) = Nat.choose m k := by
+              have hmkk : (m - k) + (k - 1) + 1 = m := by omega
+              have hk1 : (k - 1) + 1 = k := by omega
+              simpa [hmkk, hk1, Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using
+                (show
+                    (∑ i ∈ range ((m - k) + 1), ((i + (k - 1)).choose (k - 1) : ℚ)) =
+                      Nat.choose ((m - k) + (k - 1) + 1) ((k - 1) + 1) by
+                  exact_mod_cast Nat.sum_range_add_choose (m - k) (k - 1))
+          linarith [hsplit, hzero, hIco, hshift]
+    _ = m := by
+          have hm' : m - 1 + 1 = m := Nat.sub_add_cancel hm
+          have hk' : k - 1 + 1 = k := Nat.sub_add_cancel hk
+          have hchooseNat : m * Nat.choose (m - 1) (k - 1) = Nat.choose m k * k := by
+            simpa [hm', hk'] using Nat.add_one_mul_choose_eq (m - 1) (k - 1)
+          have hchoose : ((m : ℚ) * Nat.choose (m - 1) (k - 1)) = Nat.choose m k * k := by
+            exact_mod_cast hchooseNat
+          field_simp [hden]
+          ring_nf
+          simpa [mul_comm, mul_left_comm, mul_assoc] using hchoose.symm
+
+private theorem vertex_card_le_harmonic
+    (edges : Finset (Finset ℕ)) (n : ℕ) (hm : 1 ≤ edges.card)
+    (hpart : NoLargePartition edges n) :
+    ((vertexSet edges).card : ℚ) ≤ n * harmonic edges.card := by
+  let m := edges.card
+  let W : ℚ := ∑ r ∈ Icc 1 m,
+      ∑ A ∈ edges.powersetCard r,
+        ((uniqueCoverage edges A : ℚ) / Nat.choose (m - 1) (r - 1))
+  have hr_bound :
+      ∀ r ∈ Icc 1 m,
+        ∑ A ∈ edges.powersetCard r,
+          ((uniqueCoverage edges A : ℚ) / Nat.choose (m - 1) (r - 1))
+            ≤ (n : ℚ) * m / r := by
+    intro r hr
+    have hpoint :
+        ∀ A ∈ edges.powersetCard r,
+          ((uniqueCoverage edges A : ℚ) / Nat.choose (m - 1) (r - 1))
+            ≤ (n : ℚ) / Nat.choose (m - 1) (r - 1) := by
+      intro A hA
+      have hsub : A ⊆ edges := (mem_powersetCard.mp hA).1
+      exact div_le_div_of_nonneg_right (by exact_mod_cast hpart A hsub) (by positivity)
+    have hr1 : 1 ≤ r := (mem_Icc.mp hr).1
+    have hrm : r ≤ m := (mem_Icc.mp hr).2
+    have hrden_nat : 0 < Nat.choose (m - 1) (r - 1) := Nat.choose_pos (by omega : r - 1 ≤ m - 1)
+    have hrden : (Nat.choose (m - 1) (r - 1) : ℚ) ≠ 0 := by
+      exact_mod_cast hrden_nat.ne'
+    calc
+      ∑ A ∈ edges.powersetCard r, ((uniqueCoverage edges A : ℚ) / Nat.choose (m - 1) (r - 1))
+          ≤ ∑ A ∈ edges.powersetCard r, ((n : ℚ) / Nat.choose (m - 1) (r - 1)) :=
+            Finset.sum_le_sum hpoint
+      _ = ((edges.powersetCard r).card : ℚ) * ((n : ℚ) / Nat.choose (m - 1) (r - 1)) := by
+            simp
+      _ = (Nat.choose m r : ℚ) * ((n : ℚ) / Nat.choose (m - 1) (r - 1)) := by
+            rw [Finset.card_powersetCard]
+      _ = (n : ℚ) * m / r := by
+            have hchooseNat : m * Nat.choose (m - 1) (r - 1) = Nat.choose m r * r := by
+              have hm' : m - 1 + 1 = m := Nat.sub_add_cancel (by omega : 1 ≤ m)
+              have hr' : r - 1 + 1 = r := Nat.sub_add_cancel hr1
+              simpa [hm', hr'] using Nat.add_one_mul_choose_eq (m - 1) (r - 1)
+            have hchoose : ((m : ℚ) * Nat.choose (m - 1) (r - 1)) = Nat.choose m r * r := by
+              exact_mod_cast hchooseNat
+            have hratio :
+                ((Nat.choose m r : ℚ) / Nat.choose (m - 1) (r - 1)) = m / r := by
+              field_simp [hrden, show (r : ℚ) ≠ 0 by exact_mod_cast Nat.ne_of_gt hr1]
+              simpa [mul_comm, mul_left_comm, mul_assoc] using hchoose.symm
+            calc
+              (Nat.choose m r : ℚ) * ((n : ℚ) / Nat.choose (m - 1) (r - 1))
+                  = (n : ℚ) *
+                      (((Nat.choose m r : ℚ) / Nat.choose (m - 1) (r - 1))) := by
+                        ring
+              _ = (n : ℚ) * (m / r) := by rw [hratio]
+              _ = (n : ℚ) * m / r := by ring
+  have hW_upper : W ≤ (n : ℚ) * m * harmonic m := by
+    dsimp [W]
+    calc
+      ∑ r ∈ Icc 1 m,
+          ∑ A ∈ edges.powersetCard r,
+            ((uniqueCoverage edges A : ℚ) / Nat.choose (m - 1) (r - 1))
+        ≤ ∑ r ∈ Icc 1 m, (n : ℚ) * m / r := Finset.sum_le_sum hr_bound
+      _ = (n : ℚ) * m * ∑ r ∈ Icc 1 m, ((r : ℚ)⁻¹) := by
+            rw [mul_sum]
+            lia
+      _ = (n : ℚ) * m * harmonic m := by
+            rw [harmonic_eq_sum_Icc]
+  have hucov_nat (A : Finset (Finset ℕ)) :
+      uniqueCoverage edges A =
+        ∑ v ∈ vertexSet edges, if degree A v = 1 then 1 else 0 := by
+    unfold uniqueCoverage degree
+    rw [Finset.card_eq_sum_ones, Finset.sum_filter]
+  have hucov (A : Finset (Finset ℕ)) :
+      (uniqueCoverage edges A : ℚ) =
+        ∑ v ∈ vertexSet edges, if degree A v = 1 then (1 : ℚ) else 0 := by
+    exact_mod_cast hucov_nat A
+  have hswap (r : ℕ) :
+      ∑ A ∈ edges.powersetCard r,
+        ((uniqueCoverage edges A : ℚ) / Nat.choose (m - 1) (r - 1))
+        = ∑ v ∈ vertexSet edges,
+            ((((edges.powersetCard r).filter fun A => degree A v = 1).card : ℚ) /
+              Nat.choose (m - 1) (r - 1)) := by
+    let den : ℚ := Nat.choose (m - 1) (r - 1)
+    calc
+      ∑ A ∈ edges.powersetCard r, ((uniqueCoverage edges A : ℚ) / den)
+          = ∑ A ∈ edges.powersetCard r,
+              ∑ v ∈ vertexSet edges, (if degree A v = 1 then ((1 : ℚ) / den) else 0) := by
+                refine sum_congr rfl ?_
+                intro A hA
+                rw [hucov A, div_eq_mul_inv, Finset.sum_mul]
+                refine sum_congr rfl ?_
+                intro v hv
+                split_ifs <;> simp [div_eq_mul_inv]
+      _ = ∑ v ∈ vertexSet edges,
+              ∑ A ∈ edges.powersetCard r,
+                (if degree A v = 1 then ((1 : ℚ) / den) else 0) := by
+                rw [Finset.sum_comm]
+      _ = ∑ v ∈ vertexSet edges,
+              (((edges.powersetCard r).filter fun A => degree A v = 1).card : ℚ) / den := by
+                refine sum_congr rfl ?_
+                intro v hv
+                rw [← Finset.sum_filter, Finset.sum_const, nsmul_eq_mul, div_eq_mul_inv]
+                ring
+  have hW_eq : W = (m : ℚ) * (vertexSet edges).card := by
+    dsimp [W]
+    calc
+      ∑ r ∈ Icc 1 m,
+          ∑ A ∈ edges.powersetCard r,
+            ((uniqueCoverage edges A : ℚ) / Nat.choose (m - 1) (r - 1))
+        = ∑ v ∈ vertexSet edges,
+            ∑ r ∈ Icc 1 m,
+              ((((edges.powersetCard r).filter fun A => degree A v = 1).card : ℚ) /
+              Nat.choose (m - 1) (r - 1)) := by
+          rw [Finset.sum_comm]
+          exact sum_congr rfl fun x a => hswap x
+    _ = ∑ v ∈ vertexSet edges, (m : ℚ) := by
+          refine sum_congr rfl ?_
+          intro v hv
+          have hvpos : 1 ≤ degree edges v := degree_pos_of_mem_vertexSet hv
+          have hvle : degree edges v ≤ m := by simpa [m] using degree_le_card_edges edges v
+          calc
+            ∑ r ∈ Icc 1 m,
+                ((((edges.powersetCard r).filter fun A => degree A v = 1).card : ℚ) /
+                  Nat.choose (m - 1) (r - 1))
+              = ∑ r ∈ Icc 1 m,
+                  (((degree edges v : ℚ) * Nat.choose (m - degree edges v) (r - 1)) /
+                    Nat.choose (m - 1) (r - 1)) := by
+                      refine sum_congr rfl ?_
+                      intro r hr
+                      have hr1 : 1 ≤ r := (mem_Icc.mp hr).1
+                      have hsplitCard :
+                          (edges.filter fun e => v ∈ e).card +
+                            (edges.filter fun e => v ∉ e).card = edges.card := by
+                        simpa using
+                          (Finset.card_filter_add_card_filter_not (s := edges)
+                            (p := fun e => v ∈ e))
+                      have hnoncard :
+                          (edges.filter fun e => v ∉ e).card = m - degree edges v := by
+                        dsimp [m, degree]
+                        omega
+                      rw [card_degreeOneSubsets_eq edges r v hr1,
+                        Finset.card_powersetCard, hnoncard]
+                      simp [m, degree]
+            _ = m := degree_weighted_sum m (degree edges v) (by simpa [m] using hm) hvpos hvle
+    _ = (m : ℚ) * (vertexSet edges).card := by
+          simp [Finset.sum_const, nsmul_eq_mul, mul_comm]
+  have hmq : (0 : ℚ) < m := by exact_mod_cast hm
+  have hineq : (m : ℚ) * (vertexSet edges).card ≤ (m : ℚ) * ((n : ℚ) * harmonic m) := by
+    simpa [hW_eq, mul_assoc, mul_left_comm, mul_comm] using hW_upper
+  exact le_of_mul_le_mul_left hineq hmq
+
+private lemma harmonic_monotone : Monotone harmonic := by
+  refine monotone_nat_of_le_succ ?_
+  intro m
+  rw [harmonic_succ]
+  exact le_add_of_nonneg_right (by positivity)
+
+private theorem vertexSet_card_le_harmonic_of_noLargePartition
+    (edges : Finset (Finset ℕ)) (n : ℕ) (hpart : NoLargePartition edges n) :
+    ((vertexSet edges).card : ℚ) ≤ n * harmonic n := by
+  obtain ⟨C, hCsub, hCcover, hCcard⟩ :=
+    exists_cover_subset_card_le_of_noLargePartition edges n hpart
+  by_cases hCempty : C = ∅
+  · have hVempty : vertexSet edges = ∅ := by
+      rw [← hCcover, hCempty]
+      simp [vertexSet]
+    have hharm_nonneg : (0 : ℚ) ≤ harmonic n := by
+      simpa using harmonic_monotone (Nat.zero_le n)
+    have hnonneg : (0 : ℚ) ≤ (n : ℚ) * harmonic n := mul_nonneg (by positivity) hharm_nonneg
+    simpa [hVempty] using hnonneg
+  · have hCpos : 1 ≤ C.card := by
+      rcases Finset.nonempty_iff_ne_empty.mpr hCempty with ⟨e, he⟩
+      exact Finset.card_pos.mpr ⟨e, he⟩
+    have hpartC : NoLargePartition C n := by
+      intro P hP
+      have hPe : P ⊆ edges := fun e he => hCsub (hP he)
+      simpa [uniqueCoverage, hCcover] using hpart P hPe
+    calc
+      ((vertexSet edges).card : ℚ) = (vertexSet C).card := by rw [hCcover]
+      _ ≤ n * harmonic C.card := vertex_card_le_harmonic C n hCpos hpartC
+      _ ≤ n * harmonic n := by
+            gcongr
+            exact harmonic_monotone hCcard
+
+private theorem H_upper_harmonic (n : ℕ) (hn : 1 ≤ n) :
+    (H n : ℚ) ≤ n * harmonic n := by
+  have hnonempty :
+      {k : ℕ | ∃ (edges : Finset (Finset ℕ)),
+        (vertexSet edges).card = k ∧ NoLargePartition edges n}.Nonempty := by
+    rcases A_witness n hn with ⟨edges, -, hcard, hpart⟩
+    exact ⟨(vertexSet edges).card, ⟨edges, rfl, hpart⟩⟩
+  rcases Nat.sSup_mem hnonempty (H_set_bddAbove n) with ⟨edges, hcard, hpart⟩
+  unfold H
+  simpa [hcard] using vertexSet_card_le_harmonic_of_noLargePartition edges n hpart
+
+private lemma le_two_pow (n : ℕ) : n ≤ 2 ^ n := by
+  induction n with
+  | zero =>
+      simp
+  | succ n ih =>
+      calc
+        n + 1 ≤ 2 ^ n + 1 := Nat.add_le_add_right ih 1
+        _ ≤ 2 ^ n + 2 ^ n := by
+              lia
+        _ = 2 ^ (n + 1) := by
+              rw [Nat.pow_succ, Nat.mul_comm, two_mul]
+
+private lemma k_pow_two_real {m : ℕ} (hm : 1 ≤ m) :
+    (k (2 ^ m) : ℝ) = (2 ^ m : ℝ) * ((m : ℝ) / 2 + 1) := by
+  have hpow_pos : 1 ≤ 2 ^ m := Nat.one_le_two_pow
+  calc
+    (k (2 ^ m) : ℝ) = (2 ^ m : ℝ) + digitSumPrefix (2 ^ m) := by
+          exact_mod_cast digit_sum_formula (2 ^ m) hpow_pos
+    _ = (2 ^ m : ℝ) + (2 ^ m : ℝ) * ((m : ℝ) / 2) := by
+          rw [digitSumPrefix_pow_two_real hm]
+    _ = (2 ^ m : ℝ) * ((m : ℝ) / 2 + 1) := by
+          ring
+
+private theorem H_div_k_pow_two_le_two {m : ℕ} (hm : 1 ≤ m) :
+    (H (2 ^ m) : ℝ) / (k (2 ^ m) : ℝ) ≤ 2 := by
+  have hHq := H_upper_harmonic (2 ^ m) Nat.one_le_two_pow
+  have hH : (H (2 ^ m) : ℝ) ≤ (2 ^ m : ℝ) * (((harmonic (2 ^ m) : ℚ) : ℝ)) := by
+    exact_mod_cast hHq
+  have hharm : (((harmonic (2 ^ m) : ℚ) : ℝ)) ≤ 1 + Real.log (2 ^ m : ℝ) := by
+    simpa using (harmonic_le_one_add_log (2 ^ m))
+  have hlog2_lt_one : Real.log 2 < 1 := by
+    linarith [Real.log_lt_sub_one_of_pos (by positivity : 0 < (2 : ℝ))
+      (by norm_num : (2 : ℝ) ≠ 1)]
+  have hlog : Real.log (2 ^ m : ℝ) ≤ m := by
+    rw [Real.log_pow]
+    nlinarith
+  have hharm_le : (((harmonic (2 ^ m) : ℚ) : ℝ)) ≤ (m : ℝ) + 1 := by
+    linarith
+  have hk_eq := k_pow_two_real hm
+  have hk_pos : 0 < (k (2 ^ m) : ℝ) := by
+    rw [hk_eq]
+    positivity
+  apply (div_le_iff₀ hk_pos).2
+  calc
+    (H (2 ^ m) : ℝ) ≤ (2 ^ m : ℝ) * ((m : ℝ) + 1) := by
+      calc
+        (H (2 ^ m) : ℝ) ≤ (2 ^ m : ℝ) * (((harmonic (2 ^ m) : ℚ) : ℝ)) := hH
+        _ ≤ (2 ^ m : ℝ) * ((m : ℝ) + 1) := by
+              gcongr
+    _ ≤ 2 * (k (2 ^ m) : ℝ) := by
+      rw [hk_eq]
+      have hpow_nonneg : (0 : ℝ) ≤ (2 ^ m : ℝ) := by positivity
+      nlinarith
+
+private theorem ratio_isCobounded :
+    Filter.atTop.IsCoboundedUnder (· ≥ ·) (fun n : ℕ => (H n : ℝ) / (k n : ℝ)) := by
+  refine Filter.IsCoboundedUnder.of_frequently_le (a := 2) ?_
+  rw [Filter.frequently_atTop]
+  intro a
+  refine ⟨2 ^ (a + 1), ?_, ?_⟩
+  · exact le_trans (Nat.le_succ a) (le_two_pow (a + 1))
+  · exact H_div_k_pow_two_le_two (m := a + 1) (Nat.succ_le_succ (Nat.zero_le a))
+
+end HarmonicUpper
+
+/-! ## The asymptotic theorem -/
+
+/-- The asymptotic lower bound: liminf H(n)/k_n ≥ 2 ln 2. -/
+theorem asymptotic_lower_bound :
+    2 * Real.log 2 ≤
+      Filter.atTop.liminf (fun n : ℕ => (H n : ℝ) / (k n : ℝ)) := by
+  have hratio_bddBelow :
+      Filter.atTop.IsBoundedUnder (· ≥ ·) (fun n : ℕ => (H n : ℝ) / (k n : ℝ)) :=
+    Filter.isBoundedUnder_of_eventually_ge (a := 0) <|
+      Filter.Eventually.of_forall fun _ => by positivity
+  rw [Filter.le_liminf_iff' (h₁ := ratio_isCobounded) (h₂ := hratio_bddBelow)]
+  intro y hy
+  by_cases hy0 : y ≤ 0
+  · exact Filter.Eventually.of_forall fun n => by
+      have hratio_nonneg : 0 ≤ (H n : ℝ) / (k n : ℝ) := by positivity
+      linarith
+  · have hy_pos : 0 < y := lt_of_not_ge hy0
+    let ε : ℝ := 1 - y / (2 * Real.log 2)
+    have hlog2_pos : 0 < Real.log 2 := Real.log_pos one_lt_two
+    have hlog2_ne : Real.log 2 ≠ 0 := hlog2_pos.ne'
+    have htwo_log2_pos : 0 < 2 * Real.log 2 := by nlinarith
+    have hε_pos : 0 < ε := by
+      dsimp [ε]
+      have hy_div_lt_one : y / (2 * Real.log 2) < 1 := by
+        exact (div_lt_one₀ htwo_log2_pos).mpr hy
+      linarith
+    have hlog_tendsto :
+        Filter.Tendsto (fun n : ℕ => Real.log (n : ℝ)) Filter.atTop Filter.atTop :=
+      Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
+    rcases Filter.eventually_atTop.1 (hlog_tendsto.eventually_gt_atTop (1 / ε)) with ⟨N, hN⟩
+    let t : ℕ := max N 2
+    have ht : 2 ≤ t := by simp [t]
+    have htlog : 1 / ε < Real.log (t : ℝ) := by
+      apply hN
+      exact Nat.le_max_left N 2
+    have hlogt_pos : 0 < Real.log (t : ℝ) := Real.log_pos (by exact_mod_cast ht)
+    have hinv : 1 / Real.log (t : ℝ) < ε := (one_div_lt hε_pos hlogt_pos).1 htlog
+    have hyhalf : y / 2 < fixedTCoeff t := by
+      calc
+        y / 2 = Real.log 2 * (1 - ε) := by
+                  dsimp [ε]
+                  field_simp [hlog2_ne]
+                  ring
+        _ < Real.log 2 * (1 - 1 / Real.log (t : ℝ)) := by
+              exact mul_lt_mul_of_pos_left (by linarith [hinv]) hlog2_pos
+        _ ≤ fixedTCoeff t := fixedTCoeff_lower t ht
+    rcases fixed_t_bound t ht with ⟨C, hC_pos, hC⟩
+    let a : ℝ := fixedTCoeff t
+    have hdelta_pos : 0 < a - y / 2 := by simpa [a] using sub_pos.mpr hyhalf
+    have hlogb_tendsto :
+        Filter.Tendsto (fun n : ℕ => Real.logb 2 (n : ℝ)) Filter.atTop Filter.atTop :=
+      (Real.tendsto_logb_atTop one_lt_two).comp tendsto_natCast_atTop_atTop
+    let B : ℝ := (C + 2 * y) / (a - y / 2)
+    filter_upwards [Filter.eventually_ge_atTop 1,
+      hlogb_tendsto.eventually_ge_atTop B] with n hn hlog
+    have hk_pos_nat : 1 ≤ k n := by
+      simpa [digit_sum_formula n hn] using le_trans hn (Nat.le_add_right n (digitSumPrefix n))
+    have hk_pos : 0 < (k n : ℝ) := by exact_mod_cast hk_pos_nat
+    have hH : (H n : ℝ) ≥ a * (n : ℝ) * Real.logb 2 (n : ℝ) - C * (n : ℝ) := by
+      simpa [a] using hC n hn
+    have hk_upper : (k n : ℝ) ≤ (n : ℝ) * (Real.logb 2 (n : ℝ) / 2 + 2) :=
+      k_upper_bound n hn
+    have haux : y * (Real.logb 2 (n : ℝ) / 2 + 2) ≤ a * Real.logb 2 (n : ℝ) - C := by
+      have hmul : C + 2 * y ≤ Real.logb 2 (n : ℝ) * (a - y / 2) := by
+        dsimp [B] at hlog
+        exact (div_le_iff₀ hdelta_pos).1 hlog
+      linarith
+    have hyk : y * (k n : ℝ) ≤ (H n : ℝ) := by
+      calc
+        y * (k n : ℝ) ≤ y * ((n : ℝ) * (Real.logb 2 (n : ℝ) / 2 + 2)) := by
+              gcongr
+        _ = (n : ℝ) * (y * (Real.logb 2 (n : ℝ) / 2 + 2)) := by ring
+        _ ≤ (n : ℝ) * (a * Real.logb 2 (n : ℝ) - C) := by
+              gcongr
+        _ = a * (n : ℝ) * Real.logb 2 (n : ℝ) - C * (n : ℝ) := by ring
+        _ ≤ (H n : ℝ) := hH
+    exact (le_div_iff₀ hk_pos).2 hyk
+
+/-- The asymptotic theorem of `frontier.tex`, packaging the fixed-`t` lower bound and
+    its consequence for the liminf ratio `H(n) / k_n`. -/
+theorem thm_asymptotic :
+    (∀ t : ℕ, 2 ≤ t →
+      ∃ C : ℝ, 0 < C ∧ ∀ n : ℕ, 1 ≤ n →
+        (H n : ℝ) ≥
+          fixedTCoeff t *
+            (n : ℝ) * Real.logb 2 (n : ℝ) - C * (n : ℝ)) ∧
+    2 * Real.log 2 ≤
+      Filter.atTop.liminf (fun n : ℕ => (H n : ℝ) / (k n : ℝ)) := by
+  refine ⟨?_, asymptotic_lower_bound⟩
+  exact fun t a => fixed_t_bound t a
+
+
+end HypergraphLowerBound

--- a/LeanPool/FrontierMathOpenHypergraphs/Substitution.lean
+++ b/LeanPool/FrontierMathOpenHypergraphs/Substitution.lean
@@ -1,0 +1,803 @@
+/-
+Copyright (c) 2026 Dean Cureton. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dean Cureton
+-/
+
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Data.Fin.Basic
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Multiset.Basic
+import Mathlib.Data.Nat.Basic
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import LeanPool.FrontierMathOpenHypergraphs.Basic
+
+/-!
+# Support gadgets and the substitution theorem
+-/
+
+open Finset
+
+namespace HypergraphLowerBound
+
+/-! ## Support patterns and frames -/
+
+/-- A support pattern on `[t]` is a subset of `Fin t` of size at least `2`. -/
+def SupportPattern (t : ℕ) := { S : Finset (Fin t) // 2 ≤ S.card }
+
+/-- The block hypergraphs used in a substitution construction. -/
+abbrev BlockFamily (t : ℕ) := HypergraphFamily (Fin t) ℕ
+
+/-- An occurrence of a support pattern in a support multiset. -/
+abbrev SupportOcc {t : ℕ} (F : Multiset (SupportPattern t)) := Fin F.card
+
+/-- The support pattern attached to a given support-vertex occurrence. -/
+noncomputable def supportPatternAt {t : ℕ}
+    (F : Multiset (SupportPattern t)) (s : SupportOcc F) : SupportPattern t :=
+  F.toList.get ⟨s.1, by
+    rw [Multiset.length_toList]
+    exact s.2
+  ⟩
+
+/-- The underlying subset of `[t]` attached to a support occurrence. -/
+noncomputable def supportSetAt {t : ℕ}
+    (F : Multiset (SupportPattern t)) (s : SupportOcc F) : Finset (Fin t) :=
+  (supportPatternAt F s).1
+
+/-- `omegaCount F T I` counts the occurrences of support patterns `S` in `F`
+    with `S ⊆ T` and `|S ∩ I| = 1`, counting multiplicity. -/
+noncomputable def omegaCount {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (T I : Finset (Fin t)) : ℕ :=
+  ((Finset.univ : Finset (Fin F.card)).filter fun s =>
+      supportSetAt F s ⊆ T ∧ ((supportSetAt F s ∩ I).card = 1)).card
+
+/-- A support multiset `F` is an `n`-frame if the frame inequality holds for every
+    `I ⊆ T ⊆ [t]`. -/
+def IsFrame {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (cap : Fin t → ℕ) : Prop :=
+  ∀ T I : Finset (Fin t), I ⊆ T →
+    omegaCount F T I ≤ (T \ I).sum cap
+
+/-- Vertices of the substituted hypergraph: tagged block vertices together with one
+    vertex for each occurrence of a support pattern. -/
+inductive SubstVertex (t : ℕ) (F : Multiset (SupportPattern t)) where
+  | old (i : Fin t) (v : ℕ)
+  | new (s : Fin F.card)
+deriving DecidableEq
+
+/-- The substituted hypergraph whose vertices live in `SubstVertex t F`. -/
+abbrev SubstitutedHypergraph {t : ℕ} (F : Multiset (SupportPattern t)) :=
+  Hypergraph (SubstVertex t F)
+
+/-- The support vertices incident to every edge in block `i`. -/
+noncomputable def supportVerticesOnBlock {t : ℕ}
+    (F : Multiset (SupportPattern t)) (i : Fin t) : Finset (SubstVertex t F) :=
+  ((Finset.univ : Finset (Fin F.card)).filter fun s =>
+      i ∈ supportSetAt F s).image
+    SubstVertex.new
+
+/-- Lift one edge from block `i` into the substituted hypergraph. -/
+noncomputable def liftBlockEdge {t : ℕ}
+    (F : Multiset (SupportPattern t)) (i : Fin t) (e : Finset ℕ) :
+    Finset (SubstVertex t F) :=
+  (e.image fun v => SubstVertex.old i v) ∪ supportVerticesOnBlock F i
+
+/-- The substitution hypergraph `F[G_1, ..., G_t]`, realized as the hypergraph whose
+    vertices are tagged block vertices plus support vertices, and whose edges are the
+    lifted edges of the blocks. -/
+noncomputable def substitutionHypergraph {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t) : SubstitutedHypergraph F :=
+  ((Finset.univ : Finset (Fin t)).biUnion fun i =>
+    (blocks i).image (liftBlockEdge F i))
+
+/-- The selected edges from block `i` inside a chosen subfamily `P` of the substituted
+    hypergraph. -/
+noncomputable def selectedBlockEdges {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (P : SubstitutedHypergraph F) (i : Fin t) : Hypergraph ℕ :=
+  (blocks i).filter fun e => liftBlockEdge F i e ∈ P
+
+/-- The number of selected edges from block `i`. -/
+noncomputable def selectedBlockCount {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (P : SubstitutedHypergraph F) (i : Fin t) : ℕ :=
+  (selectedBlockEdges F blocks P i).card
+
+/-- The number of selected edges from block `i` containing `v`. -/
+noncomputable def selectedOldVertexCount {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (P : SubstitutedHypergraph F) (i : Fin t) (v : ℕ) : ℕ :=
+  ((selectedBlockEdges F blocks P i).filter fun e => v ∈ e).card
+
+/-- The number of selected substituted edges incident to a support occurrence. -/
+noncomputable def selectedSupportCount {t : ℕ}
+    {F : Multiset (SupportPattern t)}
+    (P : SubstitutedHypergraph F) (s : SupportOcc F) : ℕ :=
+  (P.filter fun E => SubstVertex.new s ∈ E).card
+
+/-- The blocks from which at most one selected edge is taken. -/
+noncomputable def tOf {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (P : SubstitutedHypergraph F) : Finset (Fin t) :=
+  (Finset.univ : Finset (Fin t)).filter fun i =>
+    selectedBlockCount F blocks P i ≤ 1
+
+/-- The blocks from which exactly one selected edge is taken. -/
+noncomputable def iOf {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (P : SubstitutedHypergraph F) : Finset (Fin t) :=
+  (Finset.univ : Finset (Fin t)).filter fun i =>
+    selectedBlockCount F blocks P i = 1
+
+/-- The old vertices in block `i` that are seen exactly once by the selected family `P`. -/
+noncomputable def oldUniqueVerticesOnBlock {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (P : SubstitutedHypergraph F) (i : Fin t) : Finset ℕ :=
+  (vertexSet (blocks i)).filter fun v =>
+    (selectedOldVertexCount F blocks P i v = 1)
+
+/-- The support-vertex occurrences seen exactly once by the selected family `P`. -/
+noncomputable def newUniqueSupportVertices {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (P : SubstitutedHypergraph F) : Finset (SupportOcc F) :=
+  (Finset.univ : Finset (Fin F.card)).filter fun s =>
+    (selectedSupportCount P s = 1)
+
+/-- The uniquely covered old vertices in the substituted hypergraph, grouped blockwise. -/
+noncomputable def oldUniqueVertexUnion {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (P : SubstitutedHypergraph F) : Finset (SubstVertex t F) :=
+  ((Finset.univ : Finset (Fin t)).biUnion fun i =>
+    (oldUniqueVerticesOnBlock F blocks P i).image (SubstVertex.old i))
+
+/-- The uniquely covered support vertices in the substituted hypergraph. -/
+noncomputable def newUniqueVertexUnion {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (P : SubstitutedHypergraph F) : Finset (SubstVertex t F) :=
+  (newUniqueSupportVertices F P).image SubstVertex.new
+
+/-- The old vertices coming from the block hypergraphs, tagged by their block index. -/
+noncomputable def oldVertexUnion {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t) : Finset (SubstVertex t F) :=
+  ((Finset.univ : Finset (Fin t)).biUnion fun i =>
+    (vertexSet (blocks i)).image (SubstVertex.old i))
+
+/-- All support vertices of the substituted hypergraph, indexed by their occurrences in `F`. -/
+noncomputable def allNewVertices {t : ℕ}
+    (F : Multiset (SupportPattern t)) : Finset (SubstVertex t F) :=
+  (Finset.univ : Finset (Fin F.card)).image SubstVertex.new
+
+@[simp] lemma mem_supportVerticesOnBlock_iff {t : ℕ}
+    {F : Multiset (SupportPattern t)} {i : Fin t} {s : SupportOcc F} :
+    SubstVertex.new s ∈ supportVerticesOnBlock F i ↔ i ∈ supportSetAt F s := by
+  simp [supportVerticesOnBlock]
+
+@[simp] lemma old_mem_liftBlockEdge_iff {t : ℕ}
+    {F : Multiset (SupportPattern t)} {i j : Fin t} {v : ℕ} {e : Finset ℕ} :
+    SubstVertex.old i v ∈ liftBlockEdge F j e ↔ i = j ∧ v ∈ e := by
+  constructor
+  · intro h
+    rw [liftBlockEdge, Finset.mem_union] at h
+    rcases h with h | h
+    · rcases Finset.mem_image.mp h with ⟨v', hv', hEq⟩
+      lia
+    · rcases Finset.mem_image.mp h with ⟨s, hs, hEq⟩
+      cases hEq
+  · rintro ⟨rfl, hv⟩
+    simp [liftBlockEdge, hv]
+
+@[simp] lemma new_mem_liftBlockEdge_iff {t : ℕ}
+    {F : Multiset (SupportPattern t)} {s : SupportOcc F} {i : Fin t} {e : Finset ℕ} :
+    SubstVertex.new s ∈ liftBlockEdge F i e ↔ i ∈ supportSetAt F s := by
+  simp [liftBlockEdge]
+
+lemma liftBlockEdge_injective {t : ℕ}
+    (F : Multiset (SupportPattern t)) (i : Fin t) :
+    Function.Injective (liftBlockEdge F i) := by
+  intro e e' hEq
+  ext v
+  constructor
+  · intro hv
+    have hmem : SubstVertex.old i v ∈ liftBlockEdge F i e := by
+      simp [hv]
+    rw [hEq] at hmem
+    simpa using (old_mem_liftBlockEdge_iff.mp hmem).2
+  · intro hv
+    have hmem : SubstVertex.old i v ∈ liftBlockEdge F i e' := by
+      simp [hv]
+    rw [← hEq] at hmem
+    simpa using (old_mem_liftBlockEdge_iff.mp hmem).2
+
+lemma selectedBlockEdges_subset {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (P : SubstitutedHypergraph F) (i : Fin t) :
+    selectedBlockEdges F blocks P i ⊆ blocks i := by
+  intro e he
+  exact (Finset.mem_filter.mp he).1
+
+lemma mem_vertexSet_of_count_eq_one {V : Type*} [DecidableEq V]
+    {edges P : Hypergraph V} {x : V} (hP : P ⊆ edges)
+    (hx : (P.filter fun E => x ∈ E).card = 1) :
+    x ∈ vertexSet edges := by
+  have hpos : 0 < (P.filter fun E => x ∈ E).card := by simp [hx]
+  rcases Finset.card_pos.mp hpos with ⟨E, hE⟩
+  rw [vertexSet, Finset.mem_biUnion]
+  exact ⟨E, hP (Finset.mem_filter.mp hE).1, (Finset.mem_filter.mp hE).2⟩
+
+lemma liftBlockEdge_ne_of_ne {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (hEdgeDisjoint : Pairwise fun i j => Disjoint (blocks i) (blocks j))
+    {i j : Fin t} (hij : i ≠ j) {e e' : Finset ℕ}
+    (he : e ∈ blocks i) (he' : e' ∈ blocks j) :
+    liftBlockEdge F i e ≠ liftBlockEdge F j e' := by
+  intro hEq
+  by_cases hne : e.Nonempty
+  · rcases hne with ⟨v, hv⟩
+    have hmem : SubstVertex.old i v ∈ liftBlockEdge F j e' := by
+      rw [← hEq]
+      simp [hv]
+    exact hij (old_mem_liftBlockEdge_iff.mp hmem).1
+  · have he0 : e = ∅ := Finset.not_nonempty_iff_eq_empty.mp hne
+    by_cases hne' : e'.Nonempty
+    · rcases hne' with ⟨v, hv⟩
+      have hmem : SubstVertex.old j v ∈ liftBlockEdge F i e := by
+        rw [hEq]
+        simp [hv]
+      exact hij.symm (old_mem_liftBlockEdge_iff.mp hmem).1
+    · have he'0 : e' = ∅ := Finset.not_nonempty_iff_eq_empty.mp hne'
+      exact Finset.disjoint_left.mp (hEdgeDisjoint hij)
+        (by simpa [he0] using he) (by simpa [he'0] using he')
+
+lemma liftedBlockImages_disjoint {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (hEdgeDisjoint : Pairwise fun i j => Disjoint (blocks i) (blocks j))
+    {i j : Fin t} (hij : i ≠ j) :
+    Disjoint ((blocks i).image (liftBlockEdge F i))
+      ((blocks j).image (liftBlockEdge F j)) := by
+  refine Finset.disjoint_left.mpr ?_
+  intro E hEi hEj
+  rcases Finset.mem_image.mp hEi with ⟨e, he, rfl⟩
+  rcases Finset.mem_image.mp hEj with ⟨e', he', hEq⟩
+  exact (liftBlockEdge_ne_of_ne F blocks hEdgeDisjoint hij he he') hEq.symm
+
+lemma old_mem_vertexSet_substitution_iff {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (i : Fin t) (v : ℕ) :
+    SubstVertex.old i v ∈ vertexSet (substitutionHypergraph F blocks) ↔
+      v ∈ vertexSet (blocks i) := by
+  constructor
+  · intro h
+    rw [vertexSet, Finset.mem_biUnion] at h
+    rcases h with ⟨E, hE, hmemE⟩
+    rw [substitutionHypergraph, Finset.mem_biUnion] at hE
+    rcases hE with ⟨j, -, hEj⟩
+    rcases Finset.mem_image.mp hEj with ⟨e, he, rfl⟩
+    rcases old_mem_liftBlockEdge_iff.mp hmemE with ⟨hij, hv⟩
+    subst hij
+    rw [vertexSet, Finset.mem_biUnion]
+    exact ⟨e, he, hv⟩
+  · intro hv
+    rw [vertexSet, Finset.mem_biUnion] at hv
+    rcases hv with ⟨e, he, hv⟩
+    rw [vertexSet, Finset.mem_biUnion]
+    refine ⟨liftBlockEdge F i e, ?_, ?_⟩
+    · rw [substitutionHypergraph, Finset.mem_biUnion]
+      exact ⟨i, Finset.mem_univ i, Finset.mem_image.mpr ⟨e, he, rfl⟩⟩
+    · exact old_mem_liftBlockEdge_iff.mpr ⟨rfl, hv⟩
+
+lemma new_mem_vertexSet_substitution_iff {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (s : SupportOcc F) :
+    SubstVertex.new s ∈ vertexSet (substitutionHypergraph F blocks) ↔
+      ∃ i ∈ supportSetAt F s, (blocks i).Nonempty := by
+  constructor
+  · intro h
+    rw [vertexSet, Finset.mem_biUnion] at h
+    rcases h with ⟨E, hE, hmemE⟩
+    rw [substitutionHypergraph, Finset.mem_biUnion] at hE
+    rcases hE with ⟨i, -, hEi⟩
+    rcases Finset.mem_image.mp hEi with ⟨e, he, rfl⟩
+    exact ⟨i, new_mem_liftBlockEdge_iff.mp hmemE, ⟨e, he⟩⟩
+  · rintro ⟨i, hi, e, he⟩
+    rw [vertexSet, Finset.mem_biUnion]
+    refine ⟨liftBlockEdge F i e, ?_, ?_⟩
+    · rw [substitutionHypergraph, Finset.mem_biUnion]
+      exact ⟨i, Finset.mem_univ i, Finset.mem_image.mpr ⟨e, he, rfl⟩⟩
+    · exact new_mem_liftBlockEdge_iff.mpr hi
+
+lemma old_selected_count_eq {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (P : SubstitutedHypergraph F)
+    (hP : P ⊆ substitutionHypergraph F blocks)
+    (i : Fin t) (v : ℕ) :
+    (P.filter fun E => SubstVertex.old i v ∈ E).card =
+      selectedOldVertexCount F blocks P i v := by
+  have hEq :
+      P.filter (fun E => SubstVertex.old i v ∈ E) =
+        ((selectedBlockEdges F blocks P i).filter fun e => v ∈ e).image (liftBlockEdge F i) := by
+    ext E
+    constructor
+    · intro hE
+      rcases Finset.mem_filter.mp hE with ⟨hEP, hOld⟩
+      have hEP' := hP hEP
+      rw [substitutionHypergraph, Finset.mem_biUnion] at hEP'
+      rcases hEP' with ⟨j, -, hEj⟩
+      rcases Finset.mem_image.mp hEj with ⟨e, he, rfl⟩
+      rcases old_mem_liftBlockEdge_iff.mp hOld with ⟨hij, hv⟩
+      subst hij
+      exact Finset.mem_image.mpr ⟨e, by
+        exact Finset.mem_filter.mpr ⟨Finset.mem_filter.mpr ⟨he, hEP⟩, hv⟩, rfl⟩
+    · intro hE
+      rcases Finset.mem_image.mp hE with ⟨e, he, rfl⟩
+      rcases Finset.mem_filter.mp he with ⟨heSel, hv⟩
+      exact Finset.mem_filter.mpr ⟨(Finset.mem_filter.mp heSel).2, by simp [hv]⟩
+  rw [hEq, Finset.card_image_of_injective _ (liftBlockEdge_injective F i)]
+  simp [selectedOldVertexCount]
+
+lemma filter_new_eq_biUnion {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (P : SubstitutedHypergraph F)
+    (hP : P ⊆ substitutionHypergraph F blocks)
+    (s : SupportOcc F) :
+    P.filter (fun E => SubstVertex.new s ∈ E) =
+      (supportSetAt F s).biUnion fun i =>
+        (selectedBlockEdges F blocks P i).image (liftBlockEdge F i) := by
+  ext E
+  constructor
+  · intro hE
+    rcases Finset.mem_filter.mp hE with ⟨hEP, hNew⟩
+    have hEP' := hP hEP
+    rw [substitutionHypergraph, Finset.mem_biUnion] at hEP'
+    rcases hEP' with ⟨i, hi, hEi⟩
+    rcases Finset.mem_image.mp hEi with ⟨e, he, rfl⟩
+    refine Finset.mem_biUnion.mpr ⟨i, new_mem_liftBlockEdge_iff.mp hNew, ?_⟩
+    exact Finset.mem_image.mpr ⟨e, Finset.mem_filter.mpr ⟨he, hEP⟩, rfl⟩
+  · intro hE
+    rcases Finset.mem_biUnion.mp hE with ⟨i, hi, hEi⟩
+    rcases Finset.mem_image.mp hEi with ⟨e, he, rfl⟩
+    exact Finset.mem_filter.mpr ⟨(Finset.mem_filter.mp he).2, by simp [hi]⟩
+
+lemma selectedImages_disjoint {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (P : SubstitutedHypergraph F)
+    (hEdgeDisjoint : Pairwise fun i j => Disjoint (blocks i) (blocks j))
+    {S : Finset (Fin t)} :
+    (S : Set (Fin t)).PairwiseDisjoint fun i =>
+      (selectedBlockEdges F blocks P i).image (liftBlockEdge F i) := by
+  intro i hi j hj hij
+  refine Finset.disjoint_left.mpr ?_
+  intro E hEi hEj
+  rcases Finset.mem_image.mp hEi with ⟨e, he, rfl⟩
+  rcases Finset.mem_image.mp hEj with ⟨e', he', hEq⟩
+  exact (liftBlockEdge_ne_of_ne F blocks hEdgeDisjoint hij
+    (Finset.mem_filter.mp he).1 (Finset.mem_filter.mp he').1) hEq.symm
+
+lemma new_selected_count_eq_sum {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (P : SubstitutedHypergraph F)
+    (hP : P ⊆ substitutionHypergraph F blocks)
+    (hEdgeDisjoint : Pairwise fun i j => Disjoint (blocks i) (blocks j))
+    (s : SupportOcc F) :
+    selectedSupportCount P s =
+      ∑ i ∈ supportSetAt F s, selectedBlockCount F blocks P i := by
+  unfold selectedSupportCount
+  rw [filter_new_eq_biUnion F blocks P hP s]
+  rw [Finset.card_biUnion (selectedImages_disjoint F blocks P hEdgeDisjoint)]
+  refine Finset.sum_congr rfl ?_
+  intro i hi
+  rw [Finset.card_image_of_injective _ (liftBlockEdge_injective F i), selectedBlockCount]
+
+@[simp] lemma mem_tOf_iff {t : ℕ}
+    {F : Multiset (SupportPattern t)}
+    {blocks : BlockFamily t}
+    {P : SubstitutedHypergraph F} {i : Fin t} :
+    i ∈ tOf F blocks P ↔ selectedBlockCount F blocks P i ≤ 1 := by
+  simp [tOf]
+
+@[simp] lemma mem_iOf_iff {t : ℕ}
+    {F : Multiset (SupportPattern t)}
+    {blocks : BlockFamily t}
+    {P : SubstitutedHypergraph F} {i : Fin t} :
+    i ∈ iOf F blocks P ↔ selectedBlockCount F blocks P i = 1 := by
+  simp [iOf]
+
+lemma card_inter_iOf_eq_sum_indicator {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (P : SubstitutedHypergraph F)
+    (S : Finset (Fin t)) :
+    (S ∩ iOf F blocks P).card =
+      ∑ i ∈ S, if selectedBlockCount F blocks P i = 1 then 1 else 0 := by
+  rw [show S ∩ iOf F blocks P =
+      S.filter (fun i => selectedBlockCount F blocks P i = 1) by
+      ext i
+      simp [iOf]]
+  rw [Finset.card_eq_sum_ones, Finset.sum_filter]
+
+lemma sum_selected_eq_card_inter_iOf {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (P : SubstitutedHypergraph F)
+    (S : Finset (Fin t))
+    (hST : S ⊆ tOf F blocks P) :
+    ∑ i ∈ S, selectedBlockCount F blocks P i = (S ∩ iOf F blocks P).card := by
+  rw [card_inter_iOf_eq_sum_indicator F blocks P S]
+  apply Finset.sum_congr rfl
+  intro i hi
+  have hle : selectedBlockCount F blocks P i ≤ 1 := by
+    exact (mem_tOf_iff.mp (hST hi))
+  lia
+
+lemma sum_selected_eq_one_iff {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (P : SubstitutedHypergraph F)
+    (S : Finset (Fin t)) :
+    (∑ i ∈ S, selectedBlockCount F blocks P i = 1) ↔
+      S ⊆ tOf F blocks P ∧ (S ∩ iOf F blocks P).card = 1 := by
+  constructor
+  · intro hsum
+    have hST : S ⊆ tOf F blocks P := by
+      intro i hi
+      rw [mem_tOf_iff]
+      have hle : selectedBlockCount F blocks P i ≤
+          ∑ j ∈ S, selectedBlockCount F blocks P j := by
+        exact single_le_sum_of_canonicallyOrdered hi
+      omega
+    refine ⟨hST, ?_⟩
+    rw [← sum_selected_eq_card_inter_iOf F blocks P S hST, hsum]
+  · rintro ⟨hST, hcard⟩
+    rw [sum_selected_eq_card_inter_iOf F blocks P S hST, hcard]
+
+lemma new_unique_iff {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (P : SubstitutedHypergraph F)
+    (hP : P ⊆ substitutionHypergraph F blocks)
+    (hEdgeDisjoint : Pairwise fun i j => Disjoint (blocks i) (blocks j))
+    (s : SupportOcc F) :
+    (selectedSupportCount P s = 1) ↔
+      supportSetAt F s ⊆ tOf F blocks P ∧
+      ((supportSetAt F s ∩ iOf F blocks P).card = 1) := by
+  rw [new_selected_count_eq_sum F blocks P hP hEdgeDisjoint s]
+  exact sum_selected_eq_one_iff F blocks P (supportSetAt F s)
+
+lemma support_vertex_realized {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (edgeCounts : Fin t → ℕ)
+    (blocks : BlockFamily t)
+    (hFrame : IsFrame F edgeCounts)
+    (hEdgeCounts : ∀ i, (blocks i).card = edgeCounts i)
+    (s : SupportOcc F) :
+    ∃ i ∈ supportSetAt F s, (blocks i).Nonempty := by
+  let S := supportSetAt F s
+  have hSnonempty : S.Nonempty := by
+    refine Finset.card_pos.mp ?_
+    exact lt_of_lt_of_le (by decide : 0 < 2) (supportPatternAt F s).2
+  rcases hSnonempty with ⟨i, hi⟩
+  have hOmegaPos : 0 < omegaCount F S ({i} : Finset (Fin t)) := by
+    unfold omegaCount
+    apply Finset.card_pos.mpr
+    refine ⟨s, ?_⟩
+    simp [S, hi]
+  have hBound := hFrame S ({i} : Finset (Fin t)) (Finset.singleton_subset_iff.mpr hi)
+  have hSumPos : 0 < (S \ {i}).sum edgeCounts := lt_of_lt_of_le hOmegaPos hBound
+  have hExists : ∃ j ∈ S \ {i}, 0 < edgeCounts j := by
+    exact sum_pos_iff.mp hSumPos
+  rcases hExists with ⟨j, hj, hjPos⟩
+  refine ⟨j, (Finset.mem_sdiff.mp hj).1, ?_⟩
+  rw [← hEdgeCounts j] at hjPos
+  exact Finset.card_pos.mp hjPos
+
+/-! ## Substitution theorem -/
+
+/-- The assumptions on a family of block hypergraphs needed for the qualitative
+    substitution theorem. -/
+structure PartitionedBlocks {t : ℕ}
+    (cap : Fin t → ℕ) (blocks : BlockFamily t) : Prop where
+  vertexDisjoint : Pairwise fun i j => Disjoint (vertexSet (blocks i)) (vertexSet (blocks j))
+  edgeDisjoint : Pairwise fun i j => Disjoint (blocks i) (blocks j)
+  partitionBound : ∀ i, NoLargePartition (blocks i) (cap i)
+
+/-- The additional edge/vertex count data needed for the quantitative recurrence. -/
+structure CountedBlocks {t : ℕ}
+    (edgeCounts vertexCounts : Fin t → ℕ) (blocks : BlockFamily t)
+    : Prop extends PartitionedBlocks edgeCounts blocks where
+  edgeCard : ∀ i, (blocks i).card = edgeCounts i
+  vertexCard : ∀ i, (vertexSet (blocks i)).card = vertexCounts i
+
+/-- If `F` is an `n`-frame and each block hypergraph has no partition larger than its
+    capacity, then the substituted hypergraph has no partition larger than the total
+    capacity. The hypotheses on pairwise disjoint vertex and edge sets match the setup
+    in `frontier.tex`. -/
+theorem substitution_theorem {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (cap : Fin t → ℕ)
+    (blocks : BlockFamily t)
+    (hFrame : IsFrame F cap)
+    (hBlocks : PartitionedBlocks cap blocks) :
+    NoLargePartition (substitutionHypergraph F blocks)
+      ((Finset.univ : Finset (Fin t)).sum cap) := by
+  intro P hP
+  let T := tOf F blocks P
+  let I := iOf F blocks P
+  let oldCount : Fin t → ℕ := fun i => (oldUniqueVerticesOnBlock F blocks P i).card
+  have hIT : I ⊆ T := by
+    intro i hi
+    rw [mem_tOf_iff]
+    rw [mem_iOf_iff] at hi
+    omega
+  have hUniqueSet :
+      (vertexSet (substitutionHypergraph F blocks)).filter
+        (fun x => (P.filter fun E => x ∈ E).card = 1) =
+      oldUniqueVertexUnion F blocks P ∪ newUniqueVertexUnion F P := by
+    ext x
+    cases x with
+    | old i v =>
+        constructor
+        · intro hx
+          rcases Finset.mem_filter.mp hx with ⟨hxVert, hxCount⟩
+          have hvVert : v ∈ vertexSet (blocks i) :=
+            (old_mem_vertexSet_substitution_iff F blocks i v).mp hxVert
+          have hvCount :
+              selectedOldVertexCount F blocks P i v = 1 := by
+            rw [← old_selected_count_eq F blocks P hP i v]
+            exact hxCount
+          exact Finset.mem_union.mpr <| Or.inl <|
+            Finset.mem_biUnion.mpr ⟨i, Finset.mem_univ i,
+              Finset.mem_image.mpr ⟨v, Finset.mem_filter.mpr ⟨hvVert, hvCount⟩, rfl⟩⟩
+        · intro hx
+          rcases Finset.mem_union.mp hx with hxOld | hxNew
+          · rcases Finset.mem_biUnion.mp hxOld with ⟨j, -, hEj⟩
+            rcases Finset.mem_image.mp hEj with ⟨v', hv', hEq⟩
+            rcases Finset.mem_filter.mp hv' with ⟨hvVert, hvCount⟩
+            cases hEq
+            exact Finset.mem_filter.mpr
+              ⟨(old_mem_vertexSet_substitution_iff F blocks i v).2 hvVert, by
+                rwa [old_selected_count_eq F blocks P hP i v]⟩
+          · rcases Finset.mem_image.mp hxNew with ⟨s, hs, hEq⟩
+            cases hEq
+    | new s =>
+        constructor
+        · intro hx
+          rcases Finset.mem_filter.mp hx with ⟨_, hs1⟩
+          exact Finset.mem_union.mpr <| Or.inr <|
+            Finset.mem_image.mpr ⟨s, Finset.mem_filter.mpr ⟨Finset.mem_univ s, hs1⟩, rfl⟩
+        · intro hx
+          rcases Finset.mem_union.mp hx with hxOld | hxNew
+          · rcases Finset.mem_biUnion.mp hxOld with ⟨i, -, hEi⟩
+            rcases Finset.mem_image.mp hEi with ⟨v, hv, hEq⟩
+            cases hEq
+          · rcases Finset.mem_image.mp hxNew with ⟨s', hs, hEq⟩
+            cases hEq
+            exact Finset.mem_filter.mpr
+              ⟨mem_vertexSet_of_count_eq_one hP (Finset.mem_filter.mp hs).2,
+                (Finset.mem_filter.mp hs).2⟩
+  have hOldNewDisj :
+      Disjoint (oldUniqueVertexUnion F blocks P) (newUniqueVertexUnion F P) := by
+    refine Finset.disjoint_left.mpr ?_
+    intro x hx hy
+    cases x with
+    | old i v =>
+        rcases Finset.mem_image.mp hy with ⟨s, hs, hEq⟩
+        cases hEq
+    | new s =>
+        rcases Finset.mem_biUnion.mp hx with ⟨i, -, hEi⟩
+        rcases Finset.mem_image.mp hEi with ⟨v, hv, hEq⟩
+        cases hEq
+  have hUniqueEq :
+      uniqueCoverage (substitutionHypergraph F blocks) P =
+        (oldUniqueVertexUnion F blocks P).card +
+        (newUniqueVertexUnion F P).card := by
+    rw [uniqueCoverage, hUniqueSet, Finset.card_union_of_disjoint hOldNewDisj]
+  have hOldCard :
+      (oldUniqueVertexUnion F blocks P).card = (Finset.univ : Finset (Fin t)).sum oldCount := by
+    rw [oldUniqueVertexUnion, Finset.card_biUnion]
+    · refine Finset.sum_congr rfl ?_
+      intro i hi
+      rw [Finset.card_image_of_injective]
+      intro v w h
+      simpa using h
+    · intro i hi j hj hij
+      refine Finset.disjoint_left.mpr ?_
+      intro x hx hy
+      rcases Finset.mem_image.mp hx with ⟨v, hv, rfl⟩
+      rcases Finset.mem_image.mp hy with ⟨w, hw, hEq⟩
+      exact hij (by cases hEq; rfl)
+  have hOldLe : ∀ i, oldCount i ≤ cap i := by
+    intro i
+    simpa [oldCount, uniqueCoverage, oldUniqueVerticesOnBlock, selectedOldVertexCount] using
+      hBlocks.partitionBound i (selectedBlockEdges F blocks P i)
+        (selectedBlockEdges_subset F blocks P i)
+  have hOldZero : ∀ i ∈ T \ I, oldCount i = 0 := by
+    intro i hi
+    have hle : selectedBlockCount F blocks P i ≤ 1 :=
+      mem_tOf_iff.mp (Finset.mem_sdiff.mp hi).1
+    have hne : selectedBlockCount F blocks P i ≠ 1 := fun h1 =>
+      (Finset.mem_sdiff.mp hi).2 (mem_iOf_iff.mpr h1)
+    have h0 : selectedBlockCount F blocks P i = 0 := by
+      omega
+    have hEmpty : selectedBlockEdges F blocks P i = ∅ := Finset.card_eq_zero.mp h0
+    simp [oldCount, oldUniqueVerticesOnBlock, selectedOldVertexCount, hEmpty]
+  have hOldBound :
+      (oldUniqueVertexUnion F blocks P).card ≤
+        (((Finset.univ : Finset (Fin t)) \ T).sum cap) + I.sum cap := by
+    have hRestrict :
+        (Finset.univ : Finset (Fin t)).sum oldCount =
+          ((((Finset.univ : Finset (Fin t)) \ T) ∪ I)).sum oldCount := by
+      symm
+      apply Finset.sum_subset (by simp)
+      intro i hiU hiNot
+      have hiT : i ∈ T := by
+        by_contra hiT
+        exact hiNot <| Finset.mem_union.mpr <| Or.inl <|
+          Finset.mem_sdiff.mpr ⟨Finset.mem_univ i, hiT⟩
+      have hiNotI : i ∉ I := by
+        exact fun hiI => hiNot <| Finset.mem_union.mpr <| Or.inr hiI
+      exact hOldZero i (Finset.mem_sdiff.mpr ⟨hiT, hiNotI⟩)
+    have hDisjCompI : Disjoint ((Finset.univ : Finset (Fin t)) \ T) I :=
+      Finset.disjoint_left.mpr fun i hi1 hi2 => (Finset.mem_sdiff.mp hi1).2 (hIT hi2)
+    calc
+      (oldUniqueVertexUnion F blocks P).card
+          = (Finset.univ : Finset (Fin t)).sum oldCount := hOldCard
+      _ = ((((Finset.univ : Finset (Fin t)) \ T) ∪ I)).sum oldCount := hRestrict
+      _ ≤ ((((Finset.univ : Finset (Fin t)) \ T) ∪ I)).sum cap :=
+        Finset.sum_le_sum fun i _ => hOldLe i
+      _ = (((Finset.univ : Finset (Fin t)) \ T).sum cap) + I.sum cap := by
+        rw [Finset.sum_union hDisjCompI]
+  have hNewCard :
+      (newUniqueVertexUnion F P).card = omegaCount F T I := by
+    rw [newUniqueVertexUnion, Finset.card_image_of_injective]
+    · apply congrArg Finset.card
+      ext s
+      constructor
+      · intro hs
+        have hs' : selectedSupportCount P s = 1 := by
+          simpa [newUniqueSupportVertices] using hs
+        simpa [T, I] using (new_unique_iff F blocks P hP hBlocks.edgeDisjoint s).1 hs'
+      · intro hs
+        have hsProp :
+            supportSetAt F s ⊆ tOf F blocks P ∧
+              ((supportSetAt F s ∩ iOf F blocks P).card = 1) :=
+          (Finset.mem_filter.mp hs).2
+        have hs' : selectedSupportCount P s = 1 := by
+          simpa [T, I] using (new_unique_iff F blocks P hP hBlocks.edgeDisjoint s).2 hsProp
+        simpa [newUniqueSupportVertices] using hs'
+    · intro s s' h
+      simpa using h
+  have hNewBound :
+      (newUniqueVertexUnion F P).card ≤ (T \ I).sum cap := by
+    simpa [hNewCard] using hFrame T I hIT
+  have hSumT :
+      T.sum cap = (T \ I).sum cap + I.sum cap := by
+    exact Eq.symm (sum_sdiff hIT)
+  have hSumUniv :
+      (Finset.univ : Finset (Fin t)).sum cap =
+        (((Finset.univ : Finset (Fin t)) \ T).sum cap) + T.sum cap := by
+    calc
+      (Finset.univ : Finset (Fin t)).sum cap =
+          (((Finset.univ : Finset (Fin t)) \ T) ∪ T).sum cap := by
+            simpa using
+              (congrArg (fun S : Finset (Fin t) => S.sum cap)
+                (by simp : ((Finset.univ : Finset (Fin t)) \ T) ∪ T
+                  = (Finset.univ : Finset (Fin t)))).symm
+      _ = (((Finset.univ : Finset (Fin t)) \ T).sum cap) + T.sum cap :=
+        Finset.sum_union (s₁ := ((Finset.univ : Finset (Fin t)) \ T)) (s₂ := T)
+          Finset.sdiff_disjoint
+  lia
+
+/-- Quantitative corollary of the substitution theorem used throughout the recursive
+    constructions. Since hypergraphs are encoded by their edge sets, "no isolated
+    vertices" is implicit in the use of `vertexSet`. -/
+theorem frame_recurrence {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (edgeCounts vertexCounts : Fin t → ℕ)
+    (blocks : BlockFamily t)
+    (hFrame : IsFrame F edgeCounts)
+    (hBlocks : CountedBlocks edgeCounts vertexCounts blocks) :
+    (substitutionHypergraph F blocks).card = ((Finset.univ : Finset (Fin t)).sum edgeCounts) ∧
+    (vertexSet (substitutionHypergraph F blocks)).card =
+      ((Finset.univ : Finset (Fin t)).sum vertexCounts) + F.card ∧
+    NoLargePartition (substitutionHypergraph F blocks)
+      ((Finset.univ : Finset (Fin t)).sum edgeCounts) := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [substitutionHypergraph, Finset.card_biUnion]
+    · refine Finset.sum_congr rfl ?_
+      intro i hi
+      rw [Finset.card_image_of_injective _ (liftBlockEdge_injective F i), hBlocks.edgeCard i]
+    · intro i hi j hj hij
+      simpa using liftedBlockImages_disjoint F blocks hBlocks.edgeDisjoint hij
+  · have hOldCard :
+        (oldVertexUnion F blocks).card = ∑ i, vertexCounts i := by
+      rw [oldVertexUnion, Finset.card_biUnion]
+      · refine Finset.sum_congr rfl ?_
+        intro i hi
+        rw [Finset.card_image_of_injective]
+        · exact hBlocks.vertexCard i
+        · intro v w h
+          simpa using h
+      · intro i hi j hj hij
+        refine Finset.disjoint_left.mpr ?_
+        intro x hx hy
+        rcases Finset.mem_image.mp hx with ⟨v, hv, rfl⟩
+        rcases Finset.mem_image.mp hy with ⟨w, hw, hEq⟩
+        exact hij (by cases hEq; rfl)
+    have hNewCard : (allNewVertices F).card = F.card := by
+      rw [allNewVertices, Finset.card_image_of_injective]
+      · simp
+      · intro s s' h
+        simpa using h
+    have hOldNewDisj : Disjoint (oldVertexUnion F blocks) (allNewVertices F) := by
+      refine Finset.disjoint_left.mpr ?_
+      intro x hx hy
+      cases x with
+      | old i v =>
+          rcases Finset.mem_image.mp hy with ⟨s, hs, hEq⟩
+          cases hEq
+      | new s =>
+          rcases Finset.mem_biUnion.mp hx with ⟨i, -, hEi⟩
+          rcases Finset.mem_image.mp hEi with ⟨v, hv, hEq⟩
+          cases hEq
+    have hVertexSetEq :
+        vertexSet (substitutionHypergraph F blocks) =
+          oldVertexUnion F blocks ∪ allNewVertices F := by
+      ext x
+      cases x with
+      | old i v =>
+          constructor
+          · intro hx
+            exact Finset.mem_union.mpr <| Or.inl <|
+              Finset.mem_biUnion.mpr ⟨i, Finset.mem_univ i,
+                Finset.mem_image.mpr ⟨v,
+                  (old_mem_vertexSet_substitution_iff F blocks i v).mp hx, rfl⟩⟩
+          · intro hx
+            rcases Finset.mem_union.mp hx with hxOld | hxNew
+            · rcases Finset.mem_biUnion.mp hxOld with ⟨j, -, hEj⟩
+              rcases Finset.mem_image.mp hEj with ⟨v', hv', hEq⟩
+              cases hEq
+              exact (old_mem_vertexSet_substitution_iff F blocks i v).2 hv'
+            · rcases Finset.mem_image.mp hxNew with ⟨s, hs, hEq⟩
+              cases hEq
+      | new s =>
+          constructor
+          · intro hx
+            exact Finset.mem_union.mpr <| Or.inr <|
+              Finset.mem_image.mpr ⟨s, Finset.mem_univ s, rfl⟩
+          · intro hx
+            rcases Finset.mem_union.mp hx with hxOld | hxNew
+            · rcases Finset.mem_biUnion.mp hxOld with ⟨i, -, hEi⟩
+              rcases Finset.mem_image.mp hEi with ⟨v, hv, hEq⟩
+              cases hEq
+            · rcases Finset.mem_image.mp hxNew with ⟨s', hs, hEq⟩
+              cases hEq
+              exact (new_mem_vertexSet_substitution_iff F blocks s).2
+                (support_vertex_realized F edgeCounts blocks hFrame hBlocks.edgeCard s)
+    rw [hVertexSetEq, Finset.card_union_of_disjoint hOldNewDisj, hOldCard, hNewCard]
+  · exact substitution_theorem F edgeCounts blocks hFrame hBlocks.toPartitionedBlocks
+
+end HypergraphLowerBound

--- a/LeanPool/FrontierMathOpenHypergraphs/Uniform.lean
+++ b/LeanPool/FrontierMathOpenHypergraphs/Uniform.lean
@@ -1,0 +1,2581 @@
+/-
+Copyright (c) 2026 Dean Cureton. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dean Cureton
+-/
+
+import LeanPool.FrontierMathOpenHypergraphs.Uniform.Frames
+
+/-!
+# The uniform 26/25 factor and the finite bootstrap
+-/
+
+namespace HypergraphLowerBound
+
+local macro "eval_A_small" : tactic =>
+  `(tactic| (
+    first
+    | rw [Fin.sum_univ_two]
+    | rw [Fin.sum_univ_three]
+    | rw [Fin.sum_univ_four]
+    | skip
+    try unfold A
+    first | rfl | decide | omega))
+
+local macro "eval_Ak_small" : tactic =>
+  `(tactic| (unfold A; norm_num [bootstrapValues, k]))
+
+private theorem core4Spec_valid : core4Spec.IsValid := by
+  decide
+
+private theorem core4Spec_cap_eq_three (i : Fin 4) : core4Spec.cap i = 3 := by
+  fin_cases i <;> decide
+
+private theorem core4Spec_bonus_eq : core4Spec.bonus = 13 := by
+  decide
+
+private lemma FrameSpec.supportList_length (spec : FrameSpec) :
+    spec.supportList.length = spec.bonus := by
+  simp [FrameSpec.supportList, FrameSpec.bonus]
+
+private lemma FrameSpec.supports_card (spec : FrameSpec) :
+    spec.supports.card = spec.bonus := by
+  simp [FrameSpec.supports, spec.supportList_length]
+
+private def SupportsValid {t : ℕ}
+    (l : List (SupportPattern t)) (cap : Fin t → ℕ) : Prop :=
+  ∀ T I : Finset (Fin t), I ⊆ T →
+    l.countP (frameWitnesses T I) ≤ (T \ I).sum cap
+
+private theorem SupportsValid.ofSpec (spec : FrameSpec) :
+    SupportsValid spec.supportList spec.cap ↔ spec.IsValid := by
+  rfl
+
+private theorem SupportsValid.toIsFrame {t : ℕ}
+    {l : List (SupportPattern t)} {cap : Fin t → ℕ}
+    (h : SupportsValid l cap) :
+    IsFrame (l : Multiset (SupportPattern t)) cap := by
+  intro T I hIT
+  rw [omegaCount_coe_eq_countP]
+  exact h T I hIT
+
+private theorem SupportsValid.append {t : ℕ}
+    {l₁ l₂ : List (SupportPattern t)}
+    {cap₁ cap₂ : Fin t → ℕ}
+    (h₁ : SupportsValid l₁ cap₁)
+    (h₂ : SupportsValid l₂ cap₂) :
+    SupportsValid (l₁ ++ l₂) (fun i => cap₁ i + cap₂ i) := by
+  intro T I hIT
+  calc
+    (l₁ ++ l₂).countP (frameWitnesses T I)
+        = l₁.countP (frameWitnesses T I) + l₂.countP (frameWitnesses T I) := by
+            simp [List.countP_append]
+    _ ≤ (T \ I).sum cap₁ + (T \ I).sum cap₂ := by
+          exact Nat.add_le_add (h₁ T I hIT) (h₂ T I hIT)
+    _ = (T \ I).sum (fun i => cap₁ i + cap₂ i) := by
+          symm
+          exact Finset.sum_add_distrib
+
+private def EdgesNonempty {V : Type*} (edges : Hypergraph V) : Prop :=
+  ∀ e ∈ edges, e.Nonempty
+
+private def mapHypergraph {α β : Type*} [DecidableEq α] [DecidableEq β]
+    (f : α ↪ β) (edges : Finset (Finset α)) : Finset (Finset β) :=
+  edges.image (fun e => e.image f)
+
+private theorem edgeImage_injective {α β : Type*} [DecidableEq β]
+    (f : α ↪ β) : Function.Injective (fun e : Finset α => e.image f) := by
+  intro e e' h
+  ext x
+  constructor
+  · intro hx
+    have hxImg : f x ∈ e.image f := Finset.mem_image.mpr ⟨x, hx, rfl⟩
+    have hx' : f x ∈ e'.image f := by
+      simpa [h] using hxImg
+    rcases Finset.mem_image.mp hx' with ⟨y, hy, hyx⟩
+    have : y = x := f.injective hyx
+    simpa [this] using hy
+  · intro hx
+    have hxImg : f x ∈ e'.image f := Finset.mem_image.mpr ⟨x, hx, rfl⟩
+    have hx' : f x ∈ e.image f := by
+      simpa [h] using hxImg
+    rcases Finset.mem_image.mp hx' with ⟨y, hy, hyx⟩
+    have : y = x := f.injective hyx
+    simpa [this] using hy
+
+private theorem mapHypergraph_card {α β : Type*} [DecidableEq α] [DecidableEq β]
+    (f : α ↪ β) (edges : Finset (Finset α)) :
+    (mapHypergraph f edges).card = edges.card := by
+  simpa [mapHypergraph] using Finset.card_image_of_injective edges (edgeImage_injective f)
+
+private theorem vertexSet_mapHypergraph {α β : Type*} [DecidableEq α] [DecidableEq β]
+    (f : α ↪ β) (edges : Finset (Finset α)) :
+    vertexSet (mapHypergraph f edges) = (vertexSet edges).image f := by
+  ext y
+  constructor
+  · intro hy
+    rcases Finset.mem_biUnion.mp hy with ⟨E, hE, hyE⟩
+    rcases Finset.mem_image.mp hE with ⟨e, he, rfl⟩
+    rcases Finset.mem_image.mp hyE with ⟨x, hx, rfl⟩
+    exact Finset.mem_image.mpr ⟨x, Finset.mem_biUnion.mpr ⟨e, he, hx⟩, rfl⟩
+  · intro hy
+    rcases Finset.mem_image.mp hy with ⟨x, hx, rfl⟩
+    rcases Finset.mem_biUnion.mp hx with ⟨e, he, hxE⟩
+    exact Finset.mem_biUnion.mpr ⟨e.image f, Finset.mem_image.mpr ⟨e, he, rfl⟩,
+      Finset.mem_image.mpr ⟨x, hxE, rfl⟩⟩
+
+private theorem mapHypergraph_vertexSet_card {α β : Type*} [DecidableEq α] [DecidableEq β]
+    (f : α ↪ β) (edges : Finset (Finset α)) :
+    (vertexSet (mapHypergraph f edges)).card = (vertexSet edges).card := by
+  rw [vertexSet_mapHypergraph]
+  exact Finset.card_image_of_injective _ f.injective
+
+private lemma mapHypergraph_filter_mem_eq {α β : Type*} [DecidableEq α] [DecidableEq β]
+    (f : α ↪ β) (Q : Finset (Finset α)) (x : α) :
+    (mapHypergraph f Q).filter (fun E => f x ∈ E) =
+      mapHypergraph f (Q.filter fun e => x ∈ e) := by
+  ext E
+  constructor
+  · intro hE
+    rcases Finset.mem_filter.mp hE with ⟨hEmap, hxE⟩
+    rcases Finset.mem_image.mp hEmap with ⟨e, heQ, rfl⟩
+    rcases Finset.mem_image.mp hxE with ⟨y, hy, hyx⟩
+    have : y = x := f.injective hyx
+    exact Finset.mem_image.mpr
+      ⟨e, Finset.mem_filter.mpr ⟨heQ, by simpa [this] using hy⟩, rfl⟩
+  · intro hE
+    rcases Finset.mem_image.mp hE with ⟨e, he, rfl⟩
+    refine Finset.mem_filter.mpr ⟨?_, ?_⟩
+    · exact Finset.mem_image.mpr ⟨e, (Finset.mem_filter.mp he).1, rfl⟩
+    · exact Finset.mem_image.mpr ⟨x, (Finset.mem_filter.mp he).2, rfl⟩
+
+private lemma card_filter_mapHypergraph_mem {α β : Type*} [DecidableEq α] [DecidableEq β]
+    (f : α ↪ β) (Q : Finset (Finset α)) (x : α) :
+    ((mapHypergraph f Q).filter fun E => f x ∈ E).card =
+      (Q.filter fun e => x ∈ e).card := by
+  rw [mapHypergraph_filter_mem_eq, mapHypergraph_card]
+
+private theorem uniqueCoverage_mapHypergraph {α β : Type*} [DecidableEq α] [DecidableEq β]
+    (f : α ↪ β) (edges Q : Finset (Finset α)) :
+    uniqueCoverage (mapHypergraph f edges) (mapHypergraph f Q) =
+      uniqueCoverage edges Q := by
+  unfold uniqueCoverage
+  have hset :
+      (vertexSet (mapHypergraph f edges)).filter
+          (fun y => ((mapHypergraph f Q).filter fun E => y ∈ E).card = 1) =
+        ((vertexSet edges).filter
+          (fun x => ((Q.filter fun e => x ∈ e).card = 1))).image f := by
+    ext y
+    constructor
+    · intro hy
+      rcases Finset.mem_filter.mp hy with ⟨hyv, hy1⟩
+      rw [vertexSet_mapHypergraph] at hyv
+      rcases Finset.mem_image.mp hyv with ⟨x, hxv, rfl⟩
+      refine Finset.mem_image.mpr ⟨x, Finset.mem_filter.mpr ⟨hxv, ?_⟩, rfl⟩
+      simpa [card_filter_mapHypergraph_mem f Q x] using hy1
+    · intro hy
+      rcases Finset.mem_image.mp hy with ⟨x, hx, rfl⟩
+      rcases Finset.mem_filter.mp hx with ⟨hxv, hx1⟩
+      refine Finset.mem_filter.mpr ⟨?_, ?_⟩
+      · rw [vertexSet_mapHypergraph]
+        exact Finset.mem_image.mpr ⟨x, hxv, rfl⟩
+      · simpa [card_filter_mapHypergraph_mem f Q x] using hx1
+  rw [hset, Finset.card_image_of_injective]
+  exact f.injective
+
+private theorem NoLargePartition.map {α β : Type*} [DecidableEq α] [DecidableEq β]
+    {edges : Finset (Finset α)} {n : ℕ}
+    (h : NoLargePartition edges n) (f : α ↪ β) :
+    NoLargePartition (mapHypergraph f edges) n := by
+  intro P hP
+  let Q : Finset (Finset α) := edges.filter fun e => e.image f ∈ P
+  have hQsub : Q ⊆ edges := by
+    intro e he
+    exact (Finset.mem_filter.mp he).1
+  have hP_eq : mapHypergraph f Q = P := by
+    ext E
+    constructor
+    · intro hE
+      rcases Finset.mem_image.mp hE with ⟨e, heQ, hEq⟩
+      exact hEq ▸ (Finset.mem_filter.mp heQ).2
+    · intro hE
+      have hEmap : E ∈ mapHypergraph f edges := hP hE
+      rcases Finset.mem_image.mp hEmap with ⟨e, he, hEq⟩
+      exact Finset.mem_image.mpr ⟨e, Finset.mem_filter.mpr ⟨he, hEq ▸ hE⟩, hEq⟩
+  have hQ := h Q hQsub
+  rw [← hP_eq, uniqueCoverage_mapHypergraph]
+  exact hQ
+
+private theorem EdgesNonempty.map {α β : Type*} [DecidableEq α] [DecidableEq β]
+    {edges : Finset (Finset α)} (h : ∀ e ∈ edges, e.Nonempty) (f : α ↪ β) :
+    ∀ E ∈ mapHypergraph f edges, E.Nonempty := by
+  intro E hE
+  rcases Finset.mem_image.mp hE with ⟨e, he, rfl⟩
+  rcases h e he with ⟨x, hx⟩
+  exact ⟨f x, Finset.mem_image.mpr ⟨x, hx, rfl⟩⟩
+
+private def blockEmb {t : ℕ} (i : Fin t) : ℕ ↪ ℕ where
+  toFun := fun v => Nat.pair i.1 v
+  inj' := by
+    intro v w h
+    exact (Nat.pair_eq_pair.mp h).2
+
+private def encodeSubstVertex {t : ℕ}
+    (F : Multiset (SupportPattern t)) : SubstVertex t F ↪ ℕ where
+  toFun
+    | .old i v => Nat.pair 0 (Nat.pair i.1 v)
+    | .new s => Nat.pair 1 s.1
+  inj' := by
+    intro x y h
+    cases x with
+    | old i v =>
+        cases y with
+        | old j w =>
+            rcases Nat.pair_eq_pair.mp h with ⟨_, hinner⟩
+            rcases Nat.pair_eq_pair.mp hinner with ⟨hij, hvw⟩
+            have hij' : i = j := Fin.ext hij
+            subst hij'
+            subst hvw
+            rfl
+        | new s =>
+            have : (0 : ℕ) = 1 := (Nat.pair_eq_pair.mp h).1
+            omega
+    | new s =>
+        cases y with
+        | old i v =>
+            have : (1 : ℕ) = 0 := (Nat.pair_eq_pair.mp h).1
+            omega
+        | new s' =>
+            exact congrArg SubstVertex.new (Fin.ext ((Nat.pair_eq_pair.mp h).2))
+
+private theorem substitution_edgesNonempty {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (blocks : BlockFamily t)
+    (h : ∀ i, EdgesNonempty (blocks i)) :
+    EdgesNonempty (substitutionHypergraph F blocks) := by
+  intro E hE
+  rcases Finset.mem_biUnion.mp hE with ⟨i, -, hEi⟩
+  rcases Finset.mem_image.mp hEi with ⟨e, he, rfl⟩
+  rcases h i e he with ⟨v, hv⟩
+  exact ⟨SubstVertex.old i v, by
+    simp [liftBlockEdge, hv]⟩
+
+/-- A concrete witness hypergraph with prescribed edge and vertex counts. -/
+structure Witness (edgeCount vertexCount : ℕ) where
+  /-- The witness hypergraph. -/
+  edges : Hypergraph ℕ
+  /-- The witness has the prescribed number of edges. -/
+  edgeCard : edges.card = edgeCount
+  /-- The witness has the prescribed number of vertices. -/
+  vertexCard : (vertexSet edges).card = vertexCount
+  /-- The witness satisfies the no-large-partition obstruction. -/
+  noLargePartition : NoLargePartition edges edgeCount
+
+/-- A witness together with the auxiliary fact that every edge is nonempty. -/
+private def WitnessStrong (edgeCount vertexCount : ℕ) : Prop :=
+  ∃ w : Witness edgeCount vertexCount, EdgesNonempty w.edges
+
+/-- Forget the auxiliary nonemptiness data and retain only the public witness fields. -/
+private noncomputable def WitnessStrong.toWitnessData {edgeCount vertexCount : ℕ}
+    (w : WitnessStrong edgeCount vertexCount) : Witness edgeCount vertexCount :=
+  Classical.choose w
+
+/-- The nonempty-edge part of a strong witness. -/
+private theorem WitnessStrong.edgesNonempty {edgeCount vertexCount : ℕ}
+    (w : WitnessStrong edgeCount vertexCount) :
+    EdgesNonempty w.toWitnessData.edges :=
+  Classical.choose_spec w
+
+/-- The pointwise witness package used in the main `26/25` theorem. -/
+private structure MainPointwiseWitness (n : ℕ) where
+  witness : Witness n (A n)
+  lowerBound : 15 ≤ n → 25 * (vertexSet witness.edges).card ≥ 26 * k n
+
+/-- A packaged witness family for the sequence-level form of the main theorem. -/
+structure WitnessFamily (G : ℕ → Hypergraph ℕ) : Prop where
+  edgeCard : ∀ n, 1 ≤ n → (G n).card = n
+  noLargePartition : ∀ n, 1 ≤ n → NoLargePartition (G n) n
+  lowerBoundWitness : ∀ n, 15 ≤ n → 25 * (vertexSet (G n)).card ≥ 26 * k n
+  lowerBoundH : ∀ n, 15 ≤ n → 25 * H n ≥ 26 * k n
+
+private lemma sum_get_eq_sum (l : List ℕ) :
+    ((Finset.univ : Finset (Fin l.length)).sum fun i => l.get i) = l.sum := by
+  simp
+
+private lemma sum_map_get_eq_sum_map (l : List ℕ) (f : ℕ → ℕ) :
+    ((Finset.univ : Finset (Fin l.length)).sum fun i => f (l.get i)) = (l.map f).sum := by
+  simp
+
+private theorem apply_frameData {t : ℕ}
+    (F : Multiset (SupportPattern t))
+    (edgeCounts vertexCounts : Fin t → ℕ)
+    (bonus : ℕ)
+    (hBonus : F.card = bonus)
+    (hFrame : IsFrame F edgeCounts)
+    (hw : ∀ i, WitnessStrong (edgeCounts i) (vertexCounts i)) :
+    WitnessStrong ((Finset.univ : Finset (Fin t)).sum edgeCounts)
+      (((Finset.univ : Finset (Fin t)).sum vertexCounts) + bonus) := by
+  classical
+  choose childWitness hNonempty using hw
+  let childEdges : Fin t → Hypergraph ℕ := fun i => (childWitness i).edges
+  let blocks : BlockFamily t := fun i =>
+    mapHypergraph (blockEmb i) (childEdges i)
+  have hVertexDisjoint : Pairwise fun i j =>
+      Disjoint (vertexSet (blocks i)) (vertexSet (blocks j)) := by
+    intro i j hij
+    rw [vertexSet_mapHypergraph, vertexSet_mapHypergraph]
+    refine Finset.disjoint_left.mpr ?_
+    intro x hx hy
+    rcases Finset.mem_image.mp hx with ⟨v, hv, rfl⟩
+    rcases Finset.mem_image.mp hy with ⟨w, hw, hEq⟩
+    exact hij (Fin.ext (Nat.pair_eq_pair.mp hEq).1.symm)
+  have hEdgeDisjoint : Pairwise fun i j => Disjoint (blocks i) (blocks j) := by
+    intro i j hij
+    refine Finset.disjoint_left.mpr ?_
+    intro E hEi hEj
+    rcases Finset.mem_image.mp hEi with ⟨e, he, rfl⟩
+    rcases Finset.mem_image.mp hEj with ⟨e', he', hEq⟩
+    rcases hNonempty i e he with ⟨v, hv⟩
+    have hxImg : Nat.pair i.1 v ∈ e.image (blockEmb i) :=
+      Finset.mem_image.mpr ⟨v, hv, rfl⟩
+    have hmem : Nat.pair i.1 v ∈ e'.image (blockEmb j) := by
+      simpa [hEq] using hxImg
+    rcases Finset.mem_image.mp hmem with ⟨w, hw, hPair⟩
+    exact hij (Fin.ext (Nat.pair_eq_pair.mp hPair).1.symm)
+  have hEdgeCounts : ∀ i, (blocks i).card = edgeCounts i := by
+    intro i
+    calc
+      (blocks i).card = (childEdges i).card := mapHypergraph_card (blockEmb i) (childEdges i)
+      _ = edgeCounts i := (childWitness i).edgeCard
+  have hVertexCounts : ∀ i, (vertexSet (blocks i)).card = vertexCounts i := by
+    intro i
+    calc
+      (vertexSet (blocks i)).card = (vertexSet (childEdges i)).card :=
+        mapHypergraph_vertexSet_card (blockEmb i) (childEdges i)
+      _ = vertexCounts i := (childWitness i).vertexCard
+  have hPartition : ∀ i, NoLargePartition (blocks i) (edgeCounts i) := by
+    intro i
+    exact NoLargePartition.map ((childWitness i).noLargePartition) (blockEmb i)
+  have hBlocks : CountedBlocks edgeCounts vertexCounts blocks := by
+    refine
+      { vertexDisjoint := hVertexDisjoint
+        edgeDisjoint := hEdgeDisjoint
+        partitionBound := hPartition
+        edgeCard := hEdgeCounts
+        vertexCard := hVertexCounts }
+  obtain ⟨hCardSubst, hVertexSubst, hPartSubst⟩ := frame_recurrence
+    F edgeCounts vertexCounts blocks hFrame hBlocks
+  have hBlocksNonempty : ∀ i, EdgesNonempty (blocks i) := by
+    intro i
+    exact EdgesNonempty.map (h := hNonempty i) (blockEmb i)
+  refine ⟨{
+      edges := mapHypergraph (encodeSubstVertex F) (substitutionHypergraph F blocks)
+      edgeCard := ?_
+      vertexCard := ?_
+      noLargePartition := ?_ }, ?_⟩
+  · calc
+      (mapHypergraph (encodeSubstVertex F) (substitutionHypergraph F blocks)).card
+          = (substitutionHypergraph F blocks).card := by
+              exact mapHypergraph_card (encodeSubstVertex F) (substitutionHypergraph F blocks)
+      _ = ((Finset.univ : Finset (Fin t)).sum edgeCounts) := hCardSubst
+  · calc
+      (vertexSet (mapHypergraph (encodeSubstVertex F) (substitutionHypergraph F blocks))).card
+          = (vertexSet (substitutionHypergraph F blocks)).card := by
+              exact mapHypergraph_vertexSet_card (encodeSubstVertex F)
+                (substitutionHypergraph F blocks)
+      _ = ((Finset.univ : Finset (Fin t)).sum vertexCounts) + F.card := hVertexSubst
+      _ = ((Finset.univ : Finset (Fin t)).sum vertexCounts) + bonus := by simp [hBonus]
+  · exact NoLargePartition.map hPartSubst (encodeSubstVertex F)
+  · exact EdgesNonempty.map
+      (h := substitution_edgesNonempty F blocks hBlocksNonempty) (encodeSubstVertex F)
+
+private def pairSupport : SupportPattern 2 :=
+  ⟨({0, 1} : Finset (Fin 2)), by decide⟩
+
+private def binarySupports (c : ℕ) : Multiset (SupportPattern 2) :=
+  List.replicate c pairSupport
+
+private def binaryCap (a b : ℕ) : Fin 2 → ℕ
+  | ⟨0, _⟩ => a
+  | ⟨1, _⟩ => b
+
+private def binaryValues (a b : ℕ) : Fin 2 → ℕ
+  | ⟨0, _⟩ => a
+  | ⟨1, _⟩ => b
+
+private theorem binary_isFrame (a b c : ℕ) (hc : c ≤ min a b) :
+    IsFrame (binarySupports c) (binaryCap a b) := by
+  simpa [binarySupports] using
+    (SupportsValid.toIsFrame (l := List.replicate c pairSupport) (cap := binaryCap a b) (by
+      intro T I hIT
+      have hcount :
+          ∀ n, (List.replicate n pairSupport).countP (frameWitnesses T I) =
+            if frameWitnesses T I pairSupport then n else 0 := by
+        intro n
+        induction n with
+        | zero =>
+            simp
+          | succ n ih =>
+              by_cases hw : frameWitnesses T I pairSupport <;> simp [List.replicate, ih, hw]
+      have hpair_subset :
+          (({0, 1} : Finset (Fin 2)) ⊆ T) ↔ ((0 : Fin 2) ∈ T ∧ (1 : Fin 2) ∈ T) := by
+        constructor
+        · intro h
+          exact ⟨h (by simp), h (by simp)⟩
+        · rintro ⟨h0, h1⟩ x hx
+          simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+          rcases hx with rfl | rfl
+          · exact h0
+          · exact h1
+      have hsum :
+          (if (0 : Fin 2) ∈ T \ I then a else 0) +
+            (if (1 : Fin 2) ∈ T \ I then b else 0) =
+              (T \ I).sum (binaryCap a b) := by
+        simpa [Fin.sum_univ_two, binaryCap] using
+          (Finset.sum_ite_mem_eq (s := T \ I) (f := binaryCap a b))
+      rw [hcount c]
+      rw [← hsum]
+      by_cases hT0 : (0 : Fin 2) ∈ T <;> by_cases hT1 : (1 : Fin 2) ∈ T <;>
+        by_cases hI0 : (0 : Fin 2) ∈ I <;> by_cases hI1 : (1 : Fin 2) ∈ I <;>
+        simp [hpair_subset, pairSupport, frameWitnesses, hT0, hT1, hI0, hI1] at hIT ⊢ <;>
+        omega))
+
+/-! ## Four-way identities for k_n -/
+
+private lemma k_unfold (n : ℕ) :
+    k (n + 2) = (n + 2) / 2 + k ((n + 2) / 2) + k ((n + 3) / 2) := by
+  conv_lhs => unfold k
+
+private lemma k_two_mul (m : ℕ) (hm : 1 ≤ m) : k (2 * m) = m + 2 * k m := by
+  have h : 2 * m = (2 * m - 2) + 2 := by omega
+  conv_lhs => rw [h]
+  rw [k_unfold]
+  have h1 : (2 * m - 2 + 2) / 2 = m := by omega
+  have h2 : (2 * m - 2 + 3) / 2 = m := by omega
+  rw [h1, h2]
+  ring
+
+private lemma k_two_mul_succ (m : ℕ) (hm : 1 ≤ m) :
+    k (2 * m + 1) = m + k m + k (m + 1) := by
+  have h : 2 * m + 1 = (2 * m - 1) + 2 := by omega
+  conv_lhs => rw [h]
+  rw [k_unfold]
+  have h1 : (2 * m - 1 + 2) / 2 = m := by omega
+  have h2 : (2 * m - 1 + 3) / 2 = m + 1 := by omega
+  rw [h1, h2]
+
+/-- The four-way identities satisfied by k_n. -/
+theorem k_four_way (m : ℕ) (hm : 1 ≤ m) :
+    k (4 * m) = 4 * k m + 4 * m ∧
+    k (4 * m + 1) = 3 * k m + k (m + 1) + 4 * m ∧
+    k (4 * m + 2) = 2 * k m + 2 * k (m + 1) + 4 * m + 1 ∧
+    k (4 * m + 3) = k m + 3 * k (m + 1) + 4 * m + 2 := by
+  have h2m : 1 ≤ 2 * m := by omega
+  have h2m1 : 1 ≤ 2 * m + 1 := by omega
+  have hm1 : 1 ≤ m + 1 := by omega
+  have hk2m : k (2 * m) = m + 2 * k m := k_two_mul m hm
+  have hk2m1 : k (2 * m + 1) = m + k m + k (m + 1) := k_two_mul_succ m hm
+  have hk2m2 : k (2 * (m + 1)) = (m + 1) + 2 * k (m + 1) := k_two_mul (m + 1) hm1
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · -- k(4m) = 4*k(m) + 4*m
+    have : k (4 * m) = k (2 * (2 * m)) := by ring_nf
+    rw [this, k_two_mul (2 * m) h2m, hk2m]
+    ring
+  · -- k(4m+1) = 3*k(m) + k(m+1) + 4*m
+    have : k (4 * m + 1) = k (2 * (2 * m) + 1) := by ring_nf
+    rw [this, k_two_mul_succ (2 * m) h2m, hk2m, hk2m1]
+    ring
+  · -- k(4m+2) = 2*k(m) + 2*k(m+1) + 4*m + 1
+    have : k (4 * m + 2) = k (2 * (2 * m + 1)) := by ring_nf
+    rw [this, k_two_mul (2 * m + 1) h2m1, hk2m1]
+    omega
+  · -- k(4m+3) = k(m) + 3*k(m+1) + 4*m + 2
+    have : k (4 * m + 3) = k (2 * (2 * m + 1) + 1) := by ring_nf
+    rw [this, k_two_mul_succ (2 * m + 1) h2m1, hk2m1]
+    rw [show 2 * m + 1 + 1 = 2 * (m + 1) from by ring]
+    rw [hk2m2]
+    omega
+
+/-! ## The floor inequalities -/
+
+/-- The bonus e_r(m) ≥ (26/25) × (additive term) for m ≥ 15. -/
+theorem floor_26_25 (m : ℕ) (hm : 15 ≤ m) :
+    25 * eBonus 0 m ≥ 26 * (4 * m) ∧
+    25 * eBonus 1 m ≥ 26 * (4 * m) ∧
+    25 * eBonus 2 m ≥ 26 * (4 * m + 1) ∧
+    25 * eBonus 3 m ≥ 26 * (4 * m + 2) := by
+  simp only [eBonus]
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · have h := Nat.div_add_mod (13 * m) 3
+    have hmod := Nat.mod_lt (13 * m) (by norm_num : 0 < 3)
+    omega
+  · have h := Nat.div_add_mod (13 * m + 1) 3
+    have hmod := Nat.mod_lt (13 * m + 1) (by norm_num : 0 < 3)
+    omega
+  · have h := Nat.div_add_mod (13 * m + 5) 3
+    have hmod := Nat.mod_lt (13 * m + 5) (by norm_num : 0 < 3)
+    omega
+  · have h := Nat.div_add_mod (13 * m + 6) 3
+    have hmod := Nat.mod_lt (13 * m + 6) (by norm_num : 0 < 3)
+    omega
+
+/-! ## The finite bootstrap -/
+
+/-- For 15 ≤ n < 60, 25 * A_n ≥ 26 * k_n, with equality exactly at n = 17. -/
+theorem bootstrap_26_25 (n : ℕ) (h1 : 15 ≤ n) (h2 : n < 60) :
+    25 * A n ≥ 26 * k n ∧ (25 * A n = 26 * k n ↔ n = 17) := by
+  interval_cases n <;> eval_Ak_small
+
+/-! ## Unfolding A for large n -/
+
+private lemma A_mod0 (n : ℕ) (hn : 60 ≤ n) (hr : n % 4 = 0) :
+    A n = A (n / 4) + A (n / 4) + A (n / 4) + A (n / 4) + eBonus 0 (n / 4) := by
+  have h1 : n ≠ 0 := by omega
+  have h2 : ¬(n < 60) := by omega
+  conv_lhs => unfold A
+  simp only [h1, h2, ↓reduceIte, hr]
+
+private lemma A_mod1 (n : ℕ) (hn : 60 ≤ n) (hr : n % 4 = 1) :
+    A n = A (n / 4) + A (n / 4) + A (n / 4) + A (n / 4 + 1) + eBonus 1 (n / 4) := by
+  have h1 : n ≠ 0 := by omega
+  have h2 : ¬(n < 60) := by omega
+  conv_lhs => unfold A
+  simp only [h1, h2, ↓reduceIte, hr]
+
+private lemma A_mod2 (n : ℕ) (hn : 60 ≤ n) (hr : n % 4 = 2) :
+    A n = A (n / 4) + A (n / 4) + A (n / 4 + 1) + A (n / 4 + 1) + eBonus 2 (n / 4) := by
+  have h1 : n ≠ 0 := by omega
+  have h2 : ¬(n < 60) := by omega
+  conv_lhs => unfold A
+  simp only [h1, h2, ↓reduceIte, hr]
+
+private lemma A_mod3 (n : ℕ) (hn : 60 ≤ n) (hr : n % 4 = 3) :
+    A n = A (n / 4) + A (n / 4 + 1) + A (n / 4 + 1) + A (n / 4 + 1) + eBonus 3 (n / 4) := by
+  have h1 : n ≠ 0 := by omega
+  have h2 : ¬(n < 60) := by omega
+  conv_lhs => unfold A
+  simp only [h1, h2, ↓reduceIte, hr]
+
+private lemma q_mul_three_add_mod (m q : ℕ) (hq : q = m / 3) :
+    q * 3 + m % 3 = m := by
+  subst q
+  simpa [Nat.add_comm, Nat.add_left_comm, Nat.add_assoc,
+    Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using
+    (Nat.mod_add_div m 3)
+
+private lemma four_mul_div_add_mod (n m : ℕ) (hm : m = n / 4) :
+    4 * m + n % 4 = n := by
+  subst m
+  simpa [Nat.add_comm, Nat.add_left_comm, Nat.add_assoc,
+    Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using
+    (Nat.mod_add_div n 4)
+
+private lemma q_mul_three_add_two (m q : ℕ) (hq : q = m / 3) (hs : m % 3 = 2) :
+    q * 3 + 2 = m := by
+  simpa [hs] using q_mul_three_add_mod m q hq
+
+private lemma q_mul_three_add_three (m q : ℕ) (hq : q = m / 3) (hs : m % 3 = 2) :
+    q * 3 + 3 = m + 1 := by
+  have hq2 : q * 3 + 2 = m := q_mul_three_add_two m q hq hs
+  omega
+
+private lemma add_three_of_add_two {a b : ℕ} (h : a + 2 = b) :
+    a + 3 = b + 1 := by
+  simpa [Nat.add_assoc] using congrArg Nat.succ h
+
+private lemma four_mul_div_add_three (n m : ℕ) (hm : m = n / 4) (hr : n % 4 = 3) :
+    4 * m + 3 = n := by
+  simpa [hr] using four_mul_div_add_mod n m hm
+
+private lemma four_way_sum_mod3 (n m : ℕ) (hm : m = n / 4) (hr : n % 4 = 3) :
+    m + (m + 1) + (m + 1) + (m + 1) = n := by
+  have hn3 : 4 * m + 3 = n := four_mul_div_add_three n m hm hr
+  omega
+
+private lemma eBonus1_mod0 (m q : ℕ) (hq : q = m / 3) (hs : m % 3 = 0) :
+    eBonus 1 m = q * 13 := by
+  have hq0 : q * 3 = m := by
+    simpa [hs] using q_mul_three_add_mod m q hq
+  simp only [eBonus]
+  have hnum : 13 * m + 1 = 1 + 3 * (q * 13) := by
+    rw [← hq0]
+    omega
+  rw [hnum, Nat.add_mul_div_left _ _ (by decide)]
+  norm_num
+
+private lemma eBonus1_mod1 (m q : ℕ) (hq : q = m / 3) (hs : m % 3 = 1) :
+    eBonus 1 m = q * 13 + 4 := by
+  have hq1 : q * 3 + 1 = m := by
+    simpa [hs] using q_mul_three_add_mod m q hq
+  simp only [eBonus]
+  have hnum : 13 * m + 1 = 2 + 3 * (q * 13 + 4) := by
+    rw [← hq1]
+    omega
+  rw [hnum, Nat.add_mul_div_left _ _ (by decide), Nat.div_eq_of_lt (by decide)]
+  simp
+
+private lemma eBonus1_mod2 (m q : ℕ) (hq : q = m / 3) (hs : m % 3 = 2) :
+    eBonus 1 m = q * 13 + 9 := by
+  have hq2 : q * 3 + 2 = m := by
+    simpa [hs] using q_mul_three_add_mod m q hq
+  simp only [eBonus]
+  have hnum : 13 * m + 1 = 3 * (q * 13 + 9) := by
+    rw [← hq2]
+    omega
+  rw [hnum]
+  simp
+
+private lemma eBonus2_mod0 (m q : ℕ) (hq : q = m / 3) (hs : m % 3 = 0) :
+    eBonus 2 m = q * 13 + 1 := by
+  have hq0 : q * 3 = m := by
+    simpa [hs] using q_mul_three_add_mod m q hq
+  simp only [eBonus]
+  have hnum : 13 * m + 5 = 2 + 3 * (q * 13 + 1) := by
+    rw [← hq0]
+    omega
+  rw [hnum, Nat.add_mul_div_left _ _ (by decide), Nat.div_eq_of_lt (by decide)]
+  simp
+
+private lemma eBonus2_mod1 (m q : ℕ) (hq : q = m / 3) (hs : m % 3 = 1) :
+    eBonus 2 m = q * 13 + 6 := by
+  have hq1 : q * 3 + 1 = m := by
+    simpa [hs] using q_mul_three_add_mod m q hq
+  simp only [eBonus]
+  have hnum : 13 * m + 5 = 3 * (q * 13 + 6) := by
+    rw [← hq1]
+    omega
+  rw [hnum]
+  simp
+
+private lemma eBonus2_mod2 (m q : ℕ) (hq : q = m / 3) (hs : m % 3 = 2) :
+    eBonus 2 m = q * 13 + 10 := by
+  have hq2 : q * 3 + 2 = m := by
+    simpa [hs] using q_mul_three_add_mod m q hq
+  simp only [eBonus]
+  have hnum : 13 * m + 5 = 1 + 3 * (q * 13 + 10) := by
+    rw [← hq2]
+    omega
+  rw [hnum, Nat.add_mul_div_left _ _ (by decide)]
+  norm_num
+
+private lemma eBonus3_mod0 (m q : ℕ) (hq : q = m / 3) (hs : m % 3 = 0) :
+    eBonus 3 m = q * 13 + 2 := by
+  have hq0 : q * 3 = m := by
+    simpa [hs] using q_mul_three_add_mod m q hq
+  simp only [eBonus]
+  have hnum : 13 * m + 6 = 3 * (q * 13 + 2) := by
+    rw [← hq0]
+    omega
+  rw [hnum]
+  simp
+
+private lemma eBonus3_mod1 (m q : ℕ) (hq : q = m / 3) (hs : m % 3 = 1) :
+    eBonus 3 m = q * 13 + 6 := by
+  have hq1 : q * 3 + 1 = m := by
+    simpa [hs] using q_mul_three_add_mod m q hq
+  simp only [eBonus]
+  have hnum : 13 * m + 6 = 1 + 3 * (q * 13 + 6) := by
+    rw [← hq1]
+    omega
+  rw [hnum, Nat.add_mul_div_left _ _ (by decide)]
+  norm_num
+
+private lemma eBonus3_mod2 (m q : ℕ) (hq : q = m / 3) (hs : m % 3 = 2) :
+    eBonus 3 m = q * 13 + 10 := by
+  have hq2 : q * 3 + 2 = m := by
+    simpa [hs] using q_mul_three_add_mod m q hq
+  simp only [eBonus]
+  have hnum : 13 * m + 6 = 2 + 3 * (q * 13 + 10) := by
+    rw [← hq2]
+    omega
+  rw [hnum, Nat.add_mul_div_left _ _ (by decide), Nat.div_eq_of_lt (by decide)]
+  simp
+
+/-! ## The main uniform bound -/
+
+/-- For all n ≥ 15, 25 * A_n ≥ 26 * k_n, i.e. A_n ≥ (26/25) k_n. -/
+theorem uniform_26_25 (n : ℕ) (hn : 15 ≤ n) :
+    25 * A n ≥ 26 * k n := by
+  induction n using Nat.strongRecOn with
+  | ind n ih =>
+    by_cases h60 : n < 60
+    · exact (bootstrap_26_25 n hn h60).1
+    · push Not at h60
+      set m := n / 4 with hm_def
+      have hm15 : 15 ≤ m := by omega
+      have hm_lt : m < n := Nat.div_lt_self (by omega) (by omega)
+      have hm1_lt : m + 1 < n := by omega
+      have ih_m := ih m hm_lt hm15
+      have ih_m1 := ih (m + 1) hm1_lt (by omega)
+      obtain ⟨hk0, hk1, hk2, hk3⟩ := k_four_way m (by omega)
+      obtain ⟨hf0, hf1, hf2, hf3⟩ := floor_26_25 m hm15
+      have : n % 4 = 0 ∨ n % 4 = 1 ∨ n % 4 = 2 ∨ n % 4 = 3 := by omega
+      rcases this with hr | hr | hr | hr
+      · -- n % 4 = 0
+        have hA := A_mod0 n (by omega) hr
+        rw [hA]
+        have hkn : k n = 4 * k m + 4 * m := by
+          rw [show n = 4 * m from by omega]; exact hk0
+        rw [hkn]; linarith
+      · -- n % 4 = 1
+        have hA := A_mod1 n (by omega) hr
+        rw [hA]
+        have hkn : k n = 3 * k m + k (m + 1) + 4 * m := by
+          rw [show n = 4 * m + 1 from by omega]; exact hk1
+        rw [hkn]; linarith
+      · -- n % 4 = 2
+        have hA := A_mod2 n (by omega) hr
+        rw [hA]
+        have hkn : k n = 2 * k m + 2 * k (m + 1) + 4 * m + 1 := by
+          rw [show n = 4 * m + 2 from by omega]; exact hk2
+        rw [hkn]; linarith
+      · -- n % 4 = 3
+        have hA := A_mod3 n (by omega) hr
+        rw [hA]
+        have hkn : k n = k m + 3 * k (m + 1) + 4 * m + 2 := by
+          rw [show n = 4 * m + 3 from by omega]; exact hk3
+        rw [hkn]; linarith
+
+/-- Each edge has at most n vertices when NoLargePartition holds. -/
+private lemma edge_card_le_of_noLargePartition
+    (edges : Finset (Finset ℕ)) (n : ℕ) (h : NoLargePartition edges n)
+    (e : Finset ℕ) (he : e ∈ edges) : e.card ≤ n := by
+  have h1 := h {e} (Finset.singleton_subset_iff.mpr he)
+  unfold uniqueCoverage at h1
+  -- uniqueCoverage edges {e} counts vertices in vertexSet edges that are in exactly one edge of {e}
+  -- For v ∈ e: filter gives {e}, card = 1. For v ∉ e: filter gives ∅, card = 0.
+  -- So uniqueCoverage edges {e} = |(vertexSet edges) ∩ e| = |e| (since e ⊆ vertexSet edges).
+  have h2 : ∀ v ∈ e, v ∈ vertexSet edges := by
+    intro v hv
+    simp only [vertexSet, Finset.mem_biUnion]
+    exact ⟨e, he, hv⟩
+  have h3 :
+      e ⊆ (vertexSet edges).filter
+        (fun v => (({e} : Finset (Finset ℕ)).filter (fun e' => v ∈ e')).card = 1) := by
+    intro v hv
+    simp only [Finset.mem_filter]
+    refine ⟨h2 v hv, ?_⟩
+    simp only [Finset.filter_singleton, if_pos hv, Finset.card_singleton]
+  exact le_trans (Finset.card_le_card h3) h1
+
+private lemma vertexSet_card_le_sum_card (edges : Finset (Finset ℕ)) :
+    (vertexSet edges).card ≤ edges.sum Finset.card := by
+  induction edges using Finset.induction_on with
+  | empty =>
+      simp [vertexSet]
+  | @insert e edges he ih =>
+      simpa [vertexSet, he, add_comm, add_left_comm, add_assoc] using
+        le_trans (Finset.card_union_le e (vertexSet edges))
+          (Nat.add_le_add_left ih e.card)
+
+private theorem exists_cover_subset_card_le_of_noLargePartition
+    (edges : Finset (Finset ℕ)) (n : ℕ) (hpart : NoLargePartition edges n) :
+    ∃ C ⊆ edges, vertexSet C = vertexSet edges ∧ C.card ≤ n := by
+  let covers : Finset (Finset (Finset ℕ)) :=
+    edges.powerset.filter fun P => vertexSet P = vertexSet edges
+  have hcovers_nonempty : covers.Nonempty := by
+    refine ⟨edges, ?_⟩
+    simp [covers]
+  obtain ⟨C, hCmem, hCmin⟩ := covers.exists_min_image Finset.card hcovers_nonempty
+  have hCsub : C ⊆ edges := Finset.mem_powerset.mp ((Finset.mem_filter.mp hCmem).1)
+  have hCcover : vertexSet C = vertexSet edges := (Finset.mem_filter.mp hCmem).2
+  have hprivate :
+      ∀ e, e ∈ C → ∃ v, v ∈ e ∧ v ∉ vertexSet (C.erase e) := by
+    intro e heC
+    by_contra h
+    push Not at h
+    have hsubset : e ⊆ vertexSet (C.erase e) := h
+    have hcoverErase : vertexSet (C.erase e) = vertexSet edges := by
+      refine le_antisymm ?_ ?_
+      · intro v hv
+        rw [← hCcover]
+        exact Finset.mem_biUnion.mpr <| by
+          rcases Finset.mem_biUnion.mp hv with ⟨e', he', hv'⟩
+          exact ⟨e', (Finset.mem_erase.mp he').2, hv'⟩
+      · rw [← hCcover]
+        intro v hv
+        rcases Finset.mem_biUnion.mp hv with ⟨e', he', hv'⟩
+        by_cases hEq : e' = e
+        · subst hEq
+          exact hsubset hv'
+        · exact Finset.mem_biUnion.mpr ⟨e', Finset.mem_erase.mpr ⟨hEq, he'⟩, hv'⟩
+    have hEraseMem : C.erase e ∈ covers := by
+      refine Finset.mem_filter.mpr ⟨?_, hcoverErase⟩
+      exact Finset.mem_powerset.mpr <| fun e' he' => hCsub ((Finset.mem_erase.mp he').2)
+    have hEraseCard : (C.erase e).card < C.card := Finset.card_erase_lt_of_mem heC
+    exact (Nat.not_le_of_lt hEraseCard) (hCmin _ hEraseMem)
+  choose priv hpriv_mem hpriv_not using hprivate
+  let uniqVerts : Finset ℕ :=
+    (vertexSet edges).filter fun v => (C.filter fun e => v ∈ e).card = 1
+  have hpriv_injective : Function.Injective (fun e : {e // e ∈ C} => priv e.1 e.2) := by
+    intro e₁ e₂ hEq
+    by_contra hne
+    have hne' : e₂.1 ≠ e₁.1 := fun hbase =>
+      hne <| Subtype.ext hbase.symm
+    have hmem :
+        priv e₂.1 e₂.2 ∈ vertexSet (C.erase e₁.1) :=
+      Finset.mem_biUnion.mpr
+        ⟨e₂.1, Finset.mem_erase.mpr ⟨hne', e₂.2⟩, hpriv_mem e₂.1 e₂.2⟩
+    have : priv e₁.1 e₁.2 ∈ vertexSet (C.erase e₁.1) := by
+      simpa [hEq] using hmem
+    exact hpriv_not e₁.1 e₁.2 this
+  have hpriv_subset : C.attach.image (fun e => priv e.1 e.2) ⊆ uniqVerts := by
+    intro v hv
+    rcases Finset.mem_image.mp hv with ⟨e, -, rfl⟩
+    refine Finset.mem_filter.mpr ⟨?_, ?_⟩
+    · rw [← hCcover]
+      exact Finset.mem_biUnion.mpr ⟨e.1, e.2, hpriv_mem e.1 e.2⟩
+    · have hsingleton :
+          C.filter (fun e' => priv e.1 e.2 ∈ e') ⊆ {e.1} := by
+        intro e' he'
+        have he'C : e' ∈ C := (Finset.mem_filter.mp he').1
+        have hmem' : priv e.1 e.2 ∈ e' := (Finset.mem_filter.mp he').2
+        by_contra hne
+        have hne' : e' ≠ e.1 := by
+          simpa using hne
+        have : priv e.1 e.2 ∈ vertexSet (C.erase e.1) :=
+          Finset.mem_biUnion.mpr ⟨e', Finset.mem_erase.mpr ⟨hne', he'C⟩, hmem'⟩
+        exact hpriv_not e.1 e.2 this
+      have hmemFilter : e.1 ∈ C.filter (fun e' => priv e.1 e.2 ∈ e') :=
+        Finset.mem_filter.mpr ⟨e.2, hpriv_mem e.1 e.2⟩
+      apply le_antisymm
+      · exact le_trans (Finset.card_le_card hsingleton) (by simp)
+      · exact Nat.succ_le_of_lt (Finset.card_pos.mpr ⟨e.1, hmemFilter⟩)
+  have hCcard : C.card ≤ n := by
+    have hUnique :
+        C.card ≤ uniqueCoverage edges C := by
+      calc
+        C.card = (C.attach.image (fun e => priv e.1 e.2)).card := by
+          rw [Finset.card_image_of_injective _ hpriv_injective, Finset.card_attach]
+        _ ≤ uniqVerts.card := Finset.card_le_card hpriv_subset
+        _ = uniqueCoverage edges C := rfl
+    exact le_trans hUnique (hpart C hCsub)
+  exact ⟨C, hCsub, hCcover, hCcard⟩
+
+/-- The set defining H(n) is bounded above. -/
+theorem H_set_bddAbove (n : ℕ) :
+    BddAbove {k : ℕ | ∃ (edges : Finset (Finset ℕ)),
+      (vertexSet edges).card = k ∧ NoLargePartition edges n} := by
+  refine ⟨n * n, ?_⟩
+  rintro k ⟨edges, hk, hpart⟩
+  obtain ⟨C, hCsub, hCcover, hCcard⟩ :=
+    exists_cover_subset_card_le_of_noLargePartition edges n hpart
+  have hkBound :
+      (vertexSet edges).card ≤ n * n := by
+    calc
+      (vertexSet edges).card = (vertexSet C).card := by rw [hCcover]
+      _ ≤ C.sum Finset.card := vertexSet_card_le_sum_card C
+      _ ≤ C.sum (fun _ => n) := Finset.sum_le_sum fun e he =>
+            edge_card_le_of_noLargePartition edges n hpart e (hCsub he)
+      _ = C.card * n := by simp
+      _ ≤ n * n := by
+            simpa [Nat.mul_comm] using Nat.mul_le_mul_right n hCcard
+  simpa [hk] using hkBound
+
+/-! ## Witness construction helpers -/
+
+private theorem ws_one : WitnessStrong 1 1 := by
+  refine ⟨{
+      edges := {{(0 : ℕ)}}
+      edgeCard := ?_
+      vertexCard := ?_
+      noLargePartition := ?_ }, ?_⟩
+  · simp
+  · simp [vertexSet]
+  · intro P hP
+    rw [Finset.subset_singleton_iff] at hP
+    rcases hP with rfl | rfl
+    · simp [uniqueCoverage]
+    · unfold uniqueCoverage vertexSet
+      rw [Finset.singleton_biUnion]
+      simp [Finset.filter_singleton, Finset.card_singleton]
+  · intro e he
+    rw [Finset.mem_singleton.mp he]
+    exact ⟨0, Finset.mem_singleton.mpr rfl⟩
+
+private theorem ws_bin (a b va vb c : ℕ) (hc : c ≤ min a b)
+    (ha : WitnessStrong a va) (hb : WitnessStrong b vb) :
+    WitnessStrong (a + b) (va + vb + c) := by
+  have hbonus : (binarySupports c).card = c := by
+    simp [binarySupports, List.length_replicate]
+  have h := apply_frameData (binarySupports c) (binaryCap a b) (binaryValues va vb) c
+    hbonus (binary_isFrame a b c hc)
+    (fun i => by
+      fin_cases i
+      · exact ha
+      · exact hb)
+  simp only [Fin.sum_univ_two, binaryCap, binaryValues] at h
+  exact h
+
+private theorem ws_bin_A (a b c : ℕ) (hc : c ≤ min a b)
+    (ha : WitnessStrong a (A a)) (hb : WitnessStrong b (A b))
+    (hv : A a + A b + c = A (a + b)) :
+    WitnessStrong (a + b) (A (a + b)) :=
+  hv ▸ ws_bin a b (A a) (A b) c hc ha hb
+
+/-! ## Standalone intermediate witnesses -/
+
+private theorem ws_23 : WitnessStrong 2 3 :=
+  ws_bin 1 1 1 1 1 (by omega) ws_one ws_one
+
+private theorem ws_34 : WitnessStrong 3 4 :=
+  ws_bin 1 2 1 3 0 (by omega) ws_one ws_23
+
+private theorem ws_35 : WitnessStrong 3 5 :=
+  ws_bin 1 2 1 3 1 (by omega) ws_one ws_23
+
+private theorem ws_46 : WitnessStrong 4 6 :=
+  ws_bin 1 3 1 4 1 (by omega) ws_one ws_34
+
+private theorem ws_48 : WitnessStrong 4 8 :=
+  ws_bin 2 2 3 3 2 (by omega) ws_23 ws_23
+
+private theorem ws_510 : WitnessStrong 5 10 :=
+  ws_bin 2 3 3 5 2 (by omega) ws_23 ws_35
+
+private theorem ws_820 : WitnessStrong 8 20 :=
+  ws_bin 4 4 8 8 4 (by omega) ws_48 ws_48
+
+private theorem ws_singleton : ∀ n : ℕ, 1 ≤ n → WitnessStrong n n := by
+  intro n hn
+  induction n with
+  | zero => omega
+  | succ n ih =>
+    cases n with
+    | zero => exact ws_one
+    | succ n =>
+      exact ws_bin (n + 1) 1 (n + 1) 1 0 (by omega) (ih (by omega)) ws_one
+
+private theorem ws_of_valid {t : ℕ}
+    (supports : Multiset (SupportPattern t))
+    (edgeCounts vertexCounts : Fin t → ℕ)
+    (bonus : ℕ)
+    (hBonus : supports.card = bonus)
+    (hFrame : IsFrame supports edgeCounts)
+    (hw : ∀ i, WitnessStrong (edgeCounts i) (vertexCounts i)) :
+    WitnessStrong (Finset.univ.sum edgeCounts) (Finset.univ.sum vertexCounts + bonus) :=
+  apply_frameData supports edgeCounts vertexCounts bonus hBonus hFrame hw
+
+private theorem ws_614 : WitnessStrong 6 14 := by
+  let spec := exactSmallFrames.get ⟨0, by decide⟩
+  have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+  have hFrame := spec.isValid_iff_isFrame.mp hValid
+  have h := apply_frameData spec.supports spec.cap
+    (fun _ : Fin spec.t => (3 : ℕ)) spec.bonus
+    spec.supports_card hFrame
+    (fun i => by
+      have : spec.t = 3 := by decide
+      fin_cases i <;> exact ws_23)
+  convert h using 1 <;> decide
+
+private theorem ws_923 : WitnessStrong 9 23 := by
+  let spec := exactSmallFrames.get ⟨3, by decide⟩
+  have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+  have hFrame := spec.isValid_iff_isFrame.mp hValid
+  have h := apply_frameData spec.supports spec.cap
+    (![3, 3, 3, 5] : Fin spec.t → ℕ) spec.bonus
+    spec.supports_card hFrame
+    (fun i => by
+      have : spec.t = 4 := by decide
+      fin_cases i <;> simp_all only [List.length_cons, List.length_nil, Nat.reduceAdd] <;>
+        first | exact ws_23 | exact ws_35)
+  convert h using 1 <;> decide
+
+private theorem ws_1027 : WitnessStrong 10 27 := by
+  let spec := exactSmallFrames.get ⟨4, by decide⟩
+  have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+  have hFrame := spec.isValid_iff_isFrame.mp hValid
+  have h := apply_frameData spec.supports spec.cap
+    (![3, 3, 3, 8] : Fin spec.t → ℕ) spec.bonus
+    spec.supports_card hFrame
+    (fun i => by
+      have : spec.t = 4 := by decide
+      fin_cases i <;> simp_all only [List.length_cons, List.length_nil, Nat.reduceAdd] <;>
+        first | exact ws_23 | exact ws_48)
+  convert h using 1 <;> decide
+
+private theorem ws_1234 : WitnessStrong 12 34 :=
+  ws_bin 6 6 14 14 6 (by omega) ws_614 ws_614
+
+private theorem ws_1337 : WitnessStrong 13 37 := by
+  let spec := exactSmallFrames.get ⟨11, by decide⟩
+  have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+  have hFrame := spec.isValid_iff_isFrame.mp hValid
+  have h := apply_frameData spec.supports spec.cap
+    (![3, 3, 3, 5, 8] : Fin spec.t → ℕ) spec.bonus
+    spec.supports_card hFrame
+    (fun i => by
+      have : spec.t = 5 := by decide
+      fin_cases i <;> simp_all only [List.length_cons, List.length_nil, Nat.reduceAdd] <;>
+        first | exact ws_23 | exact ws_35 | exact ws_48)
+  convert h using 1 <;> decide
+
+private theorem ws_1441 : WitnessStrong 14 41 := by
+  let spec := exactSmallFrames.get ⟨1, by decide⟩
+  have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+  have hFrame := spec.isValid_iff_isFrame.mp hValid
+  have h := apply_frameData spec.supports spec.cap
+    (![8, 8, 14] : Fin spec.t → ℕ) spec.bonus
+    spec.supports_card hFrame
+    (fun i => by
+      have : spec.t = 3 := by decide
+      fin_cases i <;> simp_all only [List.length_cons, List.length_nil, Nat.reduceAdd] <;>
+        first | exact ws_48 | exact ws_614)
+  convert h using 1 <;> decide
+
+private theorem ws_1545 : WitnessStrong 15 45 := by
+  let spec := boosters.get ⟨0, by decide⟩
+  have hValid := finite_bank_valid.2.1 spec (List.get_mem _ _)
+  have hFrame := spec.isValid_iff_isFrame.mp hValid
+  have h := apply_frameData spec.supports spec.cap
+    (![3, 3, 3, 3, 3, 3, 5] : Fin spec.t → ℕ) spec.bonus
+    spec.supports_card hFrame
+    (fun i => by
+      have : spec.t = 7 := by decide
+      fin_cases i <;> simp_all only [List.length_cons, List.length_nil, Nat.reduceAdd] <;>
+        first | exact ws_23 | exact ws_35)
+  convert h using 1 <;> decide
+
+private lemma A_bin_38 : A 18 + A 20 + 18 = A 38 := by
+  eval_A_small
+
+private lemma A_bin_41 : A 1 + A 40 + 1 = A 41 := by
+  eval_A_small
+
+private lemma A_bin_42 : A 18 + A 24 + 18 = A 42 := by
+  eval_A_small
+
+private lemma A_bin_43 : A 21 + A 22 + 21 = A 43 := by
+  eval_A_small
+
+private lemma A_bin_44 : A 22 + A 22 + 22 = A 44 := by
+  eval_A_small
+
+private lemma A_bin_45 : A 1 + A 44 + 1 = A 45 := by
+  eval_A_small
+
+private lemma A_bin_46 : A 22 + A 24 + 20 = A 46 := by
+  eval_A_small
+
+private lemma A_bin_47 : A 23 + A 24 + 23 = A 47 := by
+  eval_A_small
+
+private lemma A_bin_48 : A 24 + A 24 + 24 = A 48 := by
+  eval_A_small
+
+private lemma A_bin_50 : A 24 + A 26 + 24 = A 50 := by
+  eval_A_small
+
+private lemma A_bin_51 : A 24 + A 27 + 24 = A 51 := by
+  eval_A_small
+
+private lemma A_bin_52 : A 24 + A 28 + 24 = A 52 := by
+  eval_A_small
+
+private lemma A_bin_53 : A 26 + A 27 + 26 = A 53 := by
+  eval_A_small
+
+private lemma A_bin_54 : A 24 + A 30 + 24 = A 54 := by
+  eval_A_small
+
+private lemma A_bin_55 : A 27 + A 28 + 27 = A 55 := by
+  eval_A_small
+
+private lemma A_bin_56 : A 28 + A 28 + 28 = A 56 := by
+  eval_A_small
+
+private lemma A_bin_58 : A 28 + A 30 + 28 = A 58 := by
+  eval_A_small
+
+private lemma A_bin_59 : A 29 + A 30 + 29 = A 59 := by
+  eval_A_small
+
+/-! ## Replication helpers for the recursive case -/
+
+private def replicateList {α : Type*} (l : List α) : ℕ → List α
+  | 0 => []
+  | n + 1 => l ++ replicateList l n
+
+private theorem replicateList_length {α : Type*} (l : List α) (q : ℕ) :
+    (replicateList l q).length = q * l.length := by
+  induction q with
+  | zero => simp [replicateList]
+  | succ q ih => simp [replicateList, List.length_append, ih]; ring
+
+private theorem replicateList_valid {t : ℕ}
+    {l : List (SupportPattern t)} {cap : Fin t → ℕ}
+    (h : SupportsValid l cap) (q : ℕ) :
+    SupportsValid (replicateList l q) (fun i => q * cap i) := by
+  induction q with
+  | zero =>
+    intro T I _
+    simp [replicateList]
+  | succ q ih =>
+    intro T I hIT
+    simp only [replicateList, List.countP_append]
+    calc
+      l.countP (frameWitnesses T I) + (replicateList l q).countP (frameWitnesses T I)
+        ≤ (T \ I).sum cap + (T \ I).sum (fun i => q * cap i) :=
+            Nat.add_le_add (h T I hIT) (ih T I hIT)
+      _ = (T \ I).sum (fun i => (q + 1) * cap i) := by
+          rw [← Finset.sum_add_distrib]
+          congr 1; ext i; ring
+
+/-! ## The main witness strength theorem -/
+
+private theorem A_witnessStrong_bootstrap_1_20
+    (n : ℕ) (hn : 1 ≤ n) (h20 : n ≤ 20)
+    (ih : ∀ m < n, 1 ≤ m → WitnessStrong m (A m)) :
+    WitnessStrong n (A n) := by
+  interval_cases n
+  -- n = 1
+  · convert ws_one using 2; eval_A_small
+  -- n = 2: binary(1,1,1)
+  · exact ws_bin_A 1 1 1 (by omega)
+      (ih 1 (by omega) (by omega))
+      (ih 1 (by omega) (by omega)) (by eval_A_small)
+  -- n = 3: binary(1,2,0)
+  · exact ws_bin_A 1 2 0 (by omega)
+      (ih 1 (by omega) (by omega))
+      (ih 2 (by omega) (by omega)) (by eval_A_small)
+  -- n = 4: binary(1,3,1)
+  · exact ws_bin_A 1 3 1 (by omega)
+      (ih 1 (by omega) (by omega))
+      (ih 3 (by omega) (by omega)) (by eval_A_small)
+  -- n = 5: binary(1,4,0)
+  · exact ws_bin_A 1 4 0 (by omega)
+      (ih 1 (by omega) (by omega))
+      (ih 4 (by omega) (by omega)) (by eval_A_small)
+  -- n = 6: binary(2,4,1)
+  · exact ws_bin_A 2 4 1 (by omega)
+      (ih 2 (by omega) (by omega))
+      (ih 4 (by omega) (by omega)) (by eval_A_small)
+  -- n = 7: binary(1,6,0)
+  · exact ws_bin_A 1 6 0 (by omega)
+      (ih 1 (by omega) (by omega))
+      (ih 6 (by omega) (by omega)) (by eval_A_small)
+  -- n = 8: binary(2,6,1)
+  · exact ws_bin_A 2 6 1 (by omega)
+      (ih 2 (by omega) (by omega))
+      (ih 6 (by omega) (by omega)) (by eval_A_small)
+  -- n = 9: binary(3,6,3)
+  · exact ws_bin_A 3 6 3 (by omega)
+      (ih 3 (by omega) (by omega))
+      (ih 6 (by omega) (by omega)) (by eval_A_small)
+  -- n = 10: binary(1,9,1)
+  · exact ws_bin_A 1 9 1 (by omega)
+      (ih 1 (by omega) (by omega))
+      (ih 9 (by omega) (by omega)) (by eval_A_small)
+  -- n = 11: binary(1,10,1)
+  · exact ws_bin_A 1 10 1 (by omega)
+      (ih 1 (by omega) (by omega))
+      (ih 10 (by omega) (by omega)) (by eval_A_small)
+  -- n = 12: binary(2,10,2)
+  · exact ws_bin_A 2 10 2 (by omega)
+      (ih 2 (by omega) (by omega))
+      (ih 10 (by omega) (by omega)) (by eval_A_small)
+  -- n = 13: frame [2,2,2,3,4] with singletons
+  · let spec := exactSmallFrames.get ⟨11, by decide⟩
+    have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have hf := apply_frameData spec.supports spec.cap
+      (![2, 2, 2, 3, 4] : Fin spec.t → ℕ) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 5 := by decide
+        fin_cases i <;> simp_all only [List.length_cons, List.length_nil, Nat.reduceAdd] <;>
+          exact ws_singleton _ (by decide))
+    convert hf using 1
+    · decide
+    · have hsum :
+        ((Finset.univ : Finset (Fin spec.t)).sum
+          (![2, 2, 2, 3, 4] : Fin spec.t → ℕ)) = 13 := by
+          have ht : spec.t = 5 := by decide
+          decide
+      have hbonus : spec.bonus = 15 := by decide
+      have hA : A 13 = 28 := by eval_A_small
+      calc
+        A 13 = 28 := hA
+        _ =
+            ((Finset.univ : Finset (Fin spec.t)).sum
+              (![2, 2, 2, 3, 4] : Fin spec.t → ℕ)) + spec.bonus := by
+          omega
+  -- n = 14: binary(1,13,1)
+  · exact ws_bin_A 1 13 1 (by omega)
+      (ih 1 (by omega) (by omega))
+      (ih 13 (by omega) (by omega)) (by eval_A_small)
+  -- n = 15: boost15
+  · convert ws_1545 using 1
+    eval_A_small
+  -- n = 16: boost16
+  · let spec := boosters.get ⟨1, by decide⟩
+    have hValid := finite_bank_valid.2.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have h := apply_frameData spec.supports spec.cap
+      (fun _ : Fin spec.t => (3 : ℕ)) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 8 := by decide
+        fin_cases i <;> exact ws_23)
+    convert h using 1
+    · decide
+    · have hsum : (∑ _ : Fin spec.t, (3 : ℕ)) = 24 := by
+        have ht : spec.t = 8 := by decide
+        simp [ht]
+      have hbonus : spec.bonus = 26 := by decide
+      have hA : A 16 = 50 := by eval_A_small
+      calc
+        A 16 = 50 := hA
+        _ = (∑ _ : Fin spec.t, (3 : ℕ)) + spec.bonus := by omega
+  -- n = 17: binary(1,16,1)
+  · exact ws_bin_A 1 16 1 (by omega)
+      (ih 1 (by omega) (by omega))
+      (ih 16 (by omega) (by omega)) (by eval_A_small)
+  -- n = 18: frame [6,6,6] with WS(6,14)×3
+  · let spec := exactSmallFrames.get ⟨2, by decide⟩
+    have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have h := apply_frameData spec.supports spec.cap
+      (fun _ : Fin spec.t => (14 : ℕ)) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 3 := by decide
+        fin_cases i <;> exact ws_614)
+    convert h using 1
+    · decide
+    · have hsum : (∑ _ : Fin spec.t, (14 : ℕ)) = 42 := by
+        have ht : spec.t = 3 := by decide
+        simp [ht]
+      have hbonus : spec.bonus = 15 := by decide
+      have hA : A 18 = 57 := by eval_A_small
+      calc
+        A 18 = 57 := hA
+        _ = (∑ _ : Fin spec.t, (14 : ℕ)) + spec.bonus := by omega
+  -- n = 19: boost19 [2,2,2,3,4,6]
+  · let spec := boosters.get ⟨3, by decide⟩
+    have hValid := finite_bank_valid.2.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have h := apply_frameData spec.supports spec.cap
+      (![3, 3, 3, 5, 8, 14] : Fin spec.t → ℕ) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 6 := by decide
+        fin_cases i <;> simp_all only [List.length_cons, List.length_nil, Nat.reduceAdd] <;>
+          first | exact ws_23 | exact ws_35 | exact ws_48 | exact ws_614)
+    convert h using 1
+    · decide
+    · have hsum :
+        ((Finset.univ : Finset (Fin spec.t)).sum
+          (![3, 3, 3, 5, 8, 14] : Fin spec.t → ℕ)) = 36 := by
+          have ht : spec.t = 6 := by decide
+          decide
+      have hbonus : spec.bonus = 24 := by decide
+      have hA : A 19 = 60 := by eval_A_small
+      calc
+        A 19 = 60 := hA
+        _ =
+            ((Finset.univ : Finset (Fin spec.t)).sum
+              (![3, 3, 3, 5, 8, 14] : Fin spec.t → ℕ)) + spec.bonus := by
+          omega
+  -- n = 20: frame [4,4,4,4,4] with WS(4,8)×5
+  · let spec := exactSmallFrames.get ⟨13, by decide⟩
+    have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have h := apply_frameData spec.supports spec.cap
+      (fun _ : Fin spec.t => (8 : ℕ)) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 5 := by decide
+        fin_cases i <;> exact ws_48)
+    convert h using 1
+    · decide
+    · have hsum : (∑ _ : Fin spec.t, (8 : ℕ)) = 40 := by
+        have ht : spec.t = 5 := by decide
+        simp [ht]
+      have hbonus : spec.bonus = 25 := by decide
+      have hA : A 20 = 65 := by eval_A_small
+      calc
+        A 20 = 65 := hA
+        _ = (∑ _ : Fin spec.t, (8 : ℕ)) + spec.bonus := by omega
+
+private theorem A_witnessStrong_bootstrap_21_30
+    (n : ℕ) (h21 : 21 ≤ n) (h30 : n ≤ 30)
+    (ih : ∀ m < n, 1 ≤ m → WitnessStrong m (A m)) :
+    WitnessStrong n (A n) := by
+  interval_cases n
+  -- n = 21: frame [3,4,4,4,6] with WS(3,5)+WS(4,8)×3+WS(6,14)
+  · let spec := exactSmallFrames.get ⟨12, by decide⟩
+    have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have h := apply_frameData spec.supports spec.cap
+      (![5, 8, 8, 8, 14] : Fin spec.t → ℕ) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 5 := by decide
+        fin_cases i <;> simp_all only [List.length_cons, List.length_nil, Nat.reduceAdd] <;>
+          first | exact ws_35 | exact ws_48 | exact ws_614)
+    convert h using 1
+    · decide
+    · have hsum :
+        ((Finset.univ : Finset (Fin spec.t)).sum
+          (![5, 8, 8, 8, 14] : Fin spec.t → ℕ)) = 43 := by
+          have ht : spec.t = 5 := by decide
+          decide
+      have hbonus : spec.bonus = 25 := by decide
+      have hA : A 21 = 68 := by eval_A_small
+      calc
+        A 21 = 68 := hA
+        _ =
+            ((Finset.univ : Finset (Fin spec.t)).sum
+              (![5, 8, 8, 8, 14] : Fin spec.t → ℕ)) + spec.bonus := by
+          omega
+  -- n = 22: frame [4,4,4,4,6] with WS(4,8)×4+WS(6,14)
+  · let spec := exactSmallFrames.get ⟨14, by decide⟩
+    have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have h := apply_frameData spec.supports spec.cap
+      (![8, 8, 8, 8, 14] : Fin spec.t → ℕ) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 5 := by decide
+        fin_cases i <;> simp_all only [List.length_cons, List.length_nil, Nat.reduceAdd] <;>
+          first | exact ws_48 | exact ws_614)
+    convert h using 1
+    · decide
+    · have hsum :
+        ((Finset.univ : Finset (Fin spec.t)).sum
+          (![8, 8, 8, 8, 14] : Fin spec.t → ℕ)) = 46 := by
+          have ht : spec.t = 5 := by decide
+          decide
+      have hbonus : spec.bonus = 27 := by decide
+      have hA : A 22 = 73 := by eval_A_small
+      calc
+        A 22 = 73 := hA
+        _ =
+            ((Finset.univ : Finset (Fin spec.t)).sum
+              (![8, 8, 8, 8, 14] : Fin spec.t → ℕ)) + spec.bonus := by
+          omega
+  -- n = 23: binary(1,22,1)
+  · exact ws_bin_A 1 22 1 (by omega)
+      (ih 1 (by omega) (by omega))
+      (ih 22 (by omega) (by omega)) (by eval_A_small)
+  -- n = 24: frame [6,6,6,6] with WS(6,14)×4
+  · let spec := exactSmallFrames.get ⟨6, by decide⟩
+    have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have h := apply_frameData spec.supports spec.cap
+      (fun _ : Fin spec.t => (14 : ℕ)) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 4 := by decide
+        fin_cases i <;> exact ws_614)
+    convert h using 1
+    · decide
+    · have hsum : (∑ _ : Fin spec.t, (14 : ℕ)) = 56 := by
+        have ht : spec.t = 4 := by decide
+        simp [ht]
+      have hbonus : spec.bonus = 26 := by decide
+      have hA : A 24 = 82 := by eval_A_small
+      calc
+        A 24 = 82 := hA
+        _ = (∑ _ : Fin spec.t, (14 : ℕ)) + spec.bonus := by omega
+  -- n = 25: binary(1,24,1)
+  · exact ws_bin_A 1 24 1 (by omega)
+      (ih 1 (by omega) (by omega))
+      (ih 24 (by omega) (by omega)) (by eval_A_small)
+  -- n = 26: frame [6,6,6,8] with WS(6,14)×3+WS(8,20)
+  · let spec := exactSmallFrames.get ⟨8, by decide⟩
+    have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have h := apply_frameData spec.supports spec.cap
+      (![14, 14, 14, 20] : Fin spec.t → ℕ) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 4 := by decide
+        fin_cases i <;> simp_all only [List.length_cons, List.length_nil, Nat.reduceAdd] <;>
+          first | exact ws_614 | exact ws_820)
+    convert h using 1
+    · decide
+    · have hsum :
+        ((Finset.univ : Finset (Fin spec.t)).sum
+          (![14, 14, 14, 20] : Fin spec.t → ℕ)) = 62 := by
+          have ht : spec.t = 4 := by decide
+          decide
+      have hbonus : spec.bonus = 27 := by decide
+      have hA : A 26 = 89 := by eval_A_small
+      calc
+        A 26 = 89 := hA
+        _ =
+            ((Finset.univ : Finset (Fin spec.t)).sum
+              (![14, 14, 14, 20] : Fin spec.t → ℕ)) + spec.bonus := by
+          omega
+  -- n = 27: frame [6,6,6,9] with WS(6,14)×3+WS(9,23)
+  · let spec := exactSmallFrames.get ⟨9, by decide⟩
+    have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have h := apply_frameData spec.supports spec.cap
+      (![14, 14, 14, 23] : Fin spec.t → ℕ) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 4 := by decide
+        fin_cases i <;> simp_all only [List.length_cons, List.length_nil, Nat.reduceAdd] <;>
+          first | exact ws_614 | exact ws_923)
+    convert h using 1
+    · decide
+    · have hsum :
+        ((Finset.univ : Finset (Fin spec.t)).sum
+          (![14, 14, 14, 23] : Fin spec.t → ℕ)) = 65 := by
+          have ht : spec.t = 4 := by decide
+          decide
+      have hbonus : spec.bonus = 28 := by decide
+      have hA : A 27 = 93 := by eval_A_small
+      calc
+        A 27 = 93 := hA
+        _ =
+            ((Finset.univ : Finset (Fin spec.t)).sum
+              (![14, 14, 14, 23] : Fin spec.t → ℕ)) + spec.bonus := by
+          omega
+  -- n = 28: frame [6,6,6,10] with WS(6,14)×3+WS(10,27)
+  · let spec := exactSmallFrames.get ⟨10, by decide⟩
+    have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have h := apply_frameData spec.supports spec.cap
+      (![14, 14, 14, 27] : Fin spec.t → ℕ) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 4 := by decide
+        fin_cases i <;> simp_all only [List.length_cons, List.length_nil, Nat.reduceAdd] <;>
+          first | exact ws_614 | exact ws_1027)
+    convert h using 1
+    · decide
+    · have hsum :
+        ((Finset.univ : Finset (Fin spec.t)).sum
+          (![14, 14, 14, 27] : Fin spec.t → ℕ)) = 69 := by
+          have ht : spec.t = 4 := by decide
+          decide
+      have hbonus : spec.bonus = 29 := by decide
+      have hA : A 28 = 98 := by eval_A_small
+      calc
+        A 28 = 98 := hA
+        _ =
+            ((Finset.univ : Finset (Fin spec.t)).sum
+              (![14, 14, 14, 27] : Fin spec.t → ℕ)) + spec.bonus := by
+          omega
+  -- n = 29: frame [5,6,6,6,6] with WS(5,10)+WS(6,14)×4
+  · let spec := exactSmallFrames.get ⟨15, by decide⟩
+    have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have h := apply_frameData spec.supports spec.cap
+      (![10, 14, 14, 14, 14] : Fin spec.t → ℕ) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 5 := by decide
+        fin_cases i <;> simp_all only [List.length_cons, List.length_nil, Nat.reduceAdd] <;>
+          first | exact ws_510 | exact ws_614)
+    convert h using 1
+    · decide
+    · have hsum :
+        ((Finset.univ : Finset (Fin spec.t)).sum
+          (![10, 14, 14, 14, 14] : Fin spec.t → ℕ)) = 66 := by
+          have ht : spec.t = 5 := by decide
+          decide
+      have hbonus : spec.bonus = 35 := by decide
+      have hA : A 29 = 101 := by eval_A_small
+      calc
+        A 29 = 101 := hA
+        _ =
+            ((Finset.univ : Finset (Fin spec.t)).sum
+              (![10, 14, 14, 14, 14] : Fin spec.t → ℕ)) + spec.bonus := by
+          omega
+  -- n = 30: frame [6,6,6,6,6] with WS(6,14)×5
+  · let spec := exactSmallFrames.get ⟨16, by decide⟩
+    have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have h := apply_frameData spec.supports spec.cap
+      (fun _ : Fin spec.t => (14 : ℕ)) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 5 := by decide
+        fin_cases i <;> exact ws_614)
+    convert h using 1
+    · decide
+    · have hsum : (∑ _ : Fin spec.t, (14 : ℕ)) = 70 := by
+        have ht : spec.t = 5 := by decide
+        simp [ht]
+      have hbonus : spec.bonus = 38 := by decide
+      have hA : A 30 = 108 := by eval_A_small
+      calc
+        A 30 = 108 := hA
+        _ = (∑ _ : Fin spec.t, (14 : ℕ)) + spec.bonus := by omega
+
+private theorem A_witnessStrong_bootstrap_31_38
+    (n : ℕ) (h31 : 31 ≤ n) (h38 : n ≤ 38)
+    (ih : ∀ m < n, 1 ≤ m → WitnessStrong m (A m)) :
+    WitnessStrong n (A n) := by
+  interval_cases n
+  -- n = 31: boost31 [3,4,4,4,4,4,4,4] with WS(3,5)+WS(4,8)×7
+  · let spec := boosters.get ⟨4, by decide⟩
+    have hValid := finite_bank_valid.2.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have h := apply_frameData spec.supports spec.cap
+      (![5, 8, 8, 8, 8, 8, 8, 8] : Fin spec.t → ℕ) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 8 := by decide
+        fin_cases i <;> simp_all only [List.length_cons, List.length_nil, Nat.reduceAdd] <;>
+          first | exact ws_35 | exact ws_48)
+    convert h using 1
+    · decide
+    · have hsum :
+        ((Finset.univ : Finset (Fin spec.t)).sum
+          (![5, 8, 8, 8, 8, 8, 8, 8] : Fin spec.t → ℕ)) = 61 := by
+          have ht : spec.t = 8 := by decide
+          decide
+      have hbonus : spec.bonus = 50 := by decide
+      have hA : A 31 = 111 := by eval_A_small
+      rw [hsum, hbonus, hA]
+  -- n = 32: boost32 [4,4,4,4,4,4,4,4] with WS(4,8)×8
+  · let spec := boosters.get ⟨5, by decide⟩
+    have hValid := finite_bank_valid.2.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have h := apply_frameData spec.supports spec.cap
+      (fun _ : Fin spec.t => (8 : ℕ)) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 8 := by decide
+        fin_cases i <;> exact ws_48)
+    convert h using 1
+    · decide
+    · have hsum : (∑ _ : Fin spec.t, (8 : ℕ)) = 64 := by
+        have ht : spec.t = 8 := by decide
+        simp [ht]
+      have hbonus : spec.bonus = 53 := by decide
+      have hA : A 32 = 117 := by eval_A_small
+      rw [hsum, hbonus, hA]
+  -- n = 33: boost33 [1,4,4,4,4,4,4,4,4] with WS(1,1)+WS(4,8)×8
+  · let spec := boosters.get ⟨6, by decide⟩
+    have hValid := finite_bank_valid.2.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have h := apply_frameData spec.supports spec.cap
+      (![1, 8, 8, 8, 8, 8, 8, 8, 8] : Fin spec.t → ℕ) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 9 := by decide
+        fin_cases i <;> simp_all only [List.length_cons, List.length_nil, Nat.reduceAdd] <;>
+          first | exact ws_one | exact ws_48)
+    convert h using 1
+    · decide
+    · have hsum :
+        ((Finset.univ : Finset (Fin spec.t)).sum
+          (![1, 8, 8, 8, 8, 8, 8, 8, 8] : Fin spec.t → ℕ)) = 65 := by
+          have ht : spec.t = 9 := by decide
+          decide
+      have hbonus : spec.bonus = 55 := by decide
+      have hA : A 33 = 120 := by eval_A_small
+      calc
+        A 33 = 120 := hA
+        _ =
+            ((Finset.univ : Finset (Fin spec.t)).sum
+              (![1, 8, 8, 8, 8, 8, 8, 8, 8] : Fin spec.t → ℕ)) + spec.bonus := by
+          omega
+  -- n = 34: frame [6,6,6,6,10] with WS(6,14)×4+WS(10,27)
+  · let spec := exactSmallFrames.get ⟨17, by decide⟩
+    have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have h := apply_frameData spec.supports spec.cap
+      (![14, 14, 14, 14, 27] : Fin spec.t → ℕ) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 5 := by decide
+        fin_cases i <;> simp_all only [List.length_cons, List.length_nil, Nat.reduceAdd] <;>
+          first | exact ws_614 | exact ws_1027)
+    convert h using 1
+    · decide
+    · have hsum :
+        ((Finset.univ : Finset (Fin spec.t)).sum
+          (![14, 14, 14, 14, 27] : Fin spec.t → ℕ)) = 83 := by
+          have ht : spec.t = 5 := by decide
+          decide
+      have hbonus : spec.bonus = 42 := by decide
+      have hA : A 34 = 125 := by eval_A_small
+      calc
+        A 34 = 125 := hA
+        _ =
+            ((Finset.univ : Finset (Fin spec.t)).sum
+              (![14, 14, 14, 14, 27] : Fin spec.t → ℕ)) + spec.bonus := by
+          omega
+  -- n = 35: binary(1,34,1)
+  · exact ws_bin_A 1 34 1 (by omega)
+      (ih 1 (by omega) (by omega))
+      (ih 34 (by omega) (by omega)) (by eval_A_small)
+  -- n = 36: frame [6,6,6,6,12] with WS(6,14)×4+WS(12,34)
+  · let spec := exactSmallFrames.get ⟨19, by decide⟩
+    have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have h := apply_frameData spec.supports spec.cap
+      (![14, 14, 14, 14, 34] : Fin spec.t → ℕ) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 5 := by decide
+        fin_cases i <;> simp_all only [List.length_cons, List.length_nil, Nat.reduceAdd] <;>
+          first | exact ws_614 | exact ws_1234)
+    convert h using 1
+    · decide
+    · have hsum :
+        ((Finset.univ : Finset (Fin spec.t)).sum
+          (![14, 14, 14, 14, 34] : Fin spec.t → ℕ)) = 90 := by
+          have ht : spec.t = 5 := by decide
+          decide
+      have hbonus : spec.bonus = 44 := by decide
+      have hA : A 36 = 134 := by eval_A_small
+      calc
+        A 36 = 134 := hA
+        _ =
+            ((Finset.univ : Finset (Fin spec.t)).sum
+              (![14, 14, 14, 14, 34] : Fin spec.t → ℕ)) + spec.bonus := by
+          omega
+  -- n = 37: frame [6,6,6,6,13] with WS(6,14)×4+WS(13,37)
+  · let spec := exactSmallFrames.get ⟨20, by decide⟩
+    have hValid := finite_bank_valid.1 spec (List.get_mem _ _)
+    have hFrame := spec.isValid_iff_isFrame.mp hValid
+    have h := apply_frameData spec.supports spec.cap
+      (![14, 14, 14, 14, 37] : Fin spec.t → ℕ) spec.bonus
+      spec.supports_card hFrame
+      (fun i => by
+        have : spec.t = 5 := by decide
+        fin_cases i <;> simp_all only [List.length_cons, List.length_nil, Nat.reduceAdd] <;>
+          first | exact ws_614 | exact ws_1337)
+    convert h using 1
+    · decide
+    · have hsum :
+        ((Finset.univ : Finset (Fin spec.t)).sum
+          (![14, 14, 14, 14, 37] : Fin spec.t → ℕ)) = 93 := by
+          have ht : spec.t = 5 := by decide
+          decide
+      have hbonus : spec.bonus = 44 := by decide
+      have hA : A 37 = 137 := by eval_A_small
+      calc
+        A 37 = 137 := hA
+        _ =
+            ((Finset.univ : Finset (Fin spec.t)).sum
+              (![14, 14, 14, 14, 37] : Fin spec.t → ℕ)) + spec.bonus := by
+          omega
+  -- n = 38: binary(18,20,18)
+  · exact ws_bin_A 18 20 18 (by omega)
+      (ih 18 (by omega) (by omega))
+      (ih 20 (by omega) (by omega)) A_bin_38
+
+private theorem A_witnessStrong_bootstrap_39_49
+    (n : ℕ) (h39 : 39 ≤ n) (h49 : n ≤ 49)
+    (ih : ∀ m < n, 1 ≤ m → WitnessStrong m (A m)) :
+    WitnessStrong n (A n) := by
+  interval_cases n
+  -- n = 39: core4×3+residue[3]
+  · have core_valid : SupportsValid core4Spec.supportList core4Spec.cap :=
+      (SupportsValid.ofSpec core4Spec).mpr core4Spec_valid
+    have res3_valid : SupportsValid (residueGadgets.get ⟨3, by decide⟩).supportList
+        (residueGadgets.get ⟨3, by decide⟩).cap :=
+      (SupportsValid.ofSpec _).mpr (finite_bank_valid.2.2 _ (List.get_mem _ _))
+    have combined := ((core_valid.append core_valid).append core_valid).append res3_valid
+    have hFrame := combined.toIsFrame
+    let sl_c : List (SupportPattern 4) := core4Spec.supportList
+    let sl_r : List (SupportPattern 4) := (residueGadgets.get ⟨3, by decide⟩).supportList
+    have h := apply_frameData
+      ((sl_c ++ sl_c ++ sl_c ++ sl_r : List _) : Multiset _)
+      (fun i : Fin 4 => core4Spec.cap i + core4Spec.cap i + core4Spec.cap i +
+        (residueGadgets.get ⟨3, by decide⟩).cap i)
+      (![23, 27, 27, 27])
+      41
+      (by decide)
+      hFrame
+        (fun i => by
+          have : core4Spec.t = 4 := by decide
+          fin_cases i
+          · exact ws_923
+          · exact ws_1027
+          · exact ws_1027
+          · exact ws_1027)
+    convert h using 1
+    · decide
+    · have hsum :
+          ((Finset.univ : Finset (Fin 4)).sum
+            (![23, 27, 27, 27] : Fin 4 → ℕ)) = 104 := by
+        decide
+      have hA : A 39 = 145 := by eval_A_small
+      calc
+        A 39 = 145 := hA
+        _ =
+            ((Finset.univ : Finset (Fin 4)).sum
+              (![23, 27, 27, 27] : Fin 4 → ℕ)) + 41 := by
+          omega
+  -- n = 40: core4×3+residue[4]
+  · have core_valid : SupportsValid core4Spec.supportList core4Spec.cap :=
+      (SupportsValid.ofSpec core4Spec).mpr core4Spec_valid
+    have res4_valid : SupportsValid (residueGadgets.get ⟨4, by decide⟩).supportList
+        (residueGadgets.get ⟨4, by decide⟩).cap :=
+      (SupportsValid.ofSpec _).mpr (finite_bank_valid.2.2 _ (List.get_mem _ _))
+    have combined := ((core_valid.append core_valid).append core_valid).append res4_valid
+    have hFrame := combined.toIsFrame
+    let sl_c : List (SupportPattern 4) := core4Spec.supportList
+    let sl_r : List (SupportPattern 4) := (residueGadgets.get ⟨4, by decide⟩).supportList
+    have h := apply_frameData
+      ((sl_c ++ sl_c ++ sl_c ++ sl_r : List _) : Multiset _)
+      (fun i : Fin 4 => core4Spec.cap i + core4Spec.cap i + core4Spec.cap i +
+        (residueGadgets.get ⟨4, by decide⟩).cap i)
+      (![27, 27, 27, 27])
+      43
+      (by decide)
+      hFrame
+        (fun i => by
+          have : core4Spec.t = 4 := by decide
+          fin_cases i <;> exact ws_1027)
+    convert h using 1
+    · decide
+    · have hsum :
+          ((Finset.univ : Finset (Fin 4)).sum
+            (![27, 27, 27, 27] : Fin 4 → ℕ)) = 108 := by
+        decide
+      have hA : A 40 = 151 := by eval_A_small
+      calc
+        A 40 = 151 := hA
+        _ =
+            ((Finset.univ : Finset (Fin 4)).sum
+              (![27, 27, 27, 27] : Fin 4 → ℕ)) + 43 := by
+          omega
+  -- n = 41: binary(1,40,1)
+  · exact ws_bin_A 1 40 1 (by omega)
+      (ih 1 (by omega) (by omega))
+      (ih 40 (by omega) (by omega)) A_bin_41
+  -- n = 42: binary(18,24,18)
+  · exact ws_bin_A 18 24 18 (by omega)
+      (ih 18 (by omega) (by omega))
+      (ih 24 (by omega) (by omega)) A_bin_42
+  -- n = 43: binary(21,22,21)
+  · exact ws_bin_A 21 22 21 (by omega)
+      (ih 21 (by omega) (by omega))
+      (ih 22 (by omega) (by omega)) A_bin_43
+  -- n = 44: binary(22,22,22)
+  · exact ws_bin_A 22 22 22 (by omega)
+      (ih 22 (by omega) (by omega))
+      (ih 22 (by omega) (by omega)) A_bin_44
+  -- n = 45: binary(1,44,1)
+  · exact ws_bin_A 1 44 1 (by omega)
+      (ih 1 (by omega) (by omega))
+      (ih 44 (by omega) (by omega)) A_bin_45
+  -- n = 46: binary(22,24,20)
+  · exact ws_bin_A 22 24 20 (by omega)
+      (ih 22 (by omega) (by omega))
+      (ih 24 (by omega) (by omega)) A_bin_46
+  -- n = 47: binary(23,24,23)
+  · exact ws_bin_A 23 24 23 (by omega)
+      (ih 23 (by omega) (by omega))
+      (ih 24 (by omega) (by omega)) A_bin_47
+  -- n = 48: binary(24,24,24)
+  · exact ws_bin_A 24 24 24 (by omega)
+      (ih 24 (by omega) (by omega))
+      (ih 24 (by omega) (by omega)) A_bin_48
+  -- n = 49: core4×4+residue[1]
+  · have core_valid : SupportsValid core4Spec.supportList core4Spec.cap :=
+      (SupportsValid.ofSpec core4Spec).mpr core4Spec_valid
+    have res1_valid : SupportsValid (residueGadgets.get ⟨1, by decide⟩).supportList
+        (residueGadgets.get ⟨1, by decide⟩).cap :=
+      (SupportsValid.ofSpec _).mpr (finite_bank_valid.2.2 _ (List.get_mem _ _))
+    have combined :=
+      (((core_valid.append core_valid).append core_valid).append core_valid).append res1_valid
+    have hFrame := combined.toIsFrame
+    let sl_c : List (SupportPattern 4) := core4Spec.supportList
+    let sl_r : List (SupportPattern 4) := (residueGadgets.get ⟨1, by decide⟩).supportList
+    have h := apply_frameData
+      ((sl_c ++ sl_c ++ sl_c ++ sl_c ++ sl_r : List _) : Multiset _)
+      (fun i : Fin 4 => core4Spec.cap i + core4Spec.cap i + core4Spec.cap i +
+        core4Spec.cap i + (residueGadgets.get ⟨1, by decide⟩).cap i)
+      (![34, 34, 34, 37])
+      52
+      (by decide)
+      hFrame
+        (fun i => by
+          have : core4Spec.t = 4 := by decide
+          fin_cases i
+          · exact ws_1234
+          · exact ws_1234
+          · exact ws_1234
+          · exact ws_1337)
+    convert h using 1
+    · decide
+    · have hsum :
+          ((Finset.univ : Finset (Fin 4)).sum
+            (![34, 34, 34, 37] : Fin 4 → ℕ)) = 139 := by
+        decide
+      have hA : A 49 = 191 := by eval_A_small
+      calc
+        A 49 = 191 := hA
+        _ =
+            ((Finset.univ : Finset (Fin 4)).sum
+              (![34, 34, 34, 37] : Fin 4 → ℕ)) + 52 := by
+          omega
+
+private theorem A_witnessStrong_bootstrap_50_59
+    (n : ℕ) (h50 : 50 ≤ n) (h60 : n < 60)
+    (ih : ∀ m < n, 1 ≤ m → WitnessStrong m (A m)) :
+    WitnessStrong n (A n) := by
+  interval_cases n
+  -- n = 50: binary(24,26,24)
+  · exact ws_bin_A 24 26 24 (by omega)
+      (ih 24 (by omega) (by omega))
+      (ih 26 (by omega) (by omega)) A_bin_50
+  -- n = 51: binary(24,27,24)
+  · exact ws_bin_A 24 27 24 (by omega)
+      (ih 24 (by omega) (by omega))
+      (ih 27 (by omega) (by omega)) A_bin_51
+  -- n = 52: binary(24,28,24)
+  · exact ws_bin_A 24 28 24 (by omega)
+      (ih 24 (by omega) (by omega))
+      (ih 28 (by omega) (by omega)) A_bin_52
+  -- n = 53: binary(26,27,26)
+  · exact ws_bin_A 26 27 26 (by omega)
+      (ih 26 (by omega) (by omega))
+      (ih 27 (by omega) (by omega)) A_bin_53
+  -- n = 54: binary(24,30,24)
+  · exact ws_bin_A 24 30 24 (by omega)
+      (ih 24 (by omega) (by omega))
+      (ih 30 (by omega) (by omega)) A_bin_54
+  -- n = 55: binary(27,28,27)
+  · exact ws_bin_A 27 28 27 (by omega)
+      (ih 27 (by omega) (by omega))
+      (ih 28 (by omega) (by omega)) A_bin_55
+  -- n = 56: binary(28,28,28)
+  · exact ws_bin_A 28 28 28 (by omega)
+      (ih 28 (by omega) (by omega))
+      (ih 28 (by omega) (by omega)) A_bin_56
+  -- n = 57: core4×4+residue[9]
+  · have core_valid : SupportsValid core4Spec.supportList core4Spec.cap :=
+      (SupportsValid.ofSpec core4Spec).mpr core4Spec_valid
+    have res9_valid : SupportsValid (residueGadgets.get ⟨9, by decide⟩).supportList
+        (residueGadgets.get ⟨9, by decide⟩).cap :=
+      (SupportsValid.ofSpec _).mpr (finite_bank_valid.2.2 _ (List.get_mem _ _))
+    have combined :=
+      (((core_valid.append core_valid).append core_valid).append core_valid).append res9_valid
+    have hFrame := combined.toIsFrame
+    let sl_c : List (SupportPattern 4) := core4Spec.supportList
+    let sl_r : List (SupportPattern 4) := (residueGadgets.get ⟨9, by decide⟩).supportList
+    have h := apply_frameData
+      ((sl_c ++ sl_c ++ sl_c ++ sl_c ++ sl_r : List _) : Multiset _)
+      (fun i : Fin 4 => core4Spec.cap i + core4Spec.cap i + core4Spec.cap i +
+        core4Spec.cap i + (residueGadgets.get ⟨9, by decide⟩).cap i)
+      (![41, 41, 41, 45])
+      61
+      (by decide)
+        hFrame
+        (fun i => by
+          have : core4Spec.t = 4 := by decide
+          fin_cases i
+          · exact ws_1441
+          · exact ws_1441
+          · exact ws_1441
+          · exact ws_1545)
+    convert h using 1
+    · decide
+    · have hsum :
+          ((Finset.univ : Finset (Fin 4)).sum
+            (![41, 41, 41, 45] : Fin 4 → ℕ)) = 168 := by
+        decide
+      have hA : A 57 = 229 := by eval_A_small
+      calc
+        A 57 = 229 := hA
+        _ =
+            ((Finset.univ : Finset (Fin 4)).sum
+              (![41, 41, 41, 45] : Fin 4 → ℕ)) + 61 := by
+          omega
+  -- n = 58: binary(28,30,28)
+  · exact ws_bin_A 28 30 28 (by omega)
+      (ih 28 (by omega) (by omega))
+      (ih 30 (by omega) (by omega)) A_bin_58
+  -- n = 59: binary(29,30,29)
+  · exact ws_bin_A 29 30 29 (by omega)
+      (ih 29 (by omega) (by omega))
+      (ih 30 (by omega) (by omega)) A_bin_59
+
+private theorem A_witnessStrong_bootstrap
+    (n : ℕ) (hn : 1 ≤ n) (h60 : n < 60)
+    (ih : ∀ m < n, 1 ≤ m → WitnessStrong m (A m)) :
+    WitnessStrong n (A n) := by
+  by_cases h20 : n ≤ 20
+  · exact A_witnessStrong_bootstrap_1_20 n hn h20 ih
+  by_cases h30 : n ≤ 30
+  · exact A_witnessStrong_bootstrap_21_30 n (by omega) h30 ih
+  by_cases h38 : n ≤ 38
+  · exact A_witnessStrong_bootstrap_31_38 n (by omega) h38 ih
+  by_cases h49 : n ≤ 49
+  · exact A_witnessStrong_bootstrap_39_49 n (by omega) h49 ih
+  exact A_witnessStrong_bootstrap_50_59 n (by omega) h60 ih
+
+private theorem A_witnessStrong_recursive_mod0
+    (n : ℕ) (_hn : 1 ≤ n) (h60 : 60 ≤ n)
+    (ih : ∀ m < n, 1 ≤ m → WitnessStrong m (A m))
+    (hr : n % 4 = 0) :
+    WitnessStrong n (A n) := by
+  set m := n / 4 with hm_def
+  have hm_pos : 1 ≤ m := by omega
+  have hm_lt : m < n := Nat.div_lt_self (by omega) (by omega)
+  have ws_m := ih m hm_lt hm_pos
+  have core_valid : SupportsValid core4Spec.supportList core4Spec.cap :=
+    (SupportsValid.ofSpec core4Spec).mpr core4Spec_valid
+  have hcc : ∀ i : Fin 4, core4Spec.cap i = 3 :=
+    core4Spec_cap_eq_three
+  set q := m / 3 with hq_def
+  have hA := A_mod0 n (by omega) hr
+  rw [hA]
+  have : m % 3 = 0 ∨ m % 3 = 1 ∨ m % 3 = 2 := by omega
+  rcases this with hs | hs | hs
+  · have rv := (SupportsValid.ofSpec (residueGadgets.get ⟨0, by decide⟩)).mpr
+      (finite_bank_valid.2.2 _ (List.get_mem _ _))
+    have hF := ((replicateList_valid core_valid q).append rv).toIsFrame
+    let sc : List (SupportPattern 4) := core4Spec.supportList
+    let sr : List (SupportPattern 4) := (residueGadgets.get ⟨0, by decide⟩).supportList
+    have hrc : ∀ i : Fin 4, (residueGadgets.get ⟨0, by decide⟩).cap i = 0 := by
+      intro i
+      fin_cases i <;> decide
+    have hqm : q * 3 = m := by
+      simpa [hs] using q_mul_three_add_mod m q hq_def
+    have hedgeCounts :
+        (fun i : Fin 4 =>
+          q * core4Spec.cap i + (residueGadgets.get ⟨0, by decide⟩).cap i) =
+          ![m, m, m, m] := by
+      funext i
+      fin_cases i <;> change q * 3 + 0 = m <;> simp [hqm]
+    have h := apply_frameData
+      ((replicateList sc q ++ sr : List _) : Multiset _)
+      (fun i : Fin 4 =>
+        q * core4Spec.cap i + (residueGadgets.get ⟨0, by decide⟩).cap i)
+      (![A m, A m, A m, A m]) (q * 13 + 0)
+      (by simp only [Multiset.coe_card, List.length_append, replicateList_length,
+            show sc.length = 13 from by decide, show sr.length = 0 from by decide])
+      hF
+      (fun i => by
+        have hi := congrFun hedgeCounts i
+        rw [hi]
+        fin_cases i <;> exact ws_m)
+    convert h using 1
+    · simp only [Fin.sum_univ_four, hcc, hrc]; omega
+    · simp only [← hm_def]
+      rw [show Finset.univ.sum (![A m, A m, A m, A m] : Fin 4 → ℕ) =
+          A m + A m + A m + A m from by rw [Fin.sum_univ_four]; rfl]
+      simp only [eBonus]; omega
+  · have rv := (SupportsValid.ofSpec (residueGadgets.get ⟨4, by decide⟩)).mpr
+      (finite_bank_valid.2.2 _ (List.get_mem _ _))
+    have hF := ((replicateList_valid core_valid q).append rv).toIsFrame
+    let sc : List (SupportPattern 4) := core4Spec.supportList
+    let sr : List (SupportPattern 4) := (residueGadgets.get ⟨4, by decide⟩).supportList
+    have hrc : ∀ i : Fin 4, (residueGadgets.get ⟨4, by decide⟩).cap i = 1 := by
+      intro i
+      fin_cases i <;> decide
+    have hqm : q * 3 + 1 = m := by
+      simpa [hs] using q_mul_three_add_mod m q hq_def
+    have hedgeCounts :
+        (fun i : Fin 4 =>
+          q * core4Spec.cap i + (residueGadgets.get ⟨4, by decide⟩).cap i) =
+          ![m, m, m, m] := by
+      funext i
+      fin_cases i <;> change q * 3 + 1 = m <;> simp [hqm]
+    have h := apply_frameData
+      ((replicateList sc q ++ sr : List _) : Multiset _)
+      (fun i : Fin 4 =>
+        q * core4Spec.cap i + (residueGadgets.get ⟨4, by decide⟩).cap i)
+      (![A m, A m, A m, A m]) (q * 13 + 4)
+      (by simp only [Multiset.coe_card, List.length_append, replicateList_length,
+            show sc.length = 13 from by decide, show sr.length = 4 from by decide])
+      hF
+      (fun i => by
+        have hi := congrFun hedgeCounts i
+        rw [hi]
+        fin_cases i <;> exact ws_m)
+    convert h using 1
+    · simp only [Fin.sum_univ_four, hcc, hrc]; omega
+    · simp only [← hm_def]
+      rw [show Finset.univ.sum (![A m, A m, A m, A m] : Fin 4 → ℕ) =
+          A m + A m + A m + A m from by rw [Fin.sum_univ_four]; rfl]
+      simp only [eBonus]; omega
+  · have rv := (SupportsValid.ofSpec (residueGadgets.get ⟨8, by decide⟩)).mpr
+      (finite_bank_valid.2.2 _ (List.get_mem _ _))
+    have hF := ((replicateList_valid core_valid q).append rv).toIsFrame
+    let sc : List (SupportPattern 4) := core4Spec.supportList
+    let sr : List (SupportPattern 4) := (residueGadgets.get ⟨8, by decide⟩).supportList
+    have hrc : ∀ i : Fin 4, (residueGadgets.get ⟨8, by decide⟩).cap i = 2 := by
+      intro i
+      fin_cases i <;> decide
+    have hqm : q * 3 + 2 = m := by
+      simpa [hs] using q_mul_three_add_mod m q hq_def
+    have hedgeCounts :
+        (fun i : Fin 4 =>
+          q * core4Spec.cap i + (residueGadgets.get ⟨8, by decide⟩).cap i) =
+          ![m, m, m, m] := by
+      funext i
+      fin_cases i <;> change q * 3 + 2 = m <;> simp [hqm]
+    have h := apply_frameData
+      ((replicateList sc q ++ sr : List _) : Multiset _)
+      (fun i : Fin 4 =>
+        q * core4Spec.cap i + (residueGadgets.get ⟨8, by decide⟩).cap i)
+      (![A m, A m, A m, A m]) (q * 13 + 8)
+      (by simp only [Multiset.coe_card, List.length_append, replicateList_length,
+            show sc.length = 13 from by decide, show sr.length = 8 from by decide])
+      hF
+      (fun i => by
+        have hi := congrFun hedgeCounts i
+        rw [hi]
+        fin_cases i <;> exact ws_m)
+    convert h using 1
+    · simp only [Fin.sum_univ_four, hcc, hrc]; omega
+    · simp only [← hm_def]
+      rw [show Finset.univ.sum (![A m, A m, A m, A m] : Fin 4 → ℕ) =
+          A m + A m + A m + A m from by rw [Fin.sum_univ_four]; rfl]
+      simp only [eBonus]; omega
+
+private theorem A_witnessStrong_recursive_mod1
+    (n : ℕ) (_hn : 1 ≤ n) (h60 : 60 ≤ n)
+    (ih : ∀ m < n, 1 ≤ m → WitnessStrong m (A m))
+    (hr : n % 4 = 1) :
+    WitnessStrong n (A n) := by
+  set m := n / 4 with hm_def
+  have hm_pos : 1 ≤ m := by omega
+  have hm1_pos : 1 ≤ m + 1 := by omega
+  have hm_lt : m < n := Nat.div_lt_self (by omega) (by omega)
+  have hm1_lt : m + 1 < n := by omega
+  have ws_m := ih m hm_lt hm_pos
+  have ws_m1 := ih (m + 1) hm1_lt hm1_pos
+  have core_valid : SupportsValid core4Spec.supportList core4Spec.cap :=
+    (SupportsValid.ofSpec core4Spec).mpr core4Spec_valid
+  set q := m / 3 with hq_def
+  have hA := A_mod1 n (by omega) hr
+  rw [hA]
+  have : m % 3 = 0 ∨ m % 3 = 1 ∨ m % 3 = 2 := by omega
+  rcases this with hs | hs | hs
+  · have rv := (SupportsValid.ofSpec (residueGadgets.get ⟨1, by decide⟩)).mpr
+      (finite_bank_valid.2.2 _ (List.get_mem _ _))
+    have hF := ((replicateList_valid core_valid q).append rv).toIsFrame
+    let sc : List (SupportPattern 4) := core4Spec.supportList
+    let sr : List (SupportPattern 4) := (residueGadgets.get ⟨1, by decide⟩).supportList
+    have hqm : q * 3 = m := by
+      simpa [hs] using q_mul_three_add_mod m q hq_def
+    have hqm1 : q * 3 + 1 = m + 1 := by omega
+    have hn1 : 4 * m + 1 = n := by
+      simpa [hr] using four_mul_div_add_mod n m hm_def
+    have hbonus : eBonus 1 m = q * 13 := eBonus1_mod0 m q hq_def hs
+    have hedgeCounts :
+        (fun i : Fin 4 =>
+          q * core4Spec.cap i + (residueGadgets.get ⟨1, by decide⟩).cap i) =
+          ![m, m, m, m + 1] := by
+      funext i
+      fin_cases i
+      · change q * 3 + 0 = m; simp [hqm]
+      · change q * 3 + 0 = m; simp [hqm]
+      · change q * 3 + 0 = m; simp [hqm]
+      · change q * 3 + 1 = m + 1; simp [hqm1]
+    have h := apply_frameData
+      ((replicateList sc q ++ sr : List _) : Multiset _)
+      (fun i : Fin 4 =>
+        q * core4Spec.cap i + (residueGadgets.get ⟨1, by decide⟩).cap i)
+      (![A m, A m, A m, A (m + 1)]) (q * 13 + 0)
+      (by simp only [Multiset.coe_card, List.length_append, replicateList_length,
+            show sc.length = 13 from by decide, show sr.length = 0 from by decide])
+      hF
+      (fun i => by
+        have hi := congrFun hedgeCounts i
+        rw [hi]
+        fin_cases i <;> first | exact ws_m | exact ws_m1)
+    convert h using 1
+    · rw [← hn1, hedgeCounts, Fin.sum_univ_four]
+      simp
+      omega
+    · simp only [← hm_def]
+      rw [show Finset.univ.sum (![A m, A m, A m, A (m + 1)] : Fin 4 → ℕ) =
+          A m + A m + A m + A (m + 1) from by rw [Fin.sum_univ_four]; rfl]
+      simp [hbonus]
+  · have rv := (SupportsValid.ofSpec (residueGadgets.get ⟨5, by decide⟩)).mpr
+      (finite_bank_valid.2.2 _ (List.get_mem _ _))
+    have hF := ((replicateList_valid core_valid q).append rv).toIsFrame
+    let sc : List (SupportPattern 4) := core4Spec.supportList
+    let sr : List (SupportPattern 4) := (residueGadgets.get ⟨5, by decide⟩).supportList
+    have hqm : q * 3 + 1 = m := by
+      simpa [hs] using q_mul_three_add_mod m q hq_def
+    have hqm1 : q * 3 + 2 = m + 1 := by omega
+    have hn1 : 4 * m + 1 = n := by
+      simpa [hr] using four_mul_div_add_mod n m hm_def
+    have hbonus : eBonus 1 m = q * 13 + 4 := eBonus1_mod1 m q hq_def hs
+    have hedgeCounts :
+        (fun i : Fin 4 =>
+          q * core4Spec.cap i + (residueGadgets.get ⟨5, by decide⟩).cap i) =
+          ![m, m, m, m + 1] := by
+      funext i
+      fin_cases i
+      · change q * 3 + 1 = m; simp [hqm]
+      · change q * 3 + 1 = m; simp [hqm]
+      · change q * 3 + 1 = m; simp [hqm]
+      · change q * 3 + 2 = m + 1; simp [hqm1]
+    have h := apply_frameData
+      ((replicateList sc q ++ sr : List _) : Multiset _)
+      (fun i : Fin 4 =>
+        q * core4Spec.cap i + (residueGadgets.get ⟨5, by decide⟩).cap i)
+      (![A m, A m, A m, A (m + 1)]) (q * 13 + 4)
+      (by simp only [Multiset.coe_card, List.length_append, replicateList_length,
+            show sc.length = 13 from by decide, show sr.length = 4 from by decide])
+      hF
+      (fun i => by
+        have hi := congrFun hedgeCounts i
+        rw [hi]
+        fin_cases i <;> first | exact ws_m | exact ws_m1)
+    convert h using 1
+    · rw [← hn1, hedgeCounts, Fin.sum_univ_four]
+      simp
+      omega
+    · simp only [← hm_def]
+      rw [show Finset.univ.sum (![A m, A m, A m, A (m + 1)] : Fin 4 → ℕ) =
+          A m + A m + A m + A (m + 1) from by rw [Fin.sum_univ_four]; rfl]
+      simp [hbonus]
+  · have rv := (SupportsValid.ofSpec (residueGadgets.get ⟨9, by decide⟩)).mpr
+      (finite_bank_valid.2.2 _ (List.get_mem _ _))
+    have hF := ((replicateList_valid core_valid q).append rv).toIsFrame
+    let sc : List (SupportPattern 4) := core4Spec.supportList
+    let sr : List (SupportPattern 4) := (residueGadgets.get ⟨9, by decide⟩).supportList
+    have hqm : q * 3 + 2 = m := by
+      simpa [hs] using q_mul_three_add_mod m q hq_def
+    have hqm1 : q * 3 + 3 = m + 1 := by omega
+    have hn1 : 4 * m + 1 = n := by
+      simpa [hr] using four_mul_div_add_mod n m hm_def
+    have hbonus : eBonus 1 m = q * 13 + 9 := eBonus1_mod2 m q hq_def hs
+    have hedgeCounts :
+        (fun i : Fin 4 =>
+          q * core4Spec.cap i + (residueGadgets.get ⟨9, by decide⟩).cap i) =
+          ![m, m, m, m + 1] := by
+      funext i
+      fin_cases i
+      · change q * 3 + 2 = m; simp [hqm]
+      · change q * 3 + 2 = m; simp [hqm]
+      · change q * 3 + 2 = m; simp [hqm]
+      · change q * 3 + 3 = m + 1; simp [hqm1]
+    have h := apply_frameData
+      ((replicateList sc q ++ sr : List _) : Multiset _)
+      (fun i : Fin 4 =>
+        q * core4Spec.cap i + (residueGadgets.get ⟨9, by decide⟩).cap i)
+      (![A m, A m, A m, A (m + 1)]) (q * 13 + 9)
+      (by simp only [Multiset.coe_card, List.length_append, replicateList_length,
+            show sc.length = 13 from by decide, show sr.length = 9 from by decide])
+      hF
+      (fun i => by
+        have hi := congrFun hedgeCounts i
+        rw [hi]
+        fin_cases i <;> first | exact ws_m | exact ws_m1)
+    convert h using 1
+    · rw [← hn1, hedgeCounts, Fin.sum_univ_four]
+      simp
+      omega
+    · simp only [← hm_def]
+      rw [show Finset.univ.sum (![A m, A m, A m, A (m + 1)] : Fin 4 → ℕ) =
+          A m + A m + A m + A (m + 1) from by rw [Fin.sum_univ_four]; rfl]
+      simp [hbonus]
+
+private theorem A_witnessStrong_recursive_mod2
+    (n : ℕ) (_hn : 1 ≤ n) (h60 : 60 ≤ n)
+    (ih : ∀ m < n, 1 ≤ m → WitnessStrong m (A m))
+    (hr : n % 4 = 2) :
+    WitnessStrong n (A n) := by
+  set m := n / 4 with hm_def
+  have hm_pos : 1 ≤ m := by omega
+  have hm1_pos : 1 ≤ m + 1 := by omega
+  have hm_lt : m < n := Nat.div_lt_self (by omega) (by omega)
+  have hm1_lt : m + 1 < n := by omega
+  have ws_m := ih m hm_lt hm_pos
+  have ws_m1 := ih (m + 1) hm1_lt hm1_pos
+  have core_valid : SupportsValid core4Spec.supportList core4Spec.cap :=
+    (SupportsValid.ofSpec core4Spec).mpr core4Spec_valid
+  set q := m / 3 with hq_def
+  have hA := A_mod2 n (by omega) hr
+  rw [hA]
+  have : m % 3 = 0 ∨ m % 3 = 1 ∨ m % 3 = 2 := by omega
+  rcases this with hs | hs | hs
+  · have rv := (SupportsValid.ofSpec (residueGadgets.get ⟨2, by decide⟩)).mpr
+      (finite_bank_valid.2.2 _ (List.get_mem _ _))
+    have hF := ((replicateList_valid core_valid q).append rv).toIsFrame
+    let sc : List (SupportPattern 4) := core4Spec.supportList
+    let sr : List (SupportPattern 4) := (residueGadgets.get ⟨2, by decide⟩).supportList
+    have hqm : q * 3 = m := by
+      simpa [hs] using q_mul_three_add_mod m q hq_def
+    have hqm1 : q * 3 + 1 = m + 1 := by omega
+    have hn2 : 4 * m + 2 = n := by
+      simpa [hr] using four_mul_div_add_mod n m hm_def
+    have hbonus : eBonus 2 m = q * 13 + 1 := eBonus2_mod0 m q hq_def hs
+    have hedgeCounts :
+        (fun i : Fin 4 =>
+          q * core4Spec.cap i + (residueGadgets.get ⟨2, by decide⟩).cap i) =
+          ![m, m, m + 1, m + 1] := by
+      funext i
+      fin_cases i
+      · change q * 3 + 0 = m; simp [hqm]
+      · change q * 3 + 0 = m; simp [hqm]
+      · change q * 3 + 1 = m + 1; simp [hqm1]
+      · change q * 3 + 1 = m + 1; simp [hqm1]
+    have h := apply_frameData
+      ((replicateList sc q ++ sr : List _) : Multiset _)
+      (fun i : Fin 4 =>
+        q * core4Spec.cap i + (residueGadgets.get ⟨2, by decide⟩).cap i)
+      (![A m, A m, A (m + 1), A (m + 1)]) (q * 13 + 1)
+      (by simp only [Multiset.coe_card, List.length_append, replicateList_length,
+            show sc.length = 13 from by decide, show sr.length = 1 from by decide])
+      hF
+      (fun i => by
+        have hi := congrFun hedgeCounts i
+        rw [hi]
+        fin_cases i <;> first | exact ws_m | exact ws_m1)
+    convert h using 1
+    · rw [← hn2, hedgeCounts, Fin.sum_univ_four]
+      simp
+      omega
+    · simp only [← hm_def]
+      rw [show Finset.univ.sum (![A m, A m, A (m + 1), A (m + 1)] : Fin 4 → ℕ) =
+          A m + A m + A (m + 1) + A (m + 1) from by rw [Fin.sum_univ_four]; rfl]
+      simp [hbonus]
+  · have rv := (SupportsValid.ofSpec (residueGadgets.get ⟨6, by decide⟩)).mpr
+      (finite_bank_valid.2.2 _ (List.get_mem _ _))
+    have hF := ((replicateList_valid core_valid q).append rv).toIsFrame
+    let sc : List (SupportPattern 4) := core4Spec.supportList
+    let sr : List (SupportPattern 4) := (residueGadgets.get ⟨6, by decide⟩).supportList
+    have hqm : q * 3 + 1 = m := by
+      simpa [hs] using q_mul_three_add_mod m q hq_def
+    have hqm1 : q * 3 + 2 = m + 1 := by omega
+    have hn2 : 4 * m + 2 = n := by
+      simpa [hr] using four_mul_div_add_mod n m hm_def
+    have hbonus : eBonus 2 m = q * 13 + 6 := eBonus2_mod1 m q hq_def hs
+    have hedgeCounts :
+        (fun i : Fin 4 =>
+          q * core4Spec.cap i + (residueGadgets.get ⟨6, by decide⟩).cap i) =
+          ![m, m, m + 1, m + 1] := by
+      funext i
+      fin_cases i
+      · change q * 3 + 1 = m; simp [hqm]
+      · change q * 3 + 1 = m; simp [hqm]
+      · change q * 3 + 2 = m + 1; simp [hqm1]
+      · change q * 3 + 2 = m + 1; simp [hqm1]
+    have h := apply_frameData
+      ((replicateList sc q ++ sr : List _) : Multiset _)
+      (fun i : Fin 4 =>
+        q * core4Spec.cap i + (residueGadgets.get ⟨6, by decide⟩).cap i)
+      (![A m, A m, A (m + 1), A (m + 1)]) (q * 13 + 6)
+      (by simp only [Multiset.coe_card, List.length_append, replicateList_length,
+            show sc.length = 13 from by decide, show sr.length = 6 from by decide])
+      hF
+      (fun i => by
+        have hi := congrFun hedgeCounts i
+        rw [hi]
+        fin_cases i <;> first | exact ws_m | exact ws_m1)
+    convert h using 1
+    · rw [← hn2, hedgeCounts, Fin.sum_univ_four]
+      simp
+      omega
+    · simp only [← hm_def]
+      rw [show Finset.univ.sum (![A m, A m, A (m + 1), A (m + 1)] : Fin 4 → ℕ) =
+          A m + A m + A (m + 1) + A (m + 1) from by rw [Fin.sum_univ_four]; rfl]
+      simp [hbonus]
+  · have rv := (SupportsValid.ofSpec (residueGadgets.get ⟨10, by decide⟩)).mpr
+      (finite_bank_valid.2.2 _ (List.get_mem _ _))
+    have hF := ((replicateList_valid core_valid q).append rv).toIsFrame
+    let sc : List (SupportPattern 4) := core4Spec.supportList
+    let sr : List (SupportPattern 4) := (residueGadgets.get ⟨10, by decide⟩).supportList
+    have hqm : q * 3 + 2 = m := by
+      simpa [hs] using q_mul_three_add_mod m q hq_def
+    have hqm1 : q * 3 + 3 = m + 1 := by omega
+    have hn2 : 4 * m + 2 = n := by
+      simpa [hr] using four_mul_div_add_mod n m hm_def
+    have hbonus : eBonus 2 m = q * 13 + 10 := eBonus2_mod2 m q hq_def hs
+    have hedgeCounts :
+        (fun i : Fin 4 =>
+          q * core4Spec.cap i + (residueGadgets.get ⟨10, by decide⟩).cap i) =
+          ![m, m, m + 1, m + 1] := by
+      funext i
+      fin_cases i
+      · change q * 3 + 2 = m; simp [hqm]
+      · change q * 3 + 2 = m; simp [hqm]
+      · change q * 3 + 3 = m + 1; simp [hqm1]
+      · change q * 3 + 3 = m + 1; simp [hqm1]
+    have h := apply_frameData
+      ((replicateList sc q ++ sr : List _) : Multiset _)
+      (fun i : Fin 4 =>
+        q * core4Spec.cap i + (residueGadgets.get ⟨10, by decide⟩).cap i)
+      (![A m, A m, A (m + 1), A (m + 1)]) (q * 13 + 10)
+      (by simp only [Multiset.coe_card, List.length_append, replicateList_length,
+            show sc.length = 13 from by decide, show sr.length = 10 from by decide])
+      hF
+      (fun i => by
+        have hi := congrFun hedgeCounts i
+        rw [hi]
+        fin_cases i <;> first | exact ws_m | exact ws_m1)
+    convert h using 1
+    · rw [← hn2, hedgeCounts, Fin.sum_univ_four]
+      simp
+      omega
+    · simp only [← hm_def]
+      rw [show Finset.univ.sum (![A m, A m, A (m + 1), A (m + 1)] : Fin 4 → ℕ) =
+          A m + A m + A (m + 1) + A (m + 1) from by rw [Fin.sum_univ_four]; rfl]
+      simp [hbonus]
+
+private theorem A_witnessStrong_recursive_mod3
+    (n : ℕ) (_hn : 1 ≤ n) (h60 : 60 ≤ n)
+    (ih : ∀ m < n, 1 ≤ m → WitnessStrong m (A m))
+    (hr : n % 4 = 3) :
+    WitnessStrong n (A n) := by
+  set m := n / 4 with hm_def
+  have hm_pos : 1 ≤ m := by omega
+  have hm1_pos : 1 ≤ m + 1 := by omega
+  have hm_lt : m < n := Nat.div_lt_self (by omega) (by omega)
+  have hm1_lt : m + 1 < n := by omega
+  have ws_m := ih m hm_lt hm_pos
+  have ws_m1 := ih (m + 1) hm1_lt hm1_pos
+  have core_valid : SupportsValid core4Spec.supportList core4Spec.cap :=
+    (SupportsValid.ofSpec core4Spec).mpr core4Spec_valid
+  set q := m / 3 with hq_def
+  have hA := A_mod3 n (by omega) hr
+  rw [hA]
+  have : m % 3 = 0 ∨ m % 3 = 1 ∨ m % 3 = 2 := by omega
+  rcases this with hs | hs | hs
+  · have rv := (SupportsValid.ofSpec (residueGadgets.get ⟨3, by decide⟩)).mpr
+      (finite_bank_valid.2.2 _ (List.get_mem _ _))
+    have hF := ((replicateList_valid core_valid q).append rv).toIsFrame
+    let sc : List (SupportPattern 4) := core4Spec.supportList
+    let sr : List (SupportPattern 4) := (residueGadgets.get ⟨3, by decide⟩).supportList
+    have hqm : q * 3 = m := by
+      simpa [hs] using q_mul_three_add_mod m q hq_def
+    have hqm1 : q * 3 + 1 = m + 1 := by omega
+    have hn3 : 4 * m + 3 = n := by
+      simpa [hr] using four_mul_div_add_mod n m hm_def
+    have hbonus : eBonus 3 m = q * 13 + 2 := eBonus3_mod0 m q hq_def hs
+    have hedgeCounts :
+        (fun i : Fin 4 =>
+          q * core4Spec.cap i + (residueGadgets.get ⟨3, by decide⟩).cap i) =
+          ![m, m + 1, m + 1, m + 1] := by
+      funext i
+      fin_cases i
+      · change q * 3 + 0 = m; simp [hqm]
+      · change q * 3 + 1 = m + 1; simp [hqm1]
+      · change q * 3 + 1 = m + 1; simp [hqm1]
+      · change q * 3 + 1 = m + 1; simp [hqm1]
+    have h := apply_frameData
+      ((replicateList sc q ++ sr : List _) : Multiset _)
+      (fun i : Fin 4 =>
+        q * core4Spec.cap i + (residueGadgets.get ⟨3, by decide⟩).cap i)
+      (![A m, A (m + 1), A (m + 1), A (m + 1)]) (q * 13 + 2)
+      (by simp only [Multiset.coe_card, List.length_append, replicateList_length,
+            show sc.length = 13 from by decide, show sr.length = 2 from by decide])
+      hF
+      (fun i => by
+        have hi := congrFun hedgeCounts i
+        rw [hi]
+        fin_cases i <;> first | exact ws_m | exact ws_m1)
+    convert h using 1
+    · rw [← hn3, hedgeCounts, Fin.sum_univ_four]
+      simp
+      omega
+    · simp only [← hm_def]
+      rw [Fin.sum_univ_four]
+      simp [hbonus, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
+  · have rv := (SupportsValid.ofSpec (residueGadgets.get ⟨7, by decide⟩)).mpr
+      (finite_bank_valid.2.2 _ (List.get_mem _ _))
+    have hF := ((replicateList_valid core_valid q).append rv).toIsFrame
+    let sc : List (SupportPattern 4) := core4Spec.supportList
+    let sr : List (SupportPattern 4) := (residueGadgets.get ⟨7, by decide⟩).supportList
+    have hqm : q * 3 + 1 = m := by
+      simpa [hs] using q_mul_three_add_mod m q hq_def
+    have hqm1 : q * 3 + 2 = m + 1 := by omega
+    have hn3 : 4 * m + 3 = n := by
+      simpa [hr] using four_mul_div_add_mod n m hm_def
+    have hbonus : eBonus 3 m = q * 13 + 6 := eBonus3_mod1 m q hq_def hs
+    have hedgeCounts :
+        (fun i : Fin 4 =>
+          q * core4Spec.cap i + (residueGadgets.get ⟨7, by decide⟩).cap i) =
+          ![m, m + 1, m + 1, m + 1] := by
+      funext i
+      fin_cases i
+      · change q * 3 + 1 = m; simp [hqm]
+      · change q * 3 + 2 = m + 1; simp [hqm1]
+      · change q * 3 + 2 = m + 1; simp [hqm1]
+      · change q * 3 + 2 = m + 1; simp [hqm1]
+    have h := apply_frameData
+      ((replicateList sc q ++ sr : List _) : Multiset _)
+      (fun i : Fin 4 =>
+        q * core4Spec.cap i + (residueGadgets.get ⟨7, by decide⟩).cap i)
+      (![A m, A (m + 1), A (m + 1), A (m + 1)]) (q * 13 + 6)
+      (by simp only [Multiset.coe_card, List.length_append, replicateList_length,
+            show sc.length = 13 from by decide, show sr.length = 6 from by decide])
+      hF
+      (fun i => by
+        have hi := congrFun hedgeCounts i
+        rw [hi]
+        fin_cases i <;> first | exact ws_m | exact ws_m1)
+    convert h using 1
+    · rw [← hn3, hedgeCounts, Fin.sum_univ_four]
+      simp
+      omega
+    · simp only [← hm_def]
+      rw [Fin.sum_univ_four]
+      simp [hbonus, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
+  · have rv := (SupportsValid.ofSpec (residueGadgets.get ⟨11, by decide⟩)).mpr
+      (finite_bank_valid.2.2 _ (List.get_mem _ _))
+    have hF := ((replicateList_valid core_valid q).append rv).toIsFrame
+    let sc : List (SupportPattern 4) := core4Spec.supportList
+    let sr : List (SupportPattern 4) := (residueGadgets.get ⟨11, by decide⟩).supportList
+    have hqm : q * 3 + 2 = m := q_mul_three_add_two m q hq_def hs
+    have hsum4 : m + (m + 1) + (m + 1) + (m + 1) = n :=
+      four_way_sum_mod3 n m hm_def hr
+    have hbonus : eBonus 3 m = q * 13 + 10 := eBonus3_mod2 m q hq_def hs
+    have hedgeCounts :
+        (fun i : Fin 4 =>
+          q * core4Spec.cap i + (residueGadgets.get ⟨11, by decide⟩).cap i) =
+          ![m, m + 1, m + 1, m + 1] := by
+      funext i
+      fin_cases i
+      · change q * 3 + 2 = m; simp [hqm]
+      · change q * 3 + 3 = m + 1; omega
+      · change q * 3 + 3 = m + 1; omega
+      · change q * 3 + 3 = m + 1; omega
+    have h := apply_frameData
+      ((replicateList sc q ++ sr : List _) : Multiset _)
+      (fun i : Fin 4 =>
+        q * core4Spec.cap i + (residueGadgets.get ⟨11, by decide⟩).cap i)
+      (![A m, A (m + 1), A (m + 1), A (m + 1)]) (q * 13 + 10)
+      (by simp only [Multiset.coe_card, List.length_append, replicateList_length,
+            show sc.length = 13 from by decide, show sr.length = 10 from by decide])
+      hF
+      (fun i => by
+        have hi := congrFun hedgeCounts i
+        rw [hi]
+        fin_cases i <;> first | exact ws_m | exact ws_m1)
+    convert h using 1
+    · rw [hedgeCounts, Fin.sum_univ_four]
+      simp
+      omega
+    · simp only [← hm_def]
+      rw [Fin.sum_univ_four]
+      simp [hbonus, Nat.add_assoc, Nat.add_left_comm, Nat.add_comm]
+
+private theorem A_witnessStrong_recursive
+    (n : ℕ) (hn : 1 ≤ n) (h60 : 60 ≤ n)
+    (ih : ∀ m < n, 1 ≤ m → WitnessStrong m (A m)) :
+    WitnessStrong n (A n) := by
+  have : n % 4 = 0 ∨ n % 4 = 1 ∨ n % 4 = 2 ∨ n % 4 = 3 := by omega
+  rcases this with hr | hr | hr | hr
+  · exact A_witnessStrong_recursive_mod0 n hn h60 ih hr
+  · exact A_witnessStrong_recursive_mod1 n hn h60 ih hr
+  · exact A_witnessStrong_recursive_mod2 n hn h60 ih hr
+  · exact A_witnessStrong_recursive_mod3 n hn h60 ih hr
+
+private theorem A_witnessStrong (n : ℕ) (hn : 1 ≤ n) : WitnessStrong n (A n) := by
+  induction n using Nat.strongRecOn with
+  | ind n ih =>
+    by_cases h60 : n < 60
+    · exact A_witnessStrong_bootstrap n hn h60 ih
+    · push Not at h60
+      exact A_witnessStrong_recursive n hn h60 ih
+
+/-- A_witness for 2 ≤ n < 60: the bootstrap window. -/
+private theorem A_witness_bootstrap (n : ℕ) (h1 : 2 ≤ n) (h2 : n < 60) :
+    ∃ (edges : Finset (Finset ℕ)),
+      edges.card = n ∧ (vertexSet edges).card = A n ∧ NoLargePartition edges n := by
+  let w : Witness n (A n) := (A_witnessStrong n (by omega)).toWitnessData
+  exact ⟨w.edges, w.edgeCard, w.vertexCard, w.noLargePartition⟩
+
+/-- A_witness for n ≥ 60: the recursive four-way construction. -/
+private theorem A_witness_recursive (n : ℕ) (hn : 60 ≤ n)
+    (_ih : ∀ m, m < n → 1 ≤ m → ∃ (edges : Finset (Finset ℕ)),
+      edges.card = m ∧ (vertexSet edges).card = A m ∧ NoLargePartition edges m) :
+    ∃ (edges : Finset (Finset ℕ)),
+      edges.card = n ∧ (vertexSet edges).card = A n ∧ NoLargePartition edges n := by
+  let w : Witness n (A n) := (A_witnessStrong n (by omega)).toWitnessData
+  exact ⟨w.edges, w.edgeCard, w.vertexCard, w.noLargePartition⟩
+
+/-- A(n) is realized by a concrete hypergraph with n edges, A(n) vertices, and NoLargePartition. -/
+theorem A_witness (n : ℕ) (hn : 1 ≤ n) :
+    ∃ (edges : Finset (Finset ℕ)),
+      edges.card = n ∧ (vertexSet edges).card = A n ∧ NoLargePartition edges n := by
+  let w : Witness n (A n) := (A_witnessStrong n hn).toWitnessData
+  exact ⟨w.edges, w.edgeCard, w.vertexCard, w.noLargePartition⟩
+
+/-- For every `n ≥ 1` there exists a hypergraph with exactly `n` distinct edges,
+    no partition of size greater than `n`, and exactly `A n` vertices.
+
+    In this edge-set encoding, the "no isolated vertices" clause from the paper is
+    implicit because `vertexSet` is defined as the union of the edges. -/
+theorem constructive_An (n : ℕ) (hn : 1 ≤ n) :
+    ∃ (edges : Finset (Finset ℕ)),
+      edges.card = n ∧ (vertexSet edges).card = A n ∧ NoLargePartition edges n := by
+  exact A_witness n hn
+
+/-- A(n) ≤ H(n) for n ≥ 1: the constructive witness shows H(n) is at least A(n). -/
+theorem A_le_H (n : ℕ) (hn : 1 ≤ n) : A n ≤ H n := by
+  let w : Witness n (A n) := (A_witnessStrong n hn).toWitnessData
+  unfold H
+  apply le_csSup
+  · exact H_set_bddAbove n
+  · exact ⟨w.edges, w.vertexCard, w.noLargePartition⟩
+
+/-- Pointwise witness form of Theorem `thm:main` from `frontier.tex`.
+
+    For each `n ≥ 1`, the explicit construction gives a hypergraph with exactly `n`
+    distinct edges, no partition of size greater than `n`, and exactly `A n`
+    vertices. When `n ≥ 15`, this witness has at least `(26/25) k n` vertices.
+    As above, "no isolated vertices" is implicit in the edge-set encoding. -/
+theorem thm_main_pointwise (n : ℕ) (hn : 1 ≤ n) :
+    ∃ edges : Finset (Finset ℕ),
+      edges.card = n ∧
+        (vertexSet edges).card = A n ∧
+        NoLargePartition edges n ∧
+        (15 ≤ n → 25 * (vertexSet edges).card ≥ 26 * k n) := by
+  let w : MainPointwiseWitness n :=
+    { witness := (A_witnessStrong n hn).toWitnessData
+      lowerBound := by
+        intro hn15
+        have hV := ((A_witnessStrong n hn).toWitnessData).vertexCard
+        have hU := uniform_26_25 n hn15
+        omega }
+  exact ⟨w.witness.edges, w.witness.edgeCard, w.witness.vertexCard,
+    w.witness.noLargePartition, w.lowerBound⟩
+
+/-- Formalization of Theorem `thm:main` from `frontier.tex`, packaged as a
+    witness family.
+
+    The sequence is obtained by choosing, for each `n ≥ 1`, one witness from
+    `mainPointwiseWitness`. As above, "no isolated vertices" is implicit in the
+    edge-set encoding. -/
+theorem thm_main :
+    ∃ G : ℕ → Hypergraph ℕ, WitnessFamily G := by
+  let G : ℕ → Hypergraph ℕ := fun n =>
+    if hn : 1 ≤ n then ((A_witnessStrong n hn).toWitnessData).edges else ∅
+  refine ⟨G, ?_⟩
+  refine
+    { edgeCard := ?_
+      noLargePartition := ?_
+      lowerBoundWitness := ?_
+      lowerBoundH := ?_ }
+  · intro n hn
+    simpa [G, dif_pos hn] using ((A_witnessStrong n hn).toWitnessData).edgeCard
+  · intro n hn
+    simpa [G, dif_pos hn] using ((A_witnessStrong n hn).toWitnessData).noLargePartition
+  · intro n hn
+    have h1 : 1 ≤ n := by omega
+    have hV := ((A_witnessStrong n h1).toWitnessData).vertexCard
+    have hU := uniform_26_25 n hn
+    have hBound :
+        25 * (vertexSet (((A_witnessStrong n h1).toWitnessData).edges)).card ≥
+          26 * k n := by
+      omega
+    simpa [G, dif_pos h1] using hBound
+  · intro n hn
+    have h1 : 1 ≤ n := by omega
+    have hA := A_le_H n h1
+    have hU := uniform_26_25 n hn
+    omega
+
+/-- The `H(n)` lower bound stated as the consequence of Theorem `thm:main`. -/
+theorem thm_main_H_lower_bound (n : ℕ) (hn : 15 ≤ n) :
+    25 * H n ≥ 26 * k n := by
+  rcases thm_main with ⟨_, hG⟩
+  exact hG.lowerBoundH n hn
+
+
+end HypergraphLowerBound

--- a/LeanPool/FrontierMathOpenHypergraphs/Uniform/FrameBoosters.lean
+++ b/LeanPool/FrontierMathOpenHypergraphs/Uniform/FrameBoosters.lean
@@ -1,0 +1,362 @@
+/-
+Copyright (c) 2026 Dean Cureton. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dean Cureton
+-/
+
+import LeanPool.FrontierMathOpenHypergraphs.Uniform.FrameDefs
+
+/-!
+# Booster-frame validations
+-/
+
+namespace HypergraphLowerBound
+
+private theorem booster_0_valid :
+    (boosters.get ⟨0, by decide⟩).IsValid := by
+  exact (boosters.get ⟨0, by decide⟩).rawCheckValid_sound rfl
+
+private def booster1Spec : FrameSpec :=
+  boosters.get ⟨1, by decide⟩
+
+private theorem booster_1_check_0 :
+    checkMasksDown booster1Spec 7 0 0 = true := rfl
+
+private theorem booster_1_check_1 :
+    checkMasksDown booster1Spec 7 (((1 : Nat) <<< 7)) 0 = true := rfl
+
+private theorem booster_1_check_2 :
+    checkMasksDown booster1Spec 7 (((1 : Nat) <<< 7)) (((1 : Nat) <<< 7)) = true := rfl
+
+private theorem booster_1_rawCheckValid :
+    booster1Spec.rawCheckValid = true := by
+  unfold FrameSpec.rawCheckValid
+  change checkMasksDown booster1Spec 8 0 0 = true
+  exact
+    checkMasksDown_step_true booster1Spec 7 0 0
+      booster_1_check_0 booster_1_check_1 booster_1_check_2
+
+private theorem booster_1_valid :
+    (boosters.get ⟨1, by decide⟩).IsValid := by
+  simpa [booster1Spec] using booster1Spec.rawCheckValid_sound booster_1_rawCheckValid
+
+private theorem booster_2_valid :
+    (boosters.get ⟨2, by decide⟩).IsValid := by
+  exact (boosters.get ⟨2, by decide⟩).rawCheckValid_sound rfl
+
+private theorem booster_3_valid :
+    (boosters.get ⟨3, by decide⟩).IsValid := by
+  exact (boosters.get ⟨3, by decide⟩).rawCheckValid_sound rfl
+
+private def booster4Spec : FrameSpec :=
+  boosters.get ⟨4, by decide⟩
+
+private theorem booster_4_check_00 :
+    checkMasksDown booster4Spec 6 0 0 = true := rfl
+
+private theorem booster_4_check_01 :
+    checkMasksDown booster4Spec 6 (((1 : Nat) <<< 6)) 0 = true := rfl
+
+private theorem booster_4_check_02 :
+    checkMasksDown booster4Spec 6 (((1 : Nat) <<< 6)) (((1 : Nat) <<< 6)) = true := rfl
+
+private theorem booster_4_check_0 :
+    checkMasksDown booster4Spec 7 0 0 = true := by
+  exact checkMasksDown_step_true booster4Spec 6 0 0
+    booster_4_check_00 booster_4_check_01 booster_4_check_02
+
+private theorem booster_4_check_10 :
+    checkMasksDown booster4Spec 6 (((1 : Nat) <<< 7)) 0 = true := rfl
+
+private theorem booster_4_check_11 :
+    checkMasksDown booster4Spec 6 ((((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6))) 0 = true := rfl
+
+private theorem booster_4_check_12 :
+    checkMasksDown booster4Spec 6 ((((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6)))
+      (((1 : Nat) <<< 6)) = true := rfl
+
+private theorem booster_4_check_1 :
+    checkMasksDown booster4Spec 7 (((1 : Nat) <<< 7)) 0 = true := by
+  exact checkMasksDown_step_true booster4Spec 6 (((1 : Nat) <<< 7)) 0
+    booster_4_check_10 booster_4_check_11 booster_4_check_12
+
+private theorem booster_4_check_20 :
+    checkMasksDown booster4Spec 6 (((1 : Nat) <<< 7)) (((1 : Nat) <<< 7)) = true := rfl
+
+private theorem booster_4_check_21 :
+    checkMasksDown booster4Spec 6 ((((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6)))
+      (((1 : Nat) <<< 7)) = true := rfl
+
+private theorem booster_4_check_22 :
+    checkMasksDown booster4Spec 6 ((((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6)))
+      ((((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6))) = true := rfl
+
+private theorem booster_4_check_2 :
+    checkMasksDown booster4Spec 7 (((1 : Nat) <<< 7)) (((1 : Nat) <<< 7)) = true := by
+  exact checkMasksDown_step_true booster4Spec 6 (((1 : Nat) <<< 7)) (((1 : Nat) <<< 7))
+    booster_4_check_20 booster_4_check_21 booster_4_check_22
+
+private theorem booster_4_rawCheckValid :
+    booster4Spec.rawCheckValid = true := by
+  unfold FrameSpec.rawCheckValid
+  change checkMasksDown booster4Spec 8 0 0 = true
+  exact
+    checkMasksDown_step_true booster4Spec 7 0 0
+      booster_4_check_0 booster_4_check_1 booster_4_check_2
+
+private theorem booster_4_valid :
+    (boosters.get ⟨4, by decide⟩).IsValid := by
+  simpa [booster4Spec] using booster4Spec.rawCheckValid_sound booster_4_rawCheckValid
+
+private def booster5Spec : FrameSpec :=
+  boosters.get ⟨5, by decide⟩
+
+private theorem booster_5_check_00 :
+    checkMasksDown booster5Spec 6 0 0 = true := rfl
+
+private theorem booster_5_check_01 :
+    checkMasksDown booster5Spec 6 (((1 : Nat) <<< 6)) 0 = true := rfl
+
+private theorem booster_5_check_02 :
+    checkMasksDown booster5Spec 6 (((1 : Nat) <<< 6)) (((1 : Nat) <<< 6)) = true := rfl
+
+private theorem booster_5_check_0 :
+    checkMasksDown booster5Spec 7 0 0 = true := by
+  exact checkMasksDown_step_true booster5Spec 6 0 0
+    booster_5_check_00 booster_5_check_01 booster_5_check_02
+
+private theorem booster_5_check_10 :
+    checkMasksDown booster5Spec 6 (((1 : Nat) <<< 7)) 0 = true := rfl
+
+private theorem booster_5_check_11 :
+    checkMasksDown booster5Spec 6 ((((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6))) 0 = true := rfl
+
+private theorem booster_5_check_12 :
+    checkMasksDown booster5Spec 6 ((((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6)))
+      (((1 : Nat) <<< 6)) = true := rfl
+
+private theorem booster_5_check_1 :
+    checkMasksDown booster5Spec 7 (((1 : Nat) <<< 7)) 0 = true := by
+  exact checkMasksDown_step_true booster5Spec 6 (((1 : Nat) <<< 7)) 0
+    booster_5_check_10 booster_5_check_11 booster_5_check_12
+
+private theorem booster_5_check_20 :
+    checkMasksDown booster5Spec 6 (((1 : Nat) <<< 7)) (((1 : Nat) <<< 7)) = true := rfl
+
+private theorem booster_5_check_21 :
+    checkMasksDown booster5Spec 6 ((((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6)))
+      (((1 : Nat) <<< 7)) = true := rfl
+
+private theorem booster_5_check_22 :
+    checkMasksDown booster5Spec 6 ((((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6)))
+      ((((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6))) = true := rfl
+
+private theorem booster_5_check_2 :
+    checkMasksDown booster5Spec 7 (((1 : Nat) <<< 7)) (((1 : Nat) <<< 7)) = true := by
+  exact checkMasksDown_step_true booster5Spec 6 (((1 : Nat) <<< 7)) (((1 : Nat) <<< 7))
+    booster_5_check_20 booster_5_check_21 booster_5_check_22
+
+private theorem booster_5_rawCheckValid :
+    booster5Spec.rawCheckValid = true := by
+  unfold FrameSpec.rawCheckValid
+  change checkMasksDown booster5Spec 8 0 0 = true
+  exact
+    checkMasksDown_step_true booster5Spec 7 0 0
+      booster_5_check_0 booster_5_check_1 booster_5_check_2
+
+private theorem booster_5_valid :
+    (boosters.get ⟨5, by decide⟩).IsValid := by
+  simpa [booster5Spec] using booster5Spec.rawCheckValid_sound booster_5_rawCheckValid
+
+private def booster6Spec : FrameSpec :=
+  boosters.get ⟨6, by decide⟩
+
+private theorem booster_6_check_000 :
+    checkMasksDown booster6Spec 6 0 0 = true := rfl
+
+private theorem booster_6_check_001 :
+    checkMasksDown booster6Spec 6 (((1 : Nat) <<< 6)) 0 = true := rfl
+
+private theorem booster_6_check_002 :
+    checkMasksDown booster6Spec 6 (((1 : Nat) <<< 6)) (((1 : Nat) <<< 6)) = true := rfl
+
+private theorem booster_6_check_00 :
+    checkMasksDown booster6Spec 7 0 0 = true := by
+  exact checkMasksDown_step_true booster6Spec 6 0 0
+    booster_6_check_000 booster_6_check_001 booster_6_check_002
+
+private theorem booster_6_check_010 :
+    checkMasksDown booster6Spec 6 (((1 : Nat) <<< 7)) 0 = true := rfl
+
+private theorem booster_6_check_011 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6))) 0 = true := rfl
+
+private theorem booster_6_check_012 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6)))
+      (((1 : Nat) <<< 6)) = true := rfl
+
+private theorem booster_6_check_01 :
+    checkMasksDown booster6Spec 7 (((1 : Nat) <<< 7)) 0 = true := by
+  exact checkMasksDown_step_true booster6Spec 6 (((1 : Nat) <<< 7)) 0
+    booster_6_check_010 booster_6_check_011 booster_6_check_012
+
+private theorem booster_6_check_020 :
+    checkMasksDown booster6Spec 6 (((1 : Nat) <<< 7)) (((1 : Nat) <<< 7)) = true := rfl
+
+private theorem booster_6_check_021 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6)))
+      (((1 : Nat) <<< 7)) = true := rfl
+
+private theorem booster_6_check_022 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6)))
+      ((((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6))) = true := rfl
+
+private theorem booster_6_check_02 :
+    checkMasksDown booster6Spec 7 (((1 : Nat) <<< 7)) (((1 : Nat) <<< 7)) = true := by
+  exact checkMasksDown_step_true booster6Spec 6 (((1 : Nat) <<< 7)) (((1 : Nat) <<< 7))
+    booster_6_check_020 booster_6_check_021 booster_6_check_022
+
+private theorem booster_6_check_100 :
+    checkMasksDown booster6Spec 6 (((1 : Nat) <<< 8)) 0 = true := rfl
+
+private theorem booster_6_check_101 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 6))) 0 = true := rfl
+
+private theorem booster_6_check_102 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 6)))
+      (((1 : Nat) <<< 6)) = true := rfl
+
+private theorem booster_6_check_10 :
+    checkMasksDown booster6Spec 7 (((1 : Nat) <<< 8)) 0 = true := by
+  exact checkMasksDown_step_true booster6Spec 6 (((1 : Nat) <<< 8)) 0
+    booster_6_check_100 booster_6_check_101 booster_6_check_102
+
+private theorem booster_6_check_110 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7))) 0 = true := rfl
+
+private theorem booster_6_check_111 :
+    checkMasksDown booster6Spec 6
+      ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6))) 0 =
+        true := rfl
+
+private theorem booster_6_check_112 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6)))
+      (((1 : Nat) <<< 6)) = true := rfl
+
+private theorem booster_6_check_11 :
+    checkMasksDown booster6Spec 7 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7))) 0 = true := by
+  exact checkMasksDown_step_true booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7))) 0
+    booster_6_check_110 booster_6_check_111 booster_6_check_112
+
+private theorem booster_6_check_120 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7)))
+      (((1 : Nat) <<< 7)) = true := rfl
+
+private theorem booster_6_check_121 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6)))
+      (((1 : Nat) <<< 7)) = true := rfl
+
+private theorem booster_6_check_122 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6)))
+      ((((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6))) = true := rfl
+
+private theorem booster_6_check_12 :
+    checkMasksDown booster6Spec 7 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7)))
+      (((1 : Nat) <<< 7)) = true := by
+  exact checkMasksDown_step_true booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7)))
+    (((1 : Nat) <<< 7)) booster_6_check_120 booster_6_check_121 booster_6_check_122
+
+private theorem booster_6_check_200 :
+    checkMasksDown booster6Spec 6 (((1 : Nat) <<< 8)) (((1 : Nat) <<< 8)) = true := rfl
+
+private theorem booster_6_check_201 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 6)))
+      (((1 : Nat) <<< 8)) = true := rfl
+
+private theorem booster_6_check_202 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 6)))
+      ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 6))) = true := rfl
+
+private theorem booster_6_check_20 :
+    checkMasksDown booster6Spec 7 (((1 : Nat) <<< 8)) (((1 : Nat) <<< 8)) = true := by
+  exact checkMasksDown_step_true booster6Spec 6 (((1 : Nat) <<< 8)) (((1 : Nat) <<< 8))
+    booster_6_check_200 booster_6_check_201 booster_6_check_202
+
+private theorem booster_6_check_210 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7)))
+      (((1 : Nat) <<< 8)) = true := rfl
+
+private theorem booster_6_check_211 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6)))
+      (((1 : Nat) <<< 8)) = true := rfl
+
+private theorem booster_6_check_212 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6)))
+      ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 6))) = true := rfl
+
+private theorem booster_6_check_21 :
+    checkMasksDown booster6Spec 7 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7)))
+      (((1 : Nat) <<< 8)) = true := by
+  exact checkMasksDown_step_true booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7)))
+    (((1 : Nat) <<< 8)) booster_6_check_210 booster_6_check_211 booster_6_check_212
+
+private theorem booster_6_check_220 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7)))
+      ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7))) = true := rfl
+
+private theorem booster_6_check_221 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6)))
+      ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7))) = true := rfl
+
+private theorem booster_6_check_222 :
+    checkMasksDown booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6)))
+      ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7) ||| ((1 : Nat) <<< 6))) = true := rfl
+
+private theorem booster_6_check_22 :
+    checkMasksDown booster6Spec 7 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7)))
+      ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7))) = true := by
+  exact checkMasksDown_step_true booster6Spec 6 ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7)))
+    ((((1 : Nat) <<< 8) ||| ((1 : Nat) <<< 7))) booster_6_check_220
+    booster_6_check_221 booster_6_check_222
+
+private theorem booster_6_check_0 :
+    checkMasksDown booster6Spec 8 0 0 = true := by
+  exact checkMasksDown_step_true booster6Spec 7 0 0
+    booster_6_check_00 booster_6_check_01 booster_6_check_02
+
+private theorem booster_6_check_1 :
+    checkMasksDown booster6Spec 8 (((1 : Nat) <<< 8)) 0 = true := by
+  exact checkMasksDown_step_true booster6Spec 7 (((1 : Nat) <<< 8)) 0
+    booster_6_check_10 booster_6_check_11 booster_6_check_12
+
+private theorem booster_6_check_2 :
+    checkMasksDown booster6Spec 8 (((1 : Nat) <<< 8)) (((1 : Nat) <<< 8)) = true := by
+  exact checkMasksDown_step_true booster6Spec 7 (((1 : Nat) <<< 8)) (((1 : Nat) <<< 8))
+    booster_6_check_20 booster_6_check_21 booster_6_check_22
+
+private theorem booster_6_rawCheckValid :
+    booster6Spec.rawCheckValid = true := by
+  unfold FrameSpec.rawCheckValid
+  change checkMasksDown booster6Spec 9 0 0 = true
+  exact
+    checkMasksDown_step_true booster6Spec 8 0 0
+      booster_6_check_0 booster_6_check_1 booster_6_check_2
+
+private theorem booster_6_valid :
+    (boosters.get ⟨6, by decide⟩).IsValid := by
+  simpa [booster6Spec] using booster6Spec.rawCheckValid_sound booster_6_rawCheckValid
+
+theorem boosters_valid :
+    ∀ spec ∈ boosters, spec.IsValid := by
+  intro spec hs
+  obtain ⟨i, rfl⟩ := List.get_of_mem hs
+  fin_cases i
+  · exact booster_0_valid
+  · exact booster_1_valid
+  · exact booster_2_valid
+  · exact booster_3_valid
+  · exact booster_4_valid
+  · exact booster_5_valid
+  · exact booster_6_valid
+
+end HypergraphLowerBound

--- a/LeanPool/FrontierMathOpenHypergraphs/Uniform/FrameDefs.lean
+++ b/LeanPool/FrontierMathOpenHypergraphs/Uniform/FrameDefs.lean
@@ -1,0 +1,1849 @@
+/-
+Copyright (c) 2026 Dean Cureton. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dean Cureton
+-/
+
+import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Data.Fintype.Fin
+import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Nat.Bitwise
+import Mathlib.Data.Nat.Pairing
+import Mathlib.Data.Finset.Powerset
+import Mathlib.Tactic.Bound
+import Mathlib.Tactic.FinCases
+import Mathlib.Tactic.IntervalCases
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import LeanPool.FrontierMathOpenHypergraphs.Substitution
+
+/-!
+# The uniform 26/25 factor and the finite bootstrap
+-/
+
+namespace HypergraphLowerBound
+
+/-! ## The sequence A_n -/
+
+/-- A support gadget together with its stated capacity vector. -/
+structure FrameSpec where
+  /-- The capacity assigned to each part. -/
+  parts : List ℕ
+  /-- Raw support patterns, represented as lists of part indices. -/
+  rawSupports : List (List ℕ)
+  /-- The raw support patterns are valid subsets of the part indices of size at least two. -/
+  rawSupports_ok :
+    ∀ s ∈ rawSupports, s.Nodup ∧ (∀ i ∈ s, i < parts.length) ∧ 2 ≤ s.length
+
+/-- The arity of a frame specification. -/
+def FrameSpec.t (spec : FrameSpec) : ℕ :=
+  spec.parts.length
+
+/-- The capacity vector of a frame specification. -/
+def FrameSpec.cap (spec : FrameSpec) : Fin spec.t → ℕ :=
+  fun i => spec.parts.get i
+
+private def supportPatternOfList {t : ℕ} (s : List ℕ)
+    (hIn : ∀ i ∈ s, i < t) (hNodup : s.Nodup) (hCard : 2 ≤ s.length) :
+    SupportPattern t := by
+  let finList : List (Fin t) := s.pmap (fun i hi => (⟨i, hi⟩ : Fin t)) hIn
+  have hFinNodup : finList.Nodup := by
+    apply hNodup.pmap
+    intro a ha b hb hEq
+    simpa using congrArg Fin.val hEq
+  refine ⟨finList.toFinset, ?_⟩
+  rw [List.toFinset_card_of_nodup hFinNodup]
+  simpa [finList] using hCard
+
+/-- The support list of a frame specification, interpreted on `Fin spec.t`. -/
+def FrameSpec.supportList (spec : FrameSpec) : List (SupportPattern spec.t) :=
+  (spec.rawSupports.pmap (fun s hs =>
+      supportPatternOfList s
+        (fun i hi => (spec.rawSupports_ok s hs).2.1 i hi)
+        (spec.rawSupports_ok s hs).1
+        (spec.rawSupports_ok s hs).2.2)
+    (by
+      intro s hs
+      exact hs) : List (SupportPattern spec.t))
+
+/-- The support multiset of a frame specification, interpreted on `Fin spec.t`. -/
+def FrameSpec.supports (spec : FrameSpec) : Multiset (SupportPattern spec.t) :=
+  spec.supportList
+
+/-- The total number of support occurrences in a frame specification. -/
+def FrameSpec.bonus (spec : FrameSpec) : ℕ :=
+  spec.rawSupports.length
+
+/-- Decide whether a support pattern contributes to the frame inequality for `T` and `I`. -/
+def frameWitnesses {t : ℕ} (T I : Finset (Fin t)) (S : SupportPattern t) : Bool :=
+  decide (S.1 ⊆ T ∧ ((S.1 ∩ I).card = 1))
+
+/-- The computable count of support occurrences contributing to the frame inequality. -/
+def FrameSpec.countWitnesses (spec : FrameSpec)
+    (T I : Finset (Fin spec.t)) : ℕ :=
+  spec.supportList.countP (frameWitnesses T I)
+
+/-- A frame specification is valid when its support multiset satisfies the corresponding
+    frame inequalities. -/
+def FrameSpec.IsValid (spec : FrameSpec) : Prop :=
+  ∀ T I : Finset (Fin spec.t), I ⊆ T →
+    spec.countWitnesses T I ≤ (T \ I).sum spec.cap
+
+instance (spec : FrameSpec) : Decidable spec.IsValid := by
+  unfold FrameSpec.IsValid FrameSpec.countWitnesses
+  infer_instance
+
+private def sup2 (a b : ℕ) : List ℕ := [a, b]
+private def sup3 (a b c : ℕ) : List ℕ := [a, b, c]
+private def sup4 (a b c d : ℕ) : List ℕ := [a, b, c, d]
+private def sup5 (a b c d e : ℕ) : List ℕ := [a, b, c, d, e]
+private def sup6 (a b c d e f : ℕ) : List ℕ := [a, b, c, d, e, f]
+private def sup7 (a b c d e f g : ℕ) : List ℕ := [a, b, c, d, e, f, g]
+private def sup8 (a b c d e f g h : ℕ) : List ℕ := [a, b, c, d, e, f, g, h]
+private def sup9 (a b c d e f g h i : ℕ) : List ℕ := [a, b, c, d, e, f, g, h, i]
+
+local notation "s2" => sup2
+local notation "s3" => sup3
+local notation "s4" => sup4
+local notation "s5" => sup5
+local notation "s6" => sup6
+local notation "s7" => sup7
+local notation "s8" => sup8
+local notation "s9" => sup9
+
+private def mkFrame (parts : List ℕ) (rawSupports : List (List ℕ))
+    (h : ∀ s ∈ rawSupports, s.Nodup ∧ (∀ i ∈ s, i < parts.length) ∧ 2 ≤ s.length) :
+    FrameSpec where
+  parts := parts
+  rawSupports := rawSupports
+  rawSupports_ok := h
+
+local notation "frame" => mkFrame
+local syntax:max "frame!" term:max term:max : term
+macro_rules
+  | `(frame! $parts:term $supports:term) => `(mkFrame $parts $supports (by decide))
+
+private inductive ChoiceKind where
+  | base
+  | bin
+  | frame
+  | quadres
+  | quad4
+  | boost15
+  | boost16
+  | boost17
+  | boost19
+  | boost31
+  | boost32
+  | boost33
+deriving DecidableEq, Repr, Inhabited
+
+private structure ChoiceSpec where
+  kind : ChoiceKind
+  parts : List ℕ
+  bonus : ℕ
+deriving Inhabited
+
+private def core4Supports : List (List ℕ) :=
+  [ s2 0 1
+  , s2 0 2
+  , s2 0 3
+  , s2 1 2
+  , s2 1 3
+  , s2 2 3
+  , s3 0 1 2
+  , s3 0 1 3
+  , s3 0 2 3
+  , s3 1 2 3
+  , s4 0 1 2 3
+  , s4 0 1 2 3
+  , s4 0 1 2 3
+  ]
+
+/-- The four-part core gadget used in the residue construction. -/
+def core4Spec : FrameSpec :=
+  frame [3, 3, 3, 3] core4Supports (by decide)
+
+/-- The exact small frames listed in Appendix A. -/
+def exactSmallFrames : List FrameSpec :=
+[
+  frame! [2, 2, 2] [
+    s2 0 1,
+    s2 0 2,
+    s2 1 2,
+    s3 0 1 2,
+    s3 0 1 2
+  ],
+  frame! [4, 4, 6] [
+    s2 0 1,
+    s2 0 1,
+    s2 0 1,
+    s2 0 2,
+    s2 1 2,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 2
+  ],
+  frame! [6, 6, 6] [
+    s2 0 1,
+    s2 0 1,
+    s2 0 1,
+    s2 0 2,
+    s2 0 2,
+    s2 0 2,
+    s2 1 2,
+    s2 1 2,
+    s2 1 2,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 2
+  ],
+  frame! [2, 2, 2, 3] [
+    s2 0 1,
+    s2 0 2,
+    s2 1 2,
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 2 3,
+    s3 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3
+  ],
+  frame! [2, 2, 2, 4] [
+    s2 0 1,
+    s2 0 2,
+    s2 1 2,
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 2 3,
+    s3 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3
+  ],
+  frame! [4, 4, 6, 9] [
+    s2 0 1,
+    s2 0 1,
+    s2 0 1,
+    s2 0 2,
+    s2 1 2,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 2 3,
+    s3 0 2 3,
+    s3 0 2 3,
+    s3 1 2 3,
+    s3 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3
+  ],
+  frame! [6, 6, 6, 6] [
+    s2 0 1,
+    s2 0 1,
+    s2 0 2,
+    s2 0 2,
+    s2 0 3,
+    s2 0 3,
+    s2 1 2,
+    s2 1 2,
+    s2 1 3,
+    s2 1 3,
+    s2 2 3,
+    s2 2 3,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 2 3,
+    s3 0 2 3,
+    s3 1 2 3,
+    s3 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3
+  ],
+  frame! [6, 6, 6, 7] [
+    s2 0 1,
+    s2 0 1,
+    s2 0 1,
+    s2 0 2,
+    s2 0 2,
+    s2 0 3,
+    s2 1 2,
+    s2 1 2,
+    s2 1 3,
+    s2 2 3,
+    s2 2 3,
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 2 3,
+    s3 0 2 3,
+    s3 1 2 3,
+    s3 1 2 3,
+    s3 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3
+  ],
+  frame! [6, 6, 6, 8] [
+    s2 0 1,
+    s2 0 1,
+    s2 0 1,
+    s2 0 2,
+    s2 0 2,
+    s2 0 2,
+    s2 1 2,
+    s2 1 2,
+    s2 1 2,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 2 3,
+    s3 0 2 3,
+    s3 0 2 3,
+    s3 0 2 3,
+    s3 1 2 3,
+    s3 1 2 3,
+    s3 1 2 3,
+    s3 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3
+  ],
+  frame! [6, 6, 6, 9] [
+    s2 0 1,
+    s2 0 1,
+    s2 0 1,
+    s2 0 2,
+    s2 0 2,
+    s2 0 2,
+    s2 1 2,
+    s2 1 2,
+    s2 1 2,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 2 3,
+    s3 0 2 3,
+    s3 0 2 3,
+    s3 0 2 3,
+    s3 1 2 3,
+    s3 1 2 3,
+    s3 1 2 3,
+    s3 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3
+  ],
+  frame! [6, 6, 6, 10] [
+    s2 0 1,
+    s2 0 1,
+    s2 0 1,
+    s2 0 2,
+    s2 0 2,
+    s2 0 2,
+    s2 1 2,
+    s2 1 2,
+    s2 1 2,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 2 3,
+    s3 0 2 3,
+    s3 0 2 3,
+    s3 0 2 3,
+    s3 1 2 3,
+    s3 1 2 3,
+    s3 1 2 3,
+    s3 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3
+  ],
+  frame! [2, 2, 2, 3, 4] [
+    s2 0 1,
+    s2 0 2,
+    s2 1 2,
+    s3 0 1 3,
+    s3 0 1 4,
+    s3 0 2 3,
+    s3 0 2 4,
+    s3 0 3 4,
+    s3 1 2 3,
+    s3 1 2 3,
+    s4 1 2 3 4,
+    s4 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4
+  ],
+  frame! [3, 4, 4, 4, 6] [
+    s2 0 1,
+    s2 0 2,
+    s2 0 3,
+    s2 1 2,
+    s2 2 3,
+    s2 2 3,
+    s2 3 4,
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 1 4,
+    s3 0 2 4,
+    s3 2 3 4,
+    s3 2 3 4,
+    s3 2 3 4,
+    s4 0 1 2 3,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4
+  ],
+  frame! [4, 4, 4, 4, 4] [
+    s2 0 1,
+    s2 0 2,
+    s2 0 3,
+    s2 0 4,
+    s2 1 2,
+    s2 1 3,
+    s2 1 4,
+    s2 2 3,
+    s2 2 4,
+    s2 3 4,
+    s3 1 2 3,
+    s3 1 2 4,
+    s3 1 3 4,
+    s3 2 3 4,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4
+  ],
+  frame! [4, 4, 4, 4, 6] [
+    s2 0 1,
+    s2 0 2,
+    s2 0 3,
+    s2 0 3,
+    s2 1 2,
+    s2 1 3,
+    s2 2 3,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 4,
+    s3 0 2 4,
+    s3 0 3 4,
+    s3 1 2 3,
+    s3 1 2 4,
+    s3 1 3 4,
+    s3 2 3 4,
+    s4 0 1 2 3,
+    s4 0 1 2 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 1 2 3 4,
+    s4 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4
+  ],
+  frame! [5, 6, 6, 6, 6] [
+    s2 0 1,
+    s2 0 1,
+    s2 0 2,
+    s2 0 3,
+    s2 0 4,
+    s2 1 2,
+    s2 1 2,
+    s2 1 3,
+    s2 2 3,
+    s2 2 3,
+    s2 2 4,
+    s2 3 4,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 1 4,
+    s3 0 2 4,
+    s3 0 3 4,
+    s3 1 3 4,
+    s3 1 3 4,
+    s3 2 3 4,
+    s3 2 3 4,
+    s3 2 3 4,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4
+  ],
+  frame! [6, 6, 6, 6, 6] [
+    s2 0 1,
+    s2 0 2,
+    s2 0 3,
+    s2 0 4,
+    s2 0 4,
+    s2 0 4,
+    s2 1 2,
+    s2 1 3,
+    s2 1 4,
+    s2 2 3,
+    s2 2 4,
+    s2 3 4,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 2 3,
+    s3 0 2 3,
+    s3 1 2 3,
+    s3 1 2 3,
+    s3 1 2 4,
+    s3 1 2 4,
+    s3 1 3 4,
+    s3 1 3 4,
+    s3 2 3 4,
+    s3 2 3 4,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4
+  ],
+  frame! [6, 6, 6, 6, 10] [
+    s2 0 1,
+    s2 0 1,
+    s2 0 2,
+    s2 0 2,
+    s2 0 3,
+    s2 0 3,
+    s2 1 2,
+    s2 1 2,
+    s2 1 3,
+    s2 1 3,
+    s2 2 3,
+    s2 2 3,
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 1 4,
+    s3 0 2 3,
+    s3 0 2 4,
+    s3 0 3 4,
+    s3 1 2 3,
+    s3 1 2 4,
+    s3 1 2 4,
+    s3 1 3 4,
+    s3 2 3 4,
+    s3 2 3 4,
+    s4 0 1 2 3,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 1 2 3 4,
+    s4 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4
+  ],
+  frame! [6, 6, 6, 6, 11] [
+    s2 0 1,
+    s2 0 1,
+    s2 0 2,
+    s2 0 2,
+    s2 0 3,
+    s2 0 3,
+    s2 1 2,
+    s2 1 2,
+    s2 1 3,
+    s2 1 3,
+    s2 2 3,
+    s2 2 3,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 2 3,
+    s3 1 2 3,
+    s3 1 2 3,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 1 2 3 4,
+    s4 1 2 3 4,
+    s4 1 2 3 4,
+    s4 1 2 3 4,
+    s4 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4
+  ],
+  frame! [6, 6, 6, 6, 12] [
+    s2 0 1,
+    s2 0 1,
+    s2 0 2,
+    s2 0 2,
+    s2 0 3,
+    s2 0 3,
+    s2 1 2,
+    s2 1 2,
+    s2 1 3,
+    s2 1 3,
+    s2 2 3,
+    s2 2 3,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 2 3,
+    s3 0 2 3,
+    s3 1 2 3,
+    s3 1 2 3,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 1 2 3 4,
+    s4 1 2 3 4,
+    s4 1 2 3 4,
+    s4 1 2 3 4,
+    s4 1 2 3 4,
+    s4 1 2 3 4
+  ],
+  frame! [6, 6, 6, 6, 13] [
+    s2 0 1,
+    s2 0 1,
+    s2 0 2,
+    s2 0 2,
+    s2 0 3,
+    s2 0 3,
+    s2 1 2,
+    s2 1 2,
+    s2 1 3,
+    s2 1 3,
+    s2 2 3,
+    s2 2 3,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 2 3,
+    s3 0 2 3,
+    s3 1 2 3,
+    s3 1 2 3,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 0 1 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 0 2 3 4,
+    s4 1 2 3 4,
+    s4 1 2 3 4,
+    s4 1 2 3 4,
+    s4 1 2 3 4,
+    s4 1 2 3 4,
+    s5 0 1 2 3 4,
+    s5 0 1 2 3 4
+  ]
+]
+
+/-- The explicit boosters listed in Appendix B. -/
+def boosters : List FrameSpec :=
+[
+  frame! [2, 2, 2, 2, 2, 2, 3] [
+    s2 0 2,
+    s2 0 4,
+    s2 1 3,
+    s2 1 5,
+    s2 2 4,
+    s2 3 5,
+    s4 0 1 2 6,
+    s4 0 1 3 4,
+    s4 0 1 5 6,
+    s4 0 2 3 5,
+    s4 0 4 5 6,
+    s4 1 2 3 6,
+    s4 1 2 4 5,
+    s4 2 3 4 6,
+    s4 3 4 5 6,
+    s5 0 1 3 4 6,
+    s5 0 2 3 5 6,
+    s5 1 2 4 5 6,
+    s6 0 1 2 3 4 5,
+    s6 0 1 2 3 4 5,
+    s7 0 1 2 3 4 5 6,
+    s7 0 1 2 3 4 5 6
+  ],
+  frame! [2, 2, 2, 2, 2, 2, 2, 2] [
+    s2 0 4,
+    s2 1 5,
+    s2 2 6,
+    s2 3 7,
+    s3 0 1 6,
+    s3 0 2 3,
+    s3 0 5 7,
+    s3 1 2 7,
+    s3 1 3 4,
+    s3 2 4 5,
+    s3 3 5 6,
+    s3 4 6 7,
+    s5 0 1 2 3 5,
+    s5 0 1 2 4 7,
+    s5 0 1 3 6 7,
+    s5 0 2 5 6 7,
+    s5 0 3 4 5 6,
+    s5 1 2 3 4 6,
+    s5 1 4 5 6 7,
+    s5 2 3 4 5 7,
+    s6 0 1 2 4 5 6,
+    s6 0 1 3 4 5 7,
+    s6 0 2 3 4 6 7,
+    s6 1 2 3 5 6 7,
+    s8 0 1 2 3 4 5 6 7,
+    s8 0 1 2 3 4 5 6 7
+  ],
+  frame! [2, 2, 2, 3, 4, 4] [
+    s2 0 1,
+    s2 0 2,
+    s2 1 2,
+    s3 0 1 3,
+    s3 0 1 4,
+    s3 0 2 3,
+    s3 1 2 3,
+    s3 1 2 5,
+    s3 1 3 4,
+    s3 1 4 5,
+    s3 2 3 4,
+    s3 3 4 5,
+    s4 0 1 2 5,
+    s4 0 1 3 5,
+    s4 0 2 3 5,
+    s4 0 2 4 5,
+    s4 0 2 4 5,
+    s6 0 1 2 3 4 5,
+    s6 0 1 2 3 4 5,
+    s6 0 1 2 3 4 5,
+    s6 0 1 2 3 4 5,
+    s6 0 1 2 3 4 5
+  ],
+  frame! [2, 2, 2, 3, 4, 6] [
+    s2 0 1,
+    s2 0 2,
+    s2 1 2,
+    s2 3 4,
+    s3 0 1 3,
+    s3 0 2 3,
+    s3 1 2 3,
+    s4 0 1 2 4,
+    s4 0 1 2 4,
+    s4 0 1 3 4,
+    s4 0 2 3 4,
+    s4 0 3 4 5,
+    s4 0 3 4 5,
+    s4 0 3 4 5,
+    s4 1 2 3 4,
+    s5 0 1 2 3 5,
+    s5 0 1 2 3 5,
+    s5 0 1 2 3 5,
+    s5 0 1 2 4 5,
+    s5 0 1 2 4 5,
+    s5 0 1 2 4 5,
+    s5 1 2 3 4 5,
+    s5 1 2 3 4 5,
+    s5 1 2 3 4 5
+  ],
+  frame! [3, 4, 4, 4, 4, 4, 4, 4] [
+    s2 1 2,
+    s2 1 7,
+    s2 2 3,
+    s2 3 4,
+    s2 4 5,
+    s2 5 6,
+    s2 6 7,
+    s3 0 1 3,
+    s3 0 1 4,
+    s3 0 1 5,
+    s3 0 1 6,
+    s3 0 2 4,
+    s3 0 2 5,
+    s3 0 2 6,
+    s3 0 2 7,
+    s3 0 3 5,
+    s3 0 3 6,
+    s3 0 3 7,
+    s3 0 4 6,
+    s3 0 4 7,
+    s3 0 5 7,
+    s3 1 2 4,
+    s3 1 3 7,
+    s3 1 5 6,
+    s3 2 3 5,
+    s3 2 6 7,
+    s3 3 4 6,
+    s3 4 5 7,
+    s5 1 2 3 5 6,
+    s5 1 2 4 5 6,
+    s5 1 2 4 5 7,
+    s5 1 3 4 5 7,
+    s5 1 3 4 6 7,
+    s5 2 3 4 6 7,
+    s5 2 3 5 6 7,
+    s7 0 1 2 3 4 5 6,
+    s7 0 1 2 3 4 5 6,
+    s7 0 1 2 3 4 5 7,
+    s7 0 1 2 3 4 5 7,
+    s7 0 1 2 3 4 6 7,
+    s7 0 1 2 3 4 6 7,
+    s7 0 1 2 3 5 6 7,
+    s7 0 1 2 3 5 6 7,
+    s7 0 1 2 4 5 6 7,
+    s7 0 1 2 4 5 6 7,
+    s7 0 1 3 4 5 6 7,
+    s7 0 1 3 4 5 6 7,
+    s7 0 2 3 4 5 6 7,
+    s7 0 2 3 4 5 6 7,
+    s7 1 2 3 4 5 6 7
+  ],
+  frame! [4, 4, 4, 4, 4, 4, 4, 4] [
+    s2 0 2,
+    s2 0 4,
+    s2 0 4,
+    s2 0 6,
+    s2 1 3,
+    s2 1 5,
+    s2 1 5,
+    s2 1 7,
+    s2 2 4,
+    s2 2 6,
+    s2 2 6,
+    s2 3 5,
+    s2 3 7,
+    s2 3 7,
+    s2 4 6,
+    s2 5 7,
+    s4 0 1 2 3,
+    s4 0 1 2 7,
+    s4 0 1 3 6,
+    s4 0 1 4 5,
+    s4 0 1 6 7,
+    s4 0 2 3 5,
+    s4 0 2 4 6,
+    s4 0 2 4 6,
+    s4 0 2 5 7,
+    s4 0 3 4 7,
+    s4 0 3 5 6,
+    s4 0 5 6 7,
+    s4 1 2 3 4,
+    s4 1 2 4 7,
+    s4 1 2 5 6,
+    s4 1 3 4 6,
+    s4 1 3 5 7,
+    s4 1 3 5 7,
+    s4 1 4 6 7,
+    s4 2 3 4 5,
+    s4 2 3 6 7,
+    s4 2 4 5 7,
+    s4 3 4 5 6,
+    s4 4 5 6 7,
+    s7 0 1 2 3 4 5 6,
+    s7 0 1 2 3 4 5 7,
+    s7 0 1 2 3 4 6 7,
+    s7 0 1 2 3 5 6 7,
+    s7 0 1 2 4 5 6 7,
+    s7 0 1 3 4 5 6 7,
+    s7 0 2 3 4 5 6 7,
+    s7 1 2 3 4 5 6 7,
+    s8 0 1 2 3 4 5 6 7,
+    s8 0 1 2 3 4 5 6 7,
+    s8 0 1 2 3 4 5 6 7,
+    s8 0 1 2 3 4 5 6 7,
+    s8 0 1 2 3 4 5 6 7
+  ],
+  frame! [1, 4, 4, 4, 4, 4, 4, 4, 4] [
+    s2 1 5,
+    s2 2 6,
+    s2 3 7,
+    s2 4 8,
+    s3 0 1 3,
+    s3 0 1 7,
+    s3 0 2 4,
+    s3 0 2 8,
+    s3 0 3 5,
+    s3 0 4 6,
+    s3 0 5 7,
+    s3 0 6 8,
+    s4 0 1 3 6,
+    s4 0 1 4 6,
+    s4 0 1 4 7,
+    s4 0 2 4 7,
+    s4 0 2 5 7,
+    s4 0 2 5 8,
+    s4 0 3 5 8,
+    s4 0 3 6 8,
+    s4 1 2 3 4,
+    s4 1 2 3 8,
+    s4 1 2 4 5,
+    s4 1 2 6 7,
+    s4 1 2 7 8,
+    s4 1 3 4 8,
+    s4 1 3 5 7,
+    s4 1 5 6 8,
+    s4 1 6 7 8,
+    s4 2 3 4 5,
+    s4 2 3 5 6,
+    s4 2 3 7 8,
+    s4 2 4 6 8,
+    s4 3 4 5 6,
+    s4 3 4 6 7,
+    s4 4 5 6 7,
+    s4 4 5 7 8,
+    s4 5 6 7 8,
+    s5 0 1 2 5 6,
+    s5 0 1 4 5 8,
+    s5 0 2 3 6 7,
+    s5 0 3 4 7 8,
+    s8 0 1 2 3 4 5 6 7,
+    s8 0 1 2 3 4 5 6 8,
+    s8 0 1 2 3 4 5 7 8,
+    s8 0 1 2 3 4 6 7 8,
+    s8 0 1 2 3 5 6 7 8,
+    s8 0 1 2 4 5 6 7 8,
+    s8 0 1 3 4 5 6 7 8,
+    s8 0 2 3 4 5 6 7 8,
+    s8 1 2 3 4 5 6 7 8,
+    s8 1 2 3 4 5 6 7 8,
+    s8 1 2 3 4 5 6 7 8,
+    s8 1 2 3 4 5 6 7 8,
+    s9 0 1 2 3 4 5 6 7 8
+  ]
+]
+
+/-- The residue gadgets `R_r` used by the balanced four-way construction. -/
+def residueGadgets : List FrameSpec :=
+[
+  frame! [0, 0, 0, 0] [
+  ],
+  frame! [0, 0, 0, 1] [
+  ],
+  frame! [0, 0, 1, 1] [
+    s2 2 3
+  ],
+  frame! [0, 1, 1, 1] [
+    s3 1 2 3,
+    s3 1 2 3
+  ],
+  frame! [1, 1, 1, 1] [
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 2 3,
+    s3 1 2 3
+  ],
+  frame! [1, 1, 1, 2] [
+    s3 0 1 2,
+    s4 0 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3
+  ],
+  frame! [1, 1, 2, 2] [
+    s2 0 1,
+    s2 2 3,
+    s3 0 1 2,
+    s3 0 1 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3
+  ],
+  frame! [1, 2, 2, 2] [
+    s2 1 2,
+    s2 1 3,
+    s2 2 3,
+    s3 0 1 2,
+    s4 0 1 2 3,
+    s4 0 1 2 3
+  ],
+  frame! [2, 2, 2, 2] [
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 2 3,
+    s3 0 2 3,
+    s3 1 2 3,
+    s3 1 2 3
+  ],
+  frame! [2, 2, 2, 3] [
+    s2 0 1,
+    s2 0 2,
+    s2 1 2,
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 2 3,
+    s3 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3
+  ],
+  frame! [2, 2, 3, 3] [
+    s2 0 1,
+    s2 2 3,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 1 3,
+    s3 0 2 3,
+    s3 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3
+  ],
+  frame! [2, 3, 3, 3] [
+    s2 1 2,
+    s2 1 3,
+    s2 2 3,
+    s3 0 1 2,
+    s3 0 1 2,
+    s3 0 1 3,
+    s3 0 2 3,
+    s3 1 2 3,
+    s4 0 1 2 3,
+    s4 0 1 2 3
+  ]
+]
+
+private def under60Choices : List ChoiceSpec :=
+  [ { kind := .base, parts := [], bonus := 0 }
+  , { kind := .bin, parts := [1, 1], bonus := 1 }
+  , { kind := .bin, parts := [1, 2], bonus := 1 }
+  , { kind := .bin, parts := [2, 2], bonus := 2 }
+  , { kind := .bin, parts := [2, 3], bonus := 2 }
+  , { kind := .frame, parts := [2, 2, 2], bonus := 5 }
+  , { kind := .bin, parts := [3, 4], bonus := 3 }
+  , { kind := .bin, parts := [4, 4], bonus := 4 }
+  , { kind := .frame, parts := [2, 2, 2, 3], bonus := 9 }
+  , { kind := .frame, parts := [2, 2, 2, 4], bonus := 10 }
+  , { kind := .bin, parts := [5, 6], bonus := 5 }
+  , { kind := .bin, parts := [6, 6], bonus := 6 }
+  , { kind := .frame, parts := [2, 2, 2, 3, 4], bonus := 15 }
+  , { kind := .frame, parts := [4, 4, 6], bonus := 11 }
+  , { kind := .boost15, parts := [2, 2, 2, 2, 2, 2, 3], bonus := 22 }
+  , { kind := .boost16, parts := [2, 2, 2, 2, 2, 2, 2, 2], bonus := 26 }
+  , { kind := .boost17, parts := [2, 2, 2, 3, 4, 4], bonus := 22 }
+  , { kind := .frame, parts := [6, 6, 6], bonus := 15 }
+  , { kind := .boost19, parts := [2, 2, 2, 3, 4, 6], bonus := 24 }
+  , { kind := .frame, parts := [4, 4, 4, 4, 4], bonus := 25 }
+  , { kind := .frame, parts := [3, 4, 4, 4, 6], bonus := 25 }
+  , { kind := .frame, parts := [4, 4, 4, 4, 6], bonus := 27 }
+  , { kind := .frame, parts := [4, 4, 6, 9], bonus := 22 }
+  , { kind := .frame, parts := [6, 6, 6, 6], bonus := 26 }
+  , { kind := .frame, parts := [6, 6, 6, 7], bonus := 26 }
+  , { kind := .frame, parts := [6, 6, 6, 8], bonus := 27 }
+  , { kind := .frame, parts := [6, 6, 6, 9], bonus := 28 }
+  , { kind := .frame, parts := [6, 6, 6, 10], bonus := 29 }
+  , { kind := .frame, parts := [5, 6, 6, 6, 6], bonus := 35 }
+  , { kind := .frame, parts := [6, 6, 6, 6, 6], bonus := 38 }
+  , { kind := .boost31, parts := [3, 4, 4, 4, 4, 4, 4, 4], bonus := 50 }
+  , { kind := .boost32, parts := [4, 4, 4, 4, 4, 4, 4, 4], bonus := 53 }
+  , { kind := .boost33, parts := [1, 4, 4, 4, 4, 4, 4, 4, 4], bonus := 55 }
+  , { kind := .frame, parts := [6, 6, 6, 6, 10], bonus := 42 }
+  , { kind := .frame, parts := [6, 6, 6, 6, 11], bonus := 42 }
+  , { kind := .frame, parts := [6, 6, 6, 6, 12], bonus := 44 }
+  , { kind := .frame, parts := [6, 6, 6, 6, 13], bonus := 44 }
+  , { kind := .quadres, parts := [9, 9, 10, 10], bonus := 40 }
+  , { kind := .quadres, parts := [9, 10, 10, 10], bonus := 41 }
+  , { kind := .quadres, parts := [10, 10, 10, 10], bonus := 43 }
+  , { kind := .bin, parts := [20, 21], bonus := 20 }
+  , { kind := .bin, parts := [21, 21], bonus := 21 }
+  , { kind := .bin, parts := [21, 22], bonus := 21 }
+  , { kind := .bin, parts := [22, 22], bonus := 22 }
+  , { kind := .bin, parts := [22, 23], bonus := 22 }
+  , { kind := .quadres, parts := [11, 11, 12, 12], bonus := 49 }
+  , { kind := .bin, parts := [23, 24], bonus := 23 }
+  , { kind := .bin, parts := [24, 24], bonus := 24 }
+  , { kind := .quadres, parts := [12, 12, 12, 13], bonus := 52 }
+  , { kind := .quadres, parts := [12, 12, 13, 13], bonus := 53 }
+  , { kind := .quadres, parts := [12, 13, 13, 13], bonus := 54 }
+  , { kind := .bin, parts := [26, 26], bonus := 26 }
+  , { kind := .bin, parts := [26, 27], bonus := 26 }
+  , { kind := .quadres, parts := [13, 13, 14, 14], bonus := 58 }
+  , { kind := .bin, parts := [27, 28], bonus := 27 }
+  , { kind := .bin, parts := [28, 28], bonus := 28 }
+  , { kind := .quadres, parts := [14, 14, 14, 15], bonus := 61 }
+  , { kind := .quadres, parts := [14, 14, 15, 15], bonus := 62 }
+  , { kind := .bin, parts := [29, 30], bonus := 29 }
+  ]
+
+/-- The bonus terms e_r(m) for the balanced four-way construction. -/
+def eBonus (r : ℕ) (m : ℕ) : ℕ :=
+  match r % 4 with
+  | 0 => (13 * m) / 3
+  | 1 => (13 * m + 1) / 3
+  | 2 => (13 * m + 5) / 3
+  | _ => (13 * m + 6) / 3
+
+/-- The bootstrap table values for A_n, 0 ≤ n < 60. -/
+def bootstrapValues : List ℕ :=
+  [0, 1, 3, 4, 6, 7, 10, 11, 14, 17,     -- 0-9
+   19, 21, 24, 28, 30, 45, 50, 52, 57, 60, -- 10-19
+   65, 68, 73, 75, 82, 84, 89, 93, 98, 101, -- 20-29
+   108, 111, 117, 120, 125, 127, 134, 137, 140, 145, -- 30-39
+   151, 153, 157, 162, 168, 170, 175, 180, 188, 191, -- 40-49
+   195, 199, 204, 208, 214, 218, 224, 229, 234, 238] -- 50-59
+
+/-- The sequence A(n) of vertex counts for the explicit hypergraph family. -/
+def A (n : ℕ) : ℕ :=
+  if n = 0 then 0
+  else if n < 60 then
+    bootstrapValues[n]!
+  else
+    let m := n / 4
+    let r := n % 4
+    match r with
+    | 0 => A m + A m + A m + A m + eBonus 0 m
+    | 1 => A m + A m + A m + A (m + 1) + eBonus 1 m
+    | 2 => A m + A m + A (m + 1) + A (m + 1) + eBonus 2 m
+    | _ => A m + A (m + 1) + A (m + 1) + A (m + 1) + eBonus 3 m
+termination_by n
+decreasing_by all_goals omega
+
+local macro "eval_A_small" : tactic =>
+  `(tactic| (
+    first
+    | rw [Fin.sum_univ_two]
+    | rw [Fin.sum_univ_three]
+    | rw [Fin.sum_univ_four]
+    | skip
+    try unfold A
+    first | rfl | decide | omega))
+
+local macro "eval_Ak_small" : tactic =>
+  `(tactic| (unfold A; norm_num [bootstrapValues, k]))
+
+private theorem Fin.sum_univ_five {α : Type*} [AddCommMonoid α] (f : Fin 5 → α) :
+    (∑ i, f i) = f 0 + f 1 + f 2 + f 3 + f 4 := by
+  simp [Fin.sum_univ_succ, add_assoc]
+
+private theorem Fin.sum_univ_six {α : Type*} [AddCommMonoid α] (f : Fin 6 → α) :
+    (∑ i, f i) = f 0 + f 1 + f 2 + f 3 + f 4 + f 5 := by
+  simp [Fin.sum_univ_succ, add_assoc]
+
+private theorem Fin.sum_univ_seven {α : Type*} [AddCommMonoid α] (f : Fin 7 → α) :
+    (∑ i, f i) = f 0 + f 1 + f 2 + f 3 + f 4 + f 5 + f 6 := by
+  simp [Fin.sum_univ_succ, add_assoc]
+
+private theorem Fin.sum_univ_nine {α : Type*} [AddCommMonoid α] (f : Fin 9 → α) :
+    (∑ i, f i) = f 0 + f 1 + f 2 + f 3 + f 4 + f 5 + f 6 + f 7 + f 8 := by
+  simp [Fin.sum_univ_succ, add_assoc]
+
+private theorem sum_vec_22234 :
+    ((Finset.univ : Finset (Fin 5)).sum (![2, 2, 2, 3, 4] : Fin 5 → ℕ)) = 13 := by
+  decide
+
+private theorem sum_vec_3335814 :
+    ((Finset.univ : Finset (Fin 6)).sum (![3, 3, 3, 5, 8, 14] : Fin 6 → ℕ)) = 36 := by
+  decide
+
+private theorem sum_vec_588814 :
+    ((Finset.univ : Finset (Fin 5)).sum (![5, 8, 8, 8, 14] : Fin 5 → ℕ)) = 43 := by
+  decide
+
+private theorem sum_vec_888814 :
+    ((Finset.univ : Finset (Fin 5)).sum (![8, 8, 8, 8, 14] : Fin 5 → ℕ)) = 46 := by
+  decide
+
+private theorem sum_vec_14141420 :
+    ((Finset.univ : Finset (Fin 4)).sum
+      (![14, 14, 14, 20] : Fin 4 → ℕ)) = 62 := by
+  decide
+
+private theorem sum_vec_14141423 :
+    ((Finset.univ : Finset (Fin 4)).sum
+      (![14, 14, 14, 23] : Fin 4 → ℕ)) = 65 := by
+  decide
+
+private theorem sum_vec_14141427 :
+    ((Finset.univ : Finset (Fin 4)).sum
+      (![14, 14, 14, 27] : Fin 4 → ℕ)) = 69 := by
+  decide
+
+private theorem sum_vec_1014141414 :
+    ((Finset.univ : Finset (Fin 5)).sum (![10, 14, 14, 14, 14] : Fin 5 → ℕ)) = 66 := by
+  decide
+
+private theorem sum_vec_58888888 :
+    ((Finset.univ : Finset (Fin 8)).sum (![5, 8, 8, 8, 8, 8, 8, 8] : Fin 8 → ℕ)) = 61 := by
+  decide
+
+private theorem sum_vec_188888888 :
+    ((Finset.univ : Finset (Fin 9)).sum (![1, 8, 8, 8, 8, 8, 8, 8, 8] : Fin 9 → ℕ)) = 65 := by
+  decide
+
+private theorem sum_vec_1414141427 :
+    ((Finset.univ : Finset (Fin 5)).sum (![14, 14, 14, 14, 27] : Fin 5 → ℕ)) = 83 := by
+  decide
+
+private theorem sum_vec_1414141434 :
+    ((Finset.univ : Finset (Fin 5)).sum (![14, 14, 14, 14, 34] : Fin 5 → ℕ)) = 90 := by
+  decide
+
+private theorem sum_vec_1414141437 :
+    ((Finset.univ : Finset (Fin 5)).sum (![14, 14, 14, 14, 37] : Fin 5 → ℕ)) = 93 := by
+  decide
+
+private lemma card_filter_univ_ofFn {α : Type*} {n : ℕ} (f : Fin n → α) (p : α → Bool) :
+    ((Finset.univ : Finset (Fin n)).filter fun i => p (f i)).card =
+      (List.ofFn f).countP p := by
+  induction n with
+  | zero =>
+      simp
+  | succ n ih =>
+      calc
+        ((Finset.univ : Finset (Fin (n + 1))).filter fun i => p (f i)).card
+            = (if p (f 0) = true then 1 else 0) +
+                ((Finset.univ : Finset (Fin n)).filter fun i => p (f i.succ)).card := by
+                  simpa using
+                    (Fin.card_filter_univ_succ'
+                      (p := fun i : Fin (n + 1) => p (f i) = true))
+        _ = (if p (f 0) = true then 1 else 0) +
+              (List.ofFn fun i : Fin n => f i.succ).countP p := by
+          rw [ih (fun i : Fin n => f i.succ)]
+        _ = (List.ofFn f).countP p := by
+          simp [List.ofFn_succ, List.countP_cons, Nat.add_comm]
+
+private lemma card_filter_univ_get_eq_countP {α : Type*} (l : List α) (p : α → Bool) :
+    ((Finset.univ : Finset (Fin l.length)).filter fun i => p (l.get i)).card = l.countP p := by
+  simpa [List.ofFn_get] using card_filter_univ_ofFn l.get p
+
+lemma card_filter_univ_get_eq_countP_prop {α : Type*} (l : List α)
+    (p : α → Prop) [DecidablePred p] :
+    ((Finset.univ : Finset (Fin l.length)).filter fun i => p (l.get i)).card =
+      l.countP (fun a => decide (p a)) := by
+  simpa using card_filter_univ_get_eq_countP l (fun a => decide (p a))
+
+lemma card_filter_univ_multiset_toList_eq_countP_prop {α : Type*}
+    (m : Multiset α) (p : α → Prop) [DecidablePred p] :
+    ((Finset.univ : Finset (Fin m.card)).filter fun i =>
+      p (m.toList.get ⟨i.1, by rw [Multiset.length_toList]; exact i.2⟩)).card =
+        m.toList.countP (fun a => decide (p a)) := by
+  have hcard :
+      ((Finset.univ : Finset (Fin m.card)).filter fun i =>
+        p (m.toList.get ⟨i.1, by rw [Multiset.length_toList]; exact i.2⟩)).card =
+      ((Finset.univ : Finset (Fin m.toList.length)).filter fun i =>
+        p (m.toList.get i)).card := by
+    apply Finset.card_bij
+      (fun i _ => (⟨i.1, by rw [Multiset.length_toList]; exact i.2⟩ :
+        Fin m.toList.length))
+    · intro i hi
+      simpa using hi
+    · intro i _ j _ hij
+      apply Fin.ext
+      exact congrArg (fun x : Fin m.toList.length => x.1) hij
+    · intro j hj
+      refine ⟨(⟨j.1, by rw [← Multiset.length_toList]; exact j.2⟩ : Fin m.card), ?_, ?_⟩
+      · simpa using hj
+      · rfl
+  calc
+    ((Finset.univ : Finset (Fin m.card)).filter fun i =>
+      p (m.toList.get ⟨i.1, by rw [Multiset.length_toList]; exact i.2⟩)).card
+        = ((Finset.univ : Finset (Fin m.toList.length)).filter fun i =>
+            p (m.toList.get i)).card := hcard
+    _ = m.toList.countP (fun a => decide (p a)) :=
+      card_filter_univ_get_eq_countP_prop m.toList p
+
+private lemma card_filter_univ_get_eq_countP_cast {α : Type*} (l : List α)
+    {n : ℕ} (h : n = l.length) (p : α → Bool) :
+    ((Finset.univ : Finset (Fin n)).filter fun i =>
+      p (l.get ⟨i.1, by simpa [h] using i.2⟩)).card = l.countP p := by
+  subst h
+  simpa using card_filter_univ_get_eq_countP l p
+
+lemma omegaCount_coe_eq_countP {t : ℕ} (l : List (SupportPattern t))
+    (T I : Finset (Fin t)) :
+    omegaCount (l : Multiset (SupportPattern t)) T I =
+      l.countP (frameWitnesses T I) := by
+  let m : Multiset (SupportPattern t) := l
+  have hperm : List.Perm m.toList l := by
+    simpa [m] using
+      (Multiset.coe_eq_coe.mp (Multiset.coe_toList (l : Multiset (SupportPattern t))))
+  calc
+    omegaCount (l : Multiset (SupportPattern t)) T I =
+        m.toList.countP
+          (fun S : SupportPattern t => decide (S.1 ⊆ T ∧ ((S.1 ∩ I).card = 1))) := by
+      unfold omegaCount supportSetAt
+      unfold supportPatternAt
+      change ((Finset.univ : Finset (Fin m.card)).filter fun i =>
+        (m.toList.get ⟨i.1, by rw [Multiset.length_toList]; exact i.2⟩).1 ⊆ T ∧
+          (((m.toList.get
+            ⟨i.1, by rw [Multiset.length_toList]; exact i.2⟩).1 ∩ I).card = 1)).card =
+        m.toList.countP
+          (fun S : SupportPattern t => decide (S.1 ⊆ T ∧ ((S.1 ∩ I).card = 1)))
+      exact card_filter_univ_multiset_toList_eq_countP_prop m
+        (fun S : SupportPattern t => S.1 ⊆ T ∧ ((S.1 ∩ I).card = 1))
+    _ = m.toList.countP (frameWitnesses T I) := by
+      unfold frameWitnesses
+      simp
+    _ = l.countP (frameWitnesses T I) := hperm.countP_eq _
+
+private lemma omegaCount_supportList_eq_countWitnesses (spec : FrameSpec)
+    (T I : Finset (Fin spec.t)) :
+    omegaCount spec.supports T I = spec.countWitnesses T I := by
+  simpa [FrameSpec.supports, FrameSpec.countWitnesses] using
+    (omegaCount_coe_eq_countP spec.supportList T I)
+
+/-- The computable frame checker is equivalent to the abstract frame predicate. -/
+theorem FrameSpec.isValid_iff_isFrame (spec : FrameSpec) :
+    spec.IsValid ↔ IsFrame spec.supports spec.cap := by
+  constructor
+  · intro h T I hIT
+    rw [omegaCount_supportList_eq_countWitnesses spec T I]
+    exact h T I hIT
+  · intro h T I hIT
+    rw [← omegaCount_supportList_eq_countWitnesses spec T I]
+    exact h T I hIT
+
+private def rawInterCount (Imask : Nat) (s : List ℕ) : ℕ :=
+  s.countP fun i => Imask.testBit i
+
+private def rawWitnessAux (Tmask Imask : Nat) : Nat → List ℕ → Bool
+  | acc, [] => decide (acc = 1)
+  | acc, i :: s =>
+      Tmask.testBit i &&
+        rawWitnessAux Tmask Imask (acc + if Imask.testBit i then 1 else 0) s
+
+private def rawWitness (Tmask Imask : Nat) (s : List ℕ) : Bool :=
+  rawWitnessAux Tmask Imask 0 s
+
+private def rawAttachedWitness (spec : FrameSpec) (Tmask Imask : Nat)
+    (x : { s // s ∈ spec.rawSupports }) : Bool :=
+  rawWitness Tmask Imask x.1
+
+private theorem rawAttachedCount_eq_count (spec : FrameSpec) (Tmask Imask : Nat) :
+    spec.rawSupports.attach.countP (rawAttachedWitness spec Tmask Imask) =
+      spec.rawSupports.countP (rawWitness Tmask Imask) := by
+  change spec.rawSupports.attach.countP
+      (fun x : { s // s ∈ spec.rawSupports } => rawWitness Tmask Imask x.1) =
+    spec.rawSupports.countP (rawWitness Tmask Imask)
+  exact List.countP_attach (l := spec.rawSupports) (p := rawWitness Tmask Imask)
+
+private def rawCapSum (spec : FrameSpec) (Tmask Imask : Nat) : ℕ :=
+  (Finset.univ : Finset (Fin spec.t)).sum fun i =>
+    if Tmask.testBit i.1 && !(Imask.testBit i.1) then spec.cap i else 0
+
+/-- Recursively check all masks contributing to the raw frame inequalities. -/
+def checkMasksDown (spec : FrameSpec) : Nat → Nat → Nat → Bool
+  | 0, Tmask, Imask =>
+      decide
+        (spec.rawSupports.countP (rawWitness Tmask Imask) ≤
+          rawCapSum spec Tmask Imask)
+  | n + 1, Tmask, Imask =>
+      let bit := (1 : Nat) <<< n
+      checkMasksDown spec n Tmask Imask &&
+      checkMasksDown spec n (Tmask ||| bit) Imask &&
+      checkMasksDown spec n (Tmask ||| bit) (Imask ||| bit)
+
+/-- A Boolean validator for the raw frame inequalities of a frame specification. -/
+def FrameSpec.rawCheckValid (spec : FrameSpec) : Bool :=
+  checkMasksDown spec spec.t 0 0
+
+private theorem mem_supportPatternOfList_iff {t : ℕ} {s : List ℕ}
+    {hIn : ∀ i ∈ s, i < t} {hNodup : s.Nodup} {hCard : 2 ≤ s.length} {i : Fin t} :
+    i ∈ (supportPatternOfList s hIn hNodup hCard).1 ↔ i.1 ∈ s := by
+  unfold supportPatternOfList
+  constructor
+  · intro hi
+    rw [List.mem_toFinset, List.mem_pmap] at hi
+    rcases hi with ⟨a, ha, hEq⟩
+    have : a = i.1 := by
+      simpa using congrArg Fin.val hEq
+    simpa [this] using ha
+  · intro hi
+    rw [List.mem_toFinset, List.mem_pmap]
+    refine ⟨i.1, hi, ?_⟩
+    apply Fin.ext
+    rfl
+
+private theorem rawCapSum_eq_sum (spec : FrameSpec)
+    (Tmask Imask : Nat) (T I : Finset (Fin spec.t))
+    (hT : ∀ i : Fin spec.t, Tmask.testBit i.1 = decide (i ∈ T))
+    (hI : ∀ i : Fin spec.t, Imask.testBit i.1 = decide (i ∈ I)) :
+    rawCapSum spec Tmask Imask = (T \ I).sum spec.cap := by
+  unfold rawCapSum
+  have hfilter :
+      ((Finset.univ : Finset (Fin spec.t)).filter fun i =>
+          Tmask.testBit i.1 && !(Imask.testBit i.1)) = T \ I := by
+    ext i
+    simp [hT i, hI i]
+  rw [← Finset.sum_filter]
+  rw [hfilter]
+
+private theorem rawInterCount_eq_interCard (spec : FrameSpec)
+    (Imask : Nat) (I : Finset (Fin spec.t))
+    (hI : ∀ i : Fin spec.t, Imask.testBit i.1 = decide (i ∈ I))
+    (x : { s // s ∈ spec.rawSupports }) :
+    rawInterCount Imask x.1 =
+      (((supportPatternOfList x.1
+          (fun i hi => (spec.rawSupports_ok x.1 x.2).2.1 i hi)
+          (spec.rawSupports_ok x.1 x.2).1
+          (spec.rawSupports_ok x.1 x.2).2.2).1 ∩ I).card) := by
+  let hIn : ∀ i ∈ x.1, i < spec.t := fun i hi => (spec.rawSupports_ok x.1 x.2).2.1 i hi
+  let hNodup : x.1.Nodup := (spec.rawSupports_ok x.1 x.2).1
+  let hCard : 2 ≤ x.1.length := (spec.rawSupports_ok x.1 x.2).2.2
+  let finList : List (Fin spec.t) :=
+    x.1.pmap (fun i hi => (⟨i, hi⟩ : Fin spec.t)) hIn
+  have hfinNodup : finList.Nodup := by
+    apply hNodup.pmap
+    intro a ha b hb hEq
+    simpa using congrArg Fin.val hEq
+  have hcount :
+      rawInterCount Imask x.1 = finList.countP (fun j => decide (j ∈ I)) := by
+    unfold rawInterCount finList
+    rw [← List.countP_attach (l := x.1) (p := fun i => Imask.testBit i)]
+    rw [List.countP_pmap]
+    apply List.countP_congr
+    intro y hy
+    rcases y with ⟨a, ha⟩
+    exact Bool.eq_iff_iff.mp (hI ⟨a, hIn a ha⟩)
+  calc
+    rawInterCount Imask x.1 = finList.countP (fun j => decide (j ∈ I)) := hcount
+    _ = (finList.filter fun j => decide (j ∈ I)).length := by
+      rw [List.countP_eq_length_filter]
+    _ = ((finList.toFinset.filter fun j => decide (j ∈ I)).card) := by
+      let filtered := finList.filter fun j => decide (j ∈ I)
+      have hfilteredNodup : filtered.Nodup := hfinNodup.filter _
+      have hfilteredCard : filtered.toFinset.card = filtered.length :=
+        List.toFinset_card_of_nodup (l := filtered) hfilteredNodup
+      simpa [filtered] using hfilteredCard.symm
+    _ = (((supportPatternOfList x.1 hIn hNodup hCard).1 ∩ I).card) := by
+      congr 1
+      ext j
+      simp [supportPatternOfList, finList]
+
+private theorem rawAll_eq_decide_subset (spec : FrameSpec)
+    (Tmask : Nat) (T : Finset (Fin spec.t))
+    (hT : ∀ i : Fin spec.t, Tmask.testBit i.1 = decide (i ∈ T))
+    (x : { s // s ∈ spec.rawSupports }) :
+    x.1.all (fun i => Tmask.testBit i) =
+      decide ((supportPatternOfList x.1
+        (fun i hi => (spec.rawSupports_ok x.1 x.2).2.1 i hi)
+        (spec.rawSupports_ok x.1 x.2).1
+        (spec.rawSupports_ok x.1 x.2).2.2).1 ⊆ T) := by
+  let hIn : ∀ i ∈ x.1, i < spec.t := fun i hi => (spec.rawSupports_ok x.1 x.2).2.1 i hi
+  let hNodup : x.1.Nodup := (spec.rawSupports_ok x.1 x.2).1
+  let hCard : 2 ≤ x.1.length := (spec.rawSupports_ok x.1 x.2).2.2
+  rw [Bool.eq_iff_iff, decide_eq_true_iff]
+  constructor
+  · intro hAll i hi
+    have hiList : i.1 ∈ x.1 :=
+      (mem_supportPatternOfList_iff (hIn := hIn) (hNodup := hNodup) (hCard := hCard)).mp hi
+    have hbit : Tmask.testBit i.1 = true := List.all_eq_true.mp hAll i.1 hiList
+    let i' : Fin spec.t := ⟨i.1, by rw [FrameSpec.t]; exact i.2⟩
+    have hbit' : Tmask.testBit i'.1 = true := by
+      simpa [i'] using hbit
+    have hmem : i' ∈ T := of_decide_eq_true <| by
+      rw [← hT i']
+      exact hbit'
+    change i' ∈ T
+    exact hmem
+  · intro hSub
+    refine List.all_eq_true.mpr ?_
+    intro a ha
+    let i : Fin spec.t := ⟨a, hIn a ha⟩
+    have hi : i ∈ (supportPatternOfList x.1 hIn hNodup hCard).1 :=
+      (mem_supportPatternOfList_iff (hIn := hIn) (hNodup := hNodup) (hCard := hCard)).mpr ha
+    have hmem : i ∈ T := hSub hi
+    have hmem' : decide (i ∈ T) = true := decide_eq_true hmem
+    rw [hT i]
+    exact hmem'
+
+private theorem rawWitnessAux_eq (Tmask Imask : Nat) :
+    ∀ acc s,
+      rawWitnessAux Tmask Imask acc s =
+        (s.all (fun i => Tmask.testBit i) &&
+          decide (acc + rawInterCount Imask s = 1))
+  | acc, [] => by
+      rfl
+  | acc, i :: s => by
+      by_cases hI : Imask.testBit i
+      · simp [rawWitnessAux, rawInterCount, rawWitnessAux_eq Tmask Imask (acc + 1) s, hI,
+          Bool.and_assoc, Nat.add_comm, Nat.add_left_comm]
+      · simp [rawWitnessAux, rawInterCount, rawWitnessAux_eq Tmask Imask acc s, hI,
+          Bool.and_assoc]
+        rfl
+
+private theorem rawWitness_eq_all_and (Tmask Imask : Nat) (s : List ℕ) :
+    rawWitness Tmask Imask s =
+      (s.all (fun i => Tmask.testBit i) && decide (rawInterCount Imask s = 1)) := by
+  simpa [rawWitness] using rawWitnessAux_eq Tmask Imask 0 s
+
+private theorem frameWitness_eq_rawAttachedWitness (spec : FrameSpec)
+    (Tmask Imask : Nat) (T I : Finset (Fin spec.t))
+    (hT : ∀ i : Fin spec.t, Tmask.testBit i.1 = decide (i ∈ T))
+    (hI : ∀ i : Fin spec.t, Imask.testBit i.1 = decide (i ∈ I))
+    (x : { s // s ∈ spec.rawSupports }) :
+    frameWitnesses T I
+      (supportPatternOfList x.1
+        (fun i hi => (spec.rawSupports_ok x.1 x.2).2.1 i hi)
+        (spec.rawSupports_ok x.1 x.2).1
+        (spec.rawSupports_ok x.1 x.2).2.2) =
+      rawAttachedWitness spec Tmask Imask x := by
+  let hIn : ∀ i ∈ x.1, i < spec.t := fun i hi => (spec.rawSupports_ok x.1 x.2).2.1 i hi
+  let hNodup : x.1.Nodup := (spec.rawSupports_ok x.1 x.2).1
+  let hCard : 2 ≤ x.1.length := (spec.rawSupports_ok x.1 x.2).2.2
+  have hsub :
+      x.1.all (fun i => Tmask.testBit i) =
+        decide ((supportPatternOfList x.1 hIn hNodup hCard).1 ⊆ T) :=
+    rawAll_eq_decide_subset spec Tmask T hT x
+  have hpattern :
+      supportPatternOfList x.1
+          (fun i hi => (spec.rawSupports_ok x.1 x.2).2.1 i hi)
+          (spec.rawSupports_ok x.1 x.2).1
+          (spec.rawSupports_ok x.1 x.2).2.2 =
+        supportPatternOfList x.1 hIn hNodup hCard := by
+    apply Subtype.ext
+    ext i
+    constructor
+    · intro hi
+      exact (mem_supportPatternOfList_iff (hIn := hIn) (hNodup := hNodup)
+        (hCard := hCard)).mpr
+        ((mem_supportPatternOfList_iff
+          (hIn := fun i hi => (spec.rawSupports_ok x.1 x.2).2.1 i hi)
+          (hNodup := (spec.rawSupports_ok x.1 x.2).1)
+          (hCard := (spec.rawSupports_ok x.1 x.2).2.2)).mp hi)
+    · intro hi
+      exact (mem_supportPatternOfList_iff
+        (hIn := fun i hi => (spec.rawSupports_ok x.1 x.2).2.1 i hi)
+        (hNodup := (spec.rawSupports_ok x.1 x.2).1)
+        (hCard := (spec.rawSupports_ok x.1 x.2).2.2)).mpr
+        ((mem_supportPatternOfList_iff (hIn := hIn) (hNodup := hNodup)
+          (hCard := hCard)).mp hi)
+  have hcard :
+      decide (rawInterCount Imask x.1 = 1) =
+        decide ((((supportPatternOfList x.1 hIn hNodup hCard).1 ∩ I).card) = 1) := by
+    rw [rawInterCount_eq_interCard spec Imask I hI x]
+    rw [hpattern]
+    rfl
+  unfold frameWitnesses rawAttachedWitness
+  simp [rawWitness_eq_all_and, hsub, hcard]
+
+private theorem countWitnesses_eq_rawAttachedCount (spec : FrameSpec)
+    (Tmask Imask : Nat) (T I : Finset (Fin spec.t))
+    (hT : ∀ i : Fin spec.t, Tmask.testBit i.1 = decide (i ∈ T))
+    (hI : ∀ i : Fin spec.t, Imask.testBit i.1 = decide (i ∈ I)) :
+    spec.countWitnesses T I =
+      spec.rawSupports.attach.countP (rawAttachedWitness spec Tmask Imask) := by
+  unfold FrameSpec.countWitnesses FrameSpec.supportList
+  rw [List.countP_pmap]
+  apply List.countP_congr
+  intro x hx
+  rcases x with ⟨a, m⟩
+  constructor <;> intro h
+  · have hEq :=
+      frameWitness_eq_rawAttachedWitness spec Tmask Imask T I hT hI ⟨a, m⟩
+    simpa [hEq] using h
+  · have hEq :=
+      frameWitness_eq_rawAttachedWitness spec Tmask Imask T I hT hI ⟨a, m⟩
+    simpa [← hEq] using h
+
+private theorem bit_testBit_lt {n i : Nat} (hi : i < n) :
+    (((1 : Nat) <<< n).testBit i) = false := by
+  simp [Nat.testBit_shiftLeft, Nat.not_le.mpr hi]
+
+private theorem bit_testBit_self (n : Nat) :
+    (((1 : Nat) <<< n).testBit n) = true := by
+  simp [Nat.testBit_shiftLeft]
+
+private theorem bit_testBit_gt {n i : Nat} (hi : n < i) :
+    (((1 : Nat) <<< n).testBit i) = false := by
+  have hne : i - n ≠ 0 := by omega
+  have hbit : Nat.testBit 1 (i - n) = false := by
+    by_cases htrue : Nat.testBit 1 (i - n) = true
+    · exfalso
+      exact hne ((Nat.testBit_one_eq_true_iff_self_eq_zero).mp htrue)
+    · cases htest : Nat.testBit 1 (i - n) <;> simp_all
+  rw [Nat.testBit_shiftLeft]
+  simp [Nat.le_of_lt hi, hbit]
+
+private theorem checkMasksDown_sound (spec : FrameSpec) :
+    ∀ n Tmask Imask, n ≤ spec.t →
+      (∀ i < n, Tmask.testBit i = false ∧ Imask.testBit i = false) →
+      checkMasksDown spec n Tmask Imask = true →
+      ∀ T I : Finset (Fin spec.t), I ⊆ T →
+        (∀ i : Fin spec.t, n ≤ i.1 → Tmask.testBit i.1 = decide (i ∈ T)) →
+        (∀ i : Fin spec.t, n ≤ i.1 → Imask.testBit i.1 = decide (i ∈ I)) →
+        spec.countWitnesses T I ≤ (T \ I).sum spec.cap := by
+  intro n
+  induction n with
+  | zero =>
+      intro Tmask Imask hn hzero hcheck T I hIT hTrep hIrep
+      have hleaf :
+          spec.rawSupports.countP (rawWitness Tmask Imask) ≤
+            rawCapSum spec Tmask Imask := by
+        simpa [checkMasksDown] using hcheck
+      have hleaf' :
+          spec.rawSupports.attach.countP (rawAttachedWitness spec Tmask Imask) ≤
+            rawCapSum spec Tmask Imask := by
+        rw [rawAttachedCount_eq_count]
+        exact hleaf
+      have hTall : ∀ i : Fin spec.t, Tmask.testBit i.1 = decide (i ∈ T) := by
+        intro i
+        exact hTrep i (by omega)
+      have hIall : ∀ i : Fin spec.t, Imask.testBit i.1 = decide (i ∈ I) := by
+        intro i
+        exact hIrep i (by omega)
+      calc
+        spec.countWitnesses T I =
+            spec.rawSupports.attach.countP (rawAttachedWitness spec Tmask Imask) := by
+              symm
+              exact (countWitnesses_eq_rawAttachedCount spec Tmask Imask T I hTall hIall).symm
+        _ ≤ rawCapSum spec Tmask Imask := hleaf'
+        _ = (T \ I).sum spec.cap := rawCapSum_eq_sum spec Tmask Imask T I hTall hIall
+  | succ n ih =>
+      intro Tmask Imask hn hzero hcheck T I hIT hTrep hIrep
+      let bit := (1 : Nat) <<< n
+      have hcases :
+          (checkMasksDown spec n Tmask Imask = true ∧
+            checkMasksDown spec n (Tmask ||| bit) Imask = true) ∧
+          checkMasksDown spec n (Tmask ||| bit) (Imask ||| bit) = true := by
+        simpa [checkMasksDown, bit] using hcheck
+      rcases hcases with ⟨⟨h0, h1⟩, h2⟩
+      have hn' : n ≤ spec.t := Nat.le_of_succ_le hn
+      let i0 : Fin spec.t := ⟨n, by omega⟩
+      by_cases hTn : i0 ∈ T
+      · by_cases hIn : i0 ∈ I
+        · apply ih (Tmask ||| bit) (Imask ||| bit) hn'
+          · intro i hi
+            constructor
+            · rw [Nat.testBit_lor,
+                (hzero i (Nat.lt_trans hi (Nat.lt_succ_self n))).1, bit_testBit_lt hi]
+              simp
+            · rw [Nat.testBit_lor,
+                (hzero i (Nat.lt_trans hi (Nat.lt_succ_self n))).2, bit_testBit_lt hi]
+              simp
+          · exact h2
+          · exact hIT
+          · intro j hj
+            by_cases hEq : j.1 = n
+            · have hj0 : j = i0 := by
+                apply Fin.ext
+                simpa using hEq
+              subst hj0
+              rw [Nat.testBit_lor, (hzero n (Nat.lt_succ_self n)).1, bit_testBit_self]
+              simp [hTn]
+            · have hgt : n < j.1 := by omega
+              rw [Nat.testBit_lor, hTrep j (by omega), bit_testBit_gt hgt]
+              simp
+          · intro j hj
+            by_cases hEq : j.1 = n
+            · have hj0 : j = i0 := by
+                apply Fin.ext
+                simpa using hEq
+              subst hj0
+              rw [Nat.testBit_lor, (hzero n (Nat.lt_succ_self n)).2, bit_testBit_self]
+              simp [hIn]
+            · have hgt : n < j.1 := by omega
+              rw [Nat.testBit_lor, hIrep j (by omega), bit_testBit_gt hgt]
+              simp
+        · apply ih (Tmask ||| bit) Imask hn'
+          · intro i hi
+            constructor
+            · rw [Nat.testBit_lor,
+                (hzero i (Nat.lt_trans hi (Nat.lt_succ_self n))).1, bit_testBit_lt hi]
+              simp
+            · exact (hzero i (Nat.lt_trans hi (Nat.lt_succ_self n))).2
+          · exact h1
+          · exact hIT
+          · intro j hj
+            by_cases hEq : j.1 = n
+            · have hj0 : j = i0 := by
+                apply Fin.ext
+                simpa using hEq
+              subst hj0
+              rw [Nat.testBit_lor, (hzero n (Nat.lt_succ_self n)).1, bit_testBit_self]
+              simp [hTn]
+            · have hgt : n < j.1 := by omega
+              rw [Nat.testBit_lor, hTrep j (by omega), bit_testBit_gt hgt]
+              simp
+          · intro j hj
+            by_cases hEq : j.1 = n
+            · have hj0 : j = i0 := by
+                apply Fin.ext
+                simpa using hEq
+              subst hj0
+              have hImask : Imask.testBit n = false := (hzero n (Nat.lt_succ_self n)).2
+              rw [hImask]
+              simp [hIn]
+            · have hgt : n < j.1 := by omega
+              exact hIrep j (by omega)
+      · have hInot : i0 ∉ I := by
+          intro hi
+          exact hTn (hIT hi)
+        apply ih Tmask Imask hn'
+        · intro i hi
+          exact hzero i (Nat.lt_trans hi (Nat.lt_succ_self n))
+        · exact h0
+        · exact hIT
+        · intro j hj
+          by_cases hEq : j.1 = n
+          · have hj0 : j = i0 := by
+              apply Fin.ext
+              simpa using hEq
+            subst hj0
+            have hTmask : Tmask.testBit n = false := (hzero n (Nat.lt_succ_self n)).1
+            rw [hTmask]
+            simp [hTn]
+          · exact hTrep j (by omega)
+        · intro j hj
+          by_cases hEq : j.1 = n
+          · have hj0 : j = i0 := by
+              apply Fin.ext
+              simpa using hEq
+            subst hj0
+            have hImask : Imask.testBit n = false := (hzero n (Nat.lt_succ_self n)).2
+            rw [hImask]
+            simp [hInot]
+          · exact hIrep j (by omega)
+
+theorem FrameSpec.rawCheckValid_sound (spec : FrameSpec)
+    (h : spec.rawCheckValid = true) : spec.IsValid := by
+  intro T I hIT
+  have hzero : ∀ i < spec.t, (0 : Nat).testBit i = false ∧ (0 : Nat).testBit i = false := by
+    intro i hi
+    simp
+  have hTrep : ∀ i : Fin spec.t, spec.t ≤ i.1 → (0 : Nat).testBit i.1 = decide (i ∈ T) := by
+    intro i hi
+    exact (False.elim (Nat.not_le_of_lt i.2 hi))
+  have hIrep : ∀ i : Fin spec.t, spec.t ≤ i.1 → (0 : Nat).testBit i.1 = decide (i ∈ I) := by
+    intro i hi
+    exact (False.elim (Nat.not_le_of_lt i.2 hi))
+  exact checkMasksDown_sound spec spec.t 0 0 le_rfl hzero
+    (by simpa [FrameSpec.rawCheckValid] using h) T I hIT hTrep hIrep
+
+theorem checkMasksDown_step_true (spec : FrameSpec) (n Tmask Imask : Nat)
+    (h0 : checkMasksDown spec n Tmask Imask = true)
+    (h1 : checkMasksDown spec n (Tmask ||| ((1 : Nat) <<< n)) Imask = true)
+    (h2 : checkMasksDown spec n (Tmask ||| ((1 : Nat) <<< n))
+      (Imask ||| ((1 : Nat) <<< n)) = true) :
+    checkMasksDown spec (n + 1) Tmask Imask = true := by
+  simp [checkMasksDown, h0, h1, h2]
+
+/-- A computable checker for the frame inequalities attached to a finite specification. -/
+def FrameSpec.checkValid (spec : FrameSpec) : Bool :=
+  decide spec.IsValid
+
+private lemma all_checkValid_eq_true_iff (bank : List FrameSpec) :
+    bank.all FrameSpec.checkValid = true ↔ ∀ spec ∈ bank, spec.IsValid := by
+  induction bank with
+  | nil =>
+      simp
+  | cons spec bank ih =>
+      simp [FrameSpec.checkValid, ih]
+
+
+end HypergraphLowerBound

--- a/LeanPool/FrontierMathOpenHypergraphs/Uniform/FrameExact.lean
+++ b/LeanPool/FrontierMathOpenHypergraphs/Uniform/FrameExact.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 Dean Cureton. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dean Cureton
+-/
+
+import LeanPool.FrontierMathOpenHypergraphs.Uniform.FrameDefs
+
+/-!
+# Exact small-frame validations
+-/
+
+namespace HypergraphLowerBound
+
+private theorem exactSmallFrame_0_valid :
+    (exactSmallFrames.get ⟨0, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨0, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_1_valid :
+    (exactSmallFrames.get ⟨1, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨1, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_2_valid :
+    (exactSmallFrames.get ⟨2, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨2, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_3_valid :
+    (exactSmallFrames.get ⟨3, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨3, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_4_valid :
+    (exactSmallFrames.get ⟨4, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨4, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_5_valid :
+    (exactSmallFrames.get ⟨5, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨5, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_6_valid :
+    (exactSmallFrames.get ⟨6, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨6, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_7_valid :
+    (exactSmallFrames.get ⟨7, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨7, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_8_valid :
+    (exactSmallFrames.get ⟨8, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨8, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_9_valid :
+    (exactSmallFrames.get ⟨9, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨9, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_10_valid :
+    (exactSmallFrames.get ⟨10, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨10, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_11_valid :
+    (exactSmallFrames.get ⟨11, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨11, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_12_valid :
+    (exactSmallFrames.get ⟨12, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨12, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_13_valid :
+    (exactSmallFrames.get ⟨13, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨13, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_14_valid :
+    (exactSmallFrames.get ⟨14, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨14, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_15_valid :
+    (exactSmallFrames.get ⟨15, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨15, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_16_valid :
+    (exactSmallFrames.get ⟨16, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨16, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_17_valid :
+    (exactSmallFrames.get ⟨17, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨17, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_18_valid :
+    (exactSmallFrames.get ⟨18, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨18, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_19_valid :
+    (exactSmallFrames.get ⟨19, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨19, by decide⟩).rawCheckValid_sound rfl
+
+private theorem exactSmallFrame_20_valid :
+    (exactSmallFrames.get ⟨20, by decide⟩).IsValid := by
+  exact (exactSmallFrames.get ⟨20, by decide⟩).rawCheckValid_sound rfl
+
+theorem exactSmallFrames_valid :
+    ∀ spec ∈ exactSmallFrames, spec.IsValid := by
+  intro spec hs
+  obtain ⟨i, rfl⟩ := List.get_of_mem hs
+  fin_cases i
+  · exact exactSmallFrame_0_valid
+  · exact exactSmallFrame_1_valid
+  · exact exactSmallFrame_2_valid
+  · exact exactSmallFrame_3_valid
+  · exact exactSmallFrame_4_valid
+  · exact exactSmallFrame_5_valid
+  · exact exactSmallFrame_6_valid
+  · exact exactSmallFrame_7_valid
+  · exact exactSmallFrame_8_valid
+  · exact exactSmallFrame_9_valid
+  · exact exactSmallFrame_10_valid
+  · exact exactSmallFrame_11_valid
+  · exact exactSmallFrame_12_valid
+  · exact exactSmallFrame_13_valid
+  · exact exactSmallFrame_14_valid
+  · exact exactSmallFrame_15_valid
+  · exact exactSmallFrame_16_valid
+  · exact exactSmallFrame_17_valid
+  · exact exactSmallFrame_18_valid
+  · exact exactSmallFrame_19_valid
+  · exact exactSmallFrame_20_valid
+
+end HypergraphLowerBound

--- a/LeanPool/FrontierMathOpenHypergraphs/Uniform/FrameResidues.lean
+++ b/LeanPool/FrontierMathOpenHypergraphs/Uniform/FrameResidues.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2026 Dean Cureton. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dean Cureton
+-/
+
+import LeanPool.FrontierMathOpenHypergraphs.Uniform.FrameDefs
+
+/-!
+# Residue-gadget validations
+-/
+
+namespace HypergraphLowerBound
+
+private theorem residueGadget_0_valid :
+    (residueGadgets.get ⟨0, by decide⟩).IsValid := by
+  exact (residueGadgets.get ⟨0, by decide⟩).rawCheckValid_sound rfl
+
+private theorem residueGadget_1_valid :
+    (residueGadgets.get ⟨1, by decide⟩).IsValid := by
+  exact (residueGadgets.get ⟨1, by decide⟩).rawCheckValid_sound rfl
+
+private theorem residueGadget_2_valid :
+    (residueGadgets.get ⟨2, by decide⟩).IsValid := by
+  exact (residueGadgets.get ⟨2, by decide⟩).rawCheckValid_sound rfl
+
+private theorem residueGadget_3_valid :
+    (residueGadgets.get ⟨3, by decide⟩).IsValid := by
+  exact (residueGadgets.get ⟨3, by decide⟩).rawCheckValid_sound rfl
+
+private theorem residueGadget_4_valid :
+    (residueGadgets.get ⟨4, by decide⟩).IsValid := by
+  exact (residueGadgets.get ⟨4, by decide⟩).rawCheckValid_sound rfl
+
+private theorem residueGadget_5_valid :
+    (residueGadgets.get ⟨5, by decide⟩).IsValid := by
+  exact (residueGadgets.get ⟨5, by decide⟩).rawCheckValid_sound rfl
+
+private theorem residueGadget_6_valid :
+    (residueGadgets.get ⟨6, by decide⟩).IsValid := by
+  exact (residueGadgets.get ⟨6, by decide⟩).rawCheckValid_sound rfl
+
+private theorem residueGadget_7_valid :
+    (residueGadgets.get ⟨7, by decide⟩).IsValid := by
+  exact (residueGadgets.get ⟨7, by decide⟩).rawCheckValid_sound rfl
+
+private theorem residueGadget_8_valid :
+    (residueGadgets.get ⟨8, by decide⟩).IsValid := by
+  exact (residueGadgets.get ⟨8, by decide⟩).rawCheckValid_sound rfl
+
+private theorem residueGadget_9_valid :
+    (residueGadgets.get ⟨9, by decide⟩).IsValid := by
+  exact (residueGadgets.get ⟨9, by decide⟩).rawCheckValid_sound rfl
+
+private theorem residueGadget_10_valid :
+    (residueGadgets.get ⟨10, by decide⟩).IsValid := by
+  exact (residueGadgets.get ⟨10, by decide⟩).rawCheckValid_sound rfl
+
+private theorem residueGadget_11_valid :
+    (residueGadgets.get ⟨11, by decide⟩).IsValid := by
+  exact (residueGadgets.get ⟨11, by decide⟩).rawCheckValid_sound rfl
+
+theorem residueGadgets_valid :
+    ∀ spec ∈ residueGadgets, spec.IsValid := by
+  intro spec hs
+  obtain ⟨i, rfl⟩ := List.get_of_mem hs
+  fin_cases i
+  · exact residueGadget_0_valid
+  · exact residueGadget_1_valid
+  · exact residueGadget_2_valid
+  · exact residueGadget_3_valid
+  · exact residueGadget_4_valid
+  · exact residueGadget_5_valid
+  · exact residueGadget_6_valid
+  · exact residueGadget_7_valid
+  · exact residueGadget_8_valid
+  · exact residueGadget_9_valid
+  · exact residueGadget_10_valid
+  · exact residueGadget_11_valid
+
+
+end HypergraphLowerBound

--- a/LeanPool/FrontierMathOpenHypergraphs/Uniform/Frames.lean
+++ b/LeanPool/FrontierMathOpenHypergraphs/Uniform/Frames.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2026 Dean Cureton. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dean Cureton
+-/
+
+import LeanPool.FrontierMathOpenHypergraphs.Uniform.FrameExact
+import LeanPool.FrontierMathOpenHypergraphs.Uniform.FrameBoosters
+import LeanPool.FrontierMathOpenHypergraphs.Uniform.FrameResidues
+
+/-!
+# Finite frame bank
+-/
+
+namespace HypergraphLowerBound
+
+/-- Every exact small frame, booster, and residue gadget listed in the appendices
+    satisfies the stated frame inequalities. -/
+theorem finite_bank_valid :
+    (∀ spec ∈ exactSmallFrames, spec.IsValid) ∧
+    (∀ spec ∈ boosters, spec.IsValid) ∧
+    (∀ spec ∈ residueGadgets, spec.IsValid) := by
+  exact ⟨exactSmallFrames_valid, boosters_valid, residueGadgets_valid⟩
+
+end HypergraphLowerBound

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -3001,3 +3001,47 @@ projects:
       - commuting-probability
     msc:
       - "20P05"
+  - slug: frontiermath-open-hypergraphs
+    title: FrontierMath Ramsey Hypergraphs
+    summary: Formalizes lower bounds for the Brian-Larson hypergraph extremal function H(n), including a uniform 26/25 improvement over the recursive benchmark k_n for n ≥ 15 and a Lubell-frame asymptotic lower bound.
+    branch: combinatorics
+    entry_module: LeanPool.FrontierMathOpenHypergraphs
+    authors:
+      - Dean Cureton
+    source:
+      title: Choosing between incompatible ideals
+      authors:
+        - Will Brian
+        - Paul B. Larson
+      doi: "10.1016/j.ejc.2021.103349"
+      arxiv: "1908.10914"
+      github_repo: math-inc/FrontierMathOpen-Hypergraphs
+    status: verified
+    main_declarations:
+      - HypergraphLowerBound.thm_main_H_lower_bound
+    main_results:
+      - declaration: HypergraphLowerBound.thm_main_H_lower_bound
+        informal: Proves H(n) ≥ 26 * k(n) / 25 for every n ≥ 15.
+        source_ref: "Epoch AI FrontierMath, A Ramsey-style Problem on Hypergraphs."
+      - declaration: HypergraphLowerBound.uniform_26_25
+        informal: Proves the uniform recursive construction bound A(n) ≥ 26 * k(n) / 25 for every n ≥ 15.
+      - declaration: HypergraphLowerBound.frame_recurrence
+        informal: The substitution-frame recurrence that combines block witnesses and a valid support frame into a larger witness.
+      - declaration: HypergraphLowerBound.lubell_is_frame
+        informal: Proves that the Lubell support family forms a valid frame for every arity t ≥ 2.
+      - declaration: HypergraphLowerBound.fixed_t_bound
+        informal: Derives a fixed-t lower bound for the exact witness supremum from Lubell frames.
+      - declaration: HypergraphLowerBound.asymptotic_lower_bound
+        informal: Proves the asymptotic lower bound liminf H(n) / k(n) ≥ 2 * log 2.
+      - declaration: HypergraphLowerBound.thm_asymptotic
+        informal: States the asymptotic consequence in terms of H(n) divided by n log n.
+    tags:
+      - combinatorics
+      - hypergraphs
+      - ramsey-theory
+      - extremal-combinatorics
+      - frontiermath
+    msc:
+      - "05C65"
+      - "05D10"
+      - "03E02"


### PR DESCRIPTION
Imports [math-inc/FrontierMathOpen-Hypergraphs](https://github.com/math-inc/FrontierMathOpen-Hypergraphs) (Apache-2.0), ported from Lean **v4.28.0 → v4.32.0-rc1** (a 4-version API jump).

**Result.** Lower bounds for the extremal hypergraph Ramsey function `H(n)` — a FrontierMath open problem: the `26/25` uniform bound and the Lubell asymptotic `liminf H(n)/k(n) ≥ 2 ln 2`.

**Main declaration:** `HypergraphLowerBound.thm_main_H_lower_bound`

`sorry`-free; axioms ⊆ `{propext, Classical.choice, Quot.sound}`. All upstream statements preserved — the only name changes are `snake_case`→`camelCase` def renames forced by the naming linter (`I_of`→`iOf`, `T_of`→`tOf`, `omega_count`→`omegaCount`, …), verified by per-declaration name diff to drop **nothing**. Local `lake build` / `runLinter` / `lint-style` / quality all pass with zero warnings; collision-free by fully-qualified name. Mathlib-only (`checkdecls` is a dev tool, not imported by the library).

🤖 Generated with [Claude Code](https://claude.com/claude-code)