### PR TITLE
Import godel-loeb formalization

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -808,6 +808,15 @@ import LeanPool.FrontierMathOpenHypergraphs.Uniform.FrameExact
 import LeanPool.FrontierMathOpenHypergraphs.Uniform.FrameResidues
 import LeanPool.FrontierMathOpenHypergraphs.Uniform.Frames
 import LeanPool.FundamentalInequality
+import LeanPool.GodelLoeb.Diagonal
+import LeanPool.GodelLoeb.Incompleteness
+import LeanPool.GodelLoeb.Loeb
+import LeanPool.GodelLoeb.Modal.Kripke
+import LeanPool.GodelLoeb.Modal.Soundness
+import LeanPool.GodelLoeb.ModalFormula
+import LeanPool.GodelLoeb.Provable
+import LeanPool.GodelLoeb.Substitution
+import LeanPool.GodelLoeb.Worked
 import LeanPool.GrothendieckVanishing
 import LeanPool.GrothendieckVanishing.ClosedImmersion
 import LeanPool.GrothendieckVanishing.ClosedImmersionCohomology

--- a/LeanPool/GodelLoeb/Diagonal.lean
+++ b/LeanPool/GodelLoeb/Diagonal.lean
@@ -1,0 +1,213 @@
+/-
+Copyright (c) 2026 Adam Benenson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adam Benenson
+-/
+import LeanPool.GodelLoeb.Provable
+import LeanPool.GodelLoeb.Substitution
+
+/-!
+# Kreisel diagonal interface
+
+This file states the non-vacuous diagonal ingredient used by the
+modal-axiomatic Loeb theorem. The interface is restricted to the
+Kreisel family `x ↦ []x -> phi`, which is the family needed for Loeb's
+theorem.
+
+The canonical instance in this file is not an arithmetic-realisation
+diagonal lemma. It packages consequences of the modal-axiomatic
+`ModalFormula.kreiselFixed` postulate: the template recogniser in
+`Substitution.code` emits the primitive, and the propositional proofs unfold
+the primitive's `propEval` clause. A Solovay/PA substrate would derive this
+interface from syntactic Godel coding rather than consuming `kreiselFixed`.
+-/
+
+namespace ModalLogic.GoedelLoeb
+
+open ModalFormula
+
+universe u
+
+/-- The Kreisel operator whose fixed point drives Loeb's theorem. -/
+def kreiselOperator {α : Type u} (phi x : ModalFormula α) : ModalFormula α :=
+  □ₛx ⟶ phi
+
+/--
+Structural evidence that a fixed-point operator is built by the
+one-hole self-substitution construction.
+-/
+structure FixedpointStructuralEvidence (α : Type u) [DecidableEq α]
+    (fixedpoint : ModalFormula α → ModalFormula α) (distinguishedAtom : α) where
+  template : ModalFormula α → ModalFormula α
+  fixedpoint_eq_subst :
+    ∀ phi, fixedpoint phi =
+      Substitution.subst distinguishedAtom (template phi) (Substitution.code (template phi))
+  subst_unfolding :
+    ∀ phi, (Substitution.subst distinguishedAtom (template phi)
+      (Substitution.code (template phi)) ⟷
+        (□ₛ(Substitution.code (template phi)) ⟶ phi)).PropTaut
+  box_code_fixedpoint :
+    ∀ phi, (□ₛ(Substitution.code (template phi)) ⟷ □ₛ(fixedpoint phi)).PropTaut
+
+namespace ModalFormula
+
+/--
+Structural evidence propositionally unfolds a fixed point.
+
+This is the substitution side of the construction. It does not by itself
+derive the Kreisel diagonal equivalence; the canonical diagonal theorem still
+passes through the `kreiselFixed` postulate when the template recogniser emits
+that primitive.
+-/
+lemma fixedpoint_structural_prop_taut {α : Type u} [DecidableEq α]
+    (fixedpoint : ModalFormula α → ModalFormula α) (distinguishedAtom : α)
+    (phi : ModalFormula α)
+    (h : FixedpointStructuralEvidence α fixedpoint distinguishedAtom) :
+    (fixedpoint phi ⟷ (□ₛ(Substitution.code (h.template phi)) ⟶ phi)).PropTaut := by
+  intro val
+  have hUnfold := h.subst_unfolding phi val
+  constructor
+  · intro hFixed
+    have hSubstEval :
+        propEval val (Substitution.subst distinguishedAtom (h.template phi)
+          (Substitution.code (h.template phi))) := by
+      rw [← h.fixedpoint_eq_subst phi]
+      exact hFixed
+    exact hUnfold.mp hSubstEval
+  · intro hUnfolded
+    have hSubstEval :
+        propEval val (Substitution.subst distinguishedAtom (h.template phi)
+          (Substitution.code (h.template phi))) :=
+      hUnfold.mpr hUnfolded
+    rw [h.fixedpoint_eq_subst phi]
+    exact hSubstEval
+
+/-- The canonical substitution construction carries structural evidence. -/
+def canonicalFixedpointStructural {α : Type u} [DecidableEq α] (a : α) :
+    FixedpointStructuralEvidence α (Substitution.fixedpoint a) a where
+  template := Substitution.diagonalTemplate a
+  fixedpoint_eq_subst := fixedpoint_eq_subst_template a
+  subst_unfolding := subst_diagonalTemplate_self_prop_taut a
+  box_code_fixedpoint := box_code_diagonalTemplate_prop_taut a
+
+/--
+The canonical structural unfolding is a propositional tautology before the
+postulate-backed bridge from boxed template code to the Kreisel unfolding.
+-/
+lemma canonical_fixedpoint_structural_prop_taut {α : Type u} [DecidableEq α]
+    (a : α) (phi : ModalFormula α) :
+    (Substitution.fixedpoint a phi ⟷
+      (□ₛ(Substitution.code (Substitution.diagonalTemplate a phi)) ⟶
+        phi)).PropTaut := by
+  simpa [canonicalFixedpointStructural] using
+    fixedpoint_structural_prop_taut (Substitution.fixedpoint a) a phi
+      (canonicalFixedpointStructural a)
+
+/--
+The raw Kreisel fixed-point shape is a propositional consequence of the
+`kreiselFixed` postulate.
+-/
+lemma raw_kreisel_diagonal_prop_taut {α : Type u} [DecidableEq α]
+    (a : α) (phi : ModalFormula α) :
+    (Substitution.fixedpoint a phi ⟷
+      kreiselOperator phi (Substitution.fixedpoint a phi)).PropTaut := by
+  intro val
+  have hStructural := canonical_fixedpoint_structural_prop_taut a phi val
+  have hBox := box_code_diagonalTemplate_prop_taut a phi val
+  constructor
+  · intro hFixed hBoxFixed
+    exact hStructural.mp hFixed (hBox.mpr hBoxFixed)
+  · intro hKreisel
+    exact hStructural.mpr fun hBoxCode => hKreisel (hBox.mp hBoxCode)
+
+/--
+Derives the diagonal iff for the `Diagonalisable α` typeclass via the
+`kreiselFixed` constructor's `propEval` clause and the `code` pattern-match.
+
+The derivation consumes the modal-axiomatic postulate at the substrate level;
+consumers of `Diagonalisable α` may treat the iff as derived from K4 plus the
+`kreiselFixed` postulate. An arithmetic-realisation substrate would derive
+this without the `kreiselFixed` primitive.
+-/
+theorem canonicalDiagonalPostulateConsequence {α : Type u} [DecidableEq α]
+    (a : α) (phi : ModalFormula α) :
+    Provable (Substitution.fixedpoint a phi ⟷
+      kreiselOperator phi (Substitution.fixedpoint a phi)) := by
+  let template := Substitution.diagonalTemplate a phi
+  have hStructural :
+      Provable (Substitution.fixedpoint a phi ⟷
+        (□ₛ(Substitution.code template) ⟶ phi)) := by
+    dsimp [template]
+    exact Provable.of_prop_taut (canonical_fixedpoint_structural_prop_taut a phi)
+  have hCodeTemplate :
+      Provable (□ₛ(Substitution.code template) ⟷ □ₛ(Substitution.fixedpoint a phi)) := by
+    dsimp [template]
+    exact Provable.box_code_fixedpoint_iff a phi
+  have hImpBridge :
+      Provable (((□ₛ(Substitution.code template)) ⟶ phi) ⟷
+        ((□ₛ(Substitution.fixedpoint a phi)) ⟶ phi)) :=
+    Provable.imp_congr hCodeTemplate (Provable.iff_intro (Provable.imp_refl phi)
+      (Provable.imp_refl phi))
+  have hForward :
+      Provable (Substitution.fixedpoint a phi ⟶
+        ((□ₛ(Substitution.fixedpoint a phi)) ⟶ phi)) :=
+    Provable.imp_trans (Provable.iff_left hStructural) (Provable.iff_left hImpBridge)
+  have hBackward :
+      Provable (((□ₛ(Substitution.fixedpoint a phi)) ⟶ phi) ⟶
+        Substitution.fixedpoint a phi) :=
+    Provable.imp_trans (Provable.iff_right hImpBridge) (Provable.iff_right hStructural)
+  exact Provable.iff_intro hForward hBackward
+
+end ModalFormula
+
+/--
+Non-vacuous diagonal data for the Kreisel fixed-point family.
+
+The bundle separates the diagonal equivalence from the structural evidence
+that the fixed point is built by self-substitution. The bundle itself is not a
+discharge: an instance must supply the diagonal field, and the canonical
+instance supplies it via `canonicalDiagonalPostulateConsequence`.
+-/
+class Diagonalisable (α : Type u) [DecidableEq α] where
+  /-- The atom marking the diagonal substitution slot. -/
+  distinguishedAtom : α
+  /-- Fixed point for the target formula `phi`. -/
+  fixedpoint : ModalFormula α → ModalFormula α
+  /-- The fixed point proves equivalent to its Kreisel unfolding. -/
+  diagonal (phi : ModalFormula α) :
+    Provable (fixedpoint phi ⟷ kreiselOperator phi (fixedpoint phi))
+  /-- The fixed-point operator is backed by self-substitution structure. -/
+  fixedpoint_structural :
+    FixedpointStructuralEvidence α fixedpoint distinguishedAtom
+
+namespace Diagonalisable
+
+/-- The diagonal equivalence as a theorem alias. -/
+lemma spec {α : Type u} [DecidableEq α] [Diagonalisable α] (phi : ModalFormula α) :
+    Provable (Diagonalisable.fixedpoint phi ⟷
+      kreiselOperator phi (Diagonalisable.fixedpoint phi)) :=
+  Diagonalisable.diagonal phi
+
+/-- The fixed-point operator carries structural evidence. -/
+abbrev structural {α : Type u} [DecidableEq α] [Diagonalisable α] :
+    FixedpointStructuralEvidence α Diagonalisable.fixedpoint
+      Diagonalisable.distinguishedAtom :=
+  Diagonalisable.fixedpoint_structural
+
+end Diagonalisable
+
+/--
+Concrete modal-axiomatic diagonal instance.
+
+The `diagonal` field is the named consequence of the `kreiselFixed` postulate;
+the structural field records the canonical substitution shape consumed by
+Loeb's theorem.
+-/
+instance canonicalDiagonalisable (α : Type u) [DecidableEq α] [Inhabited α] :
+    Diagonalisable α where
+  distinguishedAtom := default
+  fixedpoint := Substitution.fixedpoint default
+  diagonal := ModalFormula.canonicalDiagonalPostulateConsequence default
+  fixedpoint_structural := ModalFormula.canonicalFixedpointStructural default
+
+end ModalLogic.GoedelLoeb

