### PR TITLE
Import AgreeToDisagree

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -51,6 +51,9 @@ import LeanPool.AFormalizationOfBorelDeterminacyInLean.Tree.TreeBody
 import LeanPool.AFormalizationOfBorelDeterminacyInLean.Tree.TreeExtensions
 import LeanPool.AFormalizationOfBorelDeterminacyInLean.Tree.TreeLim
 import LeanPool.AFormalizationOfBorelDeterminacyInLean.Tree.Trees
+import LeanPool.AgreeToDisagree
+import LeanPool.AgreeToDisagree.AgreeToDisagree
+import LeanPool.AgreeToDisagree.AgreeToDisagreeBeliefs
 import LeanPool.AharoniKorman
 import LeanPool.AharoniKorman.Counterexample
 import LeanPool.AharoniKorman.ForMathlib

--- a/LeanPool/AgreeToDisagree.lean
+++ b/LeanPool/AgreeToDisagree.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 Axiom Math contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: AgreeToDisagree contributors
+-/
+
+import LeanPool.AgreeToDisagree.AgreeToDisagree
+import LeanPool.AgreeToDisagree.AgreeToDisagreeBeliefs
+
+/-!
+# Aumann's Agreement Theorem
+
+Source: url:https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6837298
+Authors: Ruiz Chen, Ben Eltschig, Ken Ono, Jujian Zhang
+Status: verified
+Main declarations: `AgreeToDisagree.agreeToDisagree`, `AgreeToDisagree.agreeToDisagree_beliefs`
+Tags: probability, game-theory, epistemic-logic
+MSC: 60A10, 91A40
+-/
+
+/-!
+## Mathematical overview
+
+This project formalizes Aumann's theorem that agents with common prior
+probabilities cannot agree to disagree when it is common knowledge that they
+assign fixed posterior probabilities to an event.
+
+The first theorem proves equality of the posteriors under common knowledge for
+two agents and, more generally, a family of agents. The second develops a
+`p`-belief variant, proving that common `p`-belief bounds posterior
+disagreement by `2 * (1 - p)`.
+
+## Main results
+
+- `AgreeToDisagree.agreeToDisagree` — two agents with common knowledge of
+  their posteriors and equal common prior posterior on the common-knowledge
+  cell have equal posteriors.
+- `AgreeToDisagree.agreeToDisagree'` — the corresponding finite-family
+  formulation.
+- `AgreeToDisagree.agreeToDisagree_beliefs` — common `p`-belief bounds
+  posterior disagreement by `2 * (1 - p)`.
+-/