--- a/LeanPool/GodelLoeb/Diagonal.lean
+++ b/LeanPool/GodelLoeb/Diagonal.lean
@@ -38,14 +38,18 @@ one-hole self-substitution construction.
 -/
 structure FixedpointStructuralEvidence (α : Type u) [DecidableEq α]
     (fixedpoint : ModalFormula α → ModalFormula α) (distinguishedAtom : α) where
+  /-- The one-hole template whose self-substitution builds the fixed point. -/
   template : ModalFormula α → ModalFormula α
+  /-- The packaged fixed point is the template with its own code substituted in. -/
   fixedpoint_eq_subst :
     ∀ phi, fixedpoint phi =
       Substitution.subst distinguishedAtom (template phi) (Substitution.code (template phi))
+  /-- The self-substituted template propositionally unfolds to the boxed-code implication. -/
   subst_unfolding :
     ∀ phi, (Substitution.subst distinguishedAtom (template phi)
       (Substitution.code (template phi)) ⟷
         (□ₛ(Substitution.code (template phi)) ⟶ phi)).PropTaut
+  /-- The boxed template code is propositionally equivalent to the boxed fixed point. -/
   box_code_fixedpoint :
     ∀ phi, (□ₛ(Substitution.code (template phi)) ⟷ □ₛ(fixedpoint phi)).PropTaut
 
@@ -177,7 +181,7 @@ class Diagonalisable (α : Type u) [DecidableEq α] where
   diagonal (phi : ModalFormula α) :
     Provable (fixedpoint phi ⟷ kreiselOperator phi (fixedpoint phi))
   /-- The fixed-point operator is backed by self-substitution structure. -/
-  fixedpoint_structural :
+  fixedpointStructural :
     FixedpointStructuralEvidence α fixedpoint distinguishedAtom
 
 namespace Diagonalisable
@@ -192,7 +196,7 @@ lemma spec {α : Type u} [DecidableEq α] [Diagonalisable α] (phi : ModalFormul
 abbrev structural {α : Type u} [DecidableEq α] [Diagonalisable α] :
     FixedpointStructuralEvidence α Diagonalisable.fixedpoint
       Diagonalisable.distinguishedAtom :=
-  Diagonalisable.fixedpoint_structural
+  Diagonalisable.fixedpointStructural
 
 end Diagonalisable
 
@@ -208,6 +212,6 @@ instance canonicalDiagonalisable (α : Type u) [DecidableEq α] [Inhabited α] :
   distinguishedAtom := default
   fixedpoint := Substitution.fixedpoint default
   diagonal := ModalFormula.canonicalDiagonalPostulateConsequence default
-  fixedpoint_structural := ModalFormula.canonicalFixedpointStructural default
+  fixedpointStructural := ModalFormula.canonicalFixedpointStructural default
 
 end ModalLogic.GoedelLoeb

--- a/LeanPool/GodelLoeb/Incompleteness.lean
+++ b/LeanPool/GodelLoeb/Incompleteness.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2026 Adam Benenson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adam Benenson
+-/
+import LeanPool.GodelLoeb.Loeb
+
+/-!
+# Modal second incompleteness
+
+This file derives the modal-axiomatic second incompleteness corollary
+from Loeb's theorem. A consistent modal substrate cannot prove its own
+modal consistency sentence `[]⊥ -> ⊥`.
+-/
+
+namespace ModalLogic.GoedelLoeb
+
+open ModalFormula
+
+universe u
+
+/-- Consistency of the polymorphic modal substrate. -/
+class Consistent (α : Type u) where
+  not_bot : ¬ Provable (⊥ₛ : ModalFormula α)
+
+/-- The modal consistency sentence. -/
+def modalConsistencySentence {α : Type u} : ModalFormula α :=
+  □ₛ⊥ₛ ⟶ ⊥ₛ
+
+/-- Modal Goedel second incompleteness as a corollary of Loeb's theorem. -/
+theorem secondIncompleteness {α : Type u} [DecidableEq α] [Diagonalisable α]
+    [Consistent α] : ¬ Provable (modalConsistencySentence : ModalFormula α) := by
+  intro h
+  exact Consistent.not_bot (loeb h)
+
+/-- The canonical proof predicate is consistent in the empty-frame witness. -/
+instance canonicalConsistent (α : Type u) : Consistent α where
+  not_bot := Provable.not_bot
+
+end ModalLogic.GoedelLoeb

--- a/LeanPool/GodelLoeb/Loeb.lean
+++ b/LeanPool/GodelLoeb/Loeb.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 Adam Benenson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adam Benenson
+-/
+import LeanPool.GodelLoeb.Diagonal
+
+/-!
+# Modal-axiomatic Loeb theorem
+
+This file derives Loeb's theorem in the K4 substrate and the
+non-vacuous Kreisel diagonal interface.
+-/
+
+namespace ModalLogic.GoedelLoeb
+
+open ModalFormula
+
+universe u
+
+/-- Loeb's theorem in the modal-axiomatic K4 substrate. -/
+theorem loeb {α : Type u} [DecidableEq α] [Diagonalisable α] {phi : ModalFormula α}
+    (h : Provable (□ₛphi ⟶ phi)) : Provable phi := by
+  let psi := Diagonalisable.fixedpoint phi
+  let hStructuralEvidence := Diagonalisable.structural (α := α)
+  have hStructural :
+      Provable (psi ⟷ (□ₛ(Substitution.code (hStructuralEvidence.template phi)) ⟶
+        phi)) := by
+    dsimp [psi, hStructuralEvidence]
+    exact Provable.of_prop_taut
+      (ModalFormula.fixedpoint_structural_prop_taut Diagonalisable.fixedpoint
+        Diagonalisable.distinguishedAtom phi Diagonalisable.structural)
+  have hCodeTemplate :
+      Provable (□ₛ(Substitution.code (hStructuralEvidence.template phi)) ⟷ □ₛpsi) := by
+    dsimp [psi, hStructuralEvidence]
+    exact Provable.of_prop_taut (Diagonalisable.structural.box_code_fixedpoint phi)
+  have hImpBridge :
+      Provable (((□ₛ(Substitution.code (hStructuralEvidence.template phi))) ⟶ phi) ⟷
+        (□ₛpsi ⟶ phi)) :=
+    Provable.imp_congr hCodeTemplate (Provable.iff_intro (Provable.imp_refl phi)
+      (Provable.imp_refl phi))
+  have hForward : Provable (psi ⟶ (□ₛpsi ⟶ phi)) :=
+    Provable.imp_trans (Provable.iff_left hStructural) (Provable.iff_left hImpBridge)
+  have hBackward : Provable ((□ₛpsi ⟶ phi) ⟶ psi) :=
+    Provable.imp_trans (Provable.iff_right hImpBridge) (Provable.iff_right hStructural)
+  have hDiag : Provable (psi ⟷ (□ₛpsi ⟶ phi)) := by
+    exact Provable.iff_intro hForward hBackward
+  have hUnfold : Provable (psi ⟶ (□ₛpsi ⟶ phi)) :=
+    Provable.iff_left hDiag
+  have hBoxUnfold : Provable (□ₛ(psi ⟶ (□ₛpsi ⟶ phi))) :=
+    Provable.nec hUnfold
+  have hD2Unfold :
+      Provable (□ₛ(psi ⟶ (□ₛpsi ⟶ phi)) ⟶
+        (□ₛpsi ⟶ □ₛ(□ₛpsi ⟶ phi))) :=
+    Provable.k psi (□ₛpsi ⟶ phi)
+  have hBoxImp : Provable (□ₛpsi ⟶ □ₛ(□ₛpsi ⟶ phi)) :=
+    Provable.mp hD2Unfold hBoxUnfold
+  have hD2Target :
+      Provable (□ₛ(□ₛpsi ⟶ phi) ⟶ (□ₛ□ₛpsi ⟶ □ₛphi)) :=
+    Provable.k (□ₛpsi) phi
+  have hD3Psi : Provable (□ₛpsi ⟶ □ₛ□ₛpsi) :=
+    Provable.four psi
+  have hBoxToBoxTarget : Provable (□ₛpsi ⟶ □ₛphi) :=
+    Provable.imp_box_combine hBoxImp hD3Psi hD2Target
+  have hBoxToTarget : Provable (□ₛpsi ⟶ phi) :=
+    Provable.imp_trans hBoxToBoxTarget h
+  have hFold : Provable ((□ₛpsi ⟶ phi) ⟶ psi) :=
+    Provable.iff_right hDiag
+  have hPsi : Provable psi :=
+    Provable.mp hFold hBoxToTarget
+  have hBoxPsi : Provable (□ₛpsi) :=
+    Provable.nec hPsi
+  exact Provable.mp hBoxToTarget hBoxPsi
+
+end ModalLogic.GoedelLoeb

--- a/LeanPool/GodelLoeb/Modal/Kripke.lean
+++ b/LeanPool/GodelLoeb/Modal/Kripke.lean
@@ -1,0 +1,150 @@
+/-
+Copyright (c) 2026 Adam Benenson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adam Benenson
+-/
+import LeanPool.GodelLoeb.Provable
+
+/-!
+# Kripke frames and the basic modal axioms
+
+This file develops elementary Kripke-frame semantics for normal modal
+logic and the project-level forcing bridge for polymorphic modal
+formulas.
+
+The `kreiselFixed` clause in `Forces` is intentionally an identity on the
+inner formula, just like `quote`. The diagonal content of the modal-axiomatic
+postulate is not derived by that clause; for formulas using `kreiselFixed`, the
+semantic load is carried by the explicit `PropTautSound` assumption used by
+`provable_forces`. An arithmetic-realisation substrate would replace that
+assumption with a concrete frame or arithmetic soundness theorem.
+-/
+
+namespace ModalLogic.GoedelLoeb
+
+universe u w
+
+/-- A Kripke frame is a type of worlds equipped with accessibility. -/
+structure KripkeFrame where
+  /-- The type of possible worlds. -/
+  World : Type w
+  /-- The accessibility relation between worlds. -/
+  accessible : World → World → Prop
+
+namespace KripkeFrame
+
+variable (F : KripkeFrame)
+
+/-- Necessity at a world. -/
+def necessarily (P : F.World → Prop) (w : F.World) : Prop :=
+  ∀ v, F.accessible w v → P v
+
+/-- Possibility at a world. -/
+def possibly (P : F.World → Prop) (w : F.World) : Prop :=
+  ∃ v, F.accessible w v ∧ P v
+
+variable {F}
+
+/-- The distribution axiom of normal modal logic. -/
+lemma distrib_K {P Q : F.World → Prop} {w : F.World}
+    (hImp : F.necessarily (fun v => P v → Q v) w)
+    (hP : F.necessarily P w) :
+    F.necessarily Q w := by
+  intro v hwv
+  exact hImp v hwv (hP v hwv)
+
+/-- The reflexivity axiom of normal modal logic. -/
+lemma refl_T (hRefl : ∀ w, F.accessible w w)
+    {P : F.World → Prop} {w : F.World}
+    (h : F.necessarily P w) : P w :=
+  h w (hRefl w)
+
+/-- The transitivity axiom of normal modal logic. -/
+lemma four
+    (hTrans : ∀ w₁ w₂ w₃, F.accessible w₁ w₂ → F.accessible w₂ w₃ →
+      F.accessible w₁ w₃)
+    {P : F.World → Prop} {w : F.World}
+    (h : F.necessarily P w) :
+    F.necessarily (fun u => F.necessarily P u) w := by
+  intro v hwv u hvu
+  exact h u (hTrans w v u hwv hvu)
+
+/-- The Euclidean axiom of normal modal logic. -/
+lemma five
+    (hEucl : ∀ w₁ w₂ w₃, F.accessible w₁ w₂ → F.accessible w₁ w₃ →
+      F.accessible w₂ w₃)
+    {P : F.World → Prop} {w : F.World}
+    (h : F.possibly P w) :
+    F.necessarily (fun u => F.possibly P u) w := by
+  obtain ⟨u, hwu, hPu⟩ := h
+  intro v hwv
+  exact ⟨u, hEucl w v u hwv hwu, hPu⟩
+
+open ModalFormula
+
+/--
+Project-level forcing relation for `ModalFormula α`.
+
+The `quote` and `kreiselFixed` cases are both transparent at this Kripke layer.
+That is deliberately weaker than the `propEval` postulate for `kreiselFixed`;
+the bridge from propositional tautologies to forcing is the separate
+`PropTautSound` hypothesis.
+-/
+def Forces {α : Type u} (val : α → F.World → Prop) (w : F.World) :
+    ModalFormula α → Prop
+  | atom a => val a w
+  | bot => False
+  | impl phi psi => Forces val w phi → Forces val w psi
+  | iff phi psi => Forces val w phi ↔ Forces val w psi
+  | box phi => ∀ v, F.accessible w v → Forces val v phi
+  | quote phi => Forces val w phi
+  | kreiselFixed phi => Forces val w phi
+
+/--
+Semantic soundness assumption for the project-level tautology schema.
+
+For `kreiselFixed`-bearing formulas this is the Kripke-side counterpart of the
+modal-axiomatic postulate in `propEval`; `Forces` alone does not derive that
+diagonal content.
+-/
+def PropTautSound {α : Type u} (val : α → F.World → Prop) : Prop :=
+  ∀ {w : F.World} {phi : ModalFormula α}, phi.PropTaut → Forces (F := F) val w phi
+
+/-- Apply an explicit propositional-tautology soundness assumption. -/
+lemma propTaut_forces {α : Type u} {val : α → F.World → Prop} {w : F.World}
+    {phi : ModalFormula α} (hSound : PropTautSound (F := F) val) (h : phi.PropTaut) :
+    Forces (F := F) val w phi :=
+  hSound h
+
+/--
+Soundness of the canonical K4 proof predicate for every transitive frame,
+conditional on the explicit `PropTautSound` bridge for propositional
+tautologies.
+-/
+theorem provable_forces {α : Type u} {F : KripkeFrame}
+    (hTrans : ∀ w₁ w₂ w₃, F.accessible w₁ w₂ → F.accessible w₂ w₃ →
+      F.accessible w₁ w₃)
+    {val : α → F.World → Prop}
+    (hProp : PropTautSound (F := F) val)
+    {phi : ModalFormula α} (h : Provable phi) :
+    ∀ w : F.World, Forces (F := F) val w phi := by
+  induction h with
+  | pl_taut hTaut =>
+      intro w
+      exact propTaut_forces (F := F) hProp hTaut
+  | ax_K phi psi =>
+      intro w hBoxImp hBoxPhi v hwv
+      exact hBoxImp v hwv (hBoxPhi v hwv)
+  | ax_four phi =>
+      intro w hBoxPhi v hwv u hvu
+      exact hBoxPhi u (hTrans w v u hwv hvu)
+  | mp hImp hPhi ihImp ihPhi =>
+      intro w
+      exact ihImp w (ihPhi w)
+  | nec hPhi ihPhi =>
+      intro w v _hAcc
+      exact ihPhi v
+
+end KripkeFrame
+
+end ModalLogic.GoedelLoeb

--- a/LeanPool/GodelLoeb/Modal/Soundness.lean
+++ b/LeanPool/GodelLoeb/Modal/Soundness.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 Adam Benenson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adam Benenson
+-/
+import LeanPool.GodelLoeb.Modal.Kripke
+
+/-!
+# Kripke soundness bridge
+
+This file bundles the semantic soundness statements for K, T, 4, and
+5 and keeps the concrete one-world K4 frame.
+-/
+
+namespace ModalLogic.GoedelLoeb
+
+namespace KripkeFrame
+
+universe u
+
+/-- On a reflexive, transitive, Euclidean frame, K, T, 4, and 5 are sound. -/
+theorem basicModalAxiomsSound {F : KripkeFrame}
+    (hRefl : ∀ w, F.accessible w w)
+    (hTrans : ∀ w₁ w₂ w₃, F.accessible w₁ w₂ → F.accessible w₂ w₃ →
+      F.accessible w₁ w₃)
+    (hEucl : ∀ w₁ w₂ w₃, F.accessible w₁ w₂ → F.accessible w₁ w₃ →
+      F.accessible w₂ w₃)
+    {P Q : F.World → Prop} {w : F.World}
+    (hImp : F.necessarily (fun v => P v → Q v) w)
+    (hBoxP : F.necessarily P w)
+    (hPossP : F.possibly P w) :
+    F.necessarily Q w ∧
+      P w ∧
+        F.necessarily (fun u => F.necessarily P u) w ∧
+          F.necessarily (fun u => F.possibly P u) w := by
+  exact ⟨distrib_K hImp hBoxP, refl_T hRefl hBoxP, four hTrans hBoxP, five hEucl hPossP⟩
+
+/-- The one-world frame with universal accessibility. -/
+def trivialK4Frame : KripkeFrame where
+  World := Unit
+  accessible _ _ := True
+
+/-- The one-world frame is reflexive. -/
+lemma trivialK4Frame_reflexive :
+    ∀ w : trivialK4Frame.World, trivialK4Frame.accessible w w := by
+  intro w
+  trivial
+
+/-- The one-world frame is transitive. -/
+lemma trivialK4Frame_transitive :
+    ∀ w₁ w₂ w₃ : trivialK4Frame.World,
+      trivialK4Frame.accessible w₁ w₂ →
+        trivialK4Frame.accessible w₂ w₃ →
+          trivialK4Frame.accessible w₁ w₃ := by
+  intro w₁ w₂ w₃ _h₁₂ _h₂₃
+  trivial
+
+/-- The one-world frame is Euclidean. -/
+lemma trivialK4Frame_euclidean :
+    ∀ w₁ w₂ w₃ : trivialK4Frame.World,
+      trivialK4Frame.accessible w₁ w₂ →
+        trivialK4Frame.accessible w₁ w₃ →
+          trivialK4Frame.accessible w₂ w₃ := by
+  intro w₁ w₂ w₃ _h₁₂ _h₁₃
+  trivial
+
+/-- The bundled modal-axiom soundness theorem fires on the concrete frame. -/
+lemma trivialK4Frame_basicModalAxiomsSound
+    {P Q : trivialK4Frame.World → Prop} {w : trivialK4Frame.World}
+    (hImp : trivialK4Frame.necessarily (fun v => P v → Q v) w)
+    (hBoxP : trivialK4Frame.necessarily P w)
+    (hPossP : trivialK4Frame.possibly P w) :
+    trivialK4Frame.necessarily Q w ∧
+      P w ∧
+        trivialK4Frame.necessarily (fun u => trivialK4Frame.necessarily P u) w ∧
+          trivialK4Frame.necessarily (fun u => trivialK4Frame.possibly P u) w :=
+  basicModalAxiomsSound trivialK4Frame_reflexive trivialK4Frame_transitive
+    trivialK4Frame_euclidean hImp hBoxP hPossP
+
+/-- The `Provable` forcing theorem also fires on the concrete one-world frame. -/
+lemma trivialK4Frame_provable_forces {α : Type u}
+    {val : α → trivialK4Frame.World → Prop}
+    (hProp : PropTautSound (F := trivialK4Frame) val)
+    {phi : ModalFormula α} (h : Provable phi) :
+    ∀ w : trivialK4Frame.World, Forces (F := trivialK4Frame) val w phi :=
+  provable_forces trivialK4Frame_transitive hProp h
+
+end KripkeFrame
+
+end ModalLogic.GoedelLoeb

--- a/LeanPool/GodelLoeb/ModalFormula.lean
+++ b/LeanPool/GodelLoeb/ModalFormula.lean
@@ -1,0 +1,280 @@
+/-
+Copyright (c) 2026 Adam Benenson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adam Benenson
+-/
+import Mathlib.Logic.Basic
+
+/-!
+# Modal formulas
+
+This file defines the modal-axiomatic substrate for system K4 plus Loeb's
+theorem. The atomic proposition type is a parameter `α : Type u`; no encoding
+or decidable equality structure is required to form formulas.
+
+The `kreiselFixed` constructor is the substrate's irreducible postulate: its
+`propEval` clause `val (box (kreiselFixed phi)) → propEval val phi` encodes the
+Kreisel fixed-point semantics that an arithmetic-realisation substrate
+(Foundation's `StandardProvability`, Solovay arithmetic) would derive from
+syntactic Godel coding. Within the modal-axiomatic scope of this development,
+`kreiselFixed` is named as a primitive.
+
+The substitution and coding layer (`Substitution.subst`, `Substitution.code`)
+provides a syntactic facade that makes downstream theorems (the canonical
+`Diagonalisable` instance, `loeb`, and the worked examples) propositionally
+tautological by construction where they consume the primitive's evaluation.
+They are consequences of the constructor's evaluation clause, not derivations
+from an arithmetic-realisation coding theorem.
+-/
+
+namespace ModalLogic.GoedelLoeb
+
+universe u
+
+/-- Universe-polymorphic modal formulas over atomic propositions `α`. -/
+inductive ModalFormula (α : Type u) : Type u
+  | atom : α → ModalFormula α
+  | bot : ModalFormula α
+  | impl : ModalFormula α → ModalFormula α → ModalFormula α
+  | iff : ModalFormula α → ModalFormula α → ModalFormula α
+  | box : ModalFormula α → ModalFormula α
+  /--
+  Pure tag wrapper used to license `code`'s pattern-match into the
+  `kreiselFixed` primitive. It carries no independent semantic content beyond
+  tagging the diagonal-template arm. Its `propEval` clause is transparent:
+  quotation evaluates exactly as its inner formula, so the constructor is only
+  a syntactic marker.
+  -/
+  | quote : ModalFormula α → ModalFormula α
+  /--
+  The Kreisel fixed-point primitive.
+
+  This is a modal-axiomatic postulate: the `propEval` clause encodes
+  `□ₛ(kreiselFixed phi) ⟶ phi` as this constructor's evaluation. An
+  arithmetic-realisation substrate would derive this from Godel coding of
+  self-referential sentences; in this modal-axiomatic substrate it is the
+  irreducible primitive.
+  -/
+  | kreiselFixed : ModalFormula α → ModalFormula α
+  deriving DecidableEq, Repr
+
+namespace ModalFormula
+
+/-- Falsity as a formula. -/
+notation "⊥ₛ" => ModalFormula.bot
+
+/-- Object-language implication. -/
+infixr:60 " ⟶ " => ModalFormula.impl
+
+/-- Object-language equivalence. -/
+infix:55 " ⟷ " => ModalFormula.iff
+
+/-- Object-language necessity. -/
+prefix:75 "□ₛ" => ModalFormula.box
+
+/-- Object-language truth. -/
+def top {α : Type u} : ModalFormula α :=
+  ⊥ₛ ⟶ ⊥ₛ
+
+/-- Object-language negation. -/
+def neg {α : Type u} (phi : ModalFormula α) : ModalFormula α :=
+  phi ⟶ ⊥ₛ
+
+/-- Object-language conjunction, encoded classically by implication and falsity. -/
+def and {α : Type u} (phi psi : ModalFormula α) : ModalFormula α :=
+  neg (phi ⟶ neg psi)
+
+/-- Object-language disjunction, encoded classically by implication and falsity. -/
+def or {α : Type u} (phi psi : ModalFormula α) : ModalFormula α :=
+  neg phi ⟶ psi
+
+/--
+Modal-axiomatic coding function.
+
+On the diagonal-template arm `impl (box (atom a)) (quote body)`, this emits the
+`kreiselFixed` primitive; this is the modal-axiomatic substrate's encoding of
+self-reference. On non-template inputs, `code phi` is the tag wrapper
+`quote phi`, so it is syntactically non-identity but propositionally
+transparent because `quote`'s `propEval` clause is transparent. Non-trivial
+coding content lives only on the diagonal-template arm where the
+`kreiselFixed` primitive is emitted.
+-/
+def code {α : Type u} (phi : ModalFormula α) : ModalFormula α :=
+  match phi with
+  | impl (box (atom _)) (quote body) => kreiselFixed body
+  | other => quote other
+
+/--
+Decode ordinary quoted syntax.
+
+This is Phase B scaffolding for a future arithmetic-realisation integration
+that may consume explicit quoted syntax. It is not used by the current Phase A
+modal-axiomatic substrate; `kreiselFixed` remains a primitive sentence rather
+than something decoded from syntax here.
+-/
+def decode {α : Type u} (phi : ModalFormula α) : Option (ModalFormula α) :=
+  match phi with
+  | quote body => some body
+  | _ => none
+
+/-- Substitute `arg` for the distinguished atom `atom a`. -/
+def subst {α : Type u} [DecidableEq α] (a : α) :
+    ModalFormula α → ModalFormula α → ModalFormula α
+  | atom b, arg => if a = b then arg else atom b
+  | bot, _ => bot
+  | impl (box (atom b)) (quote body), _ =>
+      if a = b then kreiselFixed body else (□ₛ(atom b) ⟶ quote body)
+  | impl phi psi, arg => subst a phi arg ⟶ subst a psi arg
+  | iff phi psi, arg => subst a phi arg ⟷ subst a psi arg
+  | box phi, arg => □ₛ(subst a phi arg)
+  | quote phi, _ => quote phi
+  | kreiselFixed phi, arg => kreiselFixed (subst a phi arg)
+
+/-- The one-hole Kreisel diagonal template for a target formula. -/
+def diagonalTemplate {α : Type u} (a : α) (phi : ModalFormula α) : ModalFormula α :=
+  □ₛ(atom a) ⟶ quote phi
+
+/-- The substitution-built Kreisel fixed point for a target formula. -/
+def constructedFixedpoint {α : Type u} [DecidableEq α]
+    (a : α) (phi : ModalFormula α) : ModalFormula α :=
+  subst a (diagonalTemplate a phi) (code (diagonalTemplate a phi))
+
+/-- Propositional evaluation with syntax-indexed opaque modal slots. -/
+def propEval {α : Type u} (val : ModalFormula α → Prop) : ModalFormula α → Prop
+  | atom a => val (atom a)
+  | bot => False
+  | impl phi psi => propEval val phi → propEval val psi
+  | iff phi psi => propEval val phi ↔ propEval val psi
+  | box phi => val (box phi)
+  | quote phi => propEval val phi
+  | kreiselFixed phi => val (box (kreiselFixed phi)) → propEval val phi
+
+/-- A formula is propositionally valid when it holds under every valuation. -/
+def PropTaut {α : Type u} (phi : ModalFormula α) : Prop :=
+  ∀ val, propEval val phi
+
+/-- Empty-frame evaluation used for the non-collapse soundness check. -/
+def emptyEval {α : Type u} : ModalFormula α → Prop
+  | atom _ => False
+  | bot => False
+  | impl phi psi => emptyEval phi → emptyEval psi
+  | iff phi psi => emptyEval phi ↔ emptyEval psi
+  | box _ => True
+  | quote phi => emptyEval phi
+  | kreiselFixed phi => emptyEval phi
+
+/-- Propositional evaluation with the empty-frame valuation matches empty evaluation. -/
+lemma propEval_emptyEval {α : Type u} (phi : ModalFormula α) :
+    propEval emptyEval phi ↔ emptyEval phi := by
+  induction phi with
+  | atom a => rfl
+  | bot => rfl
+  | impl phi psi hPhi hPsi =>
+      change (propEval emptyEval phi → propEval emptyEval psi) ↔
+        (emptyEval phi → emptyEval psi)
+      rw [hPhi, hPsi]
+  | iff phi psi hPhi hPsi =>
+      change (propEval emptyEval phi ↔ propEval emptyEval psi) ↔
+        (emptyEval phi ↔ emptyEval psi)
+      rw [hPhi, hPsi]
+  | box phi => rfl
+  | quote phi hPhi => exact hPhi
+  | kreiselFixed phi hPhi =>
+      change (True → propEval emptyEval phi) ↔ emptyEval phi
+      constructor
+      · intro h
+        exact hPhi.mp (h trivial)
+      · intro h _hTrue
+        exact hPhi.mpr h
+
+/--
+Quoted syntax decodes to its body.
+
+This is tagged as a simplification rule for Phase B forward compatibility:
+the first downstream arithmetic-realisation consumer is expected to normalise
+quoted syntax while plugging this modal substrate into a concrete coding layer.
+Phase A itself only needs `decode` as scaffolding; `kreiselFixed` remains the
+load-bearing primitive here.
+-/
+@[simp]
+lemma decode_quote {α : Type u} (phi : ModalFormula α) : decode (quote phi) = some phi :=
+  rfl
+
+@[simp]
+lemma code_diagonalTemplate {α : Type u} (a : α) (phi : ModalFormula α) :
+    code (diagonalTemplate a phi) = kreiselFixed phi := by
+  rfl
+
+/--
+Syntactically, `code ⊥ₛ` is the quote-wrapped form `quote ⊥ₛ`, not `⊥ₛ`.
+
+This witnesses the non-triviality of the quote-wrapping branch on a
+non-template input; non-template inputs remain propositionally transparent
+under `propEval`.
+-/
+lemma code_bot_ne_bot {α : Type u} : code (⊥ₛ : ModalFormula α) ≠ ⊥ₛ := by
+  intro h
+  cases h
+
+@[simp]
+lemma subst_atom_self {α : Type u} [DecidableEq α] (a : α) (arg : ModalFormula α) :
+    subst a (atom a) arg = arg := by
+  simp [subst]
+
+@[simp]
+lemma subst_atom_ne {α : Type u} [DecidableEq α] {a b : α} (h : a ≠ b)
+    (arg : ModalFormula α) : subst a (atom b) arg = atom b := by
+  simp [subst, h]
+
+@[simp]
+lemma subst_iff {α : Type u} [DecidableEq α] (a : α) (phi psi arg : ModalFormula α) :
+    subst a (phi ⟷ psi) arg = (subst a phi arg ⟷ subst a psi arg) :=
+  rfl
+
+@[simp]
+lemma subst_box {α : Type u} [DecidableEq α] (a : α) (phi arg : ModalFormula α) :
+    subst a (□ₛphi) arg = □ₛ(subst a phi arg) :=
+  rfl
+
+@[simp]
+lemma subst_quote {α : Type u} [DecidableEq α] (a : α) (phi arg : ModalFormula α) :
+    subst a (quote phi) arg = quote phi :=
+  rfl
+
+@[simp]
+lemma subst_kreiselFixed {α : Type u} [DecidableEq α] (a : α)
+    (phi arg : ModalFormula α) :
+    subst a (kreiselFixed phi) arg = kreiselFixed (subst a phi arg) :=
+  rfl
+
+@[simp]
+lemma fixedpoint_eq_subst_template {α : Type u} [DecidableEq α]
+    (a : α) (phi : ModalFormula α) :
+    constructedFixedpoint a phi =
+      subst a (diagonalTemplate a phi) (code (diagonalTemplate a phi)) :=
+  rfl
+
+@[simp]
+lemma subst_diagonalTemplate_self {α : Type u} [DecidableEq α]
+    (a : α) (phi : ModalFormula α) :
+    subst a (diagonalTemplate a phi) (code (diagonalTemplate a phi)) =
+      kreiselFixed phi := by
+  simp [diagonalTemplate, subst]
+
+lemma subst_diagonalTemplate_self_prop_taut {α : Type u} [DecidableEq α]
+    (a : α) (phi : ModalFormula α) :
+    (subst a (diagonalTemplate a phi) (code (diagonalTemplate a phi)) ⟷
+      (□ₛ(code (diagonalTemplate a phi)) ⟶ phi)).PropTaut := by
+  intro val
+  simp [diagonalTemplate, subst, code, propEval]
+
+lemma box_code_diagonalTemplate_prop_taut {α : Type u} [DecidableEq α]
+    (a : α) (phi : ModalFormula α) :
+    (□ₛ(code (diagonalTemplate a phi)) ⟷
+      □ₛ(constructedFixedpoint a phi)).PropTaut := by
+  intro val
+  simp [constructedFixedpoint, diagonalTemplate, subst, code, propEval]
+
+end ModalFormula
+
+end ModalLogic.GoedelLoeb

--- a/LeanPool/GodelLoeb/ModalFormula.lean
+++ b/LeanPool/GodelLoeb/ModalFormula.lean
@@ -257,7 +257,7 @@ lemma fixedpoint_eq_subst_template {α : Type u} [DecidableEq α]
 @[simp]
 lemma subst_diagonalTemplate_self {α : Type u} [DecidableEq α]
     (a : α) (phi : ModalFormula α) :
-    subst a (diagonalTemplate a phi) (code (diagonalTemplate a phi)) =
+    subst a (diagonalTemplate a phi) (kreiselFixed phi) =
       kreiselFixed phi := by
   simp [diagonalTemplate, subst]
 

--- a/LeanPool/GodelLoeb/Provable.lean
+++ b/LeanPool/GodelLoeb/Provable.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 Adam Benenson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adam Benenson
+-/
+import LeanPool.GodelLoeb.Substitution
+
+/-!
+# Modal provability
+
+This file defines the Hilbert-style proof predicate used by the
+modal-axiomatic Loeb theorem. `Provable` is the K4 closure over the
+`ModalFormula` substrate, and that substrate includes the irreducible
+`kreiselFixed` postulate in `propEval`. Propositional reasoning is admitted by
+the usual tautology schema, so any downstream use of the canonical diagonal
+interface consumes consequences of that substrate postulate rather than an
+arithmetic-realisation derivation.
+
+The object-level normal-modal layer is system K4: K, the intrinsic 4 axiom
+`[]phi -> [][]phi`, modus ponens, and necessitation. Arithmetic realisation
+via a concrete provability predicate and Solovay-style coding is outside this
+Phase A substrate.
+-/
+
+namespace ModalLogic.GoedelLoeb
+
+open ModalFormula
+
+universe u
+
+/--
+Hilbert-style provability for the modal-axiomatic K4 substrate with the
+`kreiselFixed` postulate already present in formula evaluation.
+
+The object-level proof constructors are exactly:
+`pl_taut`, `ax_K`, `ax_four`, `mp`, and `nec`.
+-/
+inductive Provable {α : Type u} : ModalFormula α → Prop
+  | pl_taut {phi : ModalFormula α} : phi.PropTaut → Provable phi
+  | ax_K (phi psi : ModalFormula α) :
+      Provable (□ₛ(phi ⟶ psi) ⟶ (□ₛphi ⟶ □ₛpsi))
+  | ax_four (phi : ModalFormula α) : Provable (□ₛphi ⟶ □ₛ□ₛphi)
+  | mp {phi psi : ModalFormula α} : Provable (phi ⟶ psi) → Provable phi → Provable psi
+  | nec {phi : ModalFormula α} : Provable phi → Provable (□ₛphi)
+
+namespace Provable
+
+/-- Every propositional tautology is provable. -/
+lemma of_prop_taut {α : Type u} {phi : ModalFormula α} (h : phi.PropTaut) :
+    Provable phi :=
+  pl_taut h
+
+/-- The K distribution schema as a theorem alias. -/
+lemma k {α : Type u} (phi psi : ModalFormula α) :
+    Provable (□ₛ(phi ⟶ psi) ⟶ (□ₛphi ⟶ □ₛpsi)) :=
+  ax_K phi psi
+
+/-- The 4 axiom as a theorem alias. -/
+lemma four {α : Type u} (phi : ModalFormula α) : Provable (□ₛphi ⟶ □ₛ□ₛphi) :=
+  ax_four phi
+
+/--
+Boxed coding transparency for diagonal templates.
+
+This is a propositional consequence of `Substitution.code` emitting the
+`kreiselFixed` primitive on the template arm; it is not an arithmetic coding
+transparency theorem.
+-/
+lemma box_code_fixedpoint_iff {α : Type u} [DecidableEq α]
+    (a : α) (phi : ModalFormula α) :
+    Provable (□ₛ(Substitution.code (Substitution.diagonalTemplate a phi)) ⟷
+      □ₛ(Substitution.fixedpoint a phi)) :=
+  of_prop_taut (ModalFormula.box_code_diagonalTemplate_prop_taut a phi)
+
+/-- Propositional reflexivity of implication. -/
+lemma imp_refl {α : Type u} (phi : ModalFormula α) : Provable (phi ⟶ phi) :=
+  of_prop_taut <| by
+    intro val h
+    exact h
+
+/-- Extract the forward implication from a provable equivalence. -/
+lemma iff_left {α : Type u} {phi psi : ModalFormula α}
+    (h : Provable (phi ⟷ psi)) : Provable (phi ⟶ psi) := by
+  refine mp (pl_taut ?_) h
+  intro val hIff
+  exact hIff.mp
+
+/-- Extract the reverse implication from a provable equivalence. -/
+lemma iff_right {α : Type u} {phi psi : ModalFormula α}
+    (h : Provable (phi ⟷ psi)) : Provable (psi ⟶ phi) := by
+  refine mp (pl_taut ?_) h
+  intro val hIff
+  exact hIff.mpr
+
+/-- Build a provable equivalence from both provable implications. -/
+lemma iff_intro {α : Type u} {phi psi : ModalFormula α}
+    (hLeft : Provable (phi ⟶ psi))
+    (hRight : Provable (psi ⟶ phi)) : Provable (phi ⟷ psi) := by
+  refine mp (mp (pl_taut ?_) hLeft) hRight
+  intro val hpq hqp
+  exact Iff.intro hpq hqp
+
+/-- Compose two provable implications. -/
+lemma imp_trans {α : Type u} {phi psi chi : ModalFormula α}
+    (hPhiPsi : Provable (phi ⟶ psi))
+    (hPsiChi : Provable (psi ⟶ chi)) :
+    Provable (phi ⟶ chi) := by
+  refine mp (mp (pl_taut ?_) hPhiPsi) hPsiChi
+  intro val hpq hqr hp
+  exact hqr (hpq hp)
+
+/-- Combine three implications with the same antecedent. -/
+lemma imp_box_combine {α : Type u} {alpha beta gamma delta : ModalFormula α}
+    (hAlphaBeta : Provable (alpha ⟶ beta))
+    (hAlphaGamma : Provable (alpha ⟶ gamma))
+    (hBetaGammaDelta : Provable (beta ⟶ (gamma ⟶ delta))) :
+    Provable (alpha ⟶ delta) := by
+  refine mp (mp (mp (pl_taut ?_) hAlphaBeta) hAlphaGamma) hBetaGammaDelta
+  intro val hab hac hbgd ha
+  exact hbgd (hab ha) (hac ha)
+
+/-- Prefix a provable implication by a box using necessitation and K. -/
+lemma box_imp {α : Type u} {phi psi : ModalFormula α}
+    (h : Provable (phi ⟶ psi)) : Provable (□ₛphi ⟶ □ₛpsi) :=
+  mp (ax_K phi psi) (nec h)
+
+/-- Add a provable consequent on the right side of an implication. -/
+lemma imp_of_provable {α : Type u} {phi psi : ModalFormula α}
+    (hPsi : Provable psi) : Provable (phi ⟶ psi) := by
+  refine mp (pl_taut ?_) hPsi
+  intro val hpsi _hphi
+  exact hpsi
+
+/-- Transport an implication across provable equivalences. -/
+lemma imp_congr {α : Type u} {alpha beta gamma delta : ModalFormula α}
+    (hAlphaBeta : Provable (alpha ⟷ beta))
+    (hGammaDelta : Provable (gamma ⟷ delta)) :
+    Provable ((alpha ⟶ gamma) ⟷ (beta ⟶ delta)) := by
+  have hAlphaToBeta : Provable (alpha ⟶ beta) := iff_left hAlphaBeta
+  have hBetaToAlpha : Provable (beta ⟶ alpha) := iff_right hAlphaBeta
+  have hGammaToDelta : Provable (gamma ⟶ delta) := iff_left hGammaDelta
+  have hDeltaToGamma : Provable (delta ⟶ gamma) := iff_right hGammaDelta
+  have hForward : Provable ((alpha ⟶ gamma) ⟶ (beta ⟶ delta)) := by
+    refine mp (mp (pl_taut ?_) hBetaToAlpha) hGammaToDelta
+    intro val hba hgd hag hb
+    exact hgd (hag (hba hb))
+  have hBackward : Provable ((beta ⟶ delta) ⟶ (alpha ⟶ gamma)) := by
+    refine mp (mp (pl_taut ?_) hAlphaToBeta) hDeltaToGamma
+    intro val hab hdg hbd ha
+    exact hdg (hbd (hab ha))
+  exact iff_intro hForward hBackward
+
+/-- Empty-frame soundness for the canonical proof predicate. -/
+lemma sound_empty {α : Type u} {phi : ModalFormula α} (h : Provable phi) :
+    phi.emptyEval := by
+  induction h with
+  | pl_taut hTaut =>
+      exact (ModalFormula.propEval_emptyEval _).mp (hTaut ModalFormula.emptyEval)
+  | ax_K phi psi =>
+      change True → True → True
+      intro _ _
+      trivial
+  | ax_four phi =>
+      change True → True
+      intro _
+      trivial
+  | mp hImp hPhi ihImp ihPhi =>
+      exact ihImp ihPhi
+  | nec hPhi ihPhi =>
+      trivial
+
+/-- The canonical proof predicate does not prove falsity. -/
+theorem not_bot {α : Type u} : ¬ Provable (⊥ₛ : ModalFormula α) := by
+  intro h
+  exact sound_empty h
+
+/-- The canonical proof predicate does not prove every atom. -/
+lemma atom_not_provable {α : Type u} (a : α) : ¬ Provable (ModalFormula.atom a) := by
+  intro h
+  exact sound_empty h
+
+end Provable
+
+end ModalLogic.GoedelLoeb

--- a/LeanPool/GodelLoeb/Substitution.lean
+++ b/LeanPool/GodelLoeb/Substitution.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 Adam Benenson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adam Benenson
+-/
+import LeanPool.GodelLoeb.ModalFormula
+
+/-!
+# Substitution and coding aliases
+
+This file keeps the qualified `Substitution.*` names used by the
+diagonal layer. The operations themselves live in `ModalFormula.lean`
+so that the explicit Kreisel fixed-point primitive, coding, and
+distinguished-slot substitution stay definitionally aligned.
+
+These aliases are part of the modal-axiomatic substrate. In particular,
+`Substitution.code` is not an arithmetic-realisation Godel coding theorem:
+on the diagonal-template arm it emits the `ModalFormula.kreiselFixed`
+postulate, and on all other inputs it delegates to the transparent `quote`
+wrapper. Downstream structural facts are therefore consequences of the
+`kreiselFixed` evaluation clause plus this syntactic template recogniser.
+-/
+
+namespace ModalLogic.GoedelLoeb
+
+universe u
+
+/- Qualified aliases and witnesses for the substitution/coding layer. -/
+namespace Substitution
+
+/--
+Qualified name for modal-axiomatic coding.
+
+This aliases the template recogniser that emits `ModalFormula.kreiselFixed`
+on the diagonal-template arm and transparent `quote` wrappers elsewhere.
+-/
+abbrev code {α : Type u} : ModalFormula α → ModalFormula α :=
+  ModalFormula.code
+
+/--
+Qualified name for decoding quoted syntax.
+
+This is Phase B scaffolding and is not consumed by the current Phase A
+modal-axiomatic substrate.
+-/
+abbrev decode {α : Type u} : ModalFormula α → Option (ModalFormula α) :=
+  ModalFormula.decode
+
+/-- Qualified name for distinguished-slot substitution. -/
+abbrev subst {α : Type u} [DecidableEq α] (a : α) :
+    ModalFormula α → ModalFormula α → ModalFormula α :=
+  ModalFormula.subst a
+
+/-- Qualified name for the one-hole Kreisel template. -/
+abbrev diagonalTemplate {α : Type u} (a : α) : ModalFormula α → ModalFormula α :=
+  ModalFormula.diagonalTemplate a
+
+/-- Qualified name for the constructed fixed point. -/
+abbrev fixedpoint {α : Type u} [DecidableEq α] (a : α) :
+    ModalFormula α → ModalFormula α :=
+  ModalFormula.constructedFixedpoint a
+
+/-- Qualified structural self-substitution identity. -/
+lemma subst_diagonalTemplate_self {α : Type u} [DecidableEq α]
+    (a : α) (phi : ModalFormula α) :
+    subst a (diagonalTemplate a phi) (code (diagonalTemplate a phi)) =
+      ModalFormula.kreiselFixed phi :=
+  ModalFormula.subst_diagonalTemplate_self a phi
+
+end Substitution
+
+end ModalLogic.GoedelLoeb

--- a/LeanPool/GodelLoeb/Worked.lean
+++ b/LeanPool/GodelLoeb/Worked.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 Adam Benenson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adam Benenson
+-/
+import LeanPool.GodelLoeb.Incompleteness
+
+/-!
+# Worked modal-axiomatic example
+
+This file keeps concrete formula-level checks over `α := Bool`. The
+canonical diagonal instance uses `default = false` as the distinguished
+atom. The worked target uses an unprovable atomic consequent, so the file
+also records the formal obstruction to a closed Loeb hypothesis in the
+canonical consistent substrate.
+-/
+
+namespace ModalLogic.GoedelLoeb
+
+open ModalFormula
+
+/-- The canonical Bool diagonal instance is available. -/
+example : Diagonalisable Bool :=
+  inferInstance
+
+/-- The unprovable atomic consequent used by the worked target. -/
+def workedConsequent : ModalFormula Bool :=
+  ModalFormula.atom false
+
+/-- A concrete non-tautological target for the worked Loeb example. -/
+def workedPhi : ModalFormula Bool :=
+  Substitution.fixedpoint false workedConsequent
+
+/-- The worked target is not a propositional tautology. -/
+lemma workedPhi_not_prop_taut : ¬ workedPhi.PropTaut := by
+  intro h
+  let val : ModalFormula Bool → Prop
+    | box phi => phi = workedPhi
+    | _ => False
+  have hFalse : ModalFormula.propEval val workedPhi := h val
+  dsimp [workedPhi, workedConsequent, Substitution.fixedpoint,
+    ModalFormula.constructedFixedpoint, ModalFormula.diagonalTemplate,
+    ModalFormula.propEval, ModalFormula.code, ModalFormula.subst] at hFalse
+  exact hFalse rfl
+
+/-- The worked consequent is not provable in the canonical proof predicate. -/
+lemma workedConsequent_not_provable : ¬ Provable workedConsequent :=
+  Provable.atom_not_provable false
+
+/-- The worked target is not provable without an inconsistent Loeb hypothesis. -/
+lemma workedPhi_not_provable : ¬ Provable workedPhi := by
+  intro h
+  have hEmpty : workedPhi.emptyEval := Provable.sound_empty h
+  dsimp [workedPhi, workedConsequent, Substitution.fixedpoint,
+    ModalFormula.constructedFixedpoint, ModalFormula.diagonalTemplate,
+    ModalFormula.emptyEval, ModalFormula.code, ModalFormula.subst] at hEmpty
+
+/--
+Conditional Loeb firing on the concrete worked target.
+
+The theorem is intentionally not closed: `workedLoebHypothesis_not_provable`
+shows that a closed hypothesis for this atomic consequent would contradict
+the canonical non-collapse witness.
+-/
+theorem workedLoeb (h : Provable (□ₛworkedPhi ⟶ workedPhi)) : Provable workedPhi :=
+  loeb h
+
+/-- No closed Loeb hypothesis exists for the unprovable worked target. -/
+lemma workedLoebHypothesis_not_provable : ¬ Provable (□ₛworkedPhi ⟶ workedPhi) := by
+  intro h
+  exact workedPhi_not_provable (workedLoeb h)
+
+/-- The modal second-incompleteness corollary fired for the Bool instance. -/
+theorem workedSecondIncompleteness :
+    ¬ Provable (modalConsistencySentence : ModalFormula Bool) :=
+  secondIncompleteness
+
+end ModalLogic.GoedelLoeb


### PR DESCRIPTION
Imported from https://github.com/abenenson/godel-loeb.

**Slug:** `godel-loeb`
**Toolchain target:** `leanprover/lean4:v4.32.0-rc1`
**Branch:** `import/godel-loeb` (auto-generated by `scripts/import-formalization.sh`)
**Agent:** `claude` using `claude-opus-4-7` at effort `max`, exited with code `1`.

**Commits on this branch:**
- 7758819b WIP: agent partial progress on godel-loeb import

---
_Opened automatically by `scripts/import-formalization.sh`. Review the diff carefully before merging — the agent ran unattended._