--- a/LeanPool/AgreeToDisagree/AgreeToDisagree.lean
+++ b/LeanPool/AgreeToDisagree/AgreeToDisagree.lean
@@ -116,6 +116,19 @@ lemma Partition.class_eq_biUnion_of_le {P Q : Partition α} (h : P ≤ Q) (a : �
   · obtain ⟨s, hs, hs'⟩ := mem_iUnion₂.mp hb
     exact hs.2 hs'
 
+lemma Partition.class_subset_of_le {P Q : Partition α} (hle : P ≤ Q) (ω : α) :
+    P.class ω ⊆ Q.class ω :=
+  P.class_mono hle ω
+
+lemma Partition.class_eq_of_mem_part {P : Partition α} {s : Set α} {ω : α}
+    (hs : s ∈ P) (hω : ω ∈ s) : P.class ω = s :=
+  P.class_eq_of_mem hs hω
+
+lemma Partition.pairwise_disjoint_subtype_val (P : Partition α) :
+    Pairwise (Function.onFun Disjoint (fun i : ↑(P.val) => (i : Set α))) :=
+  fun ⟨_, hs⟩ ⟨_, ht⟩ hne => Set.disjoint_left.mpr fun _ has hat =>
+    hne <| Subtype.ext ((class_eq_of_mem_part hs has).symm.trans (class_eq_of_mem_part ht hat))
+
 end Prerequisites
 
 open MeasureTheory
@@ -137,6 +150,48 @@ lemma Partition.countable_of_measure_pos {μ : Measure Ω} [IsProbabilityMeasure
   · ext ⟨s, hs⟩; simp [hP' s hs]
   · intro s t hst
     exact P.2.pairwiseDisjoint s.2 t.2 (fun h ↦ hst (Subtype.ext h))
+
+lemma Partition.countable_of_pos_measure {μ : Measure Ω} [IsProbabilityMeasure μ]
+    (P : Partition Ω) (hP : P.Measurable) (hP' : ∀ s ∈ P, μ s > 0) :
+    P.val.Countable :=
+  P.countable_of_measure_pos hP hP'
+
+lemma measure_inter_eq_mul_of_probabilityAt_eq
+    (P : Partition Ω) (hP' : ∀ s ∈ P, μ s > 0)
+    {E : Set Ω} {s S : Set Ω} {p : ENNReal}
+    (hs : s ∈ P) (hsS : s ⊆ S)
+    (hconst : ∀ ω' ∈ S, P.probabilityAt μ E ω' = p) :
+    μ (E ∩ s) = p * μ s := by
+  obtain ⟨ω, hω⟩ := Setoid.nonempty_of_mem_partition P.2 hs
+  have hprob : μ (E ∩ s) / μ s = p := by
+    simpa only [Partition.probabilityAt, Partition.class_eq_of_mem_part hs hω]
+      using hconst ω (hsS hω)
+  rw [← hprob, ENNReal.div_mul_cancel (ne_of_gt (hP' s hs)) (measure_ne_top μ s)]
+
+lemma measure_inter_sup_class_eq_mul
+    (P : Partition Ω) (hPm : P.Measurable) (hP' : ∀ s ∈ P, μ s > 0)
+    {E S : Set Ω} {p : ENNReal}
+    (hE : MeasurableSet E)
+    (hS : S = ⋃ s ∈ {s ∈ P | s ⊆ S}, s)
+    (hctbl : P.val.Countable)
+    (hconst : ∀ ω' ∈ S, P.probabilityAt μ E ω' = p) :
+    μ (E ∩ S) = p * μ S := by
+  set T := {s ∈ P | s ⊆ S}
+  have hT_ctbl : T.Countable := hctbl.mono fun _ hs => hs.1
+  have hT_disj : T.PairwiseDisjoint id := fun s hs t ht hne =>
+    P.2.pairwiseDisjoint hs.1 ht.1 (fun heq => hne (heq ▸ rfl))
+  have hT_meas : ∀ s ∈ T, MeasurableSet s := fun s hs => hPm s hs.1
+  rw [show μ (E ∩ S) = ∑' (t : T), μ (E ∩ ↑t) by
+      conv_lhs => rw [hS, inter_iUnion₂]
+      exact measure_biUnion hT_ctbl
+        (fun s hs t ht hne => (hT_disj hs ht hne).mono inf_le_right inf_le_right)
+        (fun s hs => hE.inter (hT_meas s hs)),
+    show μ S = ∑' (t : T), μ (t : Set Ω) by
+      conv_lhs => rw [hS]
+      exact measure_biUnion hT_ctbl hT_disj hT_meas]
+  simp_rw [show ∀ t : T, μ (E ∩ (t : Set Ω)) = p * μ (t : Set Ω) from
+    fun t => measure_inter_eq_mul_of_probabilityAt_eq P hP' t.2.1 t.2.2 hconst]
+  exact ENNReal.tsum_mul_left
 
 /-- Let `P` be a partition of `Ω` into measurable non-null sets, `Q` a coarser partition and
 `E` a set such that `P.probabilityAt E ω' = p` for all `ω' ∈ Q.class ω`.

--- a/LeanPool/AgreeToDisagree/AgreeToDisagree.lean
+++ b/LeanPool/AgreeToDisagree/AgreeToDisagree.lean
@@ -1,0 +1,192 @@
+/-
+Copyright (c) 2026 Axiom Math contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: AgreeToDisagree contributors
+-/
+import Mathlib.Data.Setoid.Partition
+import Mathlib.MeasureTheory.Measure.Typeclasses.Probability
+import Mathlib.MeasureTheory.Measure.Typeclasses.SFinite
+
+/-!
+# Aumann's agreement theorem
+
+This file develops information partitions and conditional probabilities needed
+for Aumann's agreement theorem.
+-/
+
+namespace AgreeToDisagree
+
+open Set
+
+variable {α Ω : Type*}
+
+section Prerequisites
+
+/-- We write `Partition α` for the type of partitions of a set `α`, implemented as a subtype
+of `Set (Set α)`. Mathlib already equips this subtype with the order given by refinement (such that
+`P ≤ Q` iff `P` refines `Q`) and proves that it is a complete lattice, i.e. that arbitrary infima
+and suprema of partitions exist. -/
+abbrev Partition (α : Type*) := Setoid.Partitions α
+
+/-- When we write `s ∈ P` for a partition `P : Partition α`, we mean that `s` is a `Set α` that is
+an element of the `Set (Set α)` underlying `P`. -/
+@[reducible]
+instance Partition.instSetLike : SetLike (Partition α) (Set α) where
+  coe := Subtype.val
+  coe_injective := Subtype.val_injective
+
+/-- As expected, a partition `P` refines a partition `Q` iff every set in `P` is contained in
+a set in `Q`. -/
+lemma Partition.le_iff {P Q : Partition α} : P ≤ Q ↔ ∀ s ∈ P, ∃ t ∈ Q, s ⊆ t := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · intro s hs
+    have ⟨a, ha⟩ := Setoid.nonempty_of_mem_partition P.2 hs
+    refine ⟨{b | Setoid.mkClasses _ Q.2.2 b a}, ?_, ?_⟩
+    · have := Setoid.mem_classes (Setoid.mkClasses _ Q.2.2) a
+      rwa [Setoid.classes_mkClasses Q.1 Q.2] at this
+    · refine fun b hb ↦ h fun s' hs' hbs' ↦ ?_
+      rwa [← P.2.pairwiseDisjoint.elim hs hs' <| not_disjoint_iff.2 ⟨b, hb, hbs'⟩]
+  · intro a b hab s hs has
+    have ⟨t, ⟨ht, hat⟩, _⟩ := P.2.2 a
+    have ⟨s', hs'⟩ := h t ht
+    rw [Q.2.pairwiseDisjoint.elim hs hs'.1 <| not_disjoint_iff.2 ⟨a, has, hs'.2 hat⟩]
+    exact hs'.2 <| hab t ht hat
+
+/-- We call a partition of a measurable space measurable if it consists of measurable sets. -/
+protected def Partition.Measurable [MeasurableSpace Ω] (P : Partition Ω) :=
+  ∀ s ∈ P, MeasurableSet s
+
+/-- If a countable partition is measurable, every partition it refines is measurable too.
+Note that the countability assumption is necessary because e.g. the partition into singletons is
+usually measurable but refines all other partitions, even nonmeasurable ones. -/
+lemma Partition.Measurable.mono [MeasurableSpace Ω] {P Q : Partition Ω}
+    (hP : P.Measurable) (hP' : P.val.Countable) (hQ : P ≤ Q) : Q.Measurable := by
+  intro s hs
+  rw [← inter_univ s, ← P.2.sUnion_eq_univ, sUnion_eq_iUnion, inter_iUnion]
+  have := hP'.to_subtype
+  refine MeasurableSet.iUnion fun t ↦ ?_
+  have ⟨s', hs'⟩ := le_iff.1 hQ _ t.2
+  obtain h | h := Q.2.pairwiseDisjoint.eq_or_disjoint hs hs'.1
+  · rw [h, inter_eq_right.2 hs'.2]
+    exact hP _ t.2
+  · suffices s ∩ t ⊆ ∅ by simp_all
+    exact (inter_subset_inter_right s hs'.2).trans <| Set.disjoint_iff.1 h
+
+/-- The supremum of two measurable partitions is measurable if at least one of the two partitions
+is countable. -/
+lemma Partition.Measurable.sup [MeasurableSpace Ω] {P Q : Partition Ω}
+    (hP : P.Measurable) (hQ : Q.Measurable) (h : P.val.Countable ∨ Q.val.Countable) :
+    (P ⊔ Q).Measurable := by
+  obtain h | h := h
+  · exact hP.mono h le_sup_left
+  · exact hQ.mono h le_sup_right
+
+/-- `P.class a` is the element of a partition `P : Partition α` that contains `a : α`. -/
+protected def Partition.class (P : Partition α) (a : α) : Set α :=
+  {b | Setoid.mkClasses P.1 P.2.2 b a}
+
+lemma Partition.mem_class (P : Partition α) (a : α) : a ∈ P.class a :=
+  (Setoid.mkClasses P.1 P.2.2).2.refl _
+
+lemma Partition.class_mem (P : Partition α) (a : α) : P.class a ∈ P :=
+  (Setoid.classes_mkClasses P.1 P.2 ▸ (Setoid.mkClasses P.1 P.2.2).mem_classes a:)
+
+lemma Partition.Measurable.measurableSet_class [MeasurableSpace Ω] {P : Partition Ω}
+    (hP : P.Measurable) (ω : Ω) : MeasurableSet (P.class ω) :=
+  hP _ (P.class_mem ω)
+
+lemma Partition.class_mono {P Q : Partition α} (h : P ≤ Q) (a : α) :
+    P.class a ⊆ Q.class a :=
+  fun x ↦ @h x a
+
+lemma Partition.class_eq_class_of_mem {P : Partition α} {a a' : α} (h : a' ∈ P.class a) :
+    P.class a' = P.class a :=
+  (Setoid.eq_eqv_class_of_mem P.2.2 (P.class_mem a) h).symm
+
+lemma Partition.class_eq_of_mem {P : Partition α} {s : Set α} {a : α}
+    (hs : s ∈ P) (ha : a ∈ s) : P.class a = s :=
+  (Setoid.eq_eqv_class_of_mem P.2.2 hs ha).symm
+
+lemma Partition.class_eq_biUnion_of_le {P Q : Partition α} (h : P ≤ Q) (a : α) :
+    Q.class a = ⋃ s ∈ {s ∈ P | s ⊆ Q.class a}, s := by
+  ext b
+  refine ⟨fun hb ↦ ?_, fun hb ↦ ?_⟩
+  · exact mem_biUnion ⟨P.class_mem b, (P.class_mono h b).trans_eq (Q.class_eq_class_of_mem hb)⟩
+      (P.mem_class b)
+  · obtain ⟨s, hs, hs'⟩ := mem_iUnion₂.mp hb
+    exact hs.2 hs'
+
+end Prerequisites
+
+open MeasureTheory
+
+variable [MeasurableSpace Ω] {μ μ₁ μ₂ : Measure Ω} [IsProbabilityMeasure μ]
+  [IsProbabilityMeasure μ₁] [IsProbabilityMeasure μ₂]
+
+/-- Conditional probability of an event inside the atom of a partition containing a point. -/
+noncomputable abbrev Partition.probabilityAt (P : Partition Ω)
+    (μ : Measure Ω) (E : Set Ω) (ω : Ω) : ENNReal :=
+  μ (E ∩ P.class ω) / μ (P.class ω)
+
+/-- A partition with all parts of positive measure is countable. -/
+lemma Partition.countable_of_measure_pos {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {P : Partition Ω} (hP : P.Measurable) (hP' : ∀ s ∈ P, μ s > 0) :
+    P.val.Countable := by
+  rw [← Set.countable_coe_iff, ← Set.countable_univ_iff]
+  convert μ.countable_meas_pos_of_disjoint_iUnion (fun s : P.1 ↦ hP s.1 s.2) ?_ using 1
+  · ext ⟨s, hs⟩; simp [hP' s hs]
+  · intro s t hst
+    exact P.2.pairwiseDisjoint s.2 t.2 (fun h ↦ hst (Subtype.ext h))
+
+/-- Let `P` be a partition of `Ω` into measurable non-null sets, `Q` a coarser partition and
+`E` a set such that `P.probabilityAt E ω' = p` for all `ω' ∈ Q.class ω`.
+Then `Q.probabilityAt E ω = p`. -/
+lemma Partition.probabilityAt_eq_of_le {P Q : Partition Ω} (hP : P.Measurable)
+    (hP' : ∀ s ∈ P, μ s > 0) (hQ : P ≤ Q) {E : Set Ω} (hE : MeasurableSet E) (ω : Ω) {p : ENNReal}
+    (h : ∀ ω' ∈ Q.class ω, P.probabilityAt μ E ω' = p) :
+    Q.probabilityAt μ E ω = p := by
+  have hP'' := P.countable_of_measure_pos hP hP'
+  rw [eq_comm, ENNReal.eq_div_iff (pos_mono (P.class_mono hQ ω) (hP' _ (P.class_mem ω))).ne'
+      (measure_ne_top _ _),
+    P.class_eq_biUnion_of_le hQ ω, Set.inter_iUnion₂,
+    measure_biUnion (hP''.mono fun s hs ↦ hs.1) ?_ (fun s hs ↦ hP s hs.1), ← ENNReal.tsum_mul_right,
+    measure_biUnion (hP''.mono fun s hs ↦ hs.1) ?_ (fun s hs ↦ hE.inter (hP s hs.1))]
+  · congr; ext s
+    have ⟨ω', hω'⟩ := Setoid.nonempty_of_mem_partition P.2 s.2.1
+    rw [← P.class_eq_of_mem s.2.1 hω',
+      ← ENNReal.eq_div_iff (hP' _ (P.class_mem ω')).ne' (measure_ne_top _ _), eq_comm]
+    exact h _ (s.2.2 hω')
+  · exact (Set.Pairwise.mono inter_subset_left P.2.pairwiseDisjoint).mono'
+      (fun s t h ↦ h.mono inf_le_right inf_le_right)
+  · exact Set.Pairwise.mono inter_subset_left P.2.pairwiseDisjoint
+
+/-- Let `Ω` be a probability measure space, `P₁` and `P₂` two measurable partitions representing
+the information partitions of two agents, `E` a measurable set and `ω` an event. Then if it is
+common knowledge at `ω` that `E` appears to have probability `p₁` to the first agent and probability
+`p₂` to the second agent, `p₁ = p₂` - that is, the two agents agree on the probability of `E`. -/
+lemma agreeToDisagree {P₁ P₂ : Partition Ω} (hP₁ : P₁.Measurable) (hP₂ : P₂.Measurable)
+    (hP₁' : ∀ s ∈ P₁, μ₁ s > 0) (hP₂' : ∀ s ∈ P₂, μ₂ s > 0)
+    {E : Set Ω} (hE : MeasurableSet E) (ω : Ω) {p₁ p₂ : ENNReal}
+    (h : (P₁ ⊔ P₂).class ω ⊆ {ω' | P₁.probabilityAt μ₁ E ω' = p₁ ∧ P₂.probabilityAt μ₂ E ω' = p₂})
+    (h' : (P₁ ⊔ P₂).probabilityAt μ₁ E ω = (P₁ ⊔ P₂).probabilityAt μ₂ E ω) :
+    p₁ = p₂ := by
+  rw [← P₁.probabilityAt_eq_of_le hP₁ hP₁' le_sup_left hE ω (h.trans inter_subset_left),
+    ← P₂.probabilityAt_eq_of_le hP₂ hP₂' le_sup_right hE ω (h.trans inter_subset_right)]
+  exact h'
+
+/-- Let `Ω` be a probability measure space, `P` a family of measurable partitions representing
+the information partitions of agents indexed by a type `ι`, `E` a measurable set and `ω` an event.
+Then if it is common knowledge at `ω` that `E` appears to have probability `p i` to each agent `i`,
+`p i = p j` for all `i`, `j` - that is, all agents agree on the probability of `E`. -/
+lemma agreeToDisagree' {ι : Type*} {μ : ι → Measure Ω} [∀ i, IsProbabilityMeasure (μ i)]
+    {P : ι → Partition Ω} (hP : ∀ i, (P i).Measurable) (hP' : ∀ i, ∀ s ∈ P i, μ i s > 0)
+    {E : Set Ω} (hE : MeasurableSet E) (ω : Ω) {p : ι → ENNReal}
+    (h : (⨆ i, P i).class ω ⊆ {ω' | ∀ i, (P i).probabilityAt (μ i) E ω' = p i})
+    (h' : ∀ i j, (⨆ i, P i).probabilityAt (μ i) E ω = (⨆ i, P i).probabilityAt (μ j) E ω) :
+    ∀ i j, p i = p j := by
+  intro i j
+  rw [← (P i).probabilityAt_eq_of_le (hP i) (hP' i) (le_iSup _ i) hE ω (fun ω' hω'↦ h hω' i),
+    ← (P j).probabilityAt_eq_of_le (hP j) (hP' j) (le_iSup _ j) hE ω (fun ω' hω'↦ h hω' j)]
+  exact h' i j
+
+end AgreeToDisagree

--- a/LeanPool/AgreeToDisagree/AgreeToDisagreeBeliefs.lean
+++ b/LeanPool/AgreeToDisagree/AgreeToDisagreeBeliefs.lean
@@ -1,0 +1,341 @@
+/-
+Copyright (c) 2026 Axiom Math contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: AgreeToDisagree contributors
+-/
+import LeanPool.AgreeToDisagree.AgreeToDisagree
+import Mathlib.Analysis.Normed.Group.InfiniteSum
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.Push
+import Mathlib.Topology.Algebra.InfiniteSum.Order
+
+/-!
+# Approximate agreement under common belief
+
+This file proves the `p`-belief version of Aumann's agreement theorem.
+-/
+
+namespace AgreeToDisagree
+
+open Set MeasureTheory
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
+
+/-- The set of states where the posterior probability of `E` is at least `p`. -/
+abbrev Partition.belief (P : Partition Ω) (μ : Measure Ω)
+    (p : ENNReal) (E : Set Ω) : Set Ω :=
+  {ω | p ≤ P.probabilityAt μ E ω}
+
+/-- A set is `p`-evident for a partition if membership implies `p`-belief in itself. -/
+abbrev Partition.IsEvidentBelief (P : Partition Ω) (μ : Measure Ω)
+    (p : ENNReal) (E : Set Ω) : Prop :=
+  E ⊆ P.belief μ p E
+
+/-- Common `p`-belief at a state, represented by an evident event containing that state. -/
+abbrev IsCommonBeliefAt {ι : Type*} (P : ι → Partition Ω) (μ : Measure Ω)
+    (p : ENNReal) (C : Set Ω) (ω : Ω) : Prop :=
+  ∃ E : Set Ω, ω ∈ E ∧ (∀ i, (P i).IsEvidentBelief μ p E) ∧ ∀ i, E ⊆ (P i).belief μ p C
+
+/-- Monotonicity of belief: `X ⊆ Y` implies `P.belief μ p X ⊆ P.belief μ p Y`. -/
+lemma Partition.belief_mono (P : Partition Ω) (μ : Measure Ω) [IsProbabilityMeasure μ]
+    (p : ENNReal) {X Y : Set Ω} (hXY : X ⊆ Y) :
+    P.belief μ p X ⊆ P.belief μ p Y := fun _ hω ↦
+  hω.trans (ENNReal.div_le_div_right (measure_mono (inter_subset_inter_left _ hXY)) _)
+
+/-- The belief set equals a union over partition atoms with sufficient conditional probability. -/
+lemma Partition.belief_eq_biUnion {P : Partition Ω}
+    (μ : Measure Ω) [IsProbabilityMeasure μ]
+    (p : ENNReal) (X : Set Ω) :
+    P.belief μ p X = ⋃ s ∈ {s : Set Ω | s ∈ P ∧ p ≤ μ (X ∩ s) / μ s}, s := by
+  ext ω
+  simp only [Partition.belief, Partition.probabilityAt, Set.mem_setOf_eq,
+    Set.mem_iUnion, exists_prop]
+  refine ⟨fun hω ↦ ⟨P.class ω, ⟨P.class_mem ω, hω⟩, P.mem_class ω⟩, ?_⟩
+  rintro ⟨s, ⟨hs, hps⟩, hωs⟩
+  rw [Partition.class_eq_of_mem hs hωs]
+  exact hps
+
+/-- For a measurable countable partition `P`, the belief set `P.belief μ p X` is measurable. -/
+lemma Partition.measurableSet_belief {P : Partition Ω} (hP : P.Measurable)
+    (hPc : P.val.Countable) (μ : Measure Ω) [IsProbabilityMeasure μ]
+    (p : ENNReal) (X : Set Ω) :
+    MeasurableSet (P.belief μ p X) := by
+  rw [Partition.belief_eq_biUnion]
+  exact MeasurableSet.biUnion (hPc.mono fun _ hs ↦ hs.1) (fun s hs ↦ hP s hs.1)
+
+/-- The downward step of belief idempotence. -/
+lemma Partition.belief_belief_subset {P : Partition Ω}
+    {p : ENNReal} (hp : 0 < p) (X : Set Ω) :
+    P.belief μ p (P.belief μ p X) ⊆ P.belief μ p X := by
+  intro ω hω
+  rw [Partition.belief_eq_biUnion] at hω ⊢
+  simp only [Set.mem_iUnion, Set.mem_setOf_eq, exists_prop] at hω ⊢
+  obtain ⟨s, ⟨hsP, hs_prob⟩, hωs⟩ := hω
+  refine ⟨s, ⟨hsP, ?_⟩, hωs⟩
+  by_contra h_not
+  push Not at h_not
+  have h_empty : P.belief μ p X ∩ s = ∅ := by
+    ext ω'
+    refine ⟨fun ⟨hω'bel, hω's⟩ ↦ ?_, fun hω'empty ↦ False.elim hω'empty⟩
+    have hbel : p ≤ μ (X ∩ P.class ω') / μ (P.class ω') := hω'bel
+    rw [Partition.class_eq_of_mem hsP hω's] at hbel
+    exact (not_le.mpr h_not) hbel
+  rw [h_empty] at hs_prob
+  have h_zero : p ≤ 0 := by
+    simpa only [measure_empty, ENNReal.zero_div] using hs_prob
+  exact (not_le.mpr hp) h_zero
+
+/-- If `0 < p ≤ a / b`, then `0 < a`. -/
+lemma ennreal_num_pos_of_ratio_ge {p a b : ENNReal} (hp : 0 < p)
+    (h : p ≤ a / b) : 0 < a := by
+  by_contra h₁
+  push Not at h₁
+  rw [le_antisymm h₁ zero_le, ENNReal.zero_div] at h
+  exact absurd (h.trans_lt hp) (lt_irrefl _)
+
+omit [IsProbabilityMeasure μ] in
+/-- If `A` is `p`-evident with `0 < p`, then `μ A > 0`. -/
+lemma measure_pos_of_evident_belief {P : Partition Ω}
+    {p : ENNReal} (hp : 0 < p) {A : Set Ω} {ω : Ω}
+    (hω : ω ∈ A) (hev : A ⊆ P.belief μ p A) :
+    0 < μ A :=
+  (ennreal_num_pos_of_ratio_ge hp (hev hω)).trans_le (measure_mono Set.inter_subset_left)
+
+omit [IsProbabilityMeasure μ] in
+/-- A set of positive measure is nonempty. -/
+lemma nonempty_of_measure_pos {s : Set Ω} (h : 0 < μ s) : s.Nonempty :=
+  Set.nonempty_iff_ne_empty.mpr fun he ↦ by simp [he] at h
+
+/-- If `A ⊆ P.belief μ p {ω | P.probabilityAt μ E ω = r}`, then probability equals r on A. -/
+lemma probabilityAt_eq_of_belief_const
+    {P : Partition Ω} {p : ENNReal} (hp : 0 < p) {E A : Set Ω} {r : ENNReal}
+    (hA : A ⊆ P.belief μ p {ω | P.probabilityAt μ E ω = r}) :
+    ∀ ω ∈ A, P.probabilityAt μ E ω = r := by
+  intro ω hω
+  have hbel := hA hω
+  rw [Partition.belief_eq_biUnion] at hbel
+  simp only [Set.mem_iUnion, Set.mem_setOf_eq, exists_prop] at hbel
+  obtain ⟨s, ⟨hsP, hps⟩, hωs⟩ := hbel
+  obtain ⟨ω₀, hω₀S, hω₀s⟩ := nonempty_of_measure_pos (ennreal_num_pos_of_ratio_ge hp hps)
+  change μ (E ∩ P.class ω) / μ (P.class ω) = r
+  rw [← Partition.class_eq_class_of_mem
+    (Partition.class_eq_of_mem hsP hωs ▸ hω₀s : ω₀ ∈ P.class ω)]
+  exact hω₀S
+
+/-! ## Helpers for `core_bound` -/
+
+lemma core_bound.atom_E_eq {P : Partition Ω} (hP' : ∀ s ∈ P, μ s > 0)
+    {A E : Set Ω} {r : ENNReal}
+    (hAR : ∀ ω ∈ A, P.probabilityAt μ E ω = r)
+    {s : Set Ω} (hs : s ∈ P) {ω : Ω} (hω : ω ∈ A ∩ s) :
+    μ (E ∩ s) = r * μ s := by
+  have h : μ (E ∩ s) / μ s = r := by
+    simpa [Partition.probabilityAt, Partition.class_eq_of_mem hs hω.2] using hAR ω hω.1
+  rw [← h, ENNReal.div_mul_cancel (hP' s hs).ne' (measure_ne_top μ s)]
+
+lemma core_bound.atom_evidence {P : Partition Ω} (hP' : ∀ s ∈ P, μ s > 0)
+    {p : ENNReal} {A : Set Ω} (hAev : A ⊆ P.belief μ p A)
+    {s : Set Ω} (hs : s ∈ P) {ω : Ω} (hω : ω ∈ A ∩ s) :
+    p * μ s ≤ μ (A ∩ s) := by
+  have hbelief : p ≤ μ (A ∩ s) / μ s := by
+    rw [← Partition.class_eq_of_mem hs hω.2]; exact hAev hω.1
+  have hμs_top : μ s ≠ ⊤ := ne_top_of_le_ne_top ENNReal.one_ne_top prob_le_one
+  exact (ENNReal.le_div_iff_mul_le (Or.inl (hP' s hs).ne') (Or.inl hμs_top)).mp hbelief
+
+private lemma atom_real_arith {x αr r p δ : ℝ}
+    (hx0 : 0 ≤ x) (hx1 : x ≤ 1) (hα_le_1 : αr ≤ 1) (hp_le_α : p ≤ αr)
+    (hδ0 : 0 ≤ δ) (hδ_ub : δ ≤ 1 - αr) (heq : r = x * αr + δ) :
+    |x - r| ≤ 1 - p := by
+  have h1 : (0 : ℝ) ≤ 1 - αr := by linarith
+  rw [abs_le]
+  refine ⟨?_, ?_⟩ <;> nlinarith [mul_le_mul_of_nonneg_right hx1 h1, mul_nonneg hx0 h1]
+
+lemma core_bound.atom_real_bound {P : Partition Ω} (hP' : ∀ s ∈ P, μ s > 0)
+    {p : ENNReal} {A E : Set Ω} (hA : MeasurableSet A)
+    {r : ENNReal} {s : Set Ω} (hs : s ∈ P) (hAsmu : 0 < μ (A ∩ s))
+    (hEs : μ (E ∩ s) = r * μ s) (hαs : p * μ s ≤ μ (A ∩ s)) :
+    |(μ (E ∩ A ∩ s) / μ (A ∩ s)).toReal - r.toReal| ≤ 1 - p.toReal := by
+  have hms_pos : 0 < μ s := hP' s hs
+  have hAs_le_s : μ (A ∩ s) ≤ μ s := measure_mono Set.inter_subset_right
+  have hAs_ne_top : μ (A ∩ s) ≠ ⊤ := (hAs_le_s.trans_lt (measure_lt_top μ s)).ne
+  have hEAs_le_As : μ (E ∩ A ∩ s) ≤ μ (A ∩ s) :=
+    measure_mono fun _ hω ↦ ⟨hω.1.2, hω.2⟩
+  have hEAs_ne_top : μ (E ∩ A ∩ s) ≠ ⊤ :=
+    (hEAs_le_As.trans_lt hAs_ne_top.lt_top).ne
+  have hsdA_ne_top : μ (s \ A) ≠ ⊤ :=
+    ((measure_mono Set.sdiff_subset).trans_lt (measure_lt_top μ s)).ne
+  have hEsdA_le_sdA : μ ((E ∩ s) \ A) ≤ μ (s \ A) :=
+    measure_mono fun _ hω ↦ ⟨hω.1.2, hω.2⟩
+  have hEsdA_ne_top : μ ((E ∩ s) \ A) ≠ ⊤ :=
+    (hEsdA_le_sdA.trans_lt hsdA_ne_top.lt_top).ne
+  have hdecE : μ (E ∩ A ∩ s) + μ ((E ∩ s) \ A) = μ (E ∩ s) := by
+    rw [show E ∩ A ∩ s = (E ∩ s) ∩ A by ext x; simp [and_assoc, and_comm]]
+    exact measure_inter_add_sdiff (E ∩ s) hA
+  have hdecS : μ (A ∩ s) + μ (s \ A) = μ s := by
+    rw [inter_comm]
+    exact measure_inter_add_sdiff s hA
+  set ms := (μ s).toReal
+  set mAs := (μ (A ∩ s)).toReal
+  set mEAs := (μ (E ∩ A ∩ s)).toReal
+  set msdA := (μ (s \ A)).toReal
+  set mEsdA := (μ ((E ∩ s) \ A)).toReal
+  have hms_pos_R : 0 < ms := ENNReal.toReal_pos hms_pos.ne' (measure_lt_top μ s).ne
+  have hmAs_pos_R : 0 < mAs := ENNReal.toReal_pos hAsmu.ne' hAs_ne_top
+  have hmAs_le_ms : mAs ≤ ms := ENNReal.toReal_mono (measure_lt_top μ s).ne hAs_le_s
+  have hmEAs_le_mAs : mEAs ≤ mAs := ENNReal.toReal_mono hAs_ne_top hEAs_le_As
+  have hdecS_R : mAs + msdA = ms := by
+    rw [← ENNReal.toReal_add hAs_ne_top hsdA_ne_top, hdecS]
+  have hdecE_R : mEAs + mEsdA = (μ (E ∩ s)).toReal := by
+    rw [← ENNReal.toReal_add hEAs_ne_top hEsdA_ne_top, hdecE]
+  have hEs_R : (μ (E ∩ s)).toReal = r.toReal * ms := by rw [hEs, ENNReal.toReal_mul]
+  have hp_ev_R : p.toReal * ms ≤ mAs := by
+    have := ENNReal.toReal_mono hAs_ne_top hαs
+    rwa [ENNReal.toReal_mul] at this
+  set αr := mAs / ms with hαr_def
+  set xr := mEAs / mAs with hxr_def
+  set δ := mEsdA / ms with hδ_def
+  have hδ_ub : δ ≤ 1 - αr := by
+    have h2 : δ ≤ msdA / ms :=
+      div_le_div_of_nonneg_right (ENNReal.toReal_mono hsdA_ne_top hEsdA_le_sdA) hms_pos_R.le
+    have h3 : msdA / ms = 1 - αr := by
+      rw [show msdA = ms - mAs by linarith, hαr_def]; field_simp
+    linarith
+  have hp_le_α : p.toReal ≤ αr := by rw [hαr_def, le_div_iff₀ hms_pos_R]; linarith
+  have heq : r.toReal = xr * αr + δ := by
+    have key : r.toReal * ms = mEAs + mEsdA := by rw [← hEs_R, ← hdecE_R]
+    have : r.toReal = (mEAs + mEsdA) / ms := by field_simp at key ⊢; linarith
+    rw [this, hxr_def, hαr_def, hδ_def]; field_simp
+  rw [show (μ (E ∩ A ∩ s) / μ (A ∩ s)).toReal = xr from ENNReal.toReal_div ..]
+  exact atom_real_arith (div_nonneg ENNReal.toReal_nonneg hmAs_pos_R.le)
+    ((div_le_one hmAs_pos_R).mpr hmEAs_le_mAs)
+    ((div_le_one hms_pos_R).mpr hmAs_le_ms) hp_le_α
+    (div_nonneg ENNReal.toReal_nonneg hms_pos_R.le) hδ_ub heq
+
+lemma core_bound.tsum_decomp_A {P : Partition Ω} (hP : P.Measurable)
+    (hP' : ∀ s ∈ P, μ s > 0) {A : Set Ω} (hA : MeasurableSet A) :
+    μ A = ∑' (s : P.val), μ (A ∩ s.1) := by
+  haveI : Countable P.val := (Partition.countable_of_measure_pos hP hP').to_subtype
+  have hUnion : A = ⋃ (s : P.val), A ∩ s.1 := by
+    ext ω
+    simp only [mem_iUnion, mem_inter_iff]
+    refine ⟨fun hA ↦ ?_, fun ⟨_, hA, _⟩ ↦ hA⟩
+    obtain ⟨s, hs, hωs⟩ : ω ∈ ⋃₀ P.val := by rw [P.2.sUnion_eq_univ]; trivial
+    exact ⟨⟨s, hs⟩, hA, hωs⟩
+  conv_lhs => rw [hUnion]
+  exact measure_iUnion
+    (fun s t hst ↦ (P.2.pairwiseDisjoint s.2 t.2 (fun h ↦ hst (Subtype.ext h))).mono
+      inter_subset_right inter_subset_right)
+    (fun s ↦ hA.inter (hP s.1 s.2))
+
+lemma core_bound.abs_sub_div_le_of_mul {T q r b : ℝ} (hT : 0 < T)
+    (h : |r * T - q| ≤ T * b) : |r - q / T| ≤ b := by
+  rw [show r - q / T = (r * T - q) / T by field_simp, abs_div, abs_of_pos hT, div_le_iff₀ hT]
+  linarith
+
+lemma core_bound.weighted_atom_bound
+    {P : Partition Ω} {A E : Set Ω} {p r : ENNReal}
+    (hAtom : ∀ (s : P.val), 0 < μ (A ∩ s.1) →
+        |(μ (E ∩ A ∩ s.1) / μ (A ∩ s.1)).toReal - r.toReal| ≤ 1 - p.toReal)
+    (s : P.val) :
+    |(μ (A ∩ s.1)).toReal * r.toReal - (μ (E ∩ A ∩ s.1)).toReal|
+      ≤ (μ (A ∩ s.1)).toReal * (1 - p.toReal) := by
+  by_cases hpos : 0 < μ (A ∩ s.1)
+  · have ha : 0 < (μ (A ∩ s.1)).toReal :=
+      ENNReal.toReal_pos hpos.ne' (measure_ne_top μ _)
+    have h := hAtom s hpos
+    rw [ENNReal.toReal_div] at h
+    rw [show (μ (A ∩ s.1)).toReal * r.toReal - (μ (E ∩ A ∩ s.1)).toReal =
+      (μ (A ∩ s.1)).toReal * (r.toReal - (μ (E ∩ A ∩ s.1)).toReal / (μ (A ∩ s.1)).toReal)
+      by field_simp, abs_mul, abs_of_pos ha, abs_sub_comm]
+    exact mul_le_mul_of_nonneg_left h ha.le
+  · push Not at hpos
+    have hμA_zero : μ (A ∩ s.1) = 0 := le_antisymm hpos zero_le
+    have hμEA_zero : μ (E ∩ A ∩ s.1) = 0 :=
+      le_antisymm (hμA_zero ▸ measure_mono fun _ ⟨⟨_, h⟩, h'⟩ ↦ ⟨h, h'⟩) zero_le
+    simp [hμA_zero, hμEA_zero]
+
+lemma core_bound.weighted_sum_bound
+    {P : Partition Ω}
+    {p : ENNReal} {A E : Set Ω} {r : ENNReal}
+    (hμA : μ A = ∑' (s : P.val), μ (A ∩ s.1))
+    (hμEA : μ (E ∩ A) = ∑' (s : P.val), μ (E ∩ A ∩ s.1))
+    (hAtom : ∀ (s : P.val), 0 < μ (A ∩ s.1) →
+        |(μ (E ∩ A ∩ s.1) / μ (A ∩ s.1)).toReal - r.toReal| ≤ 1 - p.toReal) :
+    |r.toReal * (μ A).toReal - (μ (E ∩ A)).toReal|
+      ≤ (μ A).toReal * (1 - p.toReal) := by
+  have hSumA : Summable (fun s : P.val ↦ (μ (A ∩ s.1)).toReal) :=
+    ENNReal.summable_toReal (hμA ▸ measure_ne_top μ A)
+  have hSumEA : Summable (fun s : P.val ↦ (μ (E ∩ A ∩ s.1)).toReal) :=
+    ENNReal.summable_toReal (hμEA ▸ measure_ne_top μ _)
+  have hAtsum : (μ A).toReal = ∑' s : P.val, (μ (A ∩ s.1)).toReal := by
+    rw [hμA, ENNReal.tsum_toReal_eq (fun _ ↦ measure_ne_top μ _)]
+  have hEAtsum : (μ (E ∩ A)).toReal = ∑' s : P.val, (μ (E ∩ A ∩ s.1)).toReal := by
+    rw [hμEA, ENNReal.tsum_toReal_eq (fun _ ↦ measure_ne_top μ _)]
+  rw [hAtsum, hEAtsum]
+  have hSumRA := hSumA.mul_left r.toReal
+  rw [← tsum_mul_left, ← Summable.tsum_sub hSumRA hSumEA]
+  have hterm : ∀ s : P.val,
+      ‖r.toReal * (μ (A ∩ s.1)).toReal - (μ (E ∩ A ∩ s.1)).toReal‖
+        ≤ (μ (A ∩ s.1)).toReal * (1 - p.toReal) := fun s ↦ by
+    simpa [Real.norm_eq_abs, mul_comm] using core_bound.weighted_atom_bound (μ := μ) hAtom s
+  refine (tsum_of_norm_bounded (hSumA.mul_right _).hasSum hterm).trans ?_
+  rw [tsum_mul_right, ← hAtsum]
+
+/-- Core bound (Step 4 of the informal proof). -/
+lemma core_bound {P : Partition Ω} (hP : P.Measurable) (hP' : ∀ s ∈ P, μ s > 0)
+    {p : ENNReal} {A E : Set Ω}
+    (hA : MeasurableSet A) (hAmu : 0 < μ A) (hAev : A ⊆ P.belief μ p A)
+    (hE : MeasurableSet E) {r : ENNReal}
+    (hAR : ∀ ω ∈ A, P.probabilityAt μ E ω = r) :
+    |r.toReal - (μ (E ∩ A) / μ A).toReal| ≤ 1 - p.toReal := by
+  have hμA : μ A = ∑' (s : P.val), μ (A ∩ s.1) := core_bound.tsum_decomp_A hP hP' hA
+  have hμEA : μ (E ∩ A) = ∑' (s : P.val), μ (E ∩ A ∩ s.1) :=
+    core_bound.tsum_decomp_A hP hP' (hE.inter hA)
+  have hAtom : ∀ (s : P.val), 0 < μ (A ∩ s.1) →
+      |(μ (E ∩ A ∩ s.1) / μ (A ∩ s.1)).toReal - r.toReal| ≤ 1 - p.toReal := fun s hAs ↦ by
+    obtain ⟨ω, hω⟩ : (A ∩ s.1).Nonempty :=
+      Set.nonempty_iff_ne_empty.mpr (fun h ↦ by simp [h] at hAs)
+    exact core_bound.atom_real_bound hP' hA s.2 hAs
+      (core_bound.atom_E_eq hP' hAR s.2 hω) (core_bound.atom_evidence hP' hAev s.2 hω)
+  rw [ENNReal.toReal_div]
+  exact core_bound.abs_sub_div_le_of_mul
+    (ENNReal.toReal_pos hAmu.ne' (measure_lt_top μ A).ne)
+    (core_bound.weighted_sum_bound hμA hμEA hAtom)
+
+lemma agreeToDisagree_beliefs {ι : Type*} {P : ι → Partition Ω}
+    (hP : ∀ i, (P i).Measurable) (hP' : ∀ i, ∀ s ∈ P i, μ s > 0)
+    {E : Set Ω} (hE : MeasurableSet E) (ω : Ω) {p : ENNReal} (hp : 0 < p) {r : ι → ENNReal}
+    (h : IsCommonBeliefAt P μ p {ω | ∀ i, (P i).probabilityAt μ E ω = r i} ω) :
+    ∀ i j, |(r i).toReal - (r j).toReal| ≤ 2 * (1 - p.toReal) := by
+  intro i j
+  obtain ⟨A₀, hωA₀, hev, hbel⟩ := h
+  -- A is the measurable witness: intersection of belief sets for players i, j
+  set A : Set Ω := (P i).belief μ p A₀ ∩ (P j).belief μ p A₀
+  have hAmeas : MeasurableSet A :=
+    (Partition.measurableSet_belief (hP i)
+        (Partition.countable_of_measure_pos (hP i) (hP' i)) μ p A₀).inter
+      (Partition.measurableSet_belief (hP j)
+        (Partition.countable_of_measure_pos (hP j) (hP' j)) μ p A₀)
+  have hA₀A : A₀ ⊆ A := fun _ hω' ↦ ⟨hev i hω', hev j hω'⟩
+  have hevi : A ⊆ (P i).belief μ p A := fun _ hω' ↦ (P i).belief_mono μ p hA₀A hω'.1
+  have hevj : A ⊆ (P j).belief μ p A := fun _ hω' ↦ (P j).belief_mono μ p hA₀A hω'.2
+  set C : Set Ω := {ω | ∀ k, (P k).probabilityAt μ E ω = r k}
+  have hbCi : A ⊆ (P i).belief μ p C := fun _ hω' ↦
+    Partition.belief_belief_subset hp _ ((P i).belief_mono μ p (hbel i) hω'.1)
+  have hbCj : A ⊆ (P j).belief μ p C := fun _ hω' ↦
+    Partition.belief_belief_subset hp _ ((P j).belief_mono μ p (hbel j) hω'.2)
+  have hPRi : ∀ ω' ∈ A, (P i).probabilityAt μ E ω' = r i :=
+    probabilityAt_eq_of_belief_const hp
+      (hbCi.trans ((P i).belief_mono μ p fun _ hω' ↦ hω' i))
+  have hPRj : ∀ ω' ∈ A, (P j).probabilityAt μ E ω' = r j :=
+    probabilityAt_eq_of_belief_const hp
+      (hbCj.trans ((P j).belief_mono μ p fun _ hω' ↦ hω' j))
+  have hAmu : 0 < μ A := measure_pos_of_evident_belief hp (hA₀A hωA₀) hevi
+  have boundi := core_bound (hP i) (hP' i) hAmeas hAmu hevi hE hPRi
+  have boundj := core_bound (hP j) (hP' j) hAmeas hAmu hevj hE hPRj
+  have tri := abs_sub_le (r i).toReal (μ (E ∩ A) / μ A).toReal (r j).toReal
+  rw [abs_sub_comm] at boundj
+  linarith
+
+end AgreeToDisagree

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -3550,3 +3550,47 @@ projects:
     msc:
       - "11N05"
       - "11N35"
+  - slug: agree-to-disagree
+    title: "Aumann's Agreement Theorem"
+    summary: >-
+      Formalizes Aumann's agreement theorem for information partitions and a
+      common-prior setting, together with a p-belief variant bounding posterior
+      disagreement by 2 * (1 - p).
+    branch: probability theory
+    entry_module: LeanPool.AgreeToDisagree
+    authors:
+      - Ruiz Chen
+      - Ben Eltschig
+      - Ken Ono
+      - Jujian Zhang
+    source:
+      title: "We Can't Agree to Disagree, Formally: Aumann's Theorem and Assumption Accounting in Lean"
+      url: "https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6837298"
+      github_repo: AxiomMath/AgreeToDisagree
+    license: MIT
+    status: verified
+    main_declarations:
+      - AgreeToDisagree.agreeToDisagree
+      - AgreeToDisagree.agreeToDisagree_beliefs
+    main_results:
+      - declaration: AgreeToDisagree.agreeToDisagree
+        informal: >-
+          If it is common knowledge at a state that two agents assign fixed
+          posterior probabilities to an event, and the common-knowledge cell has
+          equal posterior under their priors, then the two posterior
+          probabilities are equal.
+      - declaration: AgreeToDisagree.agreeToDisagree'
+        informal: >-
+          Generalizes the agreement theorem to a family of agents indexed by an
+          arbitrary type.
+      - declaration: AgreeToDisagree.agreeToDisagree_beliefs
+        informal: >-
+          Proves that common p-belief of fixed posteriors bounds the difference
+          between any two agents' real-valued posteriors by 2 * (1 - p).
+    tags:
+      - probability
+      - game-theory
+      - epistemic-logic
+    msc:
+      - "60A10"
+      - "91A40"


### PR DESCRIPTION
## Summary
- imports AxiomMath/AgreeToDisagree under LeanPool.AgreeToDisagree
- ports the final hand-cleaned agreement theorem and p-belief theorem files to current Mathlib
- shares the common partition/probability helper surface between the two theorem files instead of importing upstream duplicate/prover-output modules

## Local checks
- lake build LeanPool.AgreeToDisagree (warning-free)
- lake exe mk_all --check
- lake exe runLinter LeanPool.AgreeToDisagree
- lake exe lint-style LeanPool.AgreeToDisagree
- direct #check of AgreeToDisagree.agreeToDisagree, AgreeToDisagree.agreeToDisagree', AgreeToDisagree.agreeToDisagree_beliefs
- forbidden-token scan over LeanPool/AgreeToDisagree*
- git diff --check