### PR TITLE
Import zeta-h123

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -2334,6 +2334,11 @@ import LeanPool.Zeta3Irrational.Equality
 import LeanPool.Zeta3Irrational.Integral
 import LeanPool.Zeta3Irrational.LegendrePoly
 import LeanPool.Zeta3Irrational.LinearForm
+import LeanPool.ZetaH123
+import LeanPool.ZetaH123.H1
+import LeanPool.ZetaH123.H2
+import LeanPool.ZetaH123.H3
+import LeanPool.ZetaH123.Lem41
 import LeanPool.ZhangYeungInequality
 import LeanPool.ZhangYeungInequality.CopyLemma
 import LeanPool.ZhangYeungInequality.Delta

--- a/LeanPool/ZetaH123.lean
+++ b/LeanPool/ZetaH123.lean
@@ -1,0 +1,21 @@
+/-
+Copyright (c) 2026 Evan Chen, Kenny Lau, Ken Ono, Jujian Zhang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Evan Chen, Kenny Lau, Ken Ono, Jujian Zhang
+-/
+
+import LeanPool.ZetaH123.H1
+import LeanPool.ZetaH123.H2
+import LeanPool.ZetaH123.H3
+import LeanPool.ZetaH123.Lem41
+
+/-!
+# Thakur's hypotheses on power sums of F_q[t]
+
+Source: arxiv:2606.16239
+Authors: Evan Chen, Kenny Lau, Ken Ono, Jujian Zhang
+Status: verified
+Main declarations: `ZetaH123.H1.main_theorem`, `ZetaH123.Lem41.main`
+Tags: number-theory, function-fields, zeta-functions
+MSC: 11M38, 11T55, 11G09
+-/

--- a/LeanPool/ZetaH123/H1.lean
+++ b/LeanPool/ZetaH123/H1.lean
@@ -1,0 +1,2458 @@
+/-
+Copyright (c) 2026 Evan Chen, Kenny Lau, Ken Ono, Jujian Zhang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Evan Chen, Kenny Lau, Ken Ono, Jujian Zhang
+-/
+
+import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.Algebra.Order.Ring.Star
+import Mathlib.Algebra.Ring.GeomSum
+import Mathlib.AlgebraicTopology.SimplexCategory.Basic
+import Mathlib.Analysis.Normed.Ring.Lemmas
+import Mathlib.Data.Int.Star
+import Mathlib.Data.Nat.ModEq
+import Mathlib.Data.Nat.Prime.Defs
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Order
+import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Push
+import Mathlib.Tactic.Ring
+
+/-!
+# H1 for Thakur's hypotheses on power sums
+-/
+
+namespace ZetaH123.H1
+
+/-
+# Problem Description
+
+Throughout, fix a prime `q` and nonnegative integers `d ≥ 0` and `k ≥ 0`.
+
+## Definition 1 (The coefficient `b(i,d)`).
+For each integer `i` with `0 ≤ i ≤ d`, define
+  `b(i,d) := -((q ^ (d + 1) - q ^ (i+1))/(q - 1) + i * q ^ i)`.
+Here `(q ^ (d + 1) - q ^ (i+1))/(q - 1) = q ^ (i+1) + q ^ (i+2) + ... + q ^ d` is an integer,
+so `b(i,d) ∈ ℤ`, and `b(i,d) ≤ 0` with equality only when `i = d = 0`.
+
+## Definition 2 (Carry-free addition in base `q`).
+Let `x_0, ..., x_d` be nonnegative integers, written in base `q` as
+`x_i = ∑_n a_{i,n} q ^ n` with `0 ≤ a_{i,n} ≤ q-1`. The addition
+`x_0 + ... + x_d` has no carries in base `q` (is carry-free) if for every digit
+position `n ≥ 0`, `∑_{i=0} ^ d a_{i,n} ≤ q-1`.
+
+## Definition 3 (Admissible tuple).
+A `(d + 1)`-tuple `(k_0, ..., k_d)` of nonnegative integers is admissible (for the
+given `q`, `d`, `k`) if:
+1. (Representation) `k = ∑_{i=0} ^ d k_i q ^ i`;
+2. (Carry-free) the addition `k_0 + ... + k_d` has no carries in base `q`.
+
+## Definition 4 (Objective function).
+For an admissible tuple, `F(k_0, ..., k_d) := b(0,d) + ∑_{i=0} ^ d k_i b(i,d)`.
+
+## Main Statement (Unique maximizer).
+Let `q` be prime and `d, k ≥ 0`. Among all admissible `(d + 1)`-tuples, the value
+`F` attains its maximum at exactly one admissible tuple.
+
+## Notes
+- The feasible set is nonempty: the tuple `(k, 0, ..., 0)` is admissible.
+- The numbering uses 0-indexing throughout (`Fin (d + 1)`), matching the math.
+-/
+
+open Finset
+
+/-- The `n`-th digit of `x` in base `q`, i.e. `a_{i,n}` for `x = ∑_n a_{i,n} q ^ n`. -/
+def digit (q x n : ℕ) : ℕ := (x / q ^ n) % q
+
+/-- The coefficient `b(i,d)`. The geometric sum `∑_{j=i+1} ^ d q ^ j` equals the integer
+`(q ^ (d + 1) - q ^ (i+1))/(q - 1)`, so this matches the informal definition exactly. -/
+def bCoeff (q i d : ℕ) : ℤ :=
+  -((∑ j ∈ Finset.Ico (i + 1) (d + 1), (q : ℤ) ^ j) + (i : ℤ) * (q : ℤ) ^ i)
+
+/-- Carry-free condition (Definition 2): in every digit position `n`, the sum of the
+`n`-th base-`q` digits of the entries is at most `q - 1`. -/
+def CarryFree (q d : ℕ) (kk : Fin (d + 1) → ℕ) : Prop :=
+  ∀ n : ℕ, (∑ i : Fin (d + 1), digit q (kk i) n) ≤ q - 1
+
+/-- Admissible tuple (Definition 3): satisfies the representation and carry-free
+conditions. -/
+def Admissible (q d k : ℕ) (kk : Fin (d + 1) → ℕ) : Prop :=
+  (k = ∑ i : Fin (d + 1), kk i * q ^ (i : ℕ)) ∧ CarryFree q d kk
+
+/-- The objective function `F` (Definition 4). -/
+def F (q d : ℕ) (kk : Fin (d + 1) → ℕ) : ℤ :=
+  bCoeff q 0 d + ∑ i : Fin (d + 1), (kk i : ℤ) * bCoeff q (i : ℕ) d
+
+/-! ## Supporting lemmas
+
+Elementary structural facts: every component of an admissible tuple is `≤ k`,
+base-`q` digits are `≤ q-1`, the "all in slot 0" tuple is admissible, and the
+admissible set is finite. -/
+
+/-- Each component of an admissible tuple is at most `k`. -/
+lemma admissible_le (q d k : ℕ) (hq : 1 ≤ q) (kk : Fin (d + 1) → ℕ)
+    (h : Admissible q d k kk) (i : Fin (d + 1)) : kk i ≤ k := by
+  obtain ⟨hrep, _⟩ := h
+  rw [hrep]
+  have hpow : 1 ≤ q ^ (i : ℕ) := Nat.one_le_pow _ _ hq
+  calc kk i ≤ kk i * q ^ (i : ℕ) := Nat.le_mul_of_pos_right _ (by positivity)
+    _ ≤ ∑ j : Fin (d + 1), kk j * q ^ (j : ℕ) :=
+        Finset.single_le_sum (f := fun j => kk j * q ^ (j : ℕ))
+          (fun j _ => Nat.zero_le _) (Finset.mem_univ i)
+
+/-- `digit q x n ≤ q - 1` whenever `q ≥ 1`. -/
+lemma digit_le (q x n : ℕ) (hq : 1 ≤ q) : digit q x n ≤ q - 1 := by
+  unfold digit
+  have := Nat.mod_lt (x / q ^ n) (show 0 < q from hq)
+  omega
+
+/-- The "all in slot 0" tuple `(k, 0, ..., 0)`. -/
+def k0tuple (d k : ℕ) : Fin (d + 1) → ℕ := fun i => if (i : ℕ) = 0 then k else 0
+
+lemma k0tuple_admissible (q d k : ℕ) (hq : 1 ≤ q) :
+    Admissible q d k (k0tuple d k) := by
+  constructor
+  · -- representation
+    rw [Finset.sum_eq_single (0 : Fin (d + 1))]
+    · simp [k0tuple]
+    · intro b _ hb
+      have : (b : ℕ) ≠ 0 := by
+        intro h; apply hb; exact Fin.ext h
+      simp [k0tuple, this]
+    · intro h; exact absurd (Finset.mem_univ _) h
+  · -- carry-free
+    intro n
+    have heq : (∑ i : Fin (d + 1), digit q (k0tuple d k i) n)
+        = digit q k n := by
+      rw [Finset.sum_eq_single (0 : Fin (d + 1))]
+      · simp [k0tuple]
+      · intro b _ hb
+        have : (b : ℕ) ≠ 0 := by
+          intro h; apply hb; exact Fin.ext h
+        simp [k0tuple, this, digit]
+      · intro h; exact absurd (Finset.mem_univ _) h
+    rw [heq]
+    exact digit_le q k n hq
+
+/-- The set of admissible tuples is finite. -/
+lemma admissible_finite (q d k : ℕ) (hq : 1 ≤ q) :
+    {kk : Fin (d + 1) → ℕ | Admissible q d k kk}.Finite := by
+  apply Set.Finite.subset
+    (s := ↑(Fintype.piFinset (fun _ : Fin (d + 1) => Finset.range (k + 1))))
+  · exact (Fintype.piFinset _).finite_toSet
+  · intro kk hkk
+    simp only [Set.mem_setOf_eq] at hkk
+    simp only [Finset.mem_coe, Fintype.mem_piFinset,
+      Finset.mem_range]
+    intro i
+    have := admissible_le q d k hq kk hkk i
+    omega
+
+/-! ## The crux: uniqueness of the maximizer
+
+Maximizing `F` is equivalent to minimizing the linear functional
+`Φ(kk) = q ^ {d+1}·∑ᵢ kkᵢ + (q - 1)·∑ᵢ i·qⁱ·kkᵢ`, in which each "stone" in cell
+`(i,n)` (one unit of the digit `a_{i,n}`) carries weight `q ^ {n+i}·g_i` with
+`g_i = q ^ {d+1-i} + (q - 1)·i` strictly decreasing in `i` (informal.tex
+`eq:Phi-H1`, `eq:g-decreasing-H1`). Two pillars: carry elimination
+(`carry_elimination`: a maximizer's column sums are exactly the base-`q`
+digits of `k`) and uniqueness of the greedy allocation via exchange arguments
+(`move_down`, `move_parallelogram`). -/
+
+/-! ### Digit bookkeeping for the single-column exchange -/
+
+/-- **Digit no-cascade, target position.** Subtracting `r * q ^ n` from `x`, where
+`r ≤ digit q x n`, decreases the `n`-th digit by exactly `r`. -/
+lemma digit_sub_self (q x n r : ℕ) (hq : 1 ≤ q) (hr : r ≤ digit q x n) :
+    digit q (x - r * q ^ n) n = digit q x n - r := by
+  unfold digit at *
+  have hpos : 0 < q ^ n := pow_pos (by omega) n
+  have hrle : r ≤ x / q ^ n := le_trans hr (Nat.mod_le _ _)
+  have hdiv : (x - r * q ^ n) / q ^ n = x / q ^ n - r := by
+    have hle : r * q ^ n ≤ x := by
+      calc r * q ^ n ≤ (x / q ^ n) * q ^ n := Nat.mul_le_mul_right _ hrle
+        _ ≤ x := Nat.div_mul_le_self x (q ^ n)
+    have key : (x - r * q ^ n) / q ^ n + r = x / q ^ n := by
+      rw [← Nat.add_mul_div_right _ r hpos]
+      congr 1; omega
+    omega
+  rw [hdiv]
+  set y := x / q ^ n with hy
+  conv_lhs => rw [← Nat.div_add_mod y q]
+  rw [Nat.mul_comm, Nat.add_sub_assoc hr, Nat.add_comm, Nat.add_mul_mod_self_right]
+  have hlt : y % q - r < q := by
+    have := Nat.mod_lt y (show 0 < q by omega); omega
+  exact Nat.mod_eq_of_lt hlt
+
+/-- **Digit no-cascade, other positions.** Subtracting `r * q ^ n` from `x`, where
+`r ≤ digit q x n`, leaves every digit at a position `m ≠ n` unchanged. -/
+lemma digit_sub_other (q x n r m : ℕ) (hq : 1 ≤ q) (hr : r ≤ digit q x n) (hmn : m ≠ n) :
+    digit q (x - r * q ^ n) m = digit q x m := by
+  have hq0 : 0 < q := by omega
+  unfold digit at *
+  -- Global no-borrow fact: r * q ^ n ≤ x
+  have hle : r * q ^ n ≤ x := by
+    have hpos : 0 < q ^ n := pow_pos hq0 n
+    have hrle : r ≤ x / q ^ n := le_trans hr (Nat.mod_le _ _)
+    calc r * q ^ n ≤ (x / q ^ n) * q ^ n := Nat.mul_le_mul_right _ hrle
+      _ ≤ x := Nat.div_mul_le_self x (q ^ n)
+  rcases lt_or_gt_of_ne hmn with hlt | hgt
+  · -- Case m < n: q ^ (m + 1) ∣ r*q ^ n, subtraction invisible mod q ^ (m + 1)
+    have hdvd : q ^ (m + 1) ∣ r * q ^ n := by
+      have hpd : q ^ (m + 1) ∣ q ^ n := pow_dvd_pow q (by omega)
+      exact hpd.mul_left r
+    have hmod : (x - r * q ^ n) % q ^ (m + 1) = x % q ^ (m + 1) := by
+      have h : (x - r * q ^ n) ≡ x [MOD q ^ (m + 1)] := by
+        rw [Nat.modEq_iff_dvd' (by omega : x - r * q ^ n ≤ x)]
+        have hsub : x - (x - r * q ^ n) = r * q ^ n := by omega
+        rw [hsub]; exact hdvd
+      exact h
+    -- relate digit to mod: y / q ^ m % q = (y % q ^ (m + 1)) / q ^ m
+    have key : ∀ y : ℕ, y / q ^ m % q = (y % q ^ (m + 1)) / q ^ m := by
+      intro y; rw [pow_succ]; exact (Nat.mod_mul_right_div_self y (q ^ m) q).symm
+    rw [key (x - r * q ^ n), key x, hmod]
+  · -- Case m > n: subtraction does not affect division by q ^ (n+1) ≤ q ^ m
+    have hpos1 : 0 < q ^ (n + 1) := pow_pos hq0 (n + 1)
+    -- r * q ^ n ≤ x % q ^ (n+1)
+    have hrbound : r * q ^ n ≤ x % q ^ (n + 1) := by
+      have hh : x % q ^ (n + 1) / q ^ n = (x / q ^ n) % q := by
+        rw [pow_succ]; exact Nat.mod_mul_right_div_self x (q ^ n) q
+      have hr2 : r ≤ x % q ^ (n + 1) / q ^ n := by rw [hh]; exact hr
+      calc r * q ^ n ≤ (x % q ^ (n + 1) / q ^ n) * q ^ n := Nat.mul_le_mul_right _ hr2
+        _ ≤ x % q ^ (n + 1) := Nat.div_mul_le_self _ _
+    -- (x - r*q ^ n) / q ^ (n+1) = x / q ^ (n+1)
+    have hdiv : (x - r * q ^ n) / q ^ (n + 1) = x / q ^ (n + 1) := by
+      have hdm := Nat.div_add_mod x (q ^ (n + 1))
+      have heq : x - r * q ^ n
+          = (x % q ^ (n + 1) - r * q ^ n) + q ^ (n + 1) * (x / q ^ (n + 1)) := by omega
+      rw [heq, Nat.add_mul_div_left _ _ hpos1]
+      have hltt : x % q ^ (n + 1) - r * q ^ n < q ^ (n + 1) := by
+        have := Nat.mod_lt x hpos1; omega
+      rw [Nat.div_eq_of_lt hltt]; simp
+    -- relate y / q ^ m to y / q ^ (n+1) via q ^ (n+1) * q ^ (m-n-1) = q ^ m
+    have hpow : q ^ (n + 1) * q ^ (m - n - 1) = q ^ m := by
+      rw [← pow_add]; congr 1; omega
+    have key : ∀ y : ℕ, y / q ^ m = (y / q ^ (n + 1)) / q ^ (m - n - 1) := by
+      intro y; rw [Nat.div_div_eq_div_mul, hpow]
+    rw [key (x - r * q ^ n), key x, hdiv]
+
+/-- **Digit add, target position.** Adding `q ^ n` to `x`, when `digit q x n < q-1`
+(no carry triggered), increases the `n`-th digit by one. -/
+lemma digit_add_self (q x n : ℕ) (hq : 1 ≤ q) (hlt : digit q x n + 1 < q) :
+    digit q (x + q ^ n) n = digit q x n + 1 := by
+  unfold digit at *
+  have hpos : 0 < q ^ n := pow_pos (by omega) n
+  have hdiv : (x + q ^ n) / q ^ n = x / q ^ n + 1 := by
+    rw [Nat.add_div_right _ hpos]
+  rw [hdiv]
+  set y := x / q ^ n with hy
+  conv_lhs => rw [← Nat.div_add_mod y q]
+  rw [Nat.add_assoc, Nat.mul_add_mod]
+  exact Nat.mod_eq_of_lt hlt
+
+/-- **Digit add, other positions.** Adding `q ^ n` to `x`, when `digit q x n < q-1`,
+leaves every digit at a position `m ≠ n` unchanged. -/
+lemma digit_add_other (q x n m : ℕ) (hq : 1 ≤ q) (hlt : digit q x n + 1 < q) (hmn : m ≠ n) :
+    digit q (x + q ^ n) m = digit q x m := by
+  have hq0 : 0 < q := by omega
+  unfold digit at *
+  rcases lt_or_gt_of_ne hmn with hmlt | hgt
+  · have hdvd : q ^ (m + 1) ∣ q ^ n := pow_dvd_pow q (by omega)
+    have hmod : (x + q ^ n) % q ^ (m + 1) = x % q ^ (m + 1) := by
+      obtain ⟨c, hc⟩ := hdvd
+      rw [hc, Nat.add_mul_mod_self_left]
+    have key : ∀ y : ℕ, y / q ^ m % q = (y % q ^ (m + 1)) / q ^ m := by
+      intro y; rw [pow_succ]; exact (Nat.mod_mul_right_div_self y (q ^ m) q).symm
+    rw [key (x + q ^ n), key x, hmod]
+  · have hpos1 : 0 < q ^ (n + 1) := pow_pos hq0 (n + 1)
+    have hposn : 0 < q ^ n := pow_pos hq0 n
+    have hbound : x % q ^ (n + 1) + q ^ n < q ^ (n + 1) := by
+      have hw : x % q ^ (n + 1) / q ^ n = (x / q ^ n) % q := by
+        rw [pow_succ]; exact Nat.mod_mul_right_div_self x (q ^ n) q
+      have hdm2 := Nat.div_add_mod (x % q ^ (n + 1)) (q ^ n)
+      have hmod2 := Nat.mod_lt (x % q ^ (n + 1)) hposn
+      rw [hw] at hdm2
+      have h2 : (x / q ^ n % q + 2) * q ^ n ≤ q ^ (n + 1) := by
+        rw [pow_succ]
+        calc (x / q ^ n % q + 2) * q ^ n ≤ q * q ^ n := by
+              apply Nat.mul_le_mul_right; omega
+          _ = q ^ n * q := by ring
+      nlinarith [hdm2, hmod2, h2]
+    have hdiv : (x + q ^ n) / q ^ (n + 1) = x / q ^ (n + 1) := by
+      have hdm := Nat.div_add_mod x (q ^ (n + 1))
+      have heq : x + q ^ n
+          = (x % q ^ (n + 1) + q ^ n) + q ^ (n + 1) * (x / q ^ (n + 1)) := by omega
+      rw [heq, Nat.add_mul_div_left _ _ hpos1, Nat.div_eq_of_lt hbound]
+      simp
+    have hpow : q ^ (n + 1) * q ^ (m - n - 1) = q ^ m := by
+      rw [← pow_add]; congr 1; omega
+    have key : ∀ y : ℕ, y / q ^ m = (y / q ^ (n + 1)) / q ^ (m - n - 1) := by
+      intro y; rw [Nat.div_div_eq_div_mul, hpow]
+    rw [key (x + q ^ n), key x, hdiv]
+
+/-- The "stone weight" `gᵢ = q ^ {d+1-i} + (q - 1)·i` (informal.tex `eq:Phi-H1`). -/
+def gWeight (q d i : ℕ) : ℕ := q ^ (d + 1 - i) + (q - 1) * i
+
+/-- **The strict Φ-decrease arithmetic.** The key identity
+`q·g_{j+1} + (q - 1) ^ 2·(d-j) = g_j + (q - 1)·g_d`, i.e.
+`g_j + (q - 1)·g_d - q·g_{j+1} = (q - 1) ^ 2·(d-j) > 0` for `j < d`, `q ≥ 2`
+(informal.tex `lem:H1-carry-elimination`). -/
+lemma gWeight_exchange_pos (q d j : ℕ) (hq : 2 ≤ q) (hj : j < d) :
+    q * gWeight q d (j + 1) + (q - 1) ^ 2 * (d - j) =
+      gWeight q d j + (q - 1) * gWeight q d d := by
+  unfold gWeight
+  obtain ⟨t, rfl⟩ : ∃ t, d = j + 1 + t := ⟨d - j - 1, by omega⟩
+  have e1 : j + 1 + t + 1 - (j + 1) = t + 1 := by omega
+  have e2 : j + 1 + t + 1 - j = t + 2 := by omega
+  have e3 : j + 1 + t + 1 - (j + 1 + t) = 1 := by omega
+  have e4 : j + 1 + t - j = t + 1 := by omega
+  rw [e1, e2, e3, e4]
+  obtain ⟨p, rfl⟩ : ∃ p, q = p + 2 := ⟨q - 2, by omega⟩
+  have e5 : p + 2 - 1 = p + 1 := by omega
+  rw [e5]
+  ring
+
+/-- **The `F ↔ Φ` reduction.** Comparing `F` of two admissible tuples with the
+**same** `k` reduces to comparing their `Φ`, where
+`Φ(kk) = q ^ {d+1}·∑ᵢ kkᵢ + (q - 1)·∑ᵢ i·qⁱ·kkᵢ`: a strict `Φ`-decrease (from `kk` to `kk'`)
+gives a strict `F`-increase. (Identity `(q - 1)·(-(∑ᵢ kkᵢ·b(i,d))) + q·k = Φ(kk)`.) -/
+lemma F_lt_of_Phi_lt (q d _k : ℕ) (hq : 2 ≤ q)
+    (kk kk' : Fin (d + 1) → ℕ)
+    (hk : (∑ i : Fin (d + 1), kk i * q ^ (i : ℕ)) = (∑ i : Fin (d + 1), kk' i * q ^ (i : ℕ)))
+    (hPhi : (q ^ (d + 1) * ∑ i : Fin (d + 1), kk' i
+              + (q - 1) * ∑ i : Fin (d + 1), (i : ℕ) * q ^ (i : ℕ) * kk' i)
+          < (q ^ (d + 1) * ∑ i : Fin (d + 1), kk i
+              + (q - 1) * ∑ i : Fin (d + 1), (i : ℕ) * q ^ (i : ℕ) * kk i)) :
+    F q d kk < F q d kk' := by
+  have hq1 : (1 : ℕ) ≤ q := by omega
+  -- per-index geometric identity
+  have geo : ∀ i : Fin (d + 1),
+      ((q : ℤ) - 1) * (∑ j ∈ Finset.Ico ((i : ℕ) + 1) (d + 1), (q : ℤ) ^ j)
+        = (q : ℤ) ^ (d + 1) - (q : ℤ) ^ ((i : ℕ) + 1) := by
+    intro i
+    have hile : (i : ℕ) + 1 ≤ d + 1 := by
+      have := i.2; omega
+    rw [Finset.sum_Ico_eq_sub _ hile, mul_sub, mul_comm ((q : ℤ) - 1), mul_comm ((q : ℤ) - 1),
+      geom_sum_mul, geom_sum_mul]
+    ring
+  -- key identity for any tuple
+  have key : ∀ (tt : Fin (d + 1) → ℕ),
+      ((q : ℤ) - 1) * (∑ i : Fin (d + 1), (tt i : ℤ) * bCoeff q (i : ℕ) d)
+        = (q : ℤ) * (∑ i : Fin (d + 1), (tt i : ℤ) * (q : ℤ) ^ (i : ℕ))
+          - ((q : ℤ) ^ (d + 1) * (∑ i : Fin (d + 1), (tt i : ℤ))
+            + ((q : ℤ) - 1) * ∑ i : Fin (d + 1),
+              (i : ℤ) * (q : ℤ) ^ (i : ℕ) * (tt i)) := by
+    intro tt
+    rw [Finset.mul_sum]
+    rw [Finset.mul_sum (s := (Finset.univ : Finset (Fin (d + 1))))
+      (f := fun i => (tt i : ℤ) * (q : ℤ) ^ (i : ℕ))]
+    rw [Finset.mul_sum (s := (Finset.univ : Finset (Fin (d + 1)))) (f := fun i => (tt i : ℤ))]
+    rw [Finset.mul_sum (s := (Finset.univ : Finset (Fin (d + 1))))
+      (f := fun i => (i : ℤ) * (q : ℤ) ^ (i : ℕ) * (tt i))]
+    rw [show (∑ i : Fin (d + 1), (q : ℤ) * ((tt i : ℤ) * (q : ℤ) ^ (i : ℕ)))
+          - ((∑ i : Fin (d + 1), (q : ℤ) ^ (d + 1) * (tt i : ℤ))
+            + ∑ i : Fin (d + 1), ((q : ℤ) - 1) * ((i : ℤ) * (q : ℤ) ^ (i : ℕ) * (tt i)))
+        = ∑ i : Fin (d + 1), ((q : ℤ) * ((tt i : ℤ) * (q : ℤ) ^ (i : ℕ))
+            - ((q : ℤ) ^ (d + 1) * (tt i : ℤ)
+              + ((q : ℤ) - 1) * ((i : ℤ) * (q : ℤ) ^ (i : ℕ) * (tt i)))) by
+      rw [Finset.sum_sub_distrib, Finset.sum_add_distrib]]
+    apply Finset.sum_congr rfl
+    intro i _
+    unfold bCoeff
+    have hg := geo i
+    have hexp : (q : ℤ) ^ ((i : ℕ) + 1) = (q : ℤ) * (q : ℤ) ^ (i : ℕ) := by
+      rw [pow_succ]; ring
+    -- LHS = (q - 1) * (tt i) * (-(S + i*q ^ i)) where (q - 1)*S = q ^ {d+1} - q ^ {i+1}
+    have : ((q : ℤ) - 1) * ((tt i : ℤ) *
+        -((∑ j ∈ Finset.Ico ((i : ℕ) + 1) (d + 1), (q : ℤ) ^ j) + (i : ℤ) * (q : ℤ) ^ (i : ℕ)))
+        = (tt i : ℤ) * (- (((q : ℤ) - 1) * (∑ j ∈ Finset.Ico ((i : ℕ) + 1) (d + 1), (q : ℤ) ^ j))
+            - ((q : ℤ) - 1) * ((i : ℤ) * (q : ℤ) ^ (i : ℕ))) := by ring
+    rw [this, hg, hexp]
+    ring
+  have kkey := key kk
+  have kkey' := key kk'
+  -- cast hk to ℤ
+  have hkZ : (∑ i : Fin (d + 1), (kk i : ℤ) * (q : ℤ) ^ (i : ℕ))
+      = (∑ i : Fin (d + 1), (kk' i : ℤ) * (q : ℤ) ^ (i : ℕ)) := by
+    have := congrArg (Nat.cast : ℕ → ℤ) hk
+    push_cast at this ⊢
+    convert this using 2
+  -- cast hPhi to ℤ
+  have hcast : ((q - 1 : ℕ) : ℤ) = (q : ℤ) - 1 := by
+    rw [Nat.cast_sub hq1]; simp
+  have hPhiZ : ((q : ℤ) ^ (d + 1) * ∑ i : Fin (d + 1), (kk' i : ℤ)
+        + ((q : ℤ) - 1) * ∑ i : Fin (d + 1), (i : ℤ) * (q : ℤ) ^ (i : ℕ) * (kk' i))
+      < ((q : ℤ) ^ (d + 1) * ∑ i : Fin (d + 1), (kk i : ℤ)
+        + ((q : ℤ) - 1) * ∑ i : Fin (d + 1), (i : ℤ) * (q : ℤ) ^ (i : ℕ) * (kk i)) := by
+    have := hPhi
+    have hcastineq := (Nat.cast_lt (α := ℤ)).mpr this
+    push_cast [hcast] at hcastineq
+    simpa only using hcastineq
+  -- now finish
+  unfold F
+  have hqpos : (0 : ℤ) < (q : ℤ) - 1 := by
+    have : (2 : ℤ) ≤ (q : ℤ) := by exact_mod_cast hq
+    linarith
+  -- (q - 1)*(F kk' - F kk) = Φ kk - Φ kk' > 0
+  rw [← sub_pos]
+  -- goal: 0 < (bCoeff q 0 d + ∑ kk' ...) - (bCoeff q 0 d + ∑ kk ...)
+  have hdiff : ((q : ℤ) - 1) *
+      ((bCoeff q 0 d + ∑ i : Fin (d + 1), (kk' i : ℤ) * bCoeff q (i : ℕ) d)
+        - (bCoeff q 0 d + ∑ i : Fin (d + 1), (kk i : ℤ) * bCoeff q (i : ℕ) d)) > 0 := by
+    have expand : ((q : ℤ) - 1) *
+        ((bCoeff q 0 d + ∑ i : Fin (d + 1), (kk' i : ℤ) * bCoeff q (i : ℕ) d)
+          - (bCoeff q 0 d + ∑ i : Fin (d + 1), (kk i : ℤ) * bCoeff q (i : ℕ) d))
+        = (((q : ℤ) - 1) * (∑ i : Fin (d + 1), (kk' i : ℤ) * bCoeff q (i : ℕ) d))
+          - (((q : ℤ) - 1) * (∑ i : Fin (d + 1), (kk i : ℤ) * bCoeff q (i : ℕ) d)) := by ring
+    rw [expand, kkey, kkey', hkZ]
+    linarith [hPhiZ]
+  nlinarith [hdiff, hqpos]
+
+/-- **Row selection (take-from-top).** Given nonnegative row-counts `a` on `Fin (d + 1)`
+and a target `c` with `1 ≤ c ≤ ∑ a`, there is a removal function `r ≤ a` removing
+exactly `c` stones, taken greedily from the *top* rows: there is a maximal removed row
+`J` (`r J > 0`) above which nothing is removed (`r i = 0` for `i > J`). -/
+theorem row_take_top : ∀ (d : ℕ) (a : Fin (d + 1) → ℕ) (c : ℕ),
+    1 ≤ c → c ≤ ∑ i, a i →
+    ∃ (r : Fin (d + 1) → ℕ),
+      (∀ i, r i ≤ a i) ∧ (∑ i, r i) = c ∧
+      (∃ J : Fin (d + 1), 0 < r J ∧ ∀ i : Fin (d + 1), (J:ℕ) < (i : ℕ) → r i = 0) := by
+  intro d
+  induction d with
+  | zero =>
+    intro a c hc hcsum
+    refine ⟨fun _ => c, ?_, ?_, ⟨0, ?_, ?_⟩⟩
+    · intro i; fin_cases i; simpa [Fin.sum_univ_one] using hcsum
+    · simp
+    · exact Nat.lt_of_lt_of_le Nat.zero_lt_one hc
+    · intro i hi; exact absurd i.2 (by omega)
+  | succ d ih =>
+    intro a c hc hcsum
+    rw [Fin.sum_univ_castSucc] at hcsum
+    set aL := a (Fin.last (d + 1)) with haL
+    set a' : Fin (d + 1) → ℕ := fun i => a i.castSucc with ha'
+    by_cases hcase : c ≤ ∑ i, a' i
+    · obtain ⟨r', hr'le, hr'sum, J', hJ'pos, hJ'top⟩ := ih a' c hc hcase
+      refine ⟨Fin.lastCases 0 r', ?_, ?_, ⟨J'.castSucc, ?_, ?_⟩⟩
+      · intro i
+        refine Fin.lastCases ?_ ?_ i
+        · simp
+        · intro i'; simpa using hr'le i'
+      · rw [Fin.sum_univ_castSucc]
+        simp only [Fin.lastCases_last, Fin.lastCases_castSucc]
+        rw [hr'sum]; ring
+      · simpa using hJ'pos
+      · refine Fin.lastCases ?_ (fun i' hi => ?_)
+        · intro hi; simp
+        · simp only [Fin.lastCases_castSucc]
+          apply hJ'top i'
+          simpa using hi
+    · push Not at hcase
+      set s := ∑ i, a' i with hs
+      have hrem : 1 ≤ c - s := by omega
+      have hremle : c - s ≤ aL := by omega
+      refine ⟨Fin.lastCases (c - s) a', ?_, ?_, ⟨Fin.last (d + 1), ?_, ?_⟩⟩
+      · intro i
+        refine Fin.lastCases ?_ (fun i' => ?_) i
+        · simpa using hremle
+        · simp only [Fin.lastCases_castSucc, ha', le_refl]
+      · rw [Fin.sum_univ_castSucc]
+        simp only [Fin.lastCases_last, Fin.lastCases_castSucc]
+        rw [← hs]; omega
+      · simp only [Fin.lastCases_last]; omega
+      · intro i hi
+        exfalso
+        have := i.2
+        simp only [Fin.val_last] at hi
+        omega
+
+/-- `digit q x n` times its place value `q ^ n` is at most `x`. -/
+theorem digit_place_le (q x n : ℕ) : digit q x n * q ^ n ≤ x := by
+  unfold digit
+  calc ((x / q ^ n) % q) * q ^ n ≤ (x / q ^ n) * q ^ n := by
+        apply Nat.mul_le_mul_right; exact Nat.mod_le _ _
+    _ ≤ x := Nat.div_mul_le_self _ _
+
+/-- A small per-index algebraic identity used in representation preservation. -/
+theorem peridx (a x b p : ℕ) (hx : x ≤ a) :
+    (a - x + b) * p + x * p = a * p + b * p := by
+  obtain ⟨t, ht⟩ := Nat.le.dest hx; subst ht; rw [Nat.add_sub_cancel_left]; ring
+
+/-- **Representation preservation for the single-column exchange.** Removing `r i`
+stones at cell `(i, m-i)` (`r i ≤ a_{i,m-i}`, `r i = 0` for `i > m`, `∑ r = q`) and
+adding one stone at cell `(j+1, m-j)` (`jj = j+1`, `j ≤ m`) leaves `∑ kk_i q ^ i`
+unchanged. -/
+theorem repr_preserved (q d m : ℕ) (_hq : 1 ≤ q) (kk : Fin (d + 1) → ℕ)
+    (r : Fin (d + 1) → ℕ) (jj : Fin (d + 1)) (j : ℕ)
+    (hjj : (jj : ℕ) = j + 1) (hjm : j ≤ m)
+    (hrle : ∀ i : Fin (d + 1), r i ≤ digit q (kk i) (m - (i : ℕ)))
+    (hr0 : ∀ i : Fin (d + 1), m < (i : ℕ) → r i = 0)
+    (hrsum : (∑ i, r i) = q) :
+    (∑ i : Fin (d + 1),
+      (kk i - r i * q ^ (m - (i : ℕ)) + (if i = jj then q ^ (m - j) else 0))
+        * q ^ (i : ℕ))
+      = ∑ i : Fin (d + 1), kk i * q ^ (i : ℕ) := by
+  have hno : ∀ i : Fin (d + 1), r i * q ^ (m - (i : ℕ)) ≤ kk i := by
+    intro i
+    calc r i * q ^ (m - (i : ℕ)) ≤ digit q (kk i) (m - (i : ℕ)) * q ^ (m-(i : ℕ)) :=
+          Nat.mul_le_mul_right _ (hrle i)
+      _ ≤ kk i := digit_place_le _ _ _
+  have hkey : (∑ i : Fin (d + 1),
+        (kk i - r i * q ^ (m - (i : ℕ)) + (if i = jj then q ^ (m - j) else 0))
+          * q ^ (i : ℕ))
+        + ∑ i : Fin (d + 1), (r i * q ^ (m - (i : ℕ))) * q ^ (i : ℕ)
+      = (∑ i : Fin (d + 1), kk i * q ^ (i : ℕ))
+        + ∑ i : Fin (d + 1), (if i = jj then q ^ (m - j) else 0) * q ^ (i : ℕ) := by
+    rw [← Finset.sum_add_distrib, ← Finset.sum_add_distrib]
+    apply Finset.sum_congr rfl
+    intro i _
+    exact peridx (kk i) (r i * q ^ (m - (i : ℕ)))
+      (if i = jj then q ^ (m - j) else 0) (q ^ (i : ℕ)) (hno i)
+  have hsum1 :
+      (∑ i : Fin (d + 1), (r i * q ^ (m - (i : ℕ))) * q ^ (i : ℕ))
+        = q ^ (m + 1) := by
+    have heq : ∑ i : Fin (d + 1), (r i * q ^ (m - (i : ℕ))) * q ^ (i : ℕ)
+        = q ^ m * ∑ i, r i := by
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro i _
+      by_cases hi : (i : ℕ) ≤ m
+      · have hpp : q ^ (m - (i : ℕ)) * q ^ (i : ℕ) = q ^ m := by
+          rw [← pow_add]
+          congr 1
+          omega
+        rw [mul_assoc, hpp, Nat.mul_comm]
+      · push Not at hi; simp [hr0 i hi]
+    rw [heq, hrsum, pow_succ]
+  have hsum2 :
+      (∑ i : Fin (d + 1), (if i = jj then q ^ (m - j) else 0) * q ^ (i : ℕ))
+        = q ^ (m + 1) := by
+    rw [Finset.sum_eq_single jj]
+    · rw [if_pos rfl, hjj, ← pow_add]; congr 1; omega
+    · intro b _ hb; rw [if_neg hb]; ring
+    · intro h; exact absurd (Finset.mem_univ _) h
+  rw [hsum1, hsum2] at hkey
+  omega
+
+/-- **Maximal removed non-top row.** From a removal `r` with `∑ r = q` whose top-row
+value is `≤ q-1`, there is a maximal row `j < d` that loses a stone, with no removed
+rows strictly between `j` and `d`. -/
+theorem row_select_j (q d : ℕ) (hq : 2 ≤ q) (r : Fin (d + 1) → ℕ)
+    (hrsum : (∑ i, r i) = q) (hrlast : r (Fin.last d) ≤ q - 1) :
+    ∃ j : Fin (d + 1), (j : ℕ) < d ∧ 0 < r j ∧
+      (∀ i : Fin (d + 1), (j : ℕ) < (i : ℕ) → (i : ℕ) < d → r i = 0) := by
+  set S : Finset (Fin (d + 1)) := Finset.univ.filter (fun i => (i : ℕ) < d ∧ 0 < r i) with hS
+  have hSne : S.Nonempty := by
+    by_contra hempty
+    rw [Finset.not_nonempty_iff_eq_empty] at hempty
+    have hall : ∀ i : Fin (d + 1), (i : ℕ) < d → r i = 0 := by
+      intro i hi
+      by_contra hr
+      have : i ∈ S := by
+        rw [hS]
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+        exact ⟨hi, Nat.pos_of_ne_zero hr⟩
+      rw [hempty] at this; exact absurd this (Finset.notMem_empty _)
+    have hsplit : (∑ i, r i) = r (Fin.last d) := by
+      rw [← Finset.sum_subset (Finset.subset_univ {Fin.last d})]
+      · simp
+      · intro i _ hi
+        simp only [Finset.mem_singleton] at hi
+        apply hall
+        have := i.2
+        rcases Nat.lt_or_ge (i : ℕ) d with h | h
+        · exact h
+        · exfalso; apply hi; apply Fin.ext; simp only [Fin.val_last]; omega
+    rw [hsplit] at hrsum; omega
+  set j := S.max' hSne with hj
+  have hjS : j ∈ S := S.max'_mem hSne
+  rw [hS] at hjS; simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hjS
+  refine ⟨j, hjS.1, hjS.2, ?_⟩
+  intro i hlt hid
+  by_contra hr
+  have hiS : i ∈ S := by
+    rw [hS]
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+    exact ⟨hid, Nat.pos_of_ne_zero hr⟩
+  have hle := S.le_max' i hiS
+  rw [← hj] at hle
+  have : (i : ℕ) ≤ (j : ℕ) := hle
+  omega
+
+/-- **Carry-free preservation for the single-column exchange.** The exchanged tuple
+`kk'` (remove `r i` stones at cell `(i,m-i)`, add one at `(jj,m-jv)`, `jj = jv+1`)
+stays carry-free. `jrow` is the maximal removed non-top row, `jv = jrow`. -/
+lemma exchange_carryfree (q d m : ℕ) (hq2 : 2 ≤ q) (kk : Fin (d + 1) → ℕ)
+    (hcf : CarryFree q d kk)
+    (r : Fin (d + 1) → ℕ) (jrow jj : Fin (d + 1)) (jv : ℕ)
+    (hjv : jv = (jrow : ℕ)) (hjjval : (jj : ℕ) = jv + 1) (_hjm : jv ≤ m)
+    (hrdig : ∀ i : Fin (d + 1), r i ≤ digit q (kk i) (m - (i : ℕ)))
+    (_hr0 : ∀ i : Fin (d + 1), m < (i : ℕ) → r i = 0)
+    (hjpos : 0 < r jrow)
+    (kk' : Fin (d + 1) → ℕ)
+    (hkk' : ∀ i, kk' i = kk i - r i * q ^ (m - (i : ℕ)) + (if i = jj then q ^ (m - jv) else 0)) :
+    CarryFree q d kk' := by
+  have hq1 : 1 ≤ q := by omega
+  -- the subtracted value at each row
+  set x : Fin (d + 1) → ℕ := fun i => kk i - r i * q ^ (m - (i : ℕ)) with hx
+  -- per-row: subtraction never increases any digit
+  have hsub_le : ∀ (i : Fin (d + 1)) (n : ℕ), digit q (x i) n ≤ digit q (kk i) n := by
+    intro i n
+    by_cases hn : n = m - (i : ℕ)
+    · subst hn
+      rw [hx, digit_sub_self q (kk i) (m - (i : ℕ)) (r i) hq1 (hrdig i)]
+      omega
+    · rw [hx, digit_sub_other q (kk i) (m - (i : ℕ)) (r i) n hq1 (hrdig i) hn]
+  -- jj ≠ jrow since their values differ
+  have hjj_ne_jrow : jj ≠ jrow := by
+    intro h
+    rw [h] at hjjval
+    omega
+  -- digit of kk jrow at m-jv is ≥ r jrow ≥ 1
+  have hjrow_pos_pos : m - (jrow : ℕ) = m - jv := by rw [hjv]
+  have hjrow_dig : r jrow ≤ digit q (kk jrow) (m - jv) := by
+    have := hrdig jrow; rw [hjrow_pos_pos] at this; exact this
+  -- the two summands jrow and jj are distinct; combined with hcf gives the no-overflow bound
+  have hkk_jj_bound : digit q (kk jj) (m - jv) + 1 < q := by
+    have hsum := hcf (m - jv)
+    -- split off jj and jrow from the sum
+    have hpair : digit q (kk jj) (m - jv) + digit q (kk jrow) (m - jv)
+        ≤ ∑ i : Fin (d + 1), digit q (kk i) (m - jv) := by
+      have hsub : ({jj, jrow} : Finset (Fin (d + 1))) ⊆ Finset.univ := Finset.subset_univ _
+      have := Finset.sum_le_sum_of_subset (f := fun i => digit q (kk i) (m - jv)) hsub
+      rw [Finset.sum_pair hjj_ne_jrow] at this
+      exact this
+    omega
+  -- precondition for digit_add_self / digit_add_other at jj
+  have hadd_pre : digit q (x jj) (m - jv) + 1 < q := by
+    have := hsub_le jj (m - jv)
+    omega
+  -- rewrite kk' via hkk'
+  intro n
+  -- We'll do two cases on n.
+  by_cases hn : n = m - jv
+  · -- the addition-affected position
+    subst hn
+    -- Need: ∑ i, digit q (kk' i) (m - jv) ≤ q - 1
+    -- precondition for digit_add_self at jj
+    -- digit q (x jj) (m-jv) ≤ digit q (kk jj) (m-jv), and the latter +1 < q
+    -- jj's digit: digit q (kk' jj)(m-jv) = digit q (x jj)(m-jv) + 1
+    have hjj_val : digit q (kk' jj) (m - jv) = digit q (x jj) (m - jv) + 1 := by
+      rw [hkk' jj, if_pos rfl]
+      exact digit_add_self q (x jj) (m - jv) hq1 hadd_pre
+    -- jrow's digit: digit q (kk' jrow)(m-jv) = digit q (x jrow)(m-jv)
+    have hjrow_val_eq : digit q (x jrow) (m - jv) = digit q (kk jrow) (m - jv) - r jrow := by
+      rw [hx, ← hjrow_pos_pos]
+      exact digit_sub_self q (kk jrow) (m - (jrow : ℕ)) (r jrow) hq1
+        (by rw [hjrow_pos_pos]; exact hjrow_dig)
+    have hjrow_val : digit q (kk' jrow) (m - jv) = digit q (kk jrow) (m - jv) - r jrow := by
+      rw [hkk' jrow, if_neg (Ne.symm hjj_ne_jrow), add_zero, ← hjrow_val_eq]
+    -- It suffices to show ∑ i, digit q (kk' i)(m-jv) ≤ ∑ i, digit q (kk i)(m-jv) ≤ q-1
+    refine le_trans ?_ (hcf (m - jv))
+    -- split off {jj, jrow}
+    have hpair_mem : ({jj, jrow} : Finset (Fin (d + 1))) ⊆ Finset.univ := Finset.subset_univ _
+    rw [← Finset.sum_sdiff hpair_mem (f := fun i => digit q (kk' i) (m - jv)),
+        ← Finset.sum_sdiff hpair_mem (f := fun i => digit q (kk i) (m - jv))]
+    apply Nat.add_le_add
+    · -- the rest: pointwise ≤
+      apply Finset.sum_le_sum
+      intro i hi
+      rw [hkk' i]
+      have hi' : i ≠ jj ∧ i ≠ jrow := by
+        simp only [Finset.mem_sdiff, Finset.mem_univ, true_and, Finset.mem_insert,
+          Finset.mem_singleton, not_or] at hi
+        exact hi
+      rw [if_neg hi'.1, add_zero]
+      exact hsub_le i (m - jv)
+    · -- the pair {jj, jrow}
+      rw [Finset.sum_pair hjj_ne_jrow, Finset.sum_pair hjj_ne_jrow]
+      rw [hjj_val, hjrow_val]
+      have h1 := hsub_le jj (m - jv)
+      omega
+  · -- n ≠ m - jv: the addition does not touch digit n, so every row is ≤ kk i
+    have hle : ∀ i : Fin (d + 1), digit q (kk' i) n ≤ digit q (kk i) n := by
+      intro i
+      rw [hkk' i]
+      by_cases hij : i = jj
+      · subst hij
+        -- kk' i = x i + q ^ (m-jv); digit at n ≠ m-jv unaffected by add
+        rw [if_pos rfl]
+        -- need precondition digit q (x i) (m-jv) + 1 < q
+        rw [digit_add_other q (x i) (m - jv) n hq1 hadd_pre hn]
+        exact hsub_le i n
+      · rw [if_neg hij, add_zero]
+        exact hsub_le i n
+    calc ∑ i, digit q (kk' i) n ≤ ∑ i : Fin (d + 1), digit q (kk i) n :=
+          Finset.sum_le_sum (fun i _ => hle i)
+      _ ≤ q - 1 := hcf n
+
+/-- **Strict `F`-increase for the single-column exchange.** The exchanged tuple `kk'`
+has strictly larger `F`, since `Φ` drops by `q ^ m·(q - 1) ^ 2·(d-jv) > 0`. -/
+lemma exchange_phi_gain (q d k m : ℕ) (hq2 : 2 ≤ q) (kk : Fin (d + 1) → ℕ)
+    (hrep : k = ∑ i : Fin (d + 1), kk i * q ^ (i : ℕ))
+    (r : Fin (d + 1) → ℕ) (jrow jj : Fin (d + 1)) (jv : ℕ)
+    (hjv : jv = (jrow : ℕ)) (hjjval : (jj : ℕ) = jv + 1) (hjm : jv ≤ m) (hjd : jv < d)
+    (hrdig : ∀ i : Fin (d + 1), r i ≤ digit q (kk i) (m - (i : ℕ)))
+    (hr0 : ∀ i : Fin (d + 1), m < (i : ℕ) → r i = 0)
+    (hrsum : (∑ i, r i) = q)
+    (hjpos : 0 < r jrow)
+    (_hjtop : ∀ i : Fin (d + 1), jv < (i : ℕ) → (i : ℕ) < d → r i = 0)
+    (kk' : Fin (d + 1) → ℕ)
+    (hkk' : ∀ i, kk' i = kk i - r i * q ^ (m - (i : ℕ)) + (if i = jj then q ^ (m - jv) else 0)) :
+    F q d kk < F q d kk' := by
+  have hq1 : 1 ≤ q := by omega
+  -- weight per row in Φ
+  set w : Fin (d + 1) → ℕ := fun i => q ^ (d + 1) + (q - 1) * ((i : ℕ) * q ^ (i : ℕ)) with hw
+  -- Φ written as ∑ w_i tt_i
+  have hPhiEq : ∀ tt : Fin (d + 1) → ℕ,
+      q ^ (d + 1) * ∑ i : Fin (d + 1), tt i
+        + (q - 1) * ∑ i : Fin (d + 1), (i : ℕ) * q ^ (i : ℕ) * tt i
+      = ∑ i : Fin (d + 1), w i * tt i := by
+    intro tt
+    rw [Finset.mul_sum, Finset.mul_sum, ← Finset.sum_add_distrib]
+    apply Finset.sum_congr rfl
+    intro i _
+    simp only [hw]
+    ring
+  -- no-borrow fact
+  have hno : ∀ i : Fin (d + 1), r i * q ^ (m - (i : ℕ)) ≤ kk i := by
+    intro i
+    calc r i * q ^ (m - (i : ℕ)) ≤ digit q (kk i) (m - (i : ℕ)) * q ^ (m - (i : ℕ)) :=
+          Nat.mul_le_mul_right _ (hrdig i)
+      _ ≤ kk i := digit_place_le _ _ _
+  -- the central additive identity:  Φ kk' + ∑ w_i r_i q ^ (m-i) = Φ kk + w_jj q ^ (m-jv)
+  have hbal : (∑ i : Fin (d + 1), w i * kk' i)
+        + ∑ i : Fin (d + 1), w i * (r i * q ^ (m - (i : ℕ)))
+      = (∑ i : Fin (d + 1), w i * kk i)
+        + ∑ i : Fin (d + 1), w i * (if i = jj then q ^ (m - jv) else 0) := by
+    rw [← Finset.sum_add_distrib, ← Finset.sum_add_distrib]
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [hkk' i]
+    have hnoi := hno i
+    have hle : w i * (r i * q ^ (m - (i : ℕ))) ≤ w i * kk i := Nat.mul_le_mul_left _ hnoi
+    set c := (if i = jj then q ^ (m - jv) else 0) with hc
+    rw [Nat.mul_add, Nat.mul_sub]
+    have hsub : w i * kk i - w i * (r i * q ^ (m - (i : ℕ))) + w i * c
+        + w i * (r i * q ^ (m - (i : ℕ))) = w i * kk i + w i * c := by omega
+    exact hsub
+  -- compute  ∑ w_i r_i q ^ (m-i) = q ^ m * ∑ g_i r_i
+  have hwq : ∀ i : Fin (d + 1), (i : ℕ) ≤ m →
+      w i * q ^ (m - (i : ℕ)) = q ^ m * gWeight q d (i : ℕ) := by
+    intro i hi
+    simp only [hw, gWeight]
+    have h1 : q ^ (d + 1) * q ^ (m - (i : ℕ)) = q ^ m * q ^ (d + 1 - (i : ℕ)) := by
+      rw [← pow_add, ← pow_add]; congr 1; omega
+    have hpp : q ^ (i : ℕ) * q ^ (m - (i : ℕ)) = q ^ m := by
+      rw [← pow_add]; congr 1; omega
+    calc (q ^ (d + 1) + (q - 1) * ((i : ℕ) * q ^ (i : ℕ))) * q ^ (m - (i : ℕ))
+        = q ^ (d + 1) * q ^ (m - (i : ℕ))
+          + (q - 1) * (i : ℕ) * (q ^ (i : ℕ) * q ^ (m - (i : ℕ))) := by ring
+      _ = q ^ m * q ^ (d + 1 - (i : ℕ)) + (q - 1) * (i : ℕ) * q ^ m := by rw [h1, hpp]
+      _ = q ^ m * (q ^ (d + 1 - (i : ℕ)) + (q - 1) * (i : ℕ)) := by ring
+  have hsumr : (∑ i : Fin (d + 1), w i * (r i * q ^ (m - (i : ℕ))))
+      = q ^ m * ∑ i : Fin (d + 1), gWeight q d (i : ℕ) * r i := by
+    rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro i _
+    by_cases hi : (i : ℕ) ≤ m
+    · have := hwq i hi
+      calc w i * (r i * q ^ (m - (i : ℕ))) = (w i * q ^ (m - (i : ℕ))) * r i := by ring
+        _ = (q ^ m * gWeight q d (i : ℕ)) * r i := by rw [this]
+        _ = q ^ m * (gWeight q d (i : ℕ) * r i) := by ring
+    · push Not at hi
+      rw [hr0 i hi]; ring
+  -- compute  w_jj q ^ (m-jv) = q ^ m * (q * g_{jv+1})
+  have hwjj : (∑ i : Fin (d + 1), w i * (if i = jj then q ^ (m - jv) else 0))
+      = q ^ m * (q * gWeight q d (jv + 1)) := by
+    rw [Finset.sum_eq_single jj]
+    · rw [if_pos rfl]
+      simp only [hw, gWeight]
+      have hjjexp : (jj : ℕ) = jv + 1 := hjjval
+      rw [hjjexp]
+      have h1 : q ^ (d + 1) * q ^ (m - jv) = q ^ m * q ^ (d + 1 - jv) := by
+        rw [← pow_add, ← pow_add]; congr 1; omega
+      have hpp : q ^ (jv + 1) * q ^ (m - jv) = q ^ m * q := by
+        rw [← pow_add, ← pow_succ]; congr 1; omega
+      have hpd : q ^ (d + 1 - jv) = q * q ^ (d + 1 - (jv + 1)) := by
+        rw [← pow_succ']; congr 1; omega
+      calc (q ^ (d + 1) + (q - 1) * ((jv + 1) * q ^ (jv + 1))) * q ^ (m - jv)
+          = q ^ (d + 1) * q ^ (m - jv)
+            + (q - 1) * (jv + 1) * (q ^ (jv + 1) * q ^ (m - jv)) := by ring
+        _ = q ^ m * q ^ (d + 1 - jv) + (q - 1) * (jv + 1) * (q ^ m * q) := by rw [h1, hpp]
+        _ = q ^ m * (q * q ^ (d + 1 - (jv + 1)) + q * ((q - 1) * (jv + 1))) := by
+              rw [hpd]; ring
+        _ = q ^ m * (q * (q ^ (d + 1 - (jv + 1)) + (q - 1) * (jv + 1))) := by ring
+    · intro b _ hb; rw [if_neg hb]; ring
+    · intro h; exact absurd (Finset.mem_univ _) h
+  -- g_d is the minimum weight
+  have hgmin : ∀ i : Fin (d + 1), gWeight q d d ≤ gWeight q d (i : ℕ) := by
+    -- helper power inequality
+    have hpow : ∀ e : ℕ, q + (q - 1) * e ≤ q ^ (e + 1) := by
+      obtain ⟨p, rfl⟩ : ∃ p, q = p + 2 := ⟨q - 2, by omega⟩
+      have he1 : p + 2 - 1 = p + 1 := by omega
+      rw [he1]
+      intro e
+      induction e with
+      | zero => simp
+      | succ n ih =>
+        have hexp : (p + 2) ^ (n + 1 + 1) = (p + 2) ^ (n + 1) * (p + 2) := by rw [pow_succ]
+        have hge : (p + 2) ≤ (p + 2) ^ (n + 1) := by nlinarith [ih]
+        have hmul : ((p + 2) + (p + 1) * n) * (p + 2)
+            ≤ (p + 2) ^ (n + 1) * (p + 2) := Nat.mul_le_mul_right _ ih
+        rw [hexp]
+        nlinarith [hmul, hge]
+    intro i
+    have hile : (i : ℕ) ≤ d := by have := i.2; omega
+    simp only [gWeight]
+    have hexp3 : d + 1 - d = 1 := by omega
+    rw [hexp3, pow_one]
+    -- goal: q + (q - 1)*d ≤ q ^ (d+1-i) + (q - 1)*i
+    have he := hpow (d - (i : ℕ))
+    have hexp2 : d - (i : ℕ) + 1 = d + 1 - (i : ℕ) := by omega
+    rw [hexp2] at he
+    have hsum : (q - 1) * (i : ℕ) + (q - 1) * (d - (i : ℕ)) = (q - 1) * d := by
+      rw [← Nat.mul_add]; congr 1; omega
+    omega
+  -- lower bound: g_jv + (q - 1)*g_d ≤ ∑ g_i r_i
+  have hrjv_le : r jrow ≤ q := by
+    rw [← hrsum]
+    exact Finset.single_le_sum (fun i _ => Nat.zero_le _) (Finset.mem_univ jrow)
+  have hlb : gWeight q d jv + (q - 1) * gWeight q d d
+      ≤ ∑ i : Fin (d + 1), gWeight q d (i : ℕ) * r i := by
+    -- pointwise: g_i r_i ≥ g_d r_i. Isolate the jrow term
+    have hsplit : (∑ i : Fin (d + 1), gWeight q d (i : ℕ) * r i)
+        = gWeight q d jv * r jrow + ∑ i ∈ Finset.univ.erase jrow, gWeight q d (i : ℕ) * r i := by
+      rw [← Finset.sum_erase_add _ _ (Finset.mem_univ jrow)]
+      rw [hjv]; ring
+    have hrest : gWeight q d d * ∑ i ∈ Finset.univ.erase jrow, r i
+        ≤ ∑ i ∈ Finset.univ.erase jrow, gWeight q d (i : ℕ) * r i := by
+      rw [Finset.mul_sum]
+      apply Finset.sum_le_sum
+      intro i _
+      exact Nat.mul_le_mul_right _ (hgmin i)
+    have hsumrest : ∑ i ∈ Finset.univ.erase jrow, r i = q - r jrow := by
+      have hh := Finset.sum_erase_add (Finset.univ) r (Finset.mem_univ jrow)
+      rw [hrsum] at hh
+      omega
+    have hgd_le_gjv : gWeight q d d ≤ gWeight q d jv := by
+      have hh := hgmin jrow; rw [← hjv] at hh; exact hh
+    -- g_jv * r_jrow + g_d * (q - r_jrow) ≥ g_jv + (q - 1)*g_d
+    have hkey2 : gWeight q d jv + (q - 1) * gWeight q d d
+        ≤ gWeight q d jv * r jrow + gWeight q d d * (q - r jrow) := by
+      obtain ⟨s, hs⟩ : ∃ s, r jrow = 1 + s := ⟨r jrow - 1, by omega⟩
+      have hsle : s ≤ q - 1 := by omega
+      have hsmul : gWeight q d d * s ≤ gWeight q d jv * s := Nat.mul_le_mul_right _ hgd_le_gjv
+      rw [hs]
+      have hqs : q - (1 + s) = (q - 1) - s := by omega
+      rw [hqs]
+      have hexpand1 : gWeight q d jv * (1 + s) = gWeight q d jv + gWeight q d jv * s := by ring
+      have hexpand2 : gWeight q d d * ((q - 1) - s) + gWeight q d d * s
+          = gWeight q d d * (q - 1) := by
+        rw [← Nat.mul_add]; congr 1; omega
+      rw [hexpand1]
+      -- goal: g_jv + (q - 1)g_d ≤ g_jv + g_jv*s + g_d*((q - 1)-s)
+      have hgd_q1 : (q - 1) * gWeight q d d = gWeight q d d * (q - 1) := by ring
+      omega
+    rw [hsplit]
+    -- hrest : g_d * (∑_{erase} r) ≤ ∑_{erase} g_i r_i.
+    -- hsumrest : ∑_{erase} r = q - r jrow
+    rw [hsumrest] at hrest
+    -- hrest : g_d * (q - r jrow) ≤ ∑_{erase} g_i r_i. hkey2 gives the bound
+    omega
+  -- the exchange identity
+  have hgex := gWeight_exchange_pos q d jv hq2 hjd
+  -- Now assemble: Φ kk' < Φ kk
+  have hPhilt : q ^ (d + 1) * ∑ i : Fin (d + 1), kk' i
+        + (q - 1) * ∑ i : Fin (d + 1), (i : ℕ) * q ^ (i : ℕ) * kk' i
+      < q ^ (d + 1) * ∑ i : Fin (d + 1), kk i
+        + (q - 1) * ∑ i : Fin (d + 1), (i : ℕ) * q ^ (i : ℕ) * kk i := by
+    rw [hPhiEq kk', hPhiEq kk]
+    -- from hbal : Φ' + S = Φ + T, with S = q ^ m ∑ g r, T = q ^ m (q g_{jv+1})
+    rw [hsumr, hwjj] at hbal
+    -- hbal : Φ' + q ^ m ∑ g r = Φ + q ^ m (q g_{jv+1})
+    -- lower bound on ∑ g r
+    have hmono : q ^ m * (gWeight q d jv + (q - 1) * gWeight q d d)
+        ≤ q ^ m * ∑ i : Fin (d + 1), gWeight q d (i : ℕ) * r i :=
+      Nat.mul_le_mul_left _ hlb
+    have hqmpos : 0 < q ^ m := pow_pos (by omega) m
+    have hdpos : 0 < (q - 1) ^ 2 * (d - jv) := by
+      have : 0 < q - 1 := by omega
+      have : 0 < d - jv := by omega
+      positivity
+    -- g_jv + (q - 1) g_d = q*g_{jv+1} + (q - 1) ^ 2(d-jv)
+    nlinarith [hbal, hmono, hgex, hqmpos, hdpos,
+      Nat.mul_le_mul_left (q ^ m) hlb]
+  -- representation preserved
+  have hk : (∑ i : Fin (d + 1), kk i * q ^ (i : ℕ))
+      = (∑ i : Fin (d + 1), kk' i * q ^ (i : ℕ)) := by
+    have := repr_preserved q d m hq1 kk r jj jv hjjval hjm hrdig hr0 hrsum
+    rw [← this]
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [hkk' i]
+  exact F_lt_of_Phi_lt q d k hq2 kk kk' hk hPhilt
+
+/-- **Carry-exchange improvement.** If an admissible `kk` has a *shifted carry* at
+some column `m` (shifted column sum `∑_i a_{i,m-i} ≥ q`), there is an admissible
+`kk'` with strictly larger `F`: remove `q` stones from `Col_m`, add one at
+`(j+1, m-j)` for `j < d` the maximal occupied non-top row
+(informal.tex `lem:H1-carry-elimination`). -/
+lemma carry_exchange_improves (q d k : ℕ) (hq : q.Prime) (kk : Fin (d + 1) → ℕ)
+    (hadm : Admissible q d k kk) (m : ℕ)
+    (hcarry : q ≤ ∑ i : Fin (d + 1),
+        (if (i : ℕ) ≤ m then digit q (kk i) (m - (i : ℕ)) else 0)) :
+    ∃ kk' : Fin (d + 1) → ℕ, Admissible q d k kk' ∧ F q d kk < F q d kk' := by
+  have hq1 : 1 ≤ q := hq.one_lt.le
+  have hq2 : 2 ≤ q := hq.two_le
+  obtain ⟨hrep, hcf⟩ := hadm
+  -- diagonal counts
+  set a : Fin (d + 1) → ℕ := fun i =>
+    if (i : ℕ) ≤ m then digit q (kk i) (m - (i : ℕ)) else 0 with ha
+  -- STEP A: choose exactly q stones from the top
+  obtain ⟨r, hrle, hrsum, _Jdummy⟩ := row_take_top d a q hq1 hcarry
+  -- r i ≤ digit; r i = 0 for i > m
+  have hrdig : ∀ i : Fin (d + 1), r i ≤ digit q (kk i) (m - (i : ℕ)) := by
+    intro i
+    have := hrle i
+    rw [ha] at this
+    by_cases hi : (i : ℕ) ≤ m
+    · simpa [hi] using this
+    · simp only [hi, if_false] at this; omega
+  have hr0 : ∀ i : Fin (d + 1), m < (i : ℕ) → r i = 0 := by
+    intro i hi
+    have := hrle i
+    rw [ha] at this
+    simp only [Nat.not_le.mpr hi, if_false] at this; omega
+  -- top row r ≤ q-1
+  have hrlast : r (Fin.last d) ≤ q - 1 := by
+    have := hrdig (Fin.last d)
+    have hd := digit_le q (kk (Fin.last d)) (m - (Fin.last d : ℕ)) hq1
+    omega
+  -- STEP A': maximal removed non-top row j < d
+  obtain ⟨jrow, hjd, hjpos, hjtop⟩ := row_select_j q d hq2 r hrsum hrlast
+  set jv : ℕ := (jrow : ℕ) with hjv
+  -- jj := j+1 as a Fin (d + 1)
+  have hjjlt : jv + 1 < d + 1 := by omega
+  set jj : Fin (d + 1) := ⟨jv + 1, hjjlt⟩ with hjjdef
+  have hjjval : (jj : ℕ) = jv + 1 := rfl
+  -- j ≤ m (since row j is occupied on the diagonal)
+  have hjm : jv ≤ m := by
+    by_contra hc
+    push Not at hc
+    have := hr0 jrow (by rw [← hjv]; exact hc)
+    omega
+  -- STEP B: the exchanged tuple
+  set kk' : Fin (d + 1) → ℕ :=
+    fun i => kk i - r i * q ^ (m - (i : ℕ)) + (if i = jj then q ^ (m - jv) else 0) with hkk'
+  refine ⟨kk', ⟨?_, ?_⟩, ?_⟩
+  · -- representation
+    rw [hrep]
+    simp only [hkk']
+    exact (repr_preserved q d m hq1 kk r jj jv hjjval hjm hrdig hr0 hrsum).symm
+  · -- carry-free preservation
+    exact exchange_carryfree q d m hq2 kk hcf r jrow jj jv hjv hjjval hjm hrdig hr0 hjpos kk'
+      (fun i => by rw [hkk'])
+  · -- strict F-increase
+    exact exchange_phi_gain q d k m hq2 kk hrep r jrow jj jv hjv hjjval hjm hjd hrdig hr0 hrsum
+      hjpos hjtop kk' (fun i => by rw [hkk'])
+
+/-- **Carry elimination.** An admissible `F`-maximizer has no shifted carries: for
+every `m`, `∑_i a_{i,m-i} ≤ q-1`. Otherwise `carry_exchange_improves` would give an
+admissible tuple with strictly larger `F` (informal.tex `lem:H1-carry-elimination`). -/
+lemma carry_elimination (q d k : ℕ) (hq : q.Prime) (kk : Fin (d + 1) → ℕ)
+    (hadm : Admissible q d k kk)
+    (hmax : ∀ kk' : Fin (d + 1) → ℕ, Admissible q d k kk' → F q d kk' ≤ F q d kk) :
+    ∀ m : ℕ, (∑ i : Fin (d + 1),
+        (if (i : ℕ) ≤ m then digit q (kk i) (m - (i : ℕ)) else 0)) ≤ q - 1 := by
+  intro m
+  by_contra hbig
+  -- `hbig : ¬ (∑ … ≤ q - 1)`, i.e. the shifted column sum is `≥ q` (since q ≥ 1).
+  have hq1 : 1 ≤ q := hq.one_lt.le
+  have hcarry : q ≤ ∑ i : Fin (d + 1),
+      (if (i : ℕ) ≤ m then digit q (kk i) (m - (i : ℕ)) else 0) := by
+    omega
+  obtain ⟨kk', hadm', hlt⟩ := carry_exchange_improves q d k hq kk hadm m hcarry
+  exact absurd (hmax kk' hadm') (not_le.mpr hlt)
+
+/-- Two naturals with all base-`q` digits equal to `0` are `0` (`q ≥ 2`). -/
+theorem digit_zero (q : ℕ) (hq : 2 ≤ q) : ∀ y : ℕ, (∀ n, digit q y n = 0) → y = 0 := by
+  intro y
+  induction y using Nat.strong_induction_on with
+  | _ y ih =>
+    intro h
+    have h0 := h 0
+    simp only [digit, pow_zero, Nat.div_one] at h0
+    have hrec : ∀ n, digit q (y / q) n = 0 := by
+      intro n
+      have hh := h (n + 1)
+      simp only [digit, pow_succ] at hh
+      rw [show q ^ n * q = q * q ^ n by ring, ← Nat.div_div_eq_div_mul] at hh
+      simpa [digit] using hh
+    by_cases hy : y = 0
+    · exact hy
+    · have hyq : y / q < y := Nat.div_lt_self (by omega) hq
+      have := ih (y / q) hyq hrec
+      have hh := Nat.div_add_mod y q
+      rw [this] at hh
+      omega
+
+/-- Two naturals with all equal base-`q` digits are equal (`q ≥ 2`). -/
+theorem digit_ext (q : ℕ) (hq : 2 ≤ q) : ∀ x y : ℕ, (∀ n, digit q x n = digit q y n) → x = y := by
+  intro x
+  induction x using Nat.strong_induction_on with
+  | _ x ih =>
+    intro y h
+    have h0 := h 0
+    simp only [digit, pow_zero, Nat.div_one] at h0
+    have hq0 : 0 < q := by omega
+    have hrec : ∀ n, digit q (x / q) n = digit q (y / q) n := by
+      intro n
+      have hh := h (n + 1)
+      simp only [digit, pow_succ] at hh
+      rw [show q ^ n * q = q * q ^ n by ring, ← Nat.div_div_eq_div_mul,
+          ← Nat.div_div_eq_div_mul] at hh
+      simpa [digit] using hh
+    by_cases hx : x = 0
+    · subst hx
+      have hyq : y / q = 0 := by
+        apply digit_zero q hq (y / q)
+        intro n
+        have := hrec n
+        simp only [Nat.zero_div, digit, Nat.zero_div, Nat.zero_mod] at this ⊢
+        omega
+      have hh := Nat.div_add_mod y q
+      rw [hyq] at hh
+      simp only [Nat.mul_zero, Nat.zero_add] at hh
+      simp only [Nat.zero_mod] at h0
+      omega
+    · have hxq : x / q < x := Nat.div_lt_self (by omega) hq
+      have hkey := ih (x / q) hxq (y / q) hrec
+      have hx2 := Nat.div_add_mod x q
+      have hy2 := Nat.div_add_mod y q
+      rw [hkey] at hx2
+      omega
+
+/-- The potential `Φ(kk) = q ^ {d+1}·∑ᵢ kkᵢ + (q - 1)·∑ᵢ i·qⁱ·kkᵢ` (matches the form used by
+`F_lt_of_Phi_lt`). Minimizing `Φ` over equal-representation admissible tuples is equivalent
+to maximizing `F`. -/
+def Phi (q d : ℕ) (kk : Fin (d + 1) → ℕ) : ℕ :=
+  q ^ (d + 1) * (∑ i : Fin (d + 1), kk i)
+    + (q - 1) * ∑ i : Fin (d + 1), (i : ℕ) * q ^ (i : ℕ) * kk i
+
+/-- **`g` is strictly decreasing in the row index** (for `q ≥ 2`): the stone weight
+`gWeight q d i = q ^ {d+1-i} + (q - 1)·i` strictly decreases as `i` increases within
+`0..d` (informal.tex `eq:g-decreasing-H1`). -/
+lemma gWeight_anti (q d i j : ℕ) (hq : 2 ≤ q) (hij : i < j) (hjd : j ≤ d) :
+    gWeight q d j < gWeight q d i := by
+  -- Single downward step: for e < d, g_{e+1} < g_e.
+  have step : ∀ e : ℕ, e < d → gWeight q d (e + 1) < gWeight q d e := by
+    intro e he
+    unfold gWeight
+    have he1 : d + 1 - e = (d - e) + 1 := by omega
+    have he2 : d + 1 - (e + 1) = d - e := by omega
+    rw [he1, he2, pow_succ]
+    -- Need: q ^ (d-e) + (q - 1)*(e + 1) < q ^ (d-e)*q + (q - 1)*e
+    have hb : 2 ≤ q ^ (d - e) := by
+      calc 2 ≤ q := hq
+        _ = q ^ 1 := (pow_one q).symm
+        _ ≤ q ^ (d - e) := Nat.pow_le_pow_right (by omega) (by omega)
+    obtain ⟨p, rfl⟩ : ∃ p, q = p + 2 := ⟨q - 2, by omega⟩
+    have hp1 : p + 2 - 1 = p + 1 := by omega
+    rw [hp1]
+    nlinarith [hb]
+  -- Chain from i to j using strong induction on the gap.
+  have chain : ∀ n : ℕ, ∀ e : ℕ, e + n ≤ d → 0 < n →
+      gWeight q d (e + n) < gWeight q d e := by
+    intro n
+    induction n with
+    | zero => omega
+    | succ m ih =>
+      intro e hle hpos
+      rcases Nat.eq_zero_or_pos m with hm | hm
+      · subst hm
+        have : e + (0 + 1) = e + 1 := by omega
+        rw [this]
+        exact step e (by omega)
+      · have h1 : gWeight q d (e + (m + 1)) < gWeight q d (e + m) := by
+          have hlt : e + m < d := by omega
+          have hs := step (e + m) hlt
+          have heq : e + m + 1 = e + (m + 1) := by omega
+          rw [heq] at hs
+          exact hs
+        have h2 : gWeight q d (e + m) < gWeight q d e := ih e (by omega) hm
+        exact lt_trans h1 h2
+  have hj : j = i + (j - i) := by omega
+  rw [hj]
+  exact chain (j - i) i (by omega) (by omega)
+
+/-- **Single downward move within a column.** Move one stone from cell `(i, m-i)` down
+to cell `(j, m-j)` (same column, rows `i < j ≤ d`), when the source cell is occupied
+and the target diagonal `m-j` has slack (`≤ q-2` stones). The result is admissible
+and has strictly smaller `Φ` (by `q ^ m (g_j - g_i) < 0`). -/
+lemma move_down (q d k m i j : ℕ) (hq : 2 ≤ q) (kk : Fin (d + 1) → ℕ)
+    (hadm : Admissible q d k kk)
+    (hi : i ≤ m) (hj : j ≤ m) (hjd : j ≤ d) (hij : i < j)
+    (hsrc : 1 ≤ digit q (kk ⟨i, by omega⟩) (m - i))
+    (hslack : (∑ r : Fin (d + 1), digit q (kk r) (m - j)) ≤ q - 2) :
+    ∃ kk' : Fin (d + 1) → ℕ, Admissible q d k kk' ∧ Phi q d kk' < Phi q d kk := by
+  have hq1 : 1 ≤ q := by omega
+  obtain ⟨hrep, hcf⟩ := hadm
+  -- the two distinct indices
+  set I : Fin (d + 1) := ⟨i, by omega⟩ with hI
+  set J : Fin (d + 1) := ⟨j, by omega⟩ with hJ
+  have hIval : (I : ℕ) = i := rfl
+  have hJval : (J : ℕ) = j := rfl
+  have hIJ : I ≠ J := by
+    intro h; apply absurd (congrArg (Fin.val) h); rw [hIval, hJval]; omega
+  -- no-borrow at I
+  have hborrow : q ^ (m - i) ≤ kk I := by
+    calc q ^ (m - i) = 1 * q ^ (m - i) := (one_mul _).symm
+      _ ≤ digit q (kk I) (m - i) * q ^ (m - i) := Nat.mul_le_mul_right _ hsrc
+      _ ≤ kk I := digit_place_le _ _ _
+  -- the new tuple
+  set kk' : Fin (d + 1) → ℕ :=
+    fun r => kk r - (if r = I then q ^ (m - i) else 0) + (if r = J then q ^ (m - j) else 0)
+    with hkk'def
+  -- pointwise characterization
+  have hkkI : kk' I = kk I - q ^ (m - i) := by
+    simp only [hkk'def, if_neg hIJ, add_zero, if_true]
+  have hkkJ : kk' J = kk J + q ^ (m - j) := by
+    simp only [hkk'def, if_neg (Ne.symm hIJ), tsub_zero, if_true]
+  have hkkO : ∀ r : Fin (d + 1), r ≠ I → r ≠ J → kk' r = kk r := by
+    intro r hrI hrJ
+    simp only [hkk'def, if_neg hrI, if_neg hrJ, tsub_zero, add_zero]
+  -- m - i ≠ m - j
+  have hmimj : m - i ≠ m - j := by omega
+  -- precondition for the addition at J
+  have hJdig : digit q (kk J) (m - j) ≤ q - 2 := by
+    have hle : digit q (kk J) (m - j) ≤ ∑ r : Fin (d + 1), digit q (kk r) (m - j) :=
+      Finset.single_le_sum (f := fun r => digit q (kk r) (m - j))
+        (fun r _ => Nat.zero_le _) (Finset.mem_univ J)
+    omega
+  have hJadd : digit q (kk J) (m - j) + 1 < q := by omega
+  -- digit of kk' at each row/position
+  -- weight per row in Φ
+  set w : Fin (d + 1) → ℕ := fun r => q ^ (d + 1) + (q - 1) * ((r : ℕ) * q ^ (r : ℕ)) with hw
+  refine ⟨kk', ⟨?_, ?_⟩, ?_⟩
+  · -- representation
+    rw [hrep]
+    -- ∑ kk' r * q ^ r = ∑ kk r * q ^ r
+    -- pull out I and J
+    have hsubset : ({I, J} : Finset (Fin (d + 1))) ⊆ Finset.univ := Finset.subset_univ _
+    rw [← Finset.sum_sdiff hsubset (f := fun r => kk' r * q ^ (r : ℕ)),
+        ← Finset.sum_sdiff hsubset (f := fun r => kk r * q ^ (r : ℕ))]
+    -- the I,J powers cancel: q ^ (m-i)*q ^ i = q ^ m = q ^ (m-j)*q ^ j
+    have hpi : q ^ (m - i) * q ^ i = q ^ m := by rw [← pow_add]; congr 1; omega
+    have hpj : q ^ (m - j) * q ^ j = q ^ m := by rw [← pow_add]; congr 1; omega
+    have hrest : (∑ r ∈ Finset.univ \ {I, J}, kk' r * q ^ (r : ℕ))
+        = ∑ r ∈ Finset.univ \ {I, J}, kk r * q ^ (r : ℕ) := by
+      apply Finset.sum_congr rfl
+      intro r hr
+      simp only [Finset.mem_sdiff, Finset.mem_univ, true_and, Finset.mem_insert,
+        Finset.mem_singleton, not_or] at hr
+      rw [hkkO r hr.1 hr.2]
+    rw [hrest]
+    apply Nat.add_left_cancel (n := q ^ m)
+    -- LHS: q ^ m + ∑_{IJ} kk' * q ^ r. RHS: q ^ m + ∑_{IJ} kk * q ^ r
+    rw [Finset.sum_pair hIJ, Finset.sum_pair hIJ, hkkI, hkkJ, hIval, hJval]
+    rw [Nat.sub_mul, Nat.add_mul, hpi, hpj]
+    -- (kk I * q ^ i - q ^ m) + (kk J * q ^ j + q ^ m): need q ^ m ≤ kk I * q ^ i
+    have hbi : q ^ m ≤ kk I * q ^ i := by
+      calc q ^ m = q ^ (m - i) * q ^ i := hpi.symm
+        _ ≤ kk I * q ^ i := Nat.mul_le_mul_right _ hborrow
+    omega
+  · -- carry-free
+    intro n
+    by_cases hnj : n = m - j
+    · -- the addition position: sum increases by 1 at J, unchanged at I, ≤ (q-2)+1 = q-1
+      subst hnj
+      -- digit at J: +1
+      have hdJ : digit q (kk' J) (m - j) = digit q (kk J) (m - j) + 1 := by
+        rw [hkkJ]; exact digit_add_self q (kk J) (m - j) hq1 hJadd
+      -- digit at I: unchanged (since m-i ≠ m-j)
+      have hdI : digit q (kk' I) (m - j) = digit q (kk I) (m - j) := by
+        rw [hkkI]
+        have : kk I - q ^ (m - i) = kk I - 1 * q ^ (m - i) := by rw [one_mul]
+        rw [this]
+        exact digit_sub_other q (kk I) (m - i) 1 (m - j) hq1 (by omega) (Ne.symm hmimj)
+      -- now split off {I, J}
+      have hsubset : ({I, J} : Finset (Fin (d + 1))) ⊆ Finset.univ := Finset.subset_univ _
+      rw [← Finset.sum_sdiff hsubset (f := fun r => digit q (kk' r) (m - j))]
+      have hrest : (∑ r ∈ Finset.univ \ {I, J}, digit q (kk' r) (m - j))
+          = ∑ r ∈ Finset.univ \ {I, J}, digit q (kk r) (m - j) := by
+        apply Finset.sum_congr rfl
+        intro r hr
+        simp only [Finset.mem_sdiff, Finset.mem_univ, true_and, Finset.mem_insert,
+          Finset.mem_singleton, not_or] at hr
+        rw [hkkO r hr.1 hr.2]
+      rw [hrest, Finset.sum_pair hIJ, hdI, hdJ]
+      -- compare with the original full sum
+      have horig : (∑ r ∈ Finset.univ \ {I, J}, digit q (kk r) (m - j))
+          + (digit q (kk I) (m - j) + digit q (kk J) (m - j))
+          = ∑ r : Fin (d + 1), digit q (kk r) (m - j) := by
+        rw [← Finset.sum_pair hIJ (f := fun r => digit q (kk r) (m - j))]
+        exact Finset.sum_sdiff hsubset
+      have hsum := hcf (m - j)
+      omega
+    · -- other positions: sum does not increase
+      have hle : ∀ r : Fin (d + 1), digit q (kk' r) n ≤ digit q (kk r) n := by
+        intro r
+        by_cases hrI : r = I
+        · subst hrI
+          rw [hkkI]
+          by_cases hni : n = m - i
+          · subst hni
+            have : kk I - q ^ (m - i) = kk I - 1 * q ^ (m - i) := by rw [one_mul]
+            rw [this, digit_sub_self q (kk I) (m - i) 1 hq1 (by omega)]
+            omega
+          · have : kk I - q ^ (m - i) = kk I - 1 * q ^ (m - i) := by rw [one_mul]
+            rw [this, digit_sub_other q (kk I) (m - i) 1 n hq1 (by omega) hni]
+        · by_cases hrJ : r = J
+          · subst hrJ
+            rw [hkkJ, digit_add_other q (kk J) (m - j) n hq1 hJadd hnj]
+          · rw [hkkO r hrI hrJ]
+      calc (∑ r : Fin (d + 1), digit q (kk' r) n)
+          ≤ ∑ r : Fin (d + 1), digit q (kk r) n := Finset.sum_le_sum (fun r _ => hle r)
+        _ ≤ q - 1 := hcf n
+  · -- Phi q d kk' < Phi q d kk
+    -- Φ written as ∑ w_r tt_r
+    have hPhiEq : ∀ tt : Fin (d + 1) → ℕ,
+        q ^ (d + 1) * ∑ r : Fin (d + 1), tt r
+          + (q - 1) * ∑ r : Fin (d + 1), (r : ℕ) * q ^ (r : ℕ) * tt r
+        = ∑ r : Fin (d + 1), w r * tt r := by
+      intro tt
+      rw [Finset.mul_sum, Finset.mul_sum, ← Finset.sum_add_distrib]
+      apply Finset.sum_congr rfl
+      intro r _
+      simp only [hw]
+      ring
+    -- the identity w r * q ^ (m-r) = q ^ m * gWeight q d r for (r:ℕ) ≤ m
+    have hwq : ∀ r : Fin (d + 1), (r : ℕ) ≤ m →
+        w r * q ^ (m - (r : ℕ)) = q ^ m * gWeight q d (r : ℕ) := by
+      intro r hr
+      simp only [hw, gWeight]
+      have h1 : q ^ (d + 1) * q ^ (m - (r : ℕ)) = q ^ m * q ^ (d + 1 - (r : ℕ)) := by
+        rw [← pow_add, ← pow_add]; congr 1; omega
+      have hpp : q ^ (r : ℕ) * q ^ (m - (r : ℕ)) = q ^ m := by
+        rw [← pow_add]; congr 1; omega
+      calc (q ^ (d + 1) + (q - 1) * ((r : ℕ) * q ^ (r : ℕ))) * q ^ (m - (r : ℕ))
+          = q ^ (d + 1) * q ^ (m - (r : ℕ))
+            + (q - 1) * (r : ℕ) * (q ^ (r : ℕ) * q ^ (m - (r : ℕ))) := by ring
+        _ = q ^ m * q ^ (d + 1 - (r : ℕ)) + (q - 1) * (r : ℕ) * q ^ m := by rw [h1, hpp]
+        _ = q ^ m * (q ^ (d + 1 - (r : ℕ)) + (q - 1) * (r : ℕ)) := by ring
+    -- the balance identity (in ℕ):  Φ' + w I * q ^ (m-i) = Φ + w J * q ^ (m-j)
+    have hbal : (∑ r : Fin (d + 1), w r * kk' r) + w I * q ^ (m - i)
+        = (∑ r : Fin (d + 1), w r * kk r) + w J * q ^ (m - j) := by
+      have hsubset : ({I, J} : Finset (Fin (d + 1))) ⊆ Finset.univ := Finset.subset_univ _
+      rw [← Finset.sum_sdiff hsubset (f := fun r => w r * kk' r),
+          ← Finset.sum_sdiff hsubset (f := fun r => w r * kk r)]
+      have hrest : (∑ r ∈ Finset.univ \ {I, J}, w r * kk' r)
+          = ∑ r ∈ Finset.univ \ {I, J}, w r * kk r := by
+        apply Finset.sum_congr rfl
+        intro r hr
+        simp only [Finset.mem_sdiff, Finset.mem_univ, true_and, Finset.mem_insert,
+          Finset.mem_singleton, not_or] at hr
+        rw [hkkO r hr.1 hr.2]
+      rw [hrest, Finset.sum_pair hIJ, Finset.sum_pair hIJ, hkkI, hkkJ]
+      -- w I * (kk I - q ^ (m-i)) + w J * (kk J + q ^ (m-j)) + w I * q ^ (m-i)
+      --   = w I * kk I + w J * kk J + w J * q ^ (m-j)
+      have hwle : w I * q ^ (m - i) ≤ w I * kk I := Nat.mul_le_mul_left _ hborrow
+      rw [Nat.mul_sub, Nat.mul_add]
+      omega
+    -- w I * q ^ (m-i) = q ^ m * g_i,  w J * q ^ (m-j) = q ^ m * g_j
+    have hwI : w I * q ^ (m - i) = q ^ m * gWeight q d i := by
+      have := hwq I (by rw [hIval]; exact hi); rw [hIval] at this; exact this
+    have hwJ : w J * q ^ (m - j) = q ^ m * gWeight q d j := by
+      have := hwq J (by rw [hJval]; exact hj); rw [hJval] at this; exact this
+    -- g_j < g_i
+    have hganti : gWeight q d j < gWeight q d i := gWeight_anti q d i j hq hij hjd
+    have hqmpos : 0 < q ^ m := pow_pos (by omega) m
+    have hstrict : w J * q ^ (m - j) < w I * q ^ (m - i) := by
+      rw [hwI, hwJ]; exact (Nat.mul_lt_mul_left hqmpos).2 hganti
+    -- conclude via Phi unfolding
+    change Phi q d kk' < Phi q d kk
+    unfold Phi
+    rw [hPhiEq kk', hPhiEq kk]
+    omega
+
+lemma move_parallelogram_representation (q d k m i j t : ℕ)
+    (kk kk' : Fin (d + 1) → ℕ) (I J IT JT : Fin (d + 1)) (hi : i ≤ m)
+    (hj : j ≤ m) (hrep : k = ∑ r : Fin (d + 1), kk r * q ^ (r : ℕ))
+    (hborrowP : q ^ (m - i) ≤ kk I) (hborrowS : q ^ (m - j) ≤ kk JT)
+    (hIval : (I : ℕ) = i) (hJval : (J : ℕ) = j)
+    (hITval : (IT : ℕ) = i + t) (hJTval : (JT : ℕ) = j + t) (hIJT : I ≠ JT)
+    (hkk'def : kk' =
+      fun r => kk r - (if r = I then q ^ (m - i) else 0)
+        - (if r = JT then q ^ (m - j) else 0)
+        + (if r = IT then q ^ (m - i) else 0) + (if r = J then q ^ (m - j) else 0)) :
+    k = ∑ r : Fin (d + 1), kk' r * q ^ (r : ℕ) := by
+  rw [hrep]
+  have hPS : ∀ r : Fin (d + 1),
+      (if r = I then q ^ (m - i) else 0) + (if r = JT then q ^ (m - j) else 0) ≤
+        kk r := by
+    intro r
+    by_cases hrI : r = I
+    · subst hrI; rw [if_pos rfl, if_neg hIJT, add_zero]; exact hborrowP
+    · by_cases hrJT : r = JT
+      · subst hrJT; rw [if_neg hIJT.symm, if_pos rfl, zero_add]; exact hborrowS
+      · rw [if_neg hrI, if_neg hrJT]; exact Nat.zero_le _
+  have hbal : (∑ r : Fin (d + 1), kk' r * q ^ (r : ℕ))
+        + ∑ r : Fin (d + 1), ((if r = I then q ^ (m - i) else 0)
+            + (if r = JT then q ^ (m - j) else 0)) * q ^ (r : ℕ)
+      = (∑ r : Fin (d + 1), kk r * q ^ (r : ℕ))
+        + ∑ r : Fin (d + 1), ((if r = IT then q ^ (m - i) else 0)
+            + (if r = J then q ^ (m - j) else 0)) * q ^ (r : ℕ) := by
+    rw [← Finset.sum_add_distrib, ← Finset.sum_add_distrib]
+    apply Finset.sum_congr rfl
+    intro r _
+    simp only [hkk'def]
+    have hps := hPS r
+    set P := (if r = I then q ^ (m - i) else 0) with hP
+    set S := (if r = JT then q ^ (m - j) else 0) with hS
+    set Q := (if r = IT then q ^ (m - i) else 0) with hQ
+    set R := (if r = J then q ^ (m - j) else 0) with hR
+    have hsub : kk r - P - S + Q + R = kk r - (P + S) + (Q + R) := by omega
+    rw [hsub]
+    have e1 : (kk r - (P + S) + (Q + R)) * q ^ (r : ℕ)
+        = (kk r - (P + S)) * q ^ (r : ℕ) + (Q + R) * q ^ (r : ℕ) := by
+      rw [Nat.add_mul]
+    have e2 : (kk r - (P + S)) * q ^ (r : ℕ)
+        = kk r * q ^ (r : ℕ) - (P + S) * q ^ (r : ℕ) := by
+      rw [Nat.sub_mul]
+    rw [e1, e2]
+    have hle : (P + S) * q ^ (r : ℕ) ≤ kk r * q ^ (r : ℕ) :=
+      Nat.mul_le_mul_right _ hps
+    omega
+  have hsumI :
+      (∑ r : Fin (d + 1), (if r = I then q ^ (m - i) else 0) * q ^ (r : ℕ)) =
+        q ^ m := by
+    rw [Finset.sum_eq_single I]
+    · rw [if_pos rfl, hIval, ← pow_add]; congr 1; omega
+    · intro b _ hb; rw [if_neg hb]; ring
+    · intro h; exact absurd (Finset.mem_univ _) h
+  have hsumJT :
+      (∑ r : Fin (d + 1), (if r = JT then q ^ (m - j) else 0) * q ^ (r : ℕ)) =
+        q ^ (m + t) := by
+    rw [Finset.sum_eq_single JT]
+    · rw [if_pos rfl, hJTval, ← pow_add]; congr 1; omega
+    · intro b _ hb; rw [if_neg hb]; ring
+    · intro h; exact absurd (Finset.mem_univ _) h
+  have hsumIT :
+      (∑ r : Fin (d + 1), (if r = IT then q ^ (m - i) else 0) * q ^ (r : ℕ)) =
+        q ^ (m + t) := by
+    rw [Finset.sum_eq_single IT]
+    · rw [if_pos rfl, hITval, ← pow_add]; congr 1; omega
+    · intro b _ hb; rw [if_neg hb]; ring
+    · intro h; exact absurd (Finset.mem_univ _) h
+  have hsumJ :
+      (∑ r : Fin (d + 1), (if r = J then q ^ (m - j) else 0) * q ^ (r : ℕ)) =
+        q ^ m := by
+    rw [Finset.sum_eq_single J]
+    · rw [if_pos rfl, hJval, ← pow_add]; congr 1; omega
+    · intro b _ hb; rw [if_neg hb]; ring
+    · intro h; exact absurd (Finset.mem_univ _) h
+  have hL : (∑ r : Fin (d + 1), ((if r = I then q ^ (m - i) else 0)
+            + (if r = JT then q ^ (m - j) else 0)) * q ^ (r : ℕ)) =
+      q ^ m + q ^ (m + t) := by
+    rw [show (∑ r : Fin (d + 1), ((if r = I then q ^ (m - i) else 0)
+            + (if r = JT then q ^ (m - j) else 0)) * q ^ (r : ℕ))
+          = (∑ r : Fin (d + 1), (if r = I then q ^ (m - i) else 0) * q ^ (r : ℕ))
+            + ∑ r : Fin (d + 1),
+                (if r = JT then q ^ (m - j) else 0) * q ^ (r : ℕ) from by
+            rw [← Finset.sum_add_distrib]
+            apply Finset.sum_congr rfl
+            intro r _
+            rw [Nat.add_mul]]
+    rw [hsumI, hsumJT]
+  have hRR : (∑ r : Fin (d + 1), ((if r = IT then q ^ (m - i) else 0)
+            + (if r = J then q ^ (m - j) else 0)) * q ^ (r : ℕ)) =
+      q ^ (m + t) + q ^ m := by
+    rw [show (∑ r : Fin (d + 1), ((if r = IT then q ^ (m - i) else 0)
+            + (if r = J then q ^ (m - j) else 0)) * q ^ (r : ℕ))
+          = (∑ r : Fin (d + 1), (if r = IT then q ^ (m - i) else 0) * q ^ (r : ℕ))
+            + ∑ r : Fin (d + 1),
+                (if r = J then q ^ (m - j) else 0) * q ^ (r : ℕ) from by
+            rw [← Finset.sum_add_distrib]
+            apply Finset.sum_congr rfl
+            intro r _
+            rw [Nat.add_mul]]
+    rw [hsumIT, hsumJ]
+  rw [hL, hRR] at hbal
+  omega
+
+lemma move_parallelogram_carry_free (q d m i j t : ℕ)
+    (kk kk' : Fin (d + 1) → ℕ) (I J IT JT : Fin (d + 1)) (hq1 : 1 ≤ q)
+    (hcf : CarryFree q d kk) (hsrcP : 1 ≤ digit q (kk I) (m - i))
+    (hsrcS : 1 ≤ digit q (kk JT) (m - j)) (hJval : (J : ℕ) = j)
+    (hITval : (IT : ℕ) = i + t)
+    (hJTval : (JT : ℕ) = j + t) (hIJ : I ≠ J) (hIIT : I ≠ IT) (hIJT : I ≠ JT)
+    (hJJT : J ≠ JT) (hITJT : IT ≠ JT) (hmimj : m - i ≠ m - j)
+    (hkk'def : kk' =
+      fun r => kk r - (if r = I then q ^ (m - i) else 0)
+        - (if r = JT then q ^ (m - j) else 0)
+        + (if r = IT then q ^ (m - i) else 0) + (if r = J then q ^ (m - j) else 0))
+    (hkkI : kk' I = kk I - q ^ (m - i))
+    (hkkJT : kk' JT = kk JT - q ^ (m - j)) :
+    CarryFree q d kk' := by
+  have hcfI : ∀ r : Fin (d + 1), r ≠ I → digit q (kk r) (m - i) + 1 < q := by
+    intro r hr
+    have hsum := hcf (m - i)
+    have hpair : digit q (kk r) (m - i) + digit q (kk I) (m - i)
+        ≤ ∑ s : Fin (d + 1), digit q (kk s) (m - i) := by
+      have hsub : ({r, I} : Finset (Fin (d + 1))) ⊆ Finset.univ := Finset.subset_univ _
+      have := Finset.sum_le_sum_of_subset (f := fun s => digit q (kk s) (m - i)) hsub
+      rwa [Finset.sum_pair hr] at this
+    omega
+  have hcfJ : ∀ r : Fin (d + 1), r ≠ JT → digit q (kk r) (m - j) + 1 < q := by
+    intro r hr
+    have hsum := hcf (m - j)
+    have hpair : digit q (kk r) (m - j) + digit q (kk JT) (m - j)
+        ≤ ∑ s : Fin (d + 1), digit q (kk s) (m - j) := by
+      have hsub : ({r, JT} : Finset (Fin (d + 1))) ⊆ Finset.univ := Finset.subset_univ _
+      have := Finset.sum_le_sum_of_subset (f := fun s => digit q (kk s) (m - j)) hsub
+      rwa [Finset.sum_pair hr] at this
+    omega
+  have hdigI : ∀ n : ℕ, digit q (kk' I) n =
+      if n = m - i then digit q (kk I) n - 1 else digit q (kk I) n := by
+    intro n
+    rw [hkkI]
+    have h1 : kk I - q ^ (m - i) = kk I - 1 * q ^ (m - i) := by rw [one_mul]
+    rw [h1]
+    by_cases hn : n = m - i
+    · subst hn; rw [if_pos rfl, digit_sub_self q (kk I) (m - i) 1 hq1 (by omega)]
+    · rw [if_neg hn, digit_sub_other q (kk I) (m - i) 1 n hq1 (by omega) hn]
+  have hdigJT : ∀ n : ℕ, digit q (kk' JT) n =
+      if n = m - j then digit q (kk JT) n - 1 else digit q (kk JT) n := by
+    intro n
+    rw [hkkJT]
+    have h1 : kk JT - q ^ (m - j) = kk JT - 1 * q ^ (m - j) := by rw [one_mul]
+    rw [h1]
+    by_cases hn : n = m - j
+    · subst hn; rw [if_pos rfl, digit_sub_self q (kk JT) (m - j) 1 hq1 (by omega)]
+    · rw [if_neg hn, digit_sub_other q (kk JT) (m - j) 1 n hq1 (by omega) hn]
+  by_cases hcol : i + t = j
+  · have hITJ : IT = J := by apply Fin.ext; rw [hITval, hJval]; omega
+    have hkkJcol : kk' J = kk J + q ^ (m - i) + q ^ (m - j) := by
+      have e : kk' J = kk J - (if J = I then q ^ (m - i) else 0)
+            - (if J = JT then q ^ (m - j) else 0)
+            + (if J = IT then q ^ (m - i) else 0) + (if J = J then q ^ (m - j) else 0) :=
+        by rw [hkk'def]
+      rw [e, if_neg hIJ.symm, if_neg hJJT, if_pos hITJ.symm, if_pos rfl,
+        Nat.sub_zero, Nat.sub_zero]
+    have hdigJ : ∀ n : ℕ, digit q (kk' J) n =
+        if n = m - i then digit q (kk J) n + 1
+        else if n = m - j then digit q (kk J) n + 1 else digit q (kk J) n := by
+      intro n
+      rw [hkkJcol]
+      have hpre_i : digit q (kk J) (m - i) + 1 < q :=
+        hcfI J (by rw [← hITJ]; exact hIIT.symm)
+      have hpre_j : digit q (kk J) (m - j) + 1 < q := hcfJ J hJJT
+      have hmid_j : digit q (kk J + q ^ (m - i)) (m - j) + 1 < q := by
+        rw [digit_add_other q (kk J) (m - i) (m - j) hq1 hpre_i hmimj.symm]
+        exact hpre_j
+      by_cases hni : n = m - i
+      · subst hni
+        rw [if_pos rfl, digit_add_other q (kk J + q ^ (m - i)) (m - j) (m - i)
+          hq1 hmid_j hmimj, digit_add_self q (kk J) (m - i) hq1 hpre_i]
+      · by_cases hnj : n = m - j
+        · subst hnj
+          rw [if_neg hni, if_pos rfl, digit_add_self q (kk J + q ^ (m - i)) (m - j)
+            hq1 hmid_j, digit_add_other q (kk J) (m - i) (m - j) hq1 hpre_i hni]
+        · rw [if_neg hni, if_neg hnj,
+            digit_add_other q (kk J + q ^ (m - i)) (m - j) n hq1 hmid_j hnj,
+            digit_add_other q (kk J) (m - i) n hq1 hpre_i hni]
+    have hkkO : ∀ r : Fin (d + 1), r ≠ I → r ≠ J → r ≠ JT → kk' r = kk r := by
+      intro r hrI hrJ hrJT
+      have hrIT : r ≠ IT := by rw [hITJ]; exact hrJ
+      simp only [hkk'def, if_neg hrI, if_neg hrJ, if_neg hrJT, if_neg hrIT,
+        Nat.sub_zero, add_zero]
+    intro n
+    have h3sub : ({I, J, JT} : Finset (Fin (d + 1))) ⊆ Finset.univ := Finset.subset_univ _
+    have heq : (∑ r : Fin (d + 1), digit q (kk' r) n) =
+        ∑ r : Fin (d + 1), digit q (kk r) n := by
+      rw [← Finset.sum_sdiff h3sub (f := fun r => digit q (kk' r) n),
+          ← Finset.sum_sdiff h3sub (f := fun r => digit q (kk r) n)]
+      have hrest : (∑ r ∈ Finset.univ \ {I, J, JT}, digit q (kk' r) n) =
+          ∑ r ∈ Finset.univ \ {I, J, JT}, digit q (kk r) n := by
+        apply Finset.sum_congr rfl
+        intro r hr
+        simp only [Finset.mem_sdiff, Finset.mem_univ, true_and, Finset.mem_insert,
+          Finset.mem_singleton, not_or] at hr
+        rw [hkkO r hr.1 hr.2.1 hr.2.2]
+      rw [hrest]
+      congr 1
+      rw [Finset.sum_insert (by simp [hIJ, hIJT]),
+          Finset.sum_insert (by simp [hJJT]), Finset.sum_singleton,
+          Finset.sum_insert (by simp [hIJ, hIJT]),
+          Finset.sum_insert (by simp [hJJT]), Finset.sum_singleton]
+      rw [hdigI n, hdigJ n, hdigJT n]
+      by_cases hni : n = m - i
+      · subst hni
+        rw [if_pos rfl, if_pos rfl, if_neg hmimj]
+        have hI1 : 1 ≤ digit q (kk I) (m - i) := hsrcP
+        omega
+      · by_cases hnj : n = m - j
+        · subst hnj
+          rw [if_neg hni, if_neg hni, if_pos rfl, if_pos rfl]
+          have hJT1 : 1 ≤ digit q (kk JT) (m - j) := hsrcS
+          omega
+        · rw [if_neg hni, if_neg hni, if_neg hnj, if_neg hnj]
+    rw [heq]; exact hcf n
+  · have hITJ : IT ≠ J := by
+      intro h
+      have := congrArg Fin.val h
+      simp [hITval, hJval] at this
+      omega
+    have hkkIT : kk' IT = kk IT + q ^ (m - i) := by
+      have e : kk' IT = kk IT - (if IT = I then q ^ (m - i) else 0)
+            - (if IT = JT then q ^ (m - j) else 0)
+            + (if IT = IT then q ^ (m - i) else 0) + (if IT = J then q ^ (m - j) else 0) :=
+        by rw [hkk'def]
+      rw [e, if_neg hIIT.symm, if_neg hITJT, if_pos rfl, if_neg hITJ,
+        Nat.sub_zero, Nat.sub_zero, add_zero]
+    have hkkJ : kk' J = kk J + q ^ (m - j) := by
+      have e : kk' J = kk J - (if J = I then q ^ (m - i) else 0)
+            - (if J = JT then q ^ (m - j) else 0)
+            + (if J = IT then q ^ (m - i) else 0) + (if J = J then q ^ (m - j) else 0) :=
+        by rw [hkk'def]
+      rw [e, if_neg hIJ.symm, if_neg hJJT, if_neg (Ne.symm hITJ), if_pos rfl,
+        Nat.sub_zero, Nat.sub_zero, add_zero]
+    have hdigIT : ∀ n : ℕ, digit q (kk' IT) n =
+        if n = m - i then digit q (kk IT) n + 1 else digit q (kk IT) n := by
+      intro n
+      rw [hkkIT]
+      have hpre : digit q (kk IT) (m - i) + 1 < q := hcfI IT hIIT.symm
+      by_cases hn : n = m - i
+      · subst hn; rw [if_pos rfl, digit_add_self q (kk IT) (m - i) hq1 hpre]
+      · rw [if_neg hn, digit_add_other q (kk IT) (m - i) n hq1 hpre hn]
+    have hdigJ : ∀ n : ℕ, digit q (kk' J) n =
+        if n = m - j then digit q (kk J) n + 1 else digit q (kk J) n := by
+      intro n
+      rw [hkkJ]
+      have hpre : digit q (kk J) (m - j) + 1 < q := hcfJ J hJJT
+      by_cases hn : n = m - j
+      · subst hn; rw [if_pos rfl, digit_add_self q (kk J) (m - j) hq1 hpre]
+      · rw [if_neg hn, digit_add_other q (kk J) (m - j) n hq1 hpre hn]
+    have hkkO : ∀ r : Fin (d + 1), r ≠ I → r ≠ J → r ≠ IT → r ≠ JT → kk' r = kk r := by
+      intro r hrI hrJ hrIT hrJT
+      simp only [hkk'def, if_neg hrI, if_neg hrJ, if_neg hrJT, if_neg hrIT,
+        Nat.sub_zero, add_zero]
+    intro n
+    have h4sub : ({I, J, IT, JT} : Finset (Fin (d + 1))) ⊆ Finset.univ := Finset.subset_univ _
+    have heq : (∑ r : Fin (d + 1), digit q (kk' r) n) =
+        ∑ r : Fin (d + 1), digit q (kk r) n := by
+      rw [← Finset.sum_sdiff h4sub (f := fun r => digit q (kk' r) n),
+          ← Finset.sum_sdiff h4sub (f := fun r => digit q (kk r) n)]
+      have hrest : (∑ r ∈ Finset.univ \ {I, J, IT, JT}, digit q (kk' r) n) =
+          ∑ r ∈ Finset.univ \ {I, J, IT, JT}, digit q (kk r) n := by
+        apply Finset.sum_congr rfl
+        intro r hr
+        simp only [Finset.mem_sdiff, Finset.mem_univ, true_and, Finset.mem_insert,
+          Finset.mem_singleton, not_or] at hr
+        rw [hkkO r hr.1 hr.2.1 hr.2.2.1 hr.2.2.2]
+      rw [hrest]
+      congr 1
+      rw [Finset.sum_insert (by simp [hIJ, hIIT, hIJT]),
+          Finset.sum_insert (by simp [hITJ.symm, hJJT]),
+          Finset.sum_insert (by simp [hITJT]), Finset.sum_singleton,
+          Finset.sum_insert (by simp [hIJ, hIIT, hIJT]),
+          Finset.sum_insert (by simp [hITJ.symm, hJJT]),
+          Finset.sum_insert (by simp [hITJT]), Finset.sum_singleton]
+      rw [hdigI n, hdigJ n, hdigIT n, hdigJT n]
+      by_cases hni : n = m - i
+      · subst hni
+        rw [if_pos rfl, if_neg hmimj, if_pos rfl, if_neg hmimj]
+        have hI1 : 1 ≤ digit q (kk I) (m - i) := hsrcP
+        omega
+      · by_cases hnj : n = m - j
+        · subst hnj
+          rw [if_neg hni, if_pos rfl, if_neg hni, if_pos rfl]
+          have hJT1 : 1 ≤ digit q (kk JT) (m - j) := hsrcS
+          omega
+        · rw [if_neg hni, if_neg hnj, if_neg hni, if_neg hnj]
+    rw [heq]; exact hcf n
+
+lemma move_parallelogram_phi_lt (q d m i j t : ℕ) (hq : 2 ≤ q)
+    (kk kk' : Fin (d + 1) → ℕ) (I J IT JT : Fin (d + 1)) (hi : i ≤ m)
+    (hj : j ≤ m) (hij : i < j) (ht : 1 ≤ t)
+    (hborrowP : q ^ (m - i) ≤ kk I) (hborrowS : q ^ (m - j) ≤ kk JT)
+    (hIval : (I : ℕ) = i) (hJval : (J : ℕ) = j)
+    (hITval : (IT : ℕ) = i + t) (hJTval : (JT : ℕ) = j + t) (hIJT : I ≠ JT)
+    (hkk'def : kk' =
+      fun r => kk r - (if r = I then q ^ (m - i) else 0)
+        - (if r = JT then q ^ (m - j) else 0)
+        + (if r = IT then q ^ (m - i) else 0) + (if r = J then q ^ (m - j) else 0)) :
+    Phi q d kk' < Phi q d kk := by
+  set w : Fin (d + 1) → ℕ := fun r => q ^ (d + 1) + (q - 1) * ((r : ℕ) * q ^ (r : ℕ)) with hw
+  have hPhiEq : ∀ tt : Fin (d + 1) → ℕ,
+      q ^ (d + 1) * ∑ r : Fin (d + 1), tt r
+        + (q - 1) * ∑ r : Fin (d + 1), (r : ℕ) * q ^ (r : ℕ) * tt r
+      = ∑ r : Fin (d + 1), w r * tt r := by
+    intro tt
+    rw [Finset.mul_sum, Finset.mul_sum, ← Finset.sum_add_distrib]
+    apply Finset.sum_congr rfl
+    intro r _
+    simp only [hw]; ring
+  have hPS : ∀ r : Fin (d + 1),
+      (if r = I then q ^ (m - i) else 0) + (if r = JT then q ^ (m - j) else 0) ≤
+        kk r := by
+    intro r
+    by_cases hrI : r = I
+    · subst hrI; rw [if_pos rfl, if_neg hIJT, add_zero]; exact hborrowP
+    · by_cases hrJT : r = JT
+      · subst hrJT; rw [if_neg hIJT.symm, if_pos rfl, zero_add]; exact hborrowS
+      · rw [if_neg hrI, if_neg hrJT]; exact Nat.zero_le _
+  have hbal : (∑ r : Fin (d + 1), w r * kk' r)
+        + ∑ r : Fin (d + 1), w r * ((if r = I then q ^ (m - i) else 0)
+            + (if r = JT then q ^ (m - j) else 0))
+      = (∑ r : Fin (d + 1), w r * kk r)
+        + ∑ r : Fin (d + 1), w r * ((if r = IT then q ^ (m - i) else 0)
+            + (if r = J then q ^ (m - j) else 0)) := by
+    rw [← Finset.sum_add_distrib, ← Finset.sum_add_distrib]
+    apply Finset.sum_congr rfl
+    intro r _
+    simp only [hkk'def]
+    have hps := hPS r
+    set P := (if r = I then q ^ (m - i) else 0) with hP
+    set S := (if r = JT then q ^ (m - j) else 0) with hS
+    set Q := (if r = IT then q ^ (m - i) else 0) with hQ
+    set R := (if r = J then q ^ (m - j) else 0) with hR
+    have hsub : kk r - P - S + Q + R = kk r - (P + S) + (Q + R) := by omega
+    rw [hsub]
+    have e1 : w r * (kk r - (P + S) + (Q + R)) =
+        w r * (kk r - (P + S)) + w r * (Q + R) := by
+      rw [Nat.mul_add]
+    have e2 : w r * (kk r - (P + S)) = w r * kk r - w r * (P + S) := by
+      rw [Nat.mul_sub]
+    rw [e1, e2]
+    have hle : w r * (P + S) ≤ w r * kk r := Nat.mul_le_mul_left _ hps
+    omega
+  have hswI : (∑ r : Fin (d + 1), w r * (if r = I then q ^ (m - i) else 0)) =
+      w I * q ^ (m - i) := by
+    rw [Finset.sum_eq_single I]
+    · rw [if_pos rfl]
+    · intro b _ hb; rw [if_neg hb, Nat.mul_zero]
+    · intro h; exact absurd (Finset.mem_univ _) h
+  have hswJT : (∑ r : Fin (d + 1), w r * (if r = JT then q ^ (m - j) else 0)) =
+      w JT * q ^ (m - j) := by
+    rw [Finset.sum_eq_single JT]
+    · rw [if_pos rfl]
+    · intro b _ hb; rw [if_neg hb, Nat.mul_zero]
+    · intro h; exact absurd (Finset.mem_univ _) h
+  have hswIT : (∑ r : Fin (d + 1), w r * (if r = IT then q ^ (m - i) else 0)) =
+      w IT * q ^ (m - i) := by
+    rw [Finset.sum_eq_single IT]
+    · rw [if_pos rfl]
+    · intro b _ hb; rw [if_neg hb, Nat.mul_zero]
+    · intro h; exact absurd (Finset.mem_univ _) h
+  have hswJ : (∑ r : Fin (d + 1), w r * (if r = J then q ^ (m - j) else 0)) =
+      w J * q ^ (m - j) := by
+    rw [Finset.sum_eq_single J]
+    · rw [if_pos rfl]
+    · intro b _ hb; rw [if_neg hb, Nat.mul_zero]
+    · intro h; exact absurd (Finset.mem_univ _) h
+  have hLb : (∑ r : Fin (d + 1), w r * ((if r = I then q ^ (m - i) else 0)
+            + (if r = JT then q ^ (m - j) else 0))) =
+      w I * q ^ (m - i) + w JT * q ^ (m - j) := by
+    rw [show (∑ r : Fin (d + 1), w r * ((if r = I then q ^ (m - i) else 0)
+            + (if r = JT then q ^ (m - j) else 0)))
+          = (∑ r : Fin (d + 1), w r * (if r = I then q ^ (m - i) else 0))
+            + ∑ r : Fin (d + 1), w r * (if r = JT then q ^ (m - j) else 0) from by
+            rw [← Finset.sum_add_distrib]
+            apply Finset.sum_congr rfl
+            intro r _
+            rw [Nat.mul_add]]
+    rw [hswI, hswJT]
+  have hRb : (∑ r : Fin (d + 1), w r * ((if r = IT then q ^ (m - i) else 0)
+            + (if r = J then q ^ (m - j) else 0))) =
+      w IT * q ^ (m - i) + w J * q ^ (m - j) := by
+    rw [show (∑ r : Fin (d + 1), w r * ((if r = IT then q ^ (m - i) else 0)
+            + (if r = J then q ^ (m - j) else 0)))
+          = (∑ r : Fin (d + 1), w r * (if r = IT then q ^ (m - i) else 0))
+            + ∑ r : Fin (d + 1), w r * (if r = J then q ^ (m - j) else 0) from by
+            rw [← Finset.sum_add_distrib]
+            apply Finset.sum_congr rfl
+            intro r _
+            rw [Nat.mul_add]]
+    rw [hswIT, hswJ]
+  rw [hLb, hRb] at hbal
+  have hppi : q ^ i * q ^ (m - i) = q ^ m := by rw [← pow_add]; congr 1; omega
+  have hppit : q ^ (i + t) * q ^ (m - i) = q ^ (m + t) := by
+    rw [← pow_add]; congr 1; omega
+  have hppj : q ^ j * q ^ (m - j) = q ^ m := by rw [← pow_add]; congr 1; omega
+  have hppjt : q ^ (j + t) * q ^ (m - j) = q ^ (m + t) := by
+    rw [← pow_add]; congr 1; omega
+  have hwIv : w I * q ^ (m - i) =
+      q ^ (d + 1) * q ^ (m - i) + (q - 1) * i * q ^ m := by
+    simp only [hw, hIval]
+    calc (q ^ (d + 1) + (q - 1) * (i * q ^ i)) * q ^ (m - i)
+        = q ^ (d + 1) * q ^ (m - i) + (q - 1) * i * (q ^ i * q ^ (m - i)) := by ring
+      _ = q ^ (d + 1) * q ^ (m - i) + (q - 1) * i * q ^ m := by rw [hppi]
+  have hwITv : w IT * q ^ (m - i) =
+      q ^ (d + 1) * q ^ (m - i) + (q - 1) * (i + t) * q ^ (m + t) := by
+    simp only [hw, hITval]
+    calc (q ^ (d + 1) + (q - 1) * ((i + t) * q ^ (i + t))) * q ^ (m - i)
+        = q ^ (d + 1) * q ^ (m - i)
+          + (q - 1) * (i + t) * (q ^ (i + t) * q ^ (m - i)) := by ring
+      _ = q ^ (d + 1) * q ^ (m - i) + (q - 1) * (i + t) * q ^ (m + t) := by
+        rw [hppit]
+  have hwJv : w J * q ^ (m - j) =
+      q ^ (d + 1) * q ^ (m - j) + (q - 1) * j * q ^ m := by
+    simp only [hw, hJval]
+    calc (q ^ (d + 1) + (q - 1) * (j * q ^ j)) * q ^ (m - j)
+        = q ^ (d + 1) * q ^ (m - j) + (q - 1) * j * (q ^ j * q ^ (m - j)) := by ring
+      _ = q ^ (d + 1) * q ^ (m - j) + (q - 1) * j * q ^ m := by rw [hppj]
+  have hwJTv : w JT * q ^ (m - j) =
+      q ^ (d + 1) * q ^ (m - j) + (q - 1) * (j + t) * q ^ (m + t) := by
+    simp only [hw, hJTval]
+    calc (q ^ (d + 1) + (q - 1) * ((j + t) * q ^ (j + t))) * q ^ (m - j)
+        = q ^ (d + 1) * q ^ (m - j)
+          + (q - 1) * (j + t) * (q ^ (j + t) * q ^ (m - j)) := by ring
+      _ = q ^ (d + 1) * q ^ (m - j) + (q - 1) * (j + t) * q ^ (m + t) := by
+        rw [hppjt]
+  have hpowlt : q ^ m < q ^ (m + t) := by
+    apply Nat.pow_lt_pow_right (by omega); omega
+  have hred : (q - 1) * (i + t) * q ^ (m + t) + (q - 1) * j * q ^ m
+      < (q - 1) * i * q ^ m + (q - 1) * (j + t) * q ^ (m + t) := by
+    set c := q - 1 with hc
+    set Pm := q ^ m with hPm
+    set Pt := q ^ (m + t) with hPt
+    have hcpos : 0 < c := by omega
+    have hbase : (i + t) * Pt + j * Pm < i * Pm + (j + t) * Pt := by
+      obtain ⟨s, hs, hspos⟩ : ∃ s, j = i + s ∧ 0 < s := ⟨j - i, by omega, by omega⟩
+      subst hs
+      have hsP : s * Pm < s * Pt := Nat.mul_lt_mul_of_pos_left hpowlt hspos
+      have hLe : (i + t) * Pt + (i + s) * Pm = (i * Pt + t * Pt + i * Pm) + s * Pm := by
+        ring
+      have hRe : i * Pm + (i + s + t) * Pt = (i * Pt + t * Pt + i * Pm) + s * Pt := by
+        ring
+      rw [hLe, hRe]
+      exact Nat.add_lt_add_left hsP _
+    calc c * (i + t) * Pt + c * j * Pm
+        = c * ((i + t) * Pt + j * Pm) := by ring
+      _ < c * (i * Pm + (j + t) * Pt) := Nat.mul_lt_mul_of_pos_left hbase hcpos
+      _ = c * i * Pm + c * (j + t) * Pt := by ring
+  have hstrict : w IT * q ^ (m - i) + w J * q ^ (m - j) <
+      w I * q ^ (m - i) + w JT * q ^ (m - j) := by
+    rw [hwIv, hwITv, hwJv, hwJTv]
+    have hL : q ^ (d + 1) * q ^ (m - i) + (q - 1) * (i + t) * q ^ (m + t)
+          + (q ^ (d + 1) * q ^ (m - j) + (q - 1) * j * q ^ m)
+        = (q ^ (d + 1) * q ^ (m - i) + q ^ (d + 1) * q ^ (m - j))
+          + ((q - 1) * (i + t) * q ^ (m + t) + (q - 1) * j * q ^ m) := by
+      ring
+    have hR : q ^ (d + 1) * q ^ (m - i) + (q - 1) * i * q ^ m
+          + (q ^ (d + 1) * q ^ (m - j) + (q - 1) * (j + t) * q ^ (m + t))
+        = (q ^ (d + 1) * q ^ (m - i) + q ^ (d + 1) * q ^ (m - j))
+          + ((q - 1) * i * q ^ m + (q - 1) * (j + t) * q ^ (m + t)) := by
+      ring
+    rw [hL, hR]
+    exact Nat.add_lt_add_left hred _
+  change Phi q d kk' < Phi q d kk
+  unfold Phi
+  rw [hPhiEq kk', hPhiEq kk]
+  omega
+
+/-- **Parallelogram double move.** When the target diagonal `m-j` is full, swap two
+stones around a parallelogram with corners `P=(i,m-i)`, `S=(j+t,m-j)`, `Q=(i+t,m-i)`,
+`R=(j,m-j)` (rows `i<j`, shift `t ≥ 1`, all rows `≤ d`): remove one from `P` and `S`,
+add one to `Q` and `R`. This preserves every column and diagonal sum (so admissibility
+needs no slack hypothesis) and strictly lowers `Φ` by `(q - 1)(j-i)(q ^ m - q ^ {m+t}) < 0`. -/
+lemma move_parallelogram (q d k m i j t : ℕ) (hq : 2 ≤ q) (kk : Fin (d + 1) → ℕ)
+    (hadm : Admissible q d k kk)
+    (hi : i ≤ m) (hj : j ≤ m) (hij : i < j) (ht : 1 ≤ t)
+    (hjt : j + t ≤ d)
+    (hsrcP : 1 ≤ digit q (kk ⟨i, by omega⟩) (m - i))
+    (hsrcS : 1 ≤ digit q (kk ⟨j + t, by omega⟩) (m - j)) :
+    ∃ kk' : Fin (d + 1) → ℕ, Admissible q d k kk' ∧ Phi q d kk' < Phi q d kk := by
+  have hq1 : 1 ≤ q := by omega
+  obtain ⟨hrep, hcf⟩ := hadm
+  -- the four indices
+  set I : Fin (d + 1) := ⟨i, by omega⟩ with hI
+  set J : Fin (d + 1) := ⟨j, by omega⟩ with hJ
+  set IT : Fin (d + 1) := ⟨i + t, by omega⟩ with hIT
+  set JT : Fin (d + 1) := ⟨j + t, by omega⟩ with hJT
+  have hIval : (I : ℕ) = i := rfl
+  have hJval : (J : ℕ) = j := rfl
+  have hITval : (IT : ℕ) = i + t := rfl
+  have hJTval : (JT : ℕ) = j + t := rfl
+  -- pairwise relations (all but IT = J are guaranteed distinct)
+  have hIJ : I ≠ J := by
+    intro h
+    have := congrArg Fin.val h
+    simp [hIval, hJval] at this
+    omega
+  have hIIT : I ≠ IT := by
+    intro h
+    have := congrArg Fin.val h
+    simp [hIval, hITval] at this
+    omega
+  have hIJT : I ≠ JT := by
+    intro h
+    have := congrArg Fin.val h
+    simp [hIval, hJTval] at this
+    omega
+  have hJJT : J ≠ JT := by
+    intro h
+    have := congrArg Fin.val h
+    simp [hJval, hJTval] at this
+    omega
+  have hITJT : IT ≠ JT := by
+    intro h
+    have := congrArg Fin.val h
+    simp [hITval, hJTval] at this
+    omega
+  -- no-borrow at I (source P) and JT (source S)
+  have hborrowP : q ^ (m - i) ≤ kk I := by
+    calc q ^ (m - i) = 1 * q ^ (m - i) := (one_mul _).symm
+      _ ≤ digit q (kk I) (m - i) * q ^ (m - i) := Nat.mul_le_mul_right _ hsrcP
+      _ ≤ kk I := digit_place_le _ _ _
+  have hborrowS : q ^ (m - j) ≤ kk JT := by
+    calc q ^ (m - j) = 1 * q ^ (m - j) := (one_mul _).symm
+      _ ≤ digit q (kk JT) (m - j) * q ^ (m - j) := Nat.mul_le_mul_right _ hsrcS
+      _ ≤ kk JT := digit_place_le _ _ _
+  -- m - i ≠ m - j
+  have hmimj : m - i ≠ m - j := by omega
+  -- the new tuple
+  set kk' : Fin (d + 1) → ℕ :=
+    fun r => kk r - (if r = I then q ^ (m - i) else 0) - (if r = JT then q ^ (m - j) else 0)
+              + (if r = IT then q ^ (m - i) else 0) + (if r = J then q ^ (m - j) else 0)
+    with hkk'def
+  -- pointwise characterization on the always-distinct rows I and JT
+  have hkkI : kk' I = kk I - q ^ (m - i) := by
+    simp only [hkk'def, if_neg hIJT, if_neg hIIT, if_neg hIJ, if_true, add_zero,
+      Nat.sub_zero]
+  have hkkJT : kk' JT = kk JT - q ^ (m - j) := by
+    simp only [hkk'def, if_neg hIJT.symm, if_neg hITJT.symm, if_neg hJJT.symm, if_true,
+      add_zero, Nat.sub_zero]
+  refine ⟨kk', ⟨?_, ?_⟩, ?_⟩
+  · exact
+      move_parallelogram_representation q d k m i j t kk kk' I J IT JT hi hj hrep
+        hborrowP hborrowS hIval hJval hITval hJTval hIJT hkk'def
+  · exact
+      move_parallelogram_carry_free q d m i j t kk kk' I J IT JT hq1 hcf hsrcP hsrcS
+        hJval hITval hJTval hIJ hIIT hIJT hJJT hITJT hmimj hkk'def hkkI hkkJT
+  · exact
+      move_parallelogram_phi_lt q d m i j t hq kk kk' I J IT JT hi hj hij ht
+        hborrowP hborrowS hIval hJval hITval hJTval hIJT hkk'def
+
+/-! ### No two distinct maximizers -/
+
+/-- **A maximizer minimizes `Φ`.** For an admissible `F`-maximizer `kk`, every
+admissible tuple `kk'` with the same `k` has `Φ kk ≤ Φ kk'` (via `F_lt_of_Phi_lt`). -/
+lemma maximizer_min_Phi (q d k : ℕ) (hq : 2 ≤ q) (kk : Fin (d + 1) → ℕ)
+    (hadm : Admissible q d k kk)
+    (hmax : ∀ kk' : Fin (d + 1) → ℕ, Admissible q d k kk' → F q d kk' ≤ F q d kk)
+    (kk' : Fin (d + 1) → ℕ) (hadm' : Admissible q d k kk') :
+    Phi q d kk ≤ Phi q d kk' := by
+  by_contra h
+  push Not at h
+  -- h : Phi q d kk' < Phi q d kk
+  have hrep : (∑ i : Fin (d + 1), kk i * q ^ (i : ℕ))
+      = (∑ i : Fin (d + 1), kk' i * q ^ (i : ℕ)) := by
+    rw [← hadm.1, ← hadm'.1]
+  have hPhi : (q ^ (d + 1) * ∑ i : Fin (d + 1), kk' i
+              + (q - 1) * ∑ i : Fin (d + 1), (i : ℕ) * q ^ (i : ℕ) * kk' i)
+          < (q ^ (d + 1) * ∑ i : Fin (d + 1), kk i
+              + (q - 1) * ∑ i : Fin (d + 1), (i : ℕ) * q ^ (i : ℕ) * kk i) := by
+    simpa [Phi] using h
+  have hF : F q d kk < F q d kk' := F_lt_of_Phi_lt q d k hq kk kk' hrep hPhi
+  have hle : F q d kk' ≤ F q d kk := hmax kk' hadm'
+  exact absurd hF (not_lt.mpr hle)
+
+/-- A natural `x` with `x < q ^ N` equals the sum of its first `N` base-`q` digits
+weighted by place value. -/
+theorem digit_sum_repr (q : ℕ) :
+    ∀ (N x : ℕ), x < q ^ N → x = ∑ n ∈ Finset.range N, digit q x n * q ^ n := by
+  intro N
+  induction N with
+  | zero =>
+    intro x hx
+    simp only [pow_zero] at hx
+    simp only [Finset.range_zero, Finset.sum_empty]; omega
+  | succ N ih =>
+    intro x hx
+    rw [Finset.sum_range_succ']
+    have hxq : x / q < q ^ N := by
+      rw [pow_succ] at hx
+      exact Nat.div_lt_of_lt_mul (by rwa [mul_comm] at hx)
+    have hih := ih (x / q) hxq
+    have hdshift : ∀ n, digit q x (n+1) = digit q (x / q) n := by
+      intro n; simp only [digit, pow_succ]
+      rw [show q ^ n * q = q * q ^ n by ring, ← Nat.div_div_eq_div_mul]
+    calc x = digit q x 0 + q * (x / q) := by
+            have := Nat.div_add_mod x q
+            simp only [digit, pow_zero, Nat.div_one]; omega
+      _ = digit q x 0 + q * (∑ n ∈ Finset.range N, digit q (x/q) n * q ^ n) := by rw [← hih]
+      _ = digit q x 0 + ∑ n ∈ Finset.range N, digit q (x/q) n * q ^ (n+1) := by
+            rw [Finset.mul_sum]; congr 1; apply Finset.sum_congr rfl; intro n _; rw [pow_succ]; ring
+      _ = (∑ n ∈ Finset.range N, digit q x (n+1) * q ^ (n+1)) + digit q x 0 * q ^ 0 := by
+            simp only [pow_zero, mul_one]; rw [add_comm]; congr 1
+            apply Finset.sum_congr rfl; intro n _; rw [hdshift]
+
+/-- Reindex a "column" sum (terms with `i ≤ m`, weighted by `q ^ m`) as a place-shifted
+digit sum: substitute `n = m - i`. -/
+theorem reindex_col (q i M : ℕ) (f : ℕ → ℕ) :
+    (∑ m ∈ Finset.range M, (if i ≤ m then f (m - i) * q ^ m else 0))
+      = q ^ i * ∑ n ∈ Finset.range (M - i), f n * q ^ n := by
+  rw [Finset.mul_sum, ← Finset.sum_filter]
+  rw [show (Finset.range M).filter (fun m => i ≤ m) = Finset.Ico i M by
+        ext x; simp [Finset.mem_Ico, Finset.mem_filter, Finset.mem_range]; omega]
+  rw [Finset.sum_Ico_eq_sum_range]
+  apply Finset.sum_congr rfl
+  intro n hn
+  rw [Nat.add_sub_cancel_left, pow_add]; ring
+
+/-- **Uniqueness of finite base-`q` representations.** If `k = ∑_{i<M} c i · q ^ i` with
+every coefficient `c n ≤ q - 1` and `c` vanishing past `M`, then `c m` is exactly the
+`m`-th base-`q` digit of `k`. -/
+theorem digit_eq_of_repr' (q : ℕ) (hq : 2 ≤ q) :
+    ∀ (m : ℕ) (c : ℕ → ℕ) (k : ℕ),
+      (∀ n, c n ≤ q - 1) →
+      (∃ M, (∀ n, M ≤ n → c n = 0) ∧ k = ∑ i ∈ Finset.range M, c i * q ^ i) →
+      c m = digit q k m := by
+  intro m
+  induction m with
+  | zero =>
+    intro c k hc ⟨M, hMvanish, hrep⟩
+    have hc0 : c 0 < q := by have := hc 0; omega
+    rcases Nat.eq_zero_or_pos M with hM | hM
+    · subst hM
+      simp at hrep
+      have : c 0 = 0 := hMvanish 0 (by omega)
+      simp [digit, hrep, this]
+    · obtain ⟨M', rfl⟩ : ∃ M', M = M' + 1 := ⟨M - 1, by omega⟩
+      have hdec : (∑ i ∈ Finset.range (M'+1), c i * q ^ i)
+          = c 0 + q * ∑ i ∈ Finset.range M', c (i+1) * q ^ i := by
+        rw [Finset.sum_range_succ', Finset.mul_sum, add_comm]
+        simp only [pow_zero, mul_one]; congr 1
+        apply Finset.sum_congr rfl; intro i _; ring
+      rw [hdec] at hrep
+      simp only [digit, pow_zero, Nat.div_one]
+      rw [hrep, Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt hc0]
+  | succ m ih =>
+    intro c k hc ⟨M, hMvanish, hrep⟩
+    have hc0 : c 0 < q := by have := hc 0; omega
+    set c' : ℕ → ℕ := fun n => c (n + 1) with hc'def
+    have hdigrec : digit q k (m + 1) = digit q (k / q) m := by
+      simp only [digit, pow_succ]
+      rw [show q ^ m * q = q * q ^ m by ring, ← Nat.div_div_eq_div_mul]
+    rcases Nat.eq_zero_or_pos M with hM | hM
+    · subst hM
+      have hkzero : k = 0 := by
+        simpa using hrep
+      have hcm : c (m + 1) = 0 := hMvanish (m + 1) (by omega)
+      rw [hcm, hdigrec, hkzero]; simp [digit]
+    · obtain ⟨M', rfl⟩ : ∃ M', M = M' + 1 := ⟨M - 1, by omega⟩
+      have hdec : (∑ i ∈ Finset.range (M'+1), c i * q ^ i)
+          = c 0 + q * ∑ i ∈ Finset.range M', c (i+1) * q ^ i := by
+        rw [Finset.sum_range_succ', Finset.mul_sum, add_comm]
+        simp only [pow_zero, mul_one]; congr 1
+        apply Finset.sum_congr rfl; intro i _; ring
+      have hkq : k / q = ∑ i ∈ Finset.range M', c' i * q ^ i := by
+        rw [hrep, hdec, Nat.add_mul_div_left _ _ (by omega : 0 < q),
+            Nat.div_eq_of_lt hc0, zero_add]
+      rw [hdigrec, show c (m + 1) = c' m from rfl]
+      apply ih c' (k / q)
+      · intro n; exact hc (n + 1)
+      · refine ⟨M', ?_, hkq⟩
+        intro n hn; simp only [hc'def]; exact hMvanish (n + 1) (by omega)
+
+/-- **Exact column sums.** A maximizer `kk` has exactly `digit q k m` stones in
+column `m` (`∑_{i ≤ m} digit q (kk i) (m-i) = digit q k m`): by `carry_elimination`
+the column sums are `≤ q-1`, so they form the unique base-`q` digit string of `k`. -/
+lemma column_sum_eq (q d k : ℕ) (hq : q.Prime) (kk : Fin (d + 1) → ℕ)
+    (hadm : Admissible q d k kk)
+    (hmax : ∀ kk' : Fin (d + 1) → ℕ, Admissible q d k kk' → F q d kk' ≤ F q d kk)
+    (m : ℕ) :
+    (∑ i : Fin (d + 1), (if (i : ℕ) ≤ m then digit q (kk i) (m - (i : ℕ)) else 0))
+      = digit q k m := by
+  have hq2 : 2 ≤ q := hq.two_le
+  have hrepk : k = ∑ i : Fin (d + 1), kk i * q ^ (i : ℕ) := hadm.1
+  have hkkle : ∀ i : Fin (d + 1), kk i ≤ k := admissible_le q d k (by omega) kk hadm
+  have hce : ∀ m : ℕ, (∑ i : Fin (d + 1),
+      (if (i : ℕ) ≤ m then digit q (kk i) (m - (i : ℕ)) else 0)) ≤ q - 1 :=
+    carry_elimination q d k hq kk hadm hmax
+  -- pick N with k < q ^ N
+  obtain ⟨N, hkN⟩ : ∃ N, k < q ^ N := by
+    refine ⟨k + 1, ?_⟩
+    calc k < 2 ^ k := Nat.lt_two_pow_self
+      _ ≤ 2 ^ (k + 1) := Nat.pow_le_pow_right (by norm_num) (by omega)
+      _ ≤ q ^ (k + 1) := Nat.pow_le_pow_left hq2 _
+  set M := N + d + 1 with hMdef
+  set colSum : ℕ → ℕ := fun m =>
+    ∑ i : Fin (d + 1), (if (i : ℕ) ≤ m then digit q (kk i) (m - (i : ℕ)) else 0) with hcsdef
+  change colSum m = digit q k m
+  -- column sums vanish past column M
+  have hvanish : ∀ mm, M ≤ mm → colSum mm = 0 := by
+    intro mm hmm
+    simp only [hcsdef]
+    apply Finset.sum_eq_zero
+    intro i _
+    by_cases hi : (i : ℕ) ≤ mm
+    · rw [if_pos hi]
+      have hbig : kk i < q ^ (mm - (i : ℕ)) := by
+        have hile : (i : ℕ) ≤ d := by have := i.2; omega
+        calc kk i ≤ k := hkkle i
+          _ < q ^ N := hkN
+          _ ≤ q ^ (mm - (i : ℕ)) := Nat.pow_le_pow_right (by omega) (by omega)
+      simp only [digit]
+      rw [Nat.div_eq_of_lt hbig]; simp
+    · rw [if_neg hi]
+  -- the finite base-q expansion: k = ∑_{mm<M} colSum mm * q ^ mm
+  have hcolrep : k = ∑ mm ∈ Finset.range M, colSum mm * q ^ mm := by
+    have step1 : (∑ mm ∈ Finset.range M, colSum mm * q ^ mm)
+        = ∑ i : Fin (d + 1), ∑ mm ∈ Finset.range M,
+            (if (i : ℕ) ≤ mm then digit q (kk i) (mm - (i : ℕ)) * q ^ mm else 0) := by
+      simp only [hcsdef]
+      rw [Finset.sum_comm]
+      apply Finset.sum_congr rfl
+      intro mm _
+      rw [Finset.sum_mul]
+      apply Finset.sum_congr rfl
+      intro i _
+      rw [ite_mul, zero_mul]
+    rw [step1]
+    have step2 : ∀ i : Fin (d + 1),
+        (∑ mm ∈ Finset.range M,
+          (if (i : ℕ) ≤ mm then digit q (kk i) (mm - (i : ℕ)) * q ^ mm else 0))
+          = kk i * q ^ (i : ℕ) := by
+      intro i
+      rw [reindex_col q (i : ℕ) M (fun n => digit q (kk i) n)]
+      have hMiN : N ≤ M - (i : ℕ) := by have := i.2; omega
+      have hkkN : kk i < q ^ (M - (i : ℕ)) := by
+        calc kk i ≤ k := hkkle i
+          _ < q ^ N := hkN
+          _ ≤ q ^ (M - (i : ℕ)) := Nat.pow_le_pow_right (by omega) hMiN
+      rw [← digit_sum_repr q (M - (i : ℕ)) (kk i) hkkN]; ring
+    rw [hrepk]
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [step2 i]
+  -- conclude by uniqueness of base-q representation
+  exact digit_eq_of_repr' q hq2 m colSum k (fun mm => hce mm) ⟨M, hvanish, hcolrep⟩
+
+/-- **Extremal differing-cell selection.** Given admissible `a ≠ b` with equal column
+sums in every column, there are a column `m₀` and rows `i₀ < j₀` (`i₀, j₀ ≤ m₀`,
+`j₀ ≤ d`) such that `a` and `b` agree on every cell in columns `< m₀`, and either
+`a` has a surplus at `(i₀, m₀-i₀)` and a deficit at `(j₀, m₀-j₀)`, or the mirror
+image with `a` and `b` swapped. In both cases the surplus row lies strictly above
+the deficit row, so a downward move on the surplus array is possible. -/
+lemma differing_cell_select (q d k : ℕ) (hq : q.Prime)
+    (a b : Fin (d + 1) → ℕ) (hadma : Admissible q d k a) (hadmb : Admissible q d k b)
+    (hcol : ∀ m : ℕ,
+      (∑ i : Fin (d + 1), (if (i : ℕ) ≤ m then digit q (a i) (m - (i : ℕ)) else 0))
+        = (∑ i : Fin (d + 1), (if (i : ℕ) ≤ m then digit q (b i) (m - (i : ℕ)) else 0)))
+    (hne : a ≠ b) :
+    ∃ (m₀ i₀ j₀ : ℕ) (_hi₀ : i₀ ≤ m₀) (_hj₀ : j₀ ≤ m₀) (hj₀d : j₀ ≤ d)
+      (hij : i₀ < j₀),
+      (∀ (r : Fin (d + 1)) (nn : ℕ), (r : ℕ) + nn < m₀ →
+          digit q (a r) nn = digit q (b r) nn) ∧
+      -- surplus on `a` (left disjunct) or on `b` (right disjunct)
+      ((1 ≤ digit q (a ⟨i₀, by omega⟩) (m₀ - i₀) ∧
+          digit q (b ⟨i₀, by omega⟩) (m₀ - i₀) < digit q (a ⟨i₀, by omega⟩) (m₀ - i₀) ∧
+          digit q (a ⟨j₀, by omega⟩) (m₀ - j₀) < digit q (b ⟨j₀, by omega⟩) (m₀ - j₀))
+        ∨
+       (1 ≤ digit q (b ⟨i₀, by omega⟩) (m₀ - i₀) ∧
+          digit q (a ⟨i₀, by omega⟩) (m₀ - i₀) < digit q (b ⟨i₀, by omega⟩) (m₀ - i₀) ∧
+           digit q (b ⟨j₀, by omega⟩) (m₀ - j₀) < digit q (a ⟨j₀, by omega⟩) (m₀ - j₀))) := by
+  classical
+  have hq2 : 2 ≤ q := hq.two_le
+  -- STEP 1: support bound. Pick N with a r, b r < q ^ N for all r.
+  have hale : ∀ i : Fin (d + 1), a i ≤ k := admissible_le q d k (by omega) a hadma
+  have hble : ∀ i : Fin (d + 1), b i ≤ k := admissible_le q d k (by omega) b hadmb
+  obtain ⟨N, hkN⟩ : ∃ N, k < q ^ N := by
+    refine ⟨k + 1, ?_⟩
+    calc k < 2 ^ k := Nat.lt_two_pow_self
+      _ ≤ 2 ^ (k + 1) := Nat.pow_le_pow_right (by norm_num) (by omega)
+      _ ≤ q ^ (k + 1) := Nat.pow_le_pow_left hq2 _
+  -- digits vanish above N
+  have hzero : ∀ (x : ℕ), x ≤ k → ∀ n, N ≤ n → digit q x n = 0 := by
+    intro x hx n hn
+    have hxq : x < q ^ n := by
+      calc x ≤ k := hx
+        _ < q ^ N := hkN
+        _ ≤ q ^ n := Nat.pow_le_pow_right (by omega) hn
+    unfold digit
+    rw [Nat.div_eq_of_lt hxq]
+    simp
+  have hazero : ∀ (r : Fin (d + 1)) n, N ≤ n → digit q (a r) n = 0 :=
+    fun r n hn => hzero (a r) (hale r) n hn
+  have hbzero : ∀ (r : Fin (d + 1)) n, N ≤ n → digit q (b r) n = 0 :=
+    fun r n hn => hzero (b r) (hble r) n hn
+  -- STEP 2 & 3: define the differing-cell finset D, prove nonempty, select extremal cell.
+  set D : Finset (Fin (d + 1) × ℕ) :=
+    (Finset.univ ×ˢ Finset.range N).filter
+      (fun p => digit q (a p.1) p.2 ≠ digit q (b p.1) p.2) with hDdef
+  -- membership characterization
+  have hDmem : ∀ p : Fin (d + 1) × ℕ, p ∈ D ↔
+      (p.2 < N ∧ digit q (a p.1) p.2 ≠ digit q (b p.1) p.2) := by
+    intro p
+    simp only [hDdef, Finset.mem_filter, Finset.mem_product, Finset.mem_univ,
+      Finset.mem_range, true_and]
+  -- nonempty: a ≠ b gives a differing digit
+  have hDne : D.Nonempty := by
+    by_contra hempty
+    rw [Finset.not_nonempty_iff_eq_empty] at hempty
+    apply hne
+    funext r
+    apply digit_ext q hq2
+    intro n
+    by_cases hn : n < N
+    · by_contra hcontra
+      have : (r, n) ∈ D := by
+        rw [hDmem]; exact ⟨hn, hcontra⟩
+      rw [hempty] at this
+      simp at this
+    · push Not at hn
+      rw [hazero r n hn, hbzero r n hn]
+  -- lex key: column primary, row tiebreak
+  set key : Fin (d + 1) × ℕ → ℕ := fun p => ((p.1 : ℕ) + p.2) * (d + 1) + (p.1 : ℕ) with hkeydef
+  obtain ⟨p₀, hp₀mem, hp₀min⟩ := Finset.exists_min_image D key hDne
+  set i₀ := (p₀.1 : ℕ) with hi₀def
+  set n₀ := p₀.2 with hn₀def
+  set m₀ := i₀ + n₀ with hm₀def
+  have hi₀lt : i₀ < d + 1 := p₀.1.2
+  have hi₀m₀ : i₀ ≤ m₀ := by omega
+  have hn₀N : n₀ < N := (hDmem p₀).mp hp₀mem |>.1
+  have hdiff₀ : digit q (a p₀.1) n₀ ≠ digit q (b p₀.1) n₀ := (hDmem p₀).mp hp₀mem |>.2
+  -- key value at p₀
+  have hkeyp₀ : key p₀ = m₀ * (d + 1) + i₀ := by
+    simp only [hkeydef, hi₀def, hn₀def, hm₀def]
+  -- STEP 4: agreement strictly below column m₀.
+  have hagree : ∀ (r : Fin (d + 1)) (nn : ℕ), (r : ℕ) + nn < m₀ →
+      digit q (a r) nn = digit q (b r) nn := by
+    intro r nn hlt
+    by_contra hcontra
+    -- (r, nn) is a differing cell, with nn < N
+    have hnnN : nn < N := by
+      by_contra hge
+      push Not at hge
+      rw [hazero r nn hge, hbzero r nn hge] at hcontra
+      exact hcontra rfl
+    have hmem : (r, nn) ∈ D := by rw [hDmem]; exact ⟨hnnN, hcontra⟩
+    have hmin := hp₀min (r, nn) hmem
+    -- key (r,nn) = (r+nn)*(d + 1)+r. key p₀ = m₀*(d + 1)+i₀
+    have hrlt : (r : ℕ) < d + 1 := r.2
+    rw [hkeyp₀] at hmin
+    simp only [hkeydef] at hmin
+    -- (r+nn) < m₀ so (r+nn)*(d + 1)+r < m₀*(d + 1) ≤ m₀*(d + 1)+i₀
+    have : ((r : ℕ) + nn) * (d + 1) + (r : ℕ) < m₀ * (d + 1) + i₀ := by
+      have h1 : ((r : ℕ) + nn + 1) * (d + 1) ≤ m₀ * (d + 1) :=
+        Nat.mul_le_mul_right _ (by omega)
+      nlinarith [hrlt]
+    omega
+  -- tiebreak: any differing cell (r, n) in column m₀ has i₀ ≤ r
+  have htiebreak : ∀ (r : Fin (d + 1)), (r : ℕ) ≤ m₀ →
+      digit q (a r) (m₀ - (r:ℕ)) ≠ digit q (b r) (m₀ - (r:ℕ)) → i₀ ≤ (r : ℕ) := by
+    intro r hrm hdiffr
+    set nn := m₀ - (r : ℕ) with hnndef
+    have hcolr : (r : ℕ) + nn = m₀ := by omega
+    have hnnN : nn < N := by
+      by_contra hge
+      push Not at hge
+      rw [hazero r nn hge, hbzero r nn hge] at hdiffr
+      exact hdiffr rfl
+    have hmem : (r, nn) ∈ D := by rw [hDmem]; exact ⟨hnnN, hdiffr⟩
+    have hmin := hp₀min (r, nn) hmem
+    rw [hkeyp₀] at hmin
+    simp only [hkeydef] at hmin
+    -- (r+nn) = m₀, so key = m₀*(d + 1) + r ≥ m₀*(d + 1)+i₀ ⟹ i₀ ≤ r
+    have hrr : ((r : ℕ) + nn) * (d + 1) + (r : ℕ) = m₀ * (d + 1) + (r : ℕ) := by
+      rw [hcolr]
+    omega
+  -- STEP 5: column functions
+  set fa : Fin (d + 1) → ℕ := fun i => if (i : ℕ) ≤ m₀ then digit q (a i) (m₀ - (i : ℕ)) else 0
+    with hfadef
+  set fb : Fin (d + 1) → ℕ := fun i => if (i : ℕ) ≤ m₀ then digit q (b i) (m₀ - (i : ℕ)) else 0
+    with hfbdef
+  have hsumeq : (∑ i : Fin (d + 1), fa i) = ∑ i : Fin (d + 1), fb i := hcol m₀
+  -- value of fa, fb at p₀.1 : position m₀ - i₀ = n₀
+  have hpos₀ : m₀ - i₀ = n₀ := by omega
+  have hfaI : fa p₀.1 = digit q (a p₀.1) n₀ := by
+    simp only [hfadef, ← hi₀def]; rw [if_pos hi₀m₀, hpos₀]
+  have hfbI : fb p₀.1 = digit q (b p₀.1) n₀ := by
+    simp only [hfbdef, ← hi₀def]; rw [if_pos hi₀m₀, hpos₀]
+  have hfdiffI : fa p₀.1 ≠ fb p₀.1 := by rw [hfaI, hfbI]; exact hdiff₀
+  -- helper: given a strict surplus f₁ I < f₂ I within equal-sum columns, find J with f₂ J < f₁ J
+  have findJ : ∀ (f₁ f₂ : Fin (d + 1) → ℕ),
+      (∑ i : Fin (d + 1), f₁ i) = (∑ i : Fin (d + 1), f₂ i) →
+      f₁ p₀.1 < f₂ p₀.1 → ∃ J : Fin (d + 1), f₂ J < f₁ J := by
+    intro f₁ f₂ heq hlt
+    by_contra hcon
+    push Not at hcon  -- ∀ J, f₁ J ≤ f₂ J
+    have hstrict : (∑ i : Fin (d + 1), f₁ i) < ∑ i : Fin (d + 1), f₂ i := by
+      apply Finset.sum_lt_sum (fun i _ => hcon i)
+      exact ⟨p₀.1, Finset.mem_univ _, hlt⟩
+    omega
+  -- a row J with `fa J < fb J` (a-deficit) lies in column m₀ and is below i₀.
+  -- (in the position-form: digit q (a J)(m₀-J) < digit q (b J)(m₀-J))
+  have JfromFa : ∀ (J : Fin (d + 1)), fa J < fb J →
+      ((J : ℕ) ≤ m₀ ∧ digit q (a J) (m₀ - (J:ℕ)) < digit q (b J) (m₀ - (J:ℕ))) := by
+    intro J hJlt
+    by_cases hJm : (J : ℕ) ≤ m₀
+    · refine ⟨hJm, ?_⟩
+      simp only [hfadef, hfbdef, if_pos hJm] at hJlt
+      exact hJlt
+    · exfalso; simp only [hfadef, hfbdef, if_neg hJm] at hJlt; omega
+  have JfromFb : ∀ (J : Fin (d + 1)), fb J < fa J →
+      ((J : ℕ) ≤ m₀ ∧ digit q (b J) (m₀ - (J:ℕ)) < digit q (a J) (m₀ - (J:ℕ))) := by
+    intro J hJlt
+    by_cases hJm : (J : ℕ) ≤ m₀
+    · refine ⟨hJm, ?_⟩
+      simp only [hfadef, hfbdef, if_pos hJm] at hJlt
+      exact hJlt
+    · exfalso; simp only [hfadef, hfbdef, if_neg hJm] at hJlt; omega
+  -- the Fin ⟨i₀, _⟩ equals p₀.1
+  have hI₀eq : (⟨i₀, by omega⟩ : Fin (d + 1)) = p₀.1 := by
+    apply Fin.ext; simp [hi₀def]
+  -- STEP 6: assemble. Case split on the sign at the upper cell i₀.
+  rcases lt_or_gt_of_ne hfdiffI with hsign | hsign
+  · -- fa I < fb I : b-surplus at i₀ ⟹ RIGHT disjunct
+    obtain ⟨J, hJ⟩ := findJ fa fb hsumeq hsign  -- fb J < fa J  (b-deficit, a-surplus at J)
+    obtain ⟨hJm, hJpos⟩ := JfromFb J hJ
+    -- hJpos : digit q (b J)(m₀-J) < digit q (a J)(m₀-J)
+    have hge := htiebreak J hJm (ne_of_lt hJpos).symm
+    have hJne : i₀ ≠ (J : ℕ) := by
+      intro heq
+      have : J = p₀.1 := by apply Fin.ext; simp [← heq, hi₀def]
+      rw [this] at hJpos
+      rw [hpos₀] at hJpos
+      -- hsign : fa p₀.1 < fb p₀.1, i.e. digit a < digit b. hJpos : digit b < digit a
+      rw [hfaI, hfbI] at hsign
+      omega
+    have hij : i₀ < (J : ℕ) := by omega
+    have hjd : (J : ℕ) ≤ d := by have := J.2; omega
+    refine ⟨m₀, i₀, (J:ℕ), hi₀m₀, hJm, hjd, hij, hagree, Or.inr ⟨?_, ?_, ?_⟩⟩
+    · -- 1 ≤ digit q (b ⟨i₀⟩)(m₀-i₀)
+      rw [hpos₀, hI₀eq]
+      rw [hfaI, hfbI] at hsign; omega
+    · -- digit q (a ⟨i₀⟩)(m₀-i₀) < digit q (b ⟨i₀⟩)(m₀-i₀)
+      rw [hpos₀, hI₀eq]
+      rw [hfaI, hfbI] at hsign; exact hsign
+    · -- digit q (b ⟨J⟩)(m₀-J) < digit q (a ⟨J⟩)(m₀-J)
+      have : (⟨(J:ℕ), by omega⟩ : Fin (d + 1)) = J := by apply Fin.ext; simp
+      rw [this]; exact hJpos
+  · -- fb I < fa I : a-surplus at i₀ ⟹ LEFT disjunct
+    obtain ⟨J, hJ⟩ := findJ fb fa hsumeq.symm hsign  -- fa J < fb J  (a-deficit at J)
+    obtain ⟨hJm, hJpos⟩ := JfromFa J hJ
+    -- hJpos : digit q (a J)(m₀-J) < digit q (b J)(m₀-J)
+    have hge := htiebreak J hJm (ne_of_lt hJpos)
+    have hJne : i₀ ≠ (J : ℕ) := by
+      intro heq
+      have : J = p₀.1 := by apply Fin.ext; simp [← heq, hi₀def]
+      rw [this] at hJpos
+      rw [hpos₀] at hJpos
+      rw [hfaI, hfbI] at hsign
+      omega
+    have hij : i₀ < (J : ℕ) := by omega
+    have hjd : (J : ℕ) ≤ d := by have := J.2; omega
+    refine ⟨m₀, i₀, (J:ℕ), hi₀m₀, hJm, hjd, hij, hagree, Or.inl ⟨?_, ?_, ?_⟩⟩
+    · rw [hpos₀, hI₀eq]
+      rw [hfaI, hfbI] at hsign; omega
+    · rw [hpos₀, hI₀eq]
+      rw [hfaI, hfbI] at hsign; exact hsign
+    · have : (⟨(J:ℕ), by omega⟩ : Fin (d + 1)) = J := by apply Fin.ext; simp
+      rw [this]; exact hJpos
+
+/-- **Surplus row exists in the full-diagonal case.** In the configuration produced by
+`differing_cell_select` (rows `i₀ < j₀ ≤ m₀`, `a,b` agree below column `m₀`, `a`
+deficit at `(j₀, m₀-j₀)`), if the target diagonal `m₀-j₀` is full in `a`
+(`∑_r digit q (a r) (m₀-j₀) = q-1`), then there is a shift `t ≥ 1` with
+`j₀ + t ≤ d` and a stone at `(j₀+t, m₀-j₀)`. -/
+lemma parallelogram_exists (q d k : ℕ) (hq : q.Prime)
+    (a b : Fin (d + 1) → ℕ) (_hadma : Admissible q d k a) (hadmb : Admissible q d k b)
+    (m₀ i₀ j₀ : ℕ) (_hi₀ : i₀ ≤ m₀) (hj₀ : j₀ ≤ m₀) (hj₀d : j₀ ≤ d)
+    (_hij : i₀ < j₀)
+    (hagree : ∀ (r : Fin (d + 1)) (nn : ℕ), (r : ℕ) + nn < m₀ →
+        digit q (a r) nn = digit q (b r) nn)
+    (hdef : digit q (a ⟨j₀, by omega⟩) (m₀ - j₀) < digit q (b ⟨j₀, by omega⟩) (m₀ - j₀))
+    (hfull : (∑ r : Fin (d + 1), digit q (a r) (m₀ - j₀)) = q - 1) :
+    ∃ (t : ℕ) (hjtd : j₀ + t ≤ d), 1 ≤ t ∧
+      1 ≤ digit q (a ⟨j₀ + t, by omega⟩) (m₀ - j₀) := by
+  set nT := m₀ - j₀ with hnT
+  set f : Fin (d + 1) → ℕ := fun r => digit q (a r) nT with hf
+  set g : Fin (d + 1) → ℕ := fun r => digit q (b r) nT with hg
+  -- The specific index `j₀`.
+  set J : Fin (d + 1) := ⟨j₀, by omega⟩ with hJ
+  by_contra hcon
+  push Not at hcon
+  -- `hcon`: for every `t` with `j₀ + t ≤ d` and `1 ≤ t`, `digit q (a ⟨j₀+t,_⟩) nT < 1`.
+  -- We show that all rows `r > j₀` have `f r = 0`.
+  have hzero : ∀ r : Fin (d + 1), j₀ < (r : ℕ) → f r = 0 := by
+    intro r hr
+    have hrd : (r : ℕ) ≤ d := by have := r.2; omega
+    set t := (r : ℕ) - j₀ with ht
+    have ht1 : 1 ≤ t := by omega
+    have htjd : j₀ + t ≤ d := by omega
+    have hcell := hcon t htjd ht1
+    have hidx : (⟨j₀ + t, by omega⟩ : Fin (d + 1)) = r := by
+      apply Fin.ext; simp [ht]; omega
+    rw [hidx] at hcell
+    simp only [hf]
+    omega
+  -- Carry-free for `b` at column `nT`.
+  have hbcf : (∑ r : Fin (d + 1), g r) ≤ q - 1 := hadmb.2 nT
+  -- The full diagonal for `a`.
+  have haf : (∑ r : Fin (d + 1), f r) = q - 1 := hfull
+  -- The subset of rows `r ≤ j₀`.
+  set Sle : Finset (Fin (d + 1)) := univ.filter (fun r => (r : ℕ) ≤ j₀) with hSle
+  -- `J ∈ Sle`.
+  have hJSle : J ∈ Sle := by
+    simp only [hSle, mem_filter, mem_univ, true_and, hJ]
+    exact le_refl j₀
+  -- Sum over `Sle` of `g` is `≤` total sum of `g`.
+  have hsubset : Sle ⊆ univ := filter_subset _ _
+  have hgle : (∑ r ∈ Sle, g r) ≤ ∑ r : Fin (d + 1), g r :=
+    sum_le_sum_of_subset hsubset
+  -- Peel `J` off the `Sle` sum for `g`.
+  have hgpeel : (∑ r ∈ Sle, g r) = (∑ r ∈ Sle.erase J, g r) + g J := by
+    rw [Finset.sum_erase_add _ _ hJSle]
+  -- For `a`: sum over `Sle` equals total sum minus rows `> j₀` (which are zero).
+  -- Equivalently, sum over `Sle` of `f` = total sum of `f`, since rows not in `Sle` are zero.
+  have hafle : (∑ r ∈ Sle, f r) = ∑ r : Fin (d + 1), f r := by
+    apply Finset.sum_subset hsubset
+    intro r _ hrnotin
+    simp only [hSle, mem_filter, mem_univ, true_and, not_le] at hrnotin
+    exact hzero r hrnotin
+  -- Peel `J` off the `Sle` sum for `f`.
+  have hfpeel : (∑ r ∈ Sle, f r) = (∑ r ∈ Sle.erase J, f r) + f J := by
+    rw [Finset.sum_erase_add _ _ hJSle]
+  -- On `Sle.erase J`, rows have `(r:ℕ) < j₀`, where `a` and `b` agree.
+  have hagree_erase : ∀ r ∈ Sle.erase J, f r = g r := by
+    intro r hrmem
+    rw [mem_erase] at hrmem
+    obtain ⟨hrne, hrle⟩ := hrmem
+    simp only [hSle, mem_filter, mem_univ, true_and] at hrle
+    have hrlt : (r : ℕ) < j₀ := by
+      rcases lt_or_eq_of_le hrle with h | h
+      · exact h
+      · exfalso; apply hrne; apply Fin.ext; simp [hJ, h]
+    -- column `(r:ℕ) + nT < m₀`.
+    have hcol : (r : ℕ) + nT < m₀ := by omega
+    have := hagree r nT hcol
+    simp only [hf, hg]
+    exact this
+  have hsumeq : (∑ r ∈ Sle.erase J, f r) = (∑ r ∈ Sle.erase J, g r) :=
+    Finset.sum_congr rfl hagree_erase
+  -- `hdef` says `f J < g J`.
+  have hdefJ : f J < g J := by
+    simp only [hf, hg, hJ]; exact hdef
+  -- Now derive the contradiction.
+  -- ∑ g ≥ ∑_{Sle} g = (∑_{erase} g) + g J = (∑_{erase} f) + g J
+  --       ≥ (∑_{erase} f) + (f J + 1) = (∑_{Sle} f) + 1 = (∑ f) + 1 = (q - 1)+1 = q
+  -- but ∑ g ≤ q-1, contradiction.
+  have hq2 := hq.two_le
+  omega
+
+/-- **No two distinct admissible maximizers.** Two admissible `F`-maximizers agree in
+every base-`q` digit of every row: both have column sums `digit q k m`
+(`column_sum_eq`), so if they differed, `differing_cell_select` plus an improving
+step (`move_down` or, via `parallelogram_exists`, `move_parallelogram`) on the
+surplus array would strictly lower `Φ`, contradicting `maximizer_min_Phi`. -/
+lemma no_two_distinct_maximizers (q d k : ℕ) (hq : q.Prime)
+    (kk₁ : Fin (d + 1) → ℕ) (hadm₁ : Admissible q d k kk₁)
+    (hmax₁ : ∀ kk' : Fin (d + 1) → ℕ, Admissible q d k kk' → F q d kk' ≤ F q d kk₁)
+    (kk₂ : Fin (d + 1) → ℕ) (hadm₂ : Admissible q d k kk₂)
+    (hmax₂ : ∀ kk' : Fin (d + 1) → ℕ, Admissible q d k kk' → F q d kk' ≤ F q d kk₂)
+    (ii : Fin (d + 1) ) (n : ℕ) :
+    digit q (kk₁ ii) n = digit q (kk₂ ii) n := by
+  -- The whole content is the array-equality `kk₁ = kk₂`; the per-cell goal follows.
+  suffices hEq : kk₁ = kk₂ by rw [hEq]
+  by_contra hne
+  -- Equal column sums: each equals `digit q k m`.
+  have hcol : ∀ m : ℕ,
+      (∑ i : Fin (d + 1), (if (i : ℕ) ≤ m then digit q (kk₁ i) (m - (i : ℕ)) else 0))
+        = (∑ i : Fin (d + 1), (if (i : ℕ) ≤ m then digit q (kk₂ i) (m - (i : ℕ)) else 0)) := by
+    intro m
+    rw [column_sum_eq q d k hq kk₁ hadm₁ hmax₁ m, column_sum_eq q d k hq kk₂ hadm₂ hmax₂ m]
+  -- A symmetric key lemma: given a maximizer `a` and another admissible `b` with the
+  -- selected differing-cell configuration (surplus on `a`), derive a contradiction.
+  have key : ∀ (a b : Fin (d + 1) → ℕ),
+      Admissible q d k a → Admissible q d k b →
+      (∀ kk' : Fin (d + 1) → ℕ, Admissible q d k kk' → F q d kk' ≤ F q d a) →
+      ∀ (m₀ i₀ j₀ : ℕ) (hi₀ : i₀ ≤ m₀) (hj₀ : j₀ ≤ m₀) (hj₀d : j₀ ≤ d) (hij : i₀ < j₀),
+      (∀ (r : Fin (d + 1)) (nn : ℕ), (r : ℕ) + nn < m₀ →
+          digit q (a r) nn = digit q (b r) nn) →
+      1 ≤ digit q (a ⟨i₀, by omega⟩) (m₀ - i₀) →
+      digit q (a ⟨j₀, by omega⟩) (m₀ - j₀) < digit q (b ⟨j₀, by omega⟩) (m₀ - j₀) →
+      False := by
+    intro a b hadma hadmb hmaxa m₀ i₀ j₀ hi₀ hj₀ hj₀d hij hagree hsrc hdef
+    by_cases hslack : (∑ r : Fin (d + 1), digit q (a r) (m₀ - j₀)) ≤ q - 2
+    · -- slack case: move_down strictly decreases Phi
+      obtain ⟨a', hadm', hlt⟩ :=
+        move_down q d k m₀ i₀ j₀ hq.two_le a hadma hi₀ hj₀ hj₀d hij hsrc hslack
+      have := maximizer_min_Phi q d k hq.two_le a hadma hmaxa a' hadm'
+      omega
+    · -- full case: ∑ = q-1, then parallelogram_exists + move_parallelogram
+      push Not at hslack
+      have hcap : (∑ r : Fin (d + 1), digit q (a r) (m₀ - j₀)) ≤ q - 1 := hadma.2 (m₀ - j₀)
+      have hq2 := hq.two_le
+      have hfull : (∑ r : Fin (d + 1), digit q (a r) (m₀ - j₀)) = q - 1 := by omega
+      obtain ⟨t, hjtd, ht, hsrcS⟩ :=
+        parallelogram_exists q d k hq a b hadma hadmb m₀ i₀ j₀ hi₀ hj₀ hj₀d hij hagree hdef hfull
+      obtain ⟨a', hadm', hlt⟩ :=
+        move_parallelogram q d k m₀ i₀ j₀ t hq.two_le a hadma hi₀ hj₀ hij ht hjtd hsrc hsrcS
+      have := maximizer_min_Phi q d k hq.two_le a hadma hmaxa a' hadm'
+      omega
+  -- select the differing cell
+  obtain ⟨m₀, i₀, j₀, hi₀, hj₀, hj₀d, hij, hagree, hdisj⟩ :=
+    differing_cell_select q d k hq kk₁ kk₂ hadm₁ hadm₂ hcol hne
+  rcases hdisj with ⟨hsrc, _, hdef⟩ | ⟨hsrc, _, hdef⟩
+  · -- surplus on kk₁ = a, kk₂ = b
+    exact key kk₁ kk₂ hadm₁ hadm₂ hmax₁ m₀ i₀ j₀ hi₀ hj₀ hj₀d hij hagree hsrc hdef
+  · -- surplus on kk₂ = a, kk₁ = b
+    exact key kk₂ kk₁ hadm₂ hadm₁ hmax₂ m₀ i₀ j₀ hi₀ hj₀ hj₀d hij
+      (fun r nn h => (hagree r nn h).symm) hsrc hdef
+
+/-- **Greedy uniqueness.** Any two admissible tuples that both maximize `F` over the
+admissible set are equal: by `digit_ext` it suffices that all base-`q` digits agree,
+which is `no_two_distinct_maximizers` (informal.tex `alg:H1-greedy`). -/
+lemma maximizer_unique (q d k : ℕ) (hq : q.Prime)
+    (kk₁ : Fin (d + 1) → ℕ) (hadm₁ : Admissible q d k kk₁)
+    (hmax₁ : ∀ kk' : Fin (d + 1) → ℕ, Admissible q d k kk' → F q d kk' ≤ F q d kk₁)
+    (kk₂ : Fin (d + 1) → ℕ) (hadm₂ : Admissible q d k kk₂)
+    (hmax₂ : ∀ kk' : Fin (d + 1) → ℕ, Admissible q d k kk' → F q d kk' ≤ F q d kk₂) :
+    kk₁ = kk₂ := by
+  have hq2 : 2 ≤ q := hq.two_le
+  funext ii
+  apply digit_ext q hq2
+  intro n
+  exact no_two_distinct_maximizers q d k hq kk₁ hadm₁ hmax₁ kk₂ hadm₂ hmax₂ ii n
+
+-- Main Statement(s)
+
+/-- **Theorem (Unique maximizer).** Let `q` be a prime and `d, k ≥ 0`. Among all
+admissible `(d + 1)`-tuples, the value `F` attains its maximum at exactly one admissible
+tuple: there exists an admissible `kstar` that maximizes `F`, and any admissible tuple
+that itself maximizes `F` over all admissible tuples must equal `kstar`. -/
+theorem main_theorem (q d k : ℕ) (hq : q.Prime) :
+    ∃ kstar : Fin (d + 1) → ℕ, Admissible q d k kstar ∧
+      (∀ kk : Fin (d + 1) → ℕ, Admissible q d k kk → F q d kk ≤ F q d kstar) ∧
+      (∀ kk : Fin (d + 1) → ℕ, Admissible q d k kk →
+        (∀ kk' : Fin (d + 1) → ℕ, Admissible q d k kk' → F q d kk' ≤ F q d kk) →
+        kk = kstar) := by
+  have hq1 : 1 ≤ q := hq.one_lt.le
+  -- Existence + optimality: the admissible set is finite and nonempty, so `F`
+  -- attains a maximum on it.
+  have hfin := admissible_finite q d k hq1
+  set T := hfin.toFinset with hT
+  have hk0mem : k0tuple d k ∈ T := by
+    rw [hT, Set.Finite.mem_toFinset]
+    exact k0tuple_admissible q d k hq1
+  have hne : T.Nonempty := ⟨_, hk0mem⟩
+  obtain ⟨kstar, hkstarMem, hkstarMax⟩ := T.exists_max_image (F q d) hne
+  have hkstarAdm : Admissible q d k kstar := by
+    rw [hT, Set.Finite.mem_toFinset] at hkstarMem; exact hkstarMem
+  have hkstarDom : ∀ kk : Fin (d + 1) → ℕ, Admissible q d k kk → F q d kk ≤ F q d kstar := by
+    intro kk hkk
+    apply hkstarMax
+    rw [hT, Set.Finite.mem_toFinset]; exact hkk
+  refine ⟨kstar, hkstarAdm, hkstarDom, ?_⟩
+  -- Uniqueness: any admissible maximizer `kk` and `kstar` are both maximizers, so
+  -- `maximizer_unique` gives `kk = kstar`.
+  intro kk hkk hkkMax
+  exact maximizer_unique q d k hq kk hkk hkkMax kstar hkstarAdm hkstarDom
+
+end ZetaH123.H1

--- a/LeanPool/ZetaH123/H2.lean
+++ b/LeanPool/ZetaH123/H2.lean
@@ -1,0 +1,2178 @@
+/-
+Copyright (c) 2026 Evan Chen, Kenny Lau, Ken Ono, Jujian Zhang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Evan Chen, Kenny Lau, Ken Ono, Jujian Zhang
+-/
+
+import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.Algebra.Order.Ring.Star
+import Mathlib.AlgebraicTopology.SimplexCategory.Basic
+import Mathlib.Analysis.Normed.Ring.Lemmas
+import Mathlib.Data.Int.Star
+import Mathlib.Data.List.GetD
+import Mathlib.Data.Nat.Choose.Factorization
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.Order
+import Mathlib.Tactic.Push
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Ring.RingNF
+
+/-!
+# H2 for Thakur's hypotheses on power sums
+-/
+
+namespace ZetaH123.H2
+
+/-
+# Problem Description
+
+Throughout, fix a prime `q`. All "digit" and "carry" conditions below are taken in
+base `q`.
+
+## Definition 1 (Base-`q` digits).
+Every nonnegative integer `x` has a unique base-`q` representation
+`x = ∑_{e ≥ 0} x_e q ^ e`, with `0 ≤ x_e ≤ q-1` and `x_e = 0` for all sufficiently
+large `e`. We call `x_e` the `e`-th base-`q` digit of `x`.
+
+## Definition 2 (Carry-free addition).
+A finite list of nonnegative integers `x_1, …, x_r` *adds without carries in base `q`*
+if, at every digit position `e ≥ 0`, the digits sum to at most `q-1`:
+`∑_{i=1} ^ r (x_i)_e ≤ q-1` for every `e ≥ 0`.
+
+## Definition 3 (The set `T_{d,k-1}`).
+For integers `d ≥ 1` and `k > 0`, `T_{d,k-1}` is the set of `d`-tuples
+`(m_1, …, m_d)` of integers satisfying:
+  1. `m_i > 0` for all `i`;
+  2. `(q - 1) ∣ m_i` for all `i`;
+  3. the list `(k-1, m_1, …, m_d)` adds without carries in base `q`.
+
+## Definition 4 (The functions `s_d`).
+For `d ≥ 1` and `k > 0`,
+`s_d(k) = d*k + min_{(m_1,…,m_d) ∈ T_{d,k-1}} (m_1 + 2 m_2 + ⋯ + d m_d)`.
+`T_{d,k-1}` is always nonempty so the minimum exists.
+
+## Main Statement (Theorem).
+Fix a prime `q` and integers `d > 1` and `k > 0`. Let `J` be the set of integers
+`j ≥ 0` with `(q - 1) ∣ j` and `q ∤ C(s_1(k) + j - 1, k-1)`. For `j ∈ J` set
+`F(j) = s_{d-1}(s_1(k) + j) + s_1(k) + j`. Then `F` attains its minimum over `J`
+uniquely at `j = 0`: `F(0) < F(j)` for every `j ∈ J` with `j > 0`.
+
+## Notes
+- Here `n = s_1(k) + j - 1 ≥ k-1 ≥ 0` and `r = k-1 ≥ 0`, so all binomial
+  coefficients are ordinary binomials of nonnegative integers.
+- `0 ∈ J` (a nontrivial fact), so the uniqueness of the minimizer is meaningful;
+  this admissibility is recorded as a separate statement `main_zero_mem`.
+- We use `ℕ` and 1-indexing of digit positions via list indices starting at 0;
+  the weight on `m_i` is `i`, encoded as `(i.val + 1)` for `i : Fin d`.
+-/
+
+/-- The `e`-th base-`q` digit of `x` (returns `0` for positions beyond the
+representation, matching the convention `x_e = 0` for large `e`). -/
+def qdigit (q x e : ℕ) : ℕ := (Nat.digits q x).getD e 0
+
+/-- A finite list of nonnegative integers `xs` *adds without carries in base `q`*
+if at every digit position `e` the base-`q` digits sum to at most `q - 1`. This is
+exactly the carry-free condition of Definition 2. -/
+def AddNoCarry (q : ℕ) (xs : List ℕ) : Prop :=
+  ∀ e : ℕ, (xs.map (fun x => qdigit q x e)).sum ≤ q - 1
+
+/-- The set `T_{d,k1}` of `d`-tuples (encoded as `m : Fin d → ℕ`) such that each
+`m i` is positive, divisible by `q - 1`, and the list `(k1, m_0, …, m_{d-1})` adds
+without carries in base `q`. Here `k1` plays the role of `k - 1`. -/
+def TSet (q d k1 : ℕ) : Set (Fin d → ℕ) :=
+  {m | (∀ i, 0 < m i) ∧ (∀ i, (q - 1) ∣ m i) ∧
+        AddNoCarry q (k1 :: (List.ofFn m))}
+
+/-- The function `s_d(k) = d*k + min over `T_{d,k-1}` of `∑ (i+1) * m i`.
+The minimum over the nonempty set of objective values is realised as the infimum
+(`sInf`) of that set of naturals. -/
+noncomputable def s (q d k : ℕ) : ℕ :=
+  d * k + sInf {v : ℕ | ∃ m ∈ TSet q d (k - 1), v = ∑ i : Fin d, (i.val + 1) * m i}
+
+/-- The objective `F(j) = s_{d-1}(s_1(k) + j) + s_1(k) + j`. -/
+noncomputable def F (q d k j : ℕ) : ℕ :=
+  s q (d - 1) (s q 1 k + j) + s q 1 k + j
+
+/-- The admissible set `J`: nonnegative integers `j` with `(q - 1) ∣ j` and
+`q ∤ C(s_1(k) + j - 1, k - 1)`. -/
+def Jset (q k : ℕ) : Set ℕ :=
+  {j | (q - 1) ∣ j ∧ ¬ (q ∣ Nat.choose (s q 1 k + j - 1) (k - 1))}
+
+-- Helper lemmas
+
+/-- The `e`-th base-`q` digit equals `x / q ^ e % q`. -/
+theorem qdigit_eq (q x e : ℕ) (hq : 2 ≤ q) : qdigit q x e = x / q ^ e % q := by
+  unfold qdigit; exact Nat.getD_digits x e hq
+
+/-- `a % q ^ i` is the base-`q` number formed by the first `i` digits. -/
+theorem digit_mod (q a i : ℕ) :
+    a % q ^ i = ∑ e ∈ Finset.range i, (a / q ^ e % q) * q ^ e := by
+  induction i with
+  | zero => simp [Nat.mod_one]
+  | succ n ih =>
+    rw [Finset.sum_range_succ, ← ih, Nat.mod_pow_succ]; ring
+
+/-- `(q - 1) * ∑_{e<i} q ^ e = q ^ i - 1`. -/
+theorem geom_pred (q i : ℕ) (hq : 1 ≤ q) :
+    (q - 1) * ∑ e ∈ Finset.range i, q ^ e = q ^ i - 1 := by
+  induction i with
+  | zero => simp
+  | succ n ih =>
+    rw [Finset.sum_range_succ, Nat.mul_add, ih, pow_succ]
+    have : 1 ≤ q ^ n := Nat.one_le_pow _ _ (by omega)
+    have h2 : (q - 1) * q ^ n = q ^ n * q - q ^ n := by rw [Nat.sub_mul, one_mul]; ring_nf
+    have hle : q ^ n ≤ q ^ n * q := Nat.le_mul_of_pos_right _ (by omega)
+    rw [h2]; omega
+
+/-- If two numbers add without carry in the first `i` positions, then their
+truncations to `i` digits sum to less than `q ^ i`. -/
+theorem noCarry_mod (q a b i : ℕ) (hq : 1 < q)
+    (h : ∀ e, e < i → (a / q ^ e % q) + (b / q ^ e % q) ≤ q - 1) :
+    a % q ^ i + b % q ^ i < q ^ i := by
+  rw [digit_mod q a i, digit_mod q b i, ← Finset.sum_add_distrib]
+  have key : ∑ e ∈ Finset.range i, ((a / q ^ e % q) * q ^ e + (b / q ^ e % q) * q ^ e)
+      ≤ q ^ i - 1 := by
+    calc ∑ e ∈ Finset.range i, ((a / q ^ e % q) * q ^ e + (b / q ^ e % q) * q ^ e)
+        = ∑ e ∈ Finset.range i, ((a / q ^ e % q) + (b / q ^ e % q)) * q ^ e := by
+          apply Finset.sum_congr rfl; intro e _; ring
+      _ ≤ ∑ e ∈ Finset.range i, (q - 1) * q ^ e := by
+          apply Finset.sum_le_sum; intro e he
+          exact Nat.mul_le_mul_right _ (h e (Finset.mem_range.mp he))
+      _ = (q - 1) * ∑ e ∈ Finset.range i, q ^ e := by rw [Finset.mul_sum]
+      _ = q ^ i - 1 := geom_pred q i (le_of_lt hq)
+  have : 1 ≤ q ^ i := Nat.one_le_pow _ _ (by omega)
+  omega
+
+/-- Kummer's theorem (one direction): if adding `k` and `n-k` produces no carry in
+any base-`q` position, then `q ∤ C(n,k)`. -/
+theorem not_dvd_choose (q n k : ℕ) (hq : q.Prime) (hkn : k ≤ n)
+    (hcarry : ∀ i, k % q ^ i + (n - k) % q ^ i < q ^ i) :
+    ¬ q ∣ Nat.choose n k := by
+  have hb : Nat.log q n < n + 1 := lt_of_le_of_lt (Nat.log_le_self q n) (Nat.lt_succ_self n)
+  have hfac : (Nat.choose n k).factorization q = 0 := by
+    rw [Nat.factorization_choose hq hkn hb, Finset.card_eq_zero,
+        Finset.filter_eq_empty_iff]
+    intro i _
+    simp only [not_le]
+    exact hcarry i
+  have hpos : 0 < Nat.choose n k := Nat.choose_pos hkn
+  intro hdvd
+  have := (Nat.Prime.dvd_iff_one_le_factorization hq (by omega)).mp hdvd
+  omega
+
+/-- The `e`-th digit of `(q - 1) * q ^ L`: equal to `q-1` at position `L`, else `0`. -/
+theorem digit_special (q L e : ℕ) (hq : 2 ≤ q) :
+    ((q - 1) * q ^ L) / q ^ e % q = if e = L then q - 1 else 0 := by
+  rcases lt_trichotomy e L with h | h | h
+  · rw [if_neg (by omega)]
+    have hd : (q - 1) * q ^ L / q ^ e = (q - 1) * q ^ (L-e) := by
+      rw [Nat.mul_div_assoc _ (pow_dvd_pow q (by omega))]
+      congr 1
+      rw [Nat.pow_div (by omega) (by omega)]
+    rw [hd]
+    have : q ∣ (q - 1) * q ^ (L-e) := Dvd.dvd.mul_left (dvd_pow_self q (by omega)) _
+    omega
+  · subst h
+    rw [if_pos rfl, Nat.mul_div_cancel _ (Nat.pow_pos (by omega : 0 < q))]
+    exact Nat.mod_eq_of_lt (by omega)
+  · rw [if_neg (by omega)]
+    have hlt : (q - 1)*q ^ L < q ^ e := by
+      calc (q - 1)*q ^ L < q * q ^ L := by
+            apply Nat.mul_lt_mul_of_lt_of_le (by omega) (le_refl _) (Nat.pow_pos (by omega : 0 < q))
+        _ = q ^ (L+1) := by rw [pow_succ]; ring
+        _ ≤ q ^ e := Nat.pow_le_pow_right (by omega) (by omega)
+    rw [Nat.div_eq_of_lt hlt]; simp
+
+-- Main Statement(s)
+
+/-- `0` is admissible: `0 ∈ J`. This nontrivial admissibility fact makes the
+uniqueness-of-minimizer statement meaningful. -/
+theorem main_zero_mem (q : ℕ) (hq : q.Prime) (d k : ℕ) (_hd : 1 < d) (hk : 0 < k) :
+    (0 : ℕ) ∈ Jset q k := by
+  have hq2 : 2 ≤ q := hq.two_le
+  -- The objective value set for d = 1.
+  set S : Set ℕ := {v : ℕ | ∃ m ∈ TSet q 1 (k - 1), v = ∑ i : Fin 1, (i.val + 1) * m i}
+    with hS
+  -- Choose L large so that k-1 < q ^ L.
+  have hLlt : k - 1 < q ^ k := by
+    calc k - 1 < k := by omega
+      _ ≤ q ^ k := Nat.le_of_lt (Nat.lt_pow_self (by omega) )
+  -- Construct a witness, proving nonemptiness of S.
+  have hofn1 : ∀ (m : Fin 1 → ℕ), List.ofFn m = [m 0] := by
+    intro m; simp [List.ofFn_succ, List.ofFn_zero]
+  have hne : S.Nonempty := by
+    refine ⟨(q - 1) * q ^ k, ?_⟩
+    refine ⟨fun _ => (q - 1) * q ^ k, ?_, by simp⟩
+    refine ⟨?_, ?_, ?_⟩
+    · intro i; have h1 : 0 < q ^ k := Nat.pow_pos (by omega)
+      have h2 : 0 < q - 1 := by omega
+      have : 0 < (q - 1) * q ^ k := Nat.mul_pos h2 h1
+      simpa using this
+    · intro i; exact ⟨q ^ k, rfl⟩
+    · -- AddNoCarry q [k-1, (q - 1)*q ^ k]
+      intro e
+      rw [hofn1]
+      simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, add_zero]
+      have h1 : qdigit q (k - 1) e ≤ q - 1 := by
+        rw [qdigit_eq _ _ _ hq2]; have := Nat.mod_lt ((k - 1) / q ^ e) (by omega : 0 < q); omega
+      have h2 : qdigit q ((q - 1) * q ^ k) e = if e = k then q - 1 else 0 := by
+        rw [qdigit_eq _ _ _ hq2]; exact digit_special q k e hq2
+      have h3 : qdigit q (k - 1) k = 0 := by
+        rw [qdigit_eq _ _ _ hq2, Nat.div_eq_of_lt hLlt]; simp
+      rcases eq_or_ne e k with he | he
+      · subst he; rw [h2, if_pos rfl, h3]; omega
+      · rw [h2, if_neg he]; omega
+  -- The infimum is attained: extract a minimizer.
+  have hmem : sInf S ∈ S := Nat.sInf_mem hne
+  obtain ⟨m, hmT, hval⟩ := hmem
+  obtain ⟨hpos, hdvd, hnc⟩ := hmT
+  -- s q 1 k - 1 = (k - 1) + (m 0), with [k-1, m 0] carry-free.
+  have hsval : s q 1 k = k + sInf S := by
+    unfold s; simp [hS]
+  -- objective for Fin 1 is m 0
+  have hv0 : sInf S = m 0 := by
+    rw [hval]; simp
+  refine ⟨by simp, ?_⟩
+  -- the binomial: n = s q 1 k - 1, r = k - 1, n - r = m 0
+  have hn : s q 1 k + 0 - 1 = (k - 1) + m 0 := by
+    rw [hsval, hv0]; omega
+  rw [hn]
+  -- apply Kummer
+  apply not_dvd_choose q ((k - 1) + m 0) (k - 1) hq (by omega)
+  intro i
+  have hsub : ((k - 1) + m 0) - (k - 1) = m 0 := by omega
+  rw [hsub]
+  -- carry-free of [k-1, m 0] gives the per-position digit bound
+  apply noCarry_mod q (k - 1) (m 0) i (by omega)
+  intro e he
+  have hh := hnc e
+  rw [hofn1] at hh
+  simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, add_zero] at hh
+  rw [qdigit_eq _ _ _ hq2, qdigit_eq _ _ _ hq2] at hh
+  exact hh
+
+/-- Carry-free addition is digit-additive (fact D2): if at every position the
+base-`q` digits of `a` and `b` sum to `≤ q-1`, then the truncated sums agree. -/
+theorem add_mod_eq (q a b i : ℕ) (hq : 1 < q)
+    (h : ∀ e, e < i → (a / q ^ e % q) + (b / q ^ e % q) ≤ q - 1) :
+    (a + b) % q ^ i = a % q ^ i + b % q ^ i := by
+  have hlt := noCarry_mod q a b i hq h
+  conv_lhs => rw [Nat.add_mod]
+  rw [Nat.mod_eq_of_lt hlt]
+
+/-- Digit additivity (fact D2): if `a` and `b` add without carry in every base-`q`
+position, then each digit of `a + b` is the sum of the corresponding digits. -/
+theorem qdigit_add (q a b e : ℕ) (hq : 2 ≤ q)
+    (h : ∀ f, (a / q ^ f % q) + (b / q ^ f % q) ≤ q - 1) :
+    (a + b) / q ^ e % q = a / q ^ e % q + b / q ^ e % q := by
+  have hdig : ∀ x : ℕ, x / q ^ e % q = x % (q ^ e * q) / q ^ e := fun x =>
+    (Nat.mod_mul_right_div_self x (q ^ e) q).symm
+  have hpe1 : q ^ (e + 1) = q ^ e * q := by rw [pow_succ]
+  rw [hdig (a+b), hdig a, hdig b, ← hpe1]
+  have h1 : (a + b) % q ^ (e + 1) = a % q ^ (e + 1) + b % q ^ (e + 1) :=
+    add_mod_eq q a b (e + 1) (by omega) (fun f _ => h f)
+  rw [h1]
+  have hsplit : ∀ x : ℕ, x % q ^ (e + 1) = x % q ^ e + q ^ e * (x / q ^ e % q) := by
+    intro x; rw [hpe1]; exact Nat.mod_mul
+  rw [hsplit a, hsplit b]
+  have hpos : 0 < q ^ e := Nat.pow_pos (by omega)
+  have hae : a % q ^ e < q ^ e := Nat.mod_lt _ hpos
+  have hbe : b % q ^ e < q ^ e := Nat.mod_lt _ hpos
+  have hlow : a % q ^ e + b % q ^ e < q ^ e :=
+    noCarry_mod q a b e (by omega) (fun f _ => h f)
+  set da := a / q ^ e % q
+  set db := b / q ^ e % q
+  have e1 : (a % q ^ e + q ^ e * da) / q ^ e = da := by
+    rw [Nat.add_mul_div_left _ _ hpos, Nat.div_eq_of_lt hae]; ring_nf
+  have e2 : (b % q ^ e + q ^ e * db) / q ^ e = db := by
+    rw [Nat.add_mul_div_left _ _ hpos, Nat.div_eq_of_lt hbe]; ring_nf
+  have e3 : (a % q ^ e + q ^ e * da + (b % q ^ e + q ^ e * db)) / q ^ e = da + db := by
+    have : a % q ^ e + q ^ e * da + (b % q ^ e + q ^ e * db)
+         = (a % q ^ e + b % q ^ e) + q ^ e * (da + db) := by ring
+    rw [this, Nat.add_mul_div_left _ _ hpos, Nat.div_eq_of_lt hlow]; ring_nf
+  rw [e1, e2, e3]
+
+/-- The objective value set for `TSet q d (k - 1)` is nonempty: an explicit witness
+places each coordinate at a distinct high power `(q - 1)·q ^ (k+i)`, which is positive,
+divisible by `q-1`, and carry-free with `k-1` (the powers are distinct and exceed
+`log_q (k - 1)`). This generalises the `Fin 1` nonemptiness in `main_zero_mem`. -/
+theorem tset_value_nonempty (q d k : ℕ) (hq : 2 ≤ q) (hk : 0 < k) :
+    {v : ℕ | ∃ m ∈ TSet q d (k - 1), v = ∑ i : Fin d, (i.val + 1) * m i}.Nonempty := by
+  classical
+  set m : Fin d → ℕ := fun i => (q - 1) * q ^ (k + i.val) with hm
+  refine ⟨∑ i : Fin d, (i.val + 1) * m i, m, ?_, rfl⟩
+  have hLlt : k - 1 < q ^ k := by
+    calc k - 1 < k := by omega
+      _ ≤ q ^ k := Nat.le_of_lt (Nat.lt_pow_self (by omega))
+  refine ⟨?_, ?_, ?_⟩
+  · intro i; have h1 : 0 < q ^ (k + i.val) := Nat.pow_pos (by omega)
+    have : 0 < (q - 1) * q ^ (k+i.val) := Nat.mul_pos (by omega) h1
+    simpa [hm] using this
+  · intro i; exact ⟨q ^ (k+i.val), by rw [hm]⟩
+  · intro e
+    rw [List.map_cons, List.sum_cons, List.map_ofFn, List.sum_ofFn]
+    have hmd : ∀ i : Fin d,
+        ((fun x => qdigit q x e) ∘ m) i = if e = k + i.val then q - 1 else 0 := by
+      intro i; simp only [Function.comp_apply]; rw [hm]; simp only
+      rw [qdigit_eq _ _ _ hq, digit_special q (k+i.val) e hq]
+    rw [Finset.sum_congr rfl (fun i _ => hmd i)]
+    have hsum : (∑ i : Fin d, (if e = k + i.val then q-1 else 0)) ≤ q - 1 := by
+      rcases Nat.lt_or_ge e k with h | h
+      · have : ∀ i : Fin d, (if e = k + i.val then (q - 1) else 0) = 0 := by
+          intro i; rw [if_neg (by omega)]
+        simp [this]
+      · by_cases hd : e - k < d
+        · rw [Finset.sum_eq_single (⟨e-k, hd⟩ : Fin d)]
+          · rw [if_pos (by simp; omega)]
+          · intro j _ hj; rw [if_neg]; intro hc; apply hj; ext; simp at hc ⊢; omega
+          · intro hcon; exact absurd (Finset.mem_univ _) hcon
+        · have : ∀ i : Fin d, (if e = k + i.val then (q - 1) else 0) = 0 := by
+            intro i; rw [if_neg (by omega)]
+          simp [this]
+    have hk1 : qdigit q (k - 1) e ≤ q - 1 := by
+      rw [qdigit_eq _ _ _ hq]; have := Nat.mod_lt ((k - 1)/q ^ e) (by omega : 0 < q); omega
+    rcases Nat.lt_or_ge e k with h | h
+    · have hz : (∑ i : Fin d, (if e = k + i.val then (q - 1) else 0)) = 0 := by
+        have : ∀ i : Fin d, (if e = k + i.val then (q - 1) else 0) = 0 := by
+          intro i; rw [if_neg (by omega)]
+        simp [this]
+      rw [hz]; omega
+    · have hk1z : qdigit q (k - 1) e = 0 := by
+        rw [qdigit_eq _ _ _ hq]
+        have hlt : k - 1 < q ^ e := lt_of_lt_of_le hLlt (Nat.pow_le_pow_right (by omega) h)
+        rw [Nat.div_eq_of_lt hlt]; simp
+      rw [hk1z]; simpa using hsum
+
+/-- Minimizer extraction: since the objective value set is nonempty, its `sInf`
+is attained by some `m ∈ TSet q d (k - 1)`, giving the value identity for `s`. -/
+theorem s_minimizer (q d k : ℕ) (hq : 2 ≤ q) (hk : 0 < k) :
+    ∃ m ∈ TSet q d (k - 1), s q d k = d * k + ∑ i : Fin d, (i.val + 1) * m i := by
+  have hne := tset_value_nonempty q d k hq hk
+  obtain ⟨m, hmT, hval⟩ := Nat.sInf_mem hne
+  exact ⟨m, hmT, by unfold s; rw [← hval]⟩
+
+/-
+The proof rests on two pillars, isolated as `composition_identity` and
+`extraction_strict` below. Both follow from the reciprocal slot formula
+(informal.tex Thm. thm:H2-slot-formula): letting `M` be the multiset of
+available digit slots of `k-1` (value `q ^ e` with multiplicity `q-1-a_e`), with
+block sums `β_r` over consecutive groups of `n = q-1` smallest slots,
+  s_d(k) = d·k + Φ_d(M),   where Φ_d(M) := d·β₁ + (d-1)·β₂ + ⋯ + β_d.        (★)
+Pillar 1 (`composition_identity`): F(0) = s_{d-1}(s_1(k)) + s_1(k) = s_d(k).
+Pillar 2 (`extraction_strict`): for admissible j > 0, s_d(k) < F(j);
+admissibility (via Kummer/Lucas) makes `u = β₁ + j` add to `k-1` carry-free,
+and `u > β₁` gives strictness.
+-/
+
+/-- Easy direction of the composition identity:
+`s_d(k) ≤ s_{d-1}(s_1(k)) + s_1(k)`. Constructive: combine a minimizer `μ₁` for
+`s_1` (placed at top weight `d`) with a minimizer of `s_{d-1}` at argument
+`s_1(k)`; the combined tuple lies in `TSet q d (k - 1)`. -/
+theorem comp_id_le (q : ℕ) (hq : q.Prime) (d k : ℕ) (hd : 1 < d) (hk : 0 < k) :
+    s q d k ≤ s q (d - 1) (s q 1 k) + s q 1 k := by
+  have hq2 : 2 ≤ q := hq.two_le
+  -- write d = d' + 1
+  obtain ⟨d', rfl⟩ : ∃ n, d = n + 1 := ⟨d - 1, by omega⟩
+  simp only [Nat.add_sub_cancel]
+  have hd' : 1 ≤ d' := by omega
+  -- minimizer for s q 1 k : gives μ := m₁ 0 with [k-1, μ] carry-free and s₁ = k + μ
+  obtain ⟨m₁, hm₁T, hm₁val⟩ := s_minimizer q 1 k hq2 hk
+  obtain ⟨hpos₁, hdvd₁, hnc₁⟩ := hm₁T
+  set μ := m₁ 0 with hμ
+  have hofn1 : List.ofFn m₁ = [m₁ 0] := by simp [List.ofFn_succ, List.ofFn_zero]
+  have hs1 : s q 1 k = k + μ := by rw [hm₁val]; simp [hμ]
+  have hs1pos : 0 < s q 1 k := by rw [hs1]; omega
+  have hsm1 : s q 1 k - 1 = (k - 1) + μ := by rw [hs1]; omega
+  -- per-position carry-free of [k-1, μ]
+  have hcf1 : ∀ e, qdigit q (k - 1) e + qdigit q μ e ≤ q - 1 := by
+    intro e
+    have := hnc₁ e
+    rw [hofn1] at this
+    simpa [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, hμ] using this
+  -- minimizer for s q d' (s q 1 k)
+  obtain ⟨mν, hmνT, hmνval⟩ := s_minimizer q d' (s q 1 k) hq2 hs1pos
+  obtain ⟨hposν, hdvdν, hncν⟩ := hmνT
+  rw [hsm1] at hncν
+  -- build the d-tuple by snoc'ing μ at the top weight
+  set m : Fin (d'+1) → ℕ := Fin.snoc mν μ with hmdef
+  have hmem : m ∈ TSet q (d'+1) (k - 1) := by
+    refine ⟨?_, ?_, ?_⟩
+    · intro i
+      refine Fin.lastCases ?_ ?_ i
+      · rw [hmdef, Fin.snoc_last]; rw [hμ]; exact hpos₁ 0
+      · intro j; rw [hmdef, Fin.snoc_castSucc]; exact hposν j
+    · intro i
+      refine Fin.lastCases ?_ ?_ i
+      · rw [hmdef, Fin.snoc_last]; rw [hμ]; exact hdvd₁ 0
+      · intro j; rw [hmdef, Fin.snoc_castSucc]; exact hdvdν j
+    · intro e
+      rw [List.map_cons, List.sum_cons, List.map_ofFn, List.sum_ofFn,
+          Fin.sum_univ_castSucc]
+      simp only [hmdef, Fin.snoc_castSucc, Fin.snoc_last, Function.comp_apply]
+      have hν := hncν e
+      rw [List.map_cons, List.sum_cons, List.map_ofFn, List.sum_ofFn] at hν
+      -- digit additivity: qdigit((k - 1)+μ, e) = qdigit(k-1,e) + qdigit(μ,e)
+      have hadd : qdigit q ((k - 1)+μ) e = qdigit q (k - 1) e + qdigit q μ e := by
+        rw [qdigit_eq _ _ _ hq2, qdigit_eq _ _ _ hq2, qdigit_eq _ _ _ hq2]
+        exact qdigit_add q (k - 1) μ e hq2 (fun f => by
+          have := hcf1 f; rw [qdigit_eq _ _ _ hq2, qdigit_eq _ _ _ hq2] at this; exact this)
+      rw [hadd] at hν
+      simp only [Function.comp_apply] at hν ⊢
+      omega
+  -- objective value of the constructed tuple
+  have hobj : ∑ i : Fin (d'+1), (i.val + 1) * m i
+      = (∑ i : Fin d', (i.val + 1) * mν i) + (d'+1) * μ := by
+    rw [Fin.sum_univ_castSucc]
+    congr 1
+    · apply Finset.sum_congr rfl; intro i _
+      rw [hmdef, Fin.snoc_castSucc, Fin.val_castSucc]
+    · rw [hmdef, Fin.snoc_last, Fin.val_last]
+  -- bound s q (d'+1) k by the constructed objective
+  have hbound : s q (d'+1) k ≤ (d'+1) * k + ∑ i : Fin (d'+1), (i.val + 1) * m i := by
+    unfold s
+    refine Nat.add_le_add_left (Nat.sInf_le ?_) _
+    exact ⟨m, hmem, rfl⟩
+  -- final algebra
+  rw [hmνval, hs1]
+  rw [hobj] at hbound
+  calc s q (d'+1) k
+      ≤ (d'+1)*k + (∑ i : Fin d', (i.val+1)*mν i + (d'+1)*μ) := hbound
+    _ = (d' * (k + μ) + ∑ i : Fin d', (i.val+1)*mν i) + (k + μ) := by ring
+
+/-
+Slot-list machinery for the slot formula. `M` is made concrete as `slotList q k1 L`:
+in increasing order of value, position `e < L` contributes `(q - 1) - qdigit q k1 e`
+copies of `q ^ e`. Since `q ^ e` increases with `e`, the list is sorted ascending, so
+blocks of `n = q-1` smallest slots are consecutive windows, and the block
+functional `Φ_d` is a weighted sum of block sums. The truncation `L` (via
+`slotLen`) is chosen large enough to contain all slots used by relevant tuples.
+-/
+
+/-- The list of available base-`q` digit slots of `k1`, truncated to positions
+`< L`, listed in INCREASING order of value: position `e` contributes
+`(q - 1) - qdigit q k1 e` copies of `q ^ e`. Sorted ascending since `q ^ e` is
+increasing in `e`. -/
+def slotList (q k1 L : ℕ) : List ℕ :=
+  (List.range L).flatMap (fun e => List.replicate ((q - 1) - qdigit q k1 e) (q ^ e))
+
+/-- The sum of the `r`-th block of `n = q-1` smallest slots (1-indexed block `r`):
+the slots at list positions `[(r-1)*n, r*n)`. -/
+def blockSum (q k1 L r : ℕ) : ℕ :=
+  ((slotList q k1 L).drop ((r - 1) * (q - 1))).take (q - 1) |>.sum
+
+/-- The block functional `Φ_d(M) = d·β₁ + (d-1)·β₂ + ⋯ + 1·β_d`
+(`β_r = blockSum … r`). -/
+def Phi (q k1 d L : ℕ) : ℕ :=
+  ∑ r ∈ Finset.range d, (d - r) * blockSum q k1 L (r + 1)
+
+/-- A truncation length large enough to contain every slot used by any tuple in
+`TSet q d (k - 1)` realizing the minimum. -/
+def slotLen (q d k : ℕ) : ℕ :=
+  if q = q then k + d * (k + 1) + 1 else k + d * (k + 1) + 1
+
+/-- `slotList` is monotone in the truncation length: a larger `L` only appends
+more slots. -/
+theorem slotList_prefix (q k1 L₁ L₂ : ℕ) (h : L₁ ≤ L₂) :
+    ∃ t, slotList q k1 L₂ = slotList q k1 L₁ ++ t := by
+  unfold slotList
+  obtain ⟨c, rfl⟩ := Nat.exists_eq_add_of_le h
+  rw [List.range_add, List.flatMap_append]; exact ⟨_, rfl⟩
+
+/-- Digits of `k1` beyond position `k1` (in fact beyond `log_q k1`) vanish. -/
+theorem qdigit_zero_of_ge (q k1 e : ℕ) (hq : 2 ≤ q) (he : k1 + 1 ≤ e) :
+    qdigit q k1 e = 0 := by
+  unfold qdigit
+  apply List.getD_eq_default
+  have : (Nat.digits q k1).length ≤ k1 + 1 := by
+    rcases eq_or_ne k1 0 with rfl | hk0
+    · simp
+    · rw [Nat.length_digits q k1 hq hk0]; have := Nat.log_le_self q k1; omega
+  omega
+
+/-- Lower bound on the length of `slotList`: positions `e ∈ [k1+1, L)` each
+contribute `q-1` slots (since the digits of `k1` vanish there). -/
+theorem slotList_length_ge (q k1 L : ℕ) (hq : 2 ≤ q) :
+    (q - 1) * (L - (k1 + 1)) ≤ (slotList q k1 L).length := by
+  unfold slotList
+  rw [List.length_flatMap]
+  simp only [List.length_replicate]
+  have hsub : Finset.Ico (k1 + 1) L ⊆ Finset.range L := by
+    intro x hx; simp only [Finset.mem_Ico] at hx; simp only [Finset.mem_range]; omega
+  calc (q - 1) * (L - (k1 + 1))
+      = ∑ _e ∈ Finset.Ico (k1 + 1) L, (q - 1) := by
+          rw [Finset.sum_const, Nat.card_Ico]; ring
+    _ = ∑ e ∈ Finset.Ico (k1 + 1) L, ((q - 1) - qdigit q k1 e) := by
+          apply Finset.sum_congr rfl; intro e he; simp only [Finset.mem_Ico] at he
+          rw [qdigit_zero_of_ge q k1 e hq (by omega), Nat.sub_zero]
+    _ ≤ ∑ e ∈ Finset.range L, ((q - 1) - qdigit q k1 e) :=
+          Finset.sum_le_sum_of_subset hsub
+
+/-- `blockSum` is independent of the truncation length once `L` is large enough
+to contain the first `r` blocks. -/
+theorem blockSum_Lindep (q k1 L₁ L₂ r : ℕ) (h : L₁ ≤ L₂) (hr : 1 ≤ r)
+    (hlen : r * (q - 1) ≤ (slotList q k1 L₁).length) :
+    blockSum q k1 L₂ r = blockSum q k1 L₁ r := by
+  unfold blockSum
+  obtain ⟨t, ht⟩ := slotList_prefix q k1 L₁ L₂ h
+  rw [ht]
+  have heq : (r - 1) * (q - 1) + (q - 1) = r * (q - 1) := by
+    cases r with | zero => omega | succ m => simp; ring
+  rw [List.drop_append_of_le_length (by omega),
+      List.take_append_of_le_length (by rw [List.length_drop]; omega)]
+
+/-- (L3, pure reindexing) Split off the first block of `Φ_d`:
+`Φ_d(M) = d·β₁ + ∑_{r<d-1} (d-1-r)·β_{r+2}`. -/
+theorem Phi_split (q k1 d L : ℕ) (hd : 1 ≤ d) :
+    Phi q k1 d L = d * blockSum q k1 L 1
+      + ∑ r ∈ Finset.range (d - 1), (d - 1 - r) * blockSum q k1 L (r + 2) := by
+  unfold Phi
+  obtain ⟨e, rfl⟩ : ∃ e, d = e + 1 := ⟨d - 1, by omega⟩
+  rw [Finset.sum_range_succ']
+  simp only [Nat.add_sub_cancel, Nat.sub_zero]
+  rw [Nat.add_comm]
+  congr 1
+  apply Finset.sum_congr rfl; intro r hr; simp only [Finset.mem_range] at hr
+  have h1 : e + 1 - (r + 1) = e - r := by omega
+  have h2 : r + 1 + 1 = r + 2 := by ring
+  rw [h1, h2]
+
+-- Recurrence for `slotList`: appending the slots at position `Lx`.
+theorem slotList_succ (q k1 Lx : ℕ) :
+    slotList q k1 (Lx+1)
+      = slotList q k1 Lx ++ List.replicate ((q - 1) - qdigit q k1 Lx) (q ^ Lx) := by
+  unfold slotList
+  rw [List.range_succ, List.flatMap_append]; simp
+
+-- Length of `slotList` as a sum of slot multiplicities.
+theorem slotList_length (q k1 Lx : ℕ) :
+    (slotList q k1 Lx).length = ∑ e ∈ Finset.range Lx, ((q - 1) - qdigit q k1 e) := by
+  induction Lx with
+  | zero => simp [slotList]
+  | succ n ih =>
+    rw [slotList_succ, List.length_append, List.length_replicate, Finset.sum_range_succ, ih]
+
+-- `slotList` length is monotone in the truncation length.
+theorem slotList_length_mono (q k1 : ℕ) {a b : ℕ} (h : a ≤ b) :
+    (slotList q k1 a).length ≤ (slotList q k1 b).length := by
+  rw [slotList_length, slotList_length]
+  apply Finset.sum_le_sum_of_subset
+  intro x hx; simp only [Finset.mem_range] at hx ⊢; omega
+
+-- Sum of `slotList`: the base-`q` value contributed by all slots.
+theorem slotList_sum (q k1 L : ℕ) :
+    (slotList q k1 L).sum = ∑ e ∈ Finset.range L, ((q - 1) - qdigit q k1 e) * q ^ e := by
+  induction L with
+  | zero => simp [slotList]
+  | succ L ih =>
+    rw [slotList_succ, List.sum_append, ih, Finset.sum_range_succ, List.sum_replicate]
+    simp [Nat.mul_comm]
+
+-- Greedy structure of `take n`: the first `n` slots are all slots up to some
+-- position `p`, plus a residual `r` slots at position `p`.
+theorem slotList_take (q k1 L : ℕ) :
+    ∀ n, n ≤ (slotList q k1 L).length →
+      ∃ p, p ≤ L ∧ ∃ r, (slotList q k1 L).take n = slotList q k1 p ++ List.replicate r (q ^ p)
+        ∧ (slotList q k1 p).length + r = n ∧ r ≤ (q - 1) - qdigit q k1 p := by
+  induction L with
+  | zero =>
+    intro n hn
+    simp only [slotList, List.range_zero, List.flatMap_nil, List.length_nil, Nat.le_zero] at hn
+    subst hn
+    refine ⟨0, le_refl _, 0, ?_, ?_, by omega⟩ <;> simp [slotList]
+  | succ L ih =>
+    intro n hn
+    rw [slotList_succ] at hn ⊢
+    rw [List.length_append, List.length_replicate] at hn
+    by_cases hcase : n ≤ (slotList q k1 L).length
+    · obtain ⟨p, hpL, r, htake, hlen, hr⟩ := ih n hcase
+      refine ⟨p, by omega, r, ?_, hlen, hr⟩
+      rw [List.take_append_of_le_length hcase]; exact htake
+    · push Not at hcase
+      refine ⟨L, by omega, n - (slotList q k1 L).length, ?_, by omega, by omega⟩
+      rw [List.take_append]
+      rw [List.take_of_length_le (by omega)]
+      congr 1
+      rw [List.take_replicate]
+      congr 1
+      omega
+
+-- `take` of `c·n` slots equals the sum of the first `c` blocks.
+theorem take_blocks (q k1 L c : ℕ) :
+    ((slotList q k1 L).take (c * (q - 1))).sum
+      = ∑ r ∈ Finset.range c, blockSum q k1 L (r+1) := by
+  induction c with
+  | zero => simp
+  | succ c ih =>
+    rw [Finset.sum_range_succ, ← ih]
+    unfold blockSum
+    simp only [Nat.add_sub_cancel]
+    have hn : (c + 1)*(q - 1) = c*(q - 1) + (q - 1) := by ring
+    rw [hn, List.take_add, List.sum_append]
+
+-- Abel-summation swap identity for the block functional.
+theorem abel_swap (d : ℕ) (b : ℕ → ℕ) :
+    ∑ r ∈ Finset.range d, (d - r) * b (r + 1)
+      = ∑ c ∈ Finset.range d, ∑ r ∈ Finset.range (c + 1), b (r+1) := by
+  induction d with
+  | zero => simp
+  | succ d ih =>
+    rw [Finset.sum_range_succ (f := fun c => ∑ r ∈ Finset.range (c + 1), b (r+1)), ← ih]
+    rw [Finset.sum_range_succ (f := fun r => (d+1-r) * b (r+1))]
+    have hcong : ∀ r ∈ Finset.range d, (d+1-r) * b (r+1) = (d-r) * b (r+1) + b (r+1) := by
+      intro r hr; simp only [Finset.mem_range] at hr
+      have : d + 1 - r = (d-r) + 1 := by omega
+      rw [this]; ring
+    rw [Finset.sum_congr rfl hcong, Finset.sum_add_distrib]
+    rw [Finset.sum_range_succ (f := fun r => b (r+1))]
+    have h1 : d + 1 - d = 1 := by omega
+    rw [h1, Nat.one_mul]
+    ring
+
+/-- Abel reformulation of `Φ_d(M)`: the layer-cake identity
+`Φ_d(M) = ∑_{c<d} (sum of the smallest (c + 1)·n slots)`. -/
+theorem Phi_eq_take_sum (q k1 d L : ℕ) :
+    Phi q k1 d L = ∑ c ∈ Finset.range d, ((slotList q k1 L).take ((c + 1) * (q - 1))).sum := by
+  unfold Phi
+  rw [abel_swap d (fun r => blockSum q k1 L r)]
+  apply Finset.sum_congr rfl
+  intro c hc
+  rw [take_blocks]
+
+-- Pure arithmetic greedy core: the smallest `m = ∑_{e<p} s_e + r` slots
+-- (values `q ^ e`) have the least value among any selection `b` with `b e ≤ s e`
+-- and total count `≥ m`.
+theorem greedy_core (q p L : ℕ) (hq : 2 ≤ q) (hpL : p ≤ L)
+    (b s : ℕ → ℕ) (r : ℕ)
+    (hbs : ∀ e, e < L → b e ≤ s e)
+    (hcount : (∑ e ∈ Finset.range p, s e) + r ≤ ∑ e ∈ Finset.range L, b e) :
+    (∑ e ∈ Finset.range p, s e * q ^ e) + r * q ^ p ≤ ∑ e ∈ Finset.range L, b e * q ^ e := by
+  have hsplit : Finset.range L = Finset.range p ∪ Finset.Ico p L := by
+    ext e
+    simp
+    omega
+  have hdisj : Disjoint (Finset.range p) (Finset.Ico p L) := by
+    rw [Finset.range_eq_Ico]; exact Finset.Ico_disjoint_Ico_consecutive 0 p L
+  set A := ∑ e ∈ Finset.range p, b e * q ^ e with hA
+  have hRHS : ∑ e ∈ Finset.range L, b e * q ^ e
+      = A + ∑ e ∈ Finset.Ico p L, b e * q ^ e := by
+    rw [hsplit, Finset.sum_union hdisj]
+  have hIco : (∑ e ∈ Finset.Ico p L, b e) * q ^ p ≤ ∑ e ∈ Finset.Ico p L, b e * q ^ e := by
+    rw [Finset.sum_mul]
+    apply Finset.sum_le_sum
+    intro e he; simp only [Finset.mem_Ico] at he
+    apply Nat.mul_le_mul_left
+    exact Nat.pow_le_pow_right (by omega) he.1
+  have hLHSsplit : ∑ e ∈ Finset.range p, s e * q ^ e
+      = A + ∑ e ∈ Finset.range p, (s e - b e) * q ^ e := by
+    rw [hA, ← Finset.sum_add_distrib]
+    apply Finset.sum_congr rfl; intro e he; simp only [Finset.mem_range] at he
+    have := hbs e (by omega)
+    rw [← Nat.add_mul]; congr 1; omega
+  have hupper : ∑ e ∈ Finset.range p, (s e - b e) * q ^ e
+      ≤ (∑ e ∈ Finset.range p, (s e - b e)) * q ^ p := by
+    rw [Finset.sum_mul]
+    apply Finset.sum_le_sum
+    intro e he; simp only [Finset.mem_range] at he
+    apply Nat.mul_le_mul_left
+    exact Nat.pow_le_pow_right (by omega) (by omega)
+  have hcountIco : (∑ e ∈ Finset.range p, (s e - b e)) + r ≤ ∑ e ∈ Finset.Ico p L, b e := by
+    have hb_le_s : ∑ e ∈ Finset.range p, b e ≤ ∑ e ∈ Finset.range p, s e := by
+      apply Finset.sum_le_sum
+      intro e he
+      simp only [Finset.mem_range] at he
+      exact hbs e (by omega)
+    have hsubsum : ∑ e ∈ Finset.range p, (s e - b e)
+        = (∑ e ∈ Finset.range p, s e) - ∑ e ∈ Finset.range p, b e := by
+      rw [← Finset.sum_tsub_distrib]
+      intro e he
+      simp only [Finset.mem_range] at he
+      exact hbs e (by omega)
+    have hLsplit2 : ∑ e ∈ Finset.range L, b e
+        = (∑ e ∈ Finset.range p, b e) + ∑ e ∈ Finset.Ico p L, b e := by
+      rw [hsplit, Finset.sum_union hdisj]
+    rw [hsubsum]
+    omega
+  rw [hRHS, hLHSsplit]
+  have hpp : 1 ≤ q ^ p := Nat.one_le_pow _ _ (by omega)
+  calc A + ∑ e ∈ Finset.range p, (s e - b e) * q ^ e + r * q ^ p
+      ≤ A + (∑ e ∈ Finset.range p, (s e - b e)) * q ^ p + r * q ^ p := by
+        have := hupper; omega
+    _ = A + ((∑ e ∈ Finset.range p, (s e - b e)) + r) * q ^ p := by ring
+    _ ≤ A + (∑ e ∈ Finset.Ico p L, b e) * q ^ p := by
+        apply Nat.add_le_add_left
+        exact Nat.mul_le_mul_right _ hcountIco
+    _ ≤ A + ∑ e ∈ Finset.Ico p L, b e * q ^ e := by
+        apply Nat.add_le_add_left hIco
+
+/-- Bridge: the value of the smallest `m` slots of `M(k - 1)` is at most any `N`
+that adds to `k-1` without carry and whose total slot count (digit sum) is `≥ m`.
+The greedy/exchange argument in closed arithmetic form. -/
+theorem slot_value_le (q d k : ℕ) (hq : 2 ≤ q) (N m : ℕ)
+    (hcarry : ∀ e, qdigit q (k - 1) e + qdigit q N e ≤ q - 1)
+    (hm_len : m ≤ (slotList q (k - 1) (slotLen q d k)).length)
+    (hcount : m ≤ ∑ e ∈ Finset.range (slotLen q d k + N + 1), qdigit q N e) :
+    ((slotList q (k - 1) (slotLen q d k)).take m).sum ≤ N := by
+  set k1 := k - 1 with hk1
+  set Ls := slotLen q d k with hLs
+  set L' := slotLen q d k + N + 1 with hL'
+  obtain ⟨p, hpL, r, htake, hlen, hr⟩ := slotList_take q k1 Ls m hm_len
+  -- value of the smallest m slots
+  have hval : ((slotList q k1 Ls).take m).sum
+      = (∑ e ∈ Finset.range p, ((q - 1) - qdigit q k1 e) * q ^ e) + r * q ^ p := by
+    rw [htake, List.sum_append, List.sum_replicate, slotList_sum]
+    simp [Nat.mul_comm]
+  rw [hval]
+  -- N as a truncated base-q expansion
+  have hNlt : N < q ^ L' := by
+    calc N < q ^ N := Nat.lt_pow_self (by omega)
+      _ ≤ q ^ L' := Nat.pow_le_pow_right (by omega) (by omega)
+  have hNexp : ∑ e ∈ Finset.range L', qdigit q N e * q ^ e = N := by
+    have h1 : N % q ^ L' = ∑ e ∈ Finset.range L', (N / q ^ e % q) * q ^ e := digit_mod q N L'
+    rw [Nat.mod_eq_of_lt hNlt] at h1
+    rw [show (∑ e ∈ Finset.range L', qdigit q N e * q ^ e)
+          = ∑ e ∈ Finset.range L', (N / q ^ e % q) * q ^ e from
+        Finset.sum_congr rfl (fun e _ => by rw [qdigit_eq _ _ _ hq])]
+    exact h1.symm
+  rw [← hNexp]
+  -- apply greedy_core
+  apply greedy_core q p L' hq (by omega)
+    (fun e => qdigit q N e) (fun e => (q - 1) - qdigit q k1 e) r
+  · intro e _; have := hcarry e; omega
+  · -- ∑_{e<p} s_e + r ≤ ∑_{e<L'} qdigit N e
+    have hpcount : (∑ e ∈ Finset.range p, ((q - 1) - qdigit q k1 e)) + r = m := by
+      rw [← slotList_length q k1 p]; omega
+    rw [hpcount]; exact hcount
+
+-- Finite-family digit additivity: if a family adds without carry then each digit
+-- of the sum is the sum of the digits.
+theorem qdigit_sum {ι : Type*} (q : ℕ) (hq : 2 ≤ q) (I : Finset ι) (f : ι → ℕ)
+    (h : ∀ e, ∑ i ∈ I, qdigit q (f i) e ≤ q - 1) :
+    ∀ e, qdigit q (∑ i ∈ I, f i) e = ∑ i ∈ I, qdigit q (f i) e := by
+  classical
+  induction I using Finset.induction with
+  | empty => intro e; simp [qdigit, Nat.digits_zero]
+  | insert a s ha ih =>
+    have hsub : ∀ g, ∑ i ∈ s, qdigit q (f i) g ≤ q - 1 := by
+      intro g; have := h g; rw [Finset.sum_insert ha] at this; omega
+    have iheq := ih hsub
+    intro e
+    rw [Finset.sum_insert ha, Finset.sum_insert ha]
+    have hcf : ∀ g, (f a / q ^ g % q) + ((∑ i ∈ s, f i) / q ^ g % q) ≤ q - 1 := by
+      intro g
+      have hsg := h g; rw [Finset.sum_insert ha] at hsg
+      rw [← qdigit_eq _ _ _ hq, ← qdigit_eq _ _ _ hq, iheq g]
+      exact hsg
+    rw [qdigit_eq _ _ _ hq, qdigit_add q (f a) (∑ i ∈ s, f i) e hq hcf]
+    rw [← qdigit_eq _ _ _ hq, ← qdigit_eq _ _ _ hq, iheq e]
+
+-- `∑ d_e q ^ e ≡ ∑ d_e  (mod q-1)`, since `q ≡ 1 (mod q-1)`.
+theorem sum_pow_modEq (q L : ℕ) (hq : 2 ≤ q) (d : ℕ → ℕ) :
+    ∑ e ∈ Finset.range L, d e * q ^ e ≡ ∑ e ∈ Finset.range L, d e [MOD (q - 1)] := by
+  have hpow : ∀ e, q ^ e ≡ 1 [MOD (q - 1)] := by
+    intro e
+    have h0 : (q - 1) ≡ 0 [MOD (q - 1)] := (Nat.modEq_zero_iff_dvd).mpr dvd_rfl
+    have h1 : q ≡ 1 [MOD (q - 1)] := by
+      calc q = (q - 1) + 1 := by omega
+        _ ≡ 0 + 1 [MOD (q - 1)] := Nat.ModEq.add_right 1 h0
+        _ = 1 := by ring
+    calc q ^ e ≡ 1 ^ e [MOD (q - 1)] := h1.pow e
+      _ = 1 := one_pow e
+  induction L with
+  | zero => simp [Nat.ModEq.refl]
+  | succ L ih =>
+    rw [Finset.sum_range_succ, Finset.sum_range_succ]
+    have hh : d L * q ^ L ≡ d L * 1 [MOD (q - 1)] := Nat.ModEq.mul_left _ (hpow L)
+    rw [Nat.mul_one] at hh
+    exact Nat.ModEq.add ih hh
+
+-- The digit sum (slot count) of a positive multiple of `q-1` is at least `q-1`.
+theorem digitsum_ge (q x L : ℕ) (hq : 2 ≤ q) (hdvd : (q - 1) ∣ x) (hpos : 0 < x)
+    (hxL : x < q ^ L) :
+    q - 1 ≤ ∑ e ∈ Finset.range L, qdigit q x e := by
+  have hexp : x = ∑ e ∈ Finset.range L, qdigit q x e * q ^ e := by
+    have h1 : x % q ^ L = ∑ e ∈ Finset.range L, (x / q ^ e % q) * q ^ e := digit_mod q x L
+    rw [Nat.mod_eq_of_lt hxL] at h1
+    rw [show (∑ e ∈ Finset.range L, qdigit q x e * q ^ e)
+          = ∑ e ∈ Finset.range L, (x / q ^ e % q) * q ^ e from
+        Finset.sum_congr rfl (fun e _ => by rw [qdigit_eq _ _ _ hq])]
+    exact h1
+  have hmod : x ≡ ∑ e ∈ Finset.range L, qdigit q x e [MOD (q - 1)] := by
+    conv_lhs => rw [hexp]
+    exact sum_pow_modEq q L hq (fun e => qdigit q x e)
+  have hSdvd : (q - 1) ∣ ∑ e ∈ Finset.range L, qdigit q x e :=
+    (Nat.modEq_zero_iff_dvd).mp (hmod.symm.trans ((Nat.modEq_zero_iff_dvd).mpr hdvd))
+  have hSpos : 0 < ∑ e ∈ Finset.range L, qdigit q x e := by
+    by_contra hc
+    push Not at hc
+    have hz : ∑ e ∈ Finset.range L, qdigit q x e = 0 := by omega
+    have hx0 : x = 0 := by
+      rw [hexp]
+      apply Finset.sum_eq_zero
+      intro e he
+      have : qdigit q x e = 0 := Finset.sum_eq_zero_iff.mp hz e he
+      rw [this]; ring
+    omega
+  exact Nat.le_of_dvd hSpos hSdvd
+
+-- Reindexing the objective `∑ (i+1)·m_i` as a sum over weight levels: the `c`-th
+-- level groups the top `c+1` coordinates `{i : d-1-c ≤ i}`.
+theorem rhs_reindex (d : ℕ) (m : Fin d → ℕ) :
+    ∑ i : Fin d, (i.val + 1) * m i
+      = ∑ c ∈ Finset.range d,
+          ∑ i ∈ Finset.univ.filter (fun i : Fin d => d - 1 - c ≤ i.val), m i := by
+  have hinner : ∀ c ∈ Finset.range d,
+      ∑ i ∈ Finset.univ.filter (fun i : Fin d => d - 1 - c ≤ i.val), m i
+        = ∑ i : Fin d, (if d - 1 - c ≤ i.val then m i else 0) := by
+    intro c _; rw [Finset.sum_filter]
+  rw [Finset.sum_congr rfl hinner, Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [← Finset.sum_filter, Finset.sum_const]
+  have hcard : (Finset.range d |>.filter (fun c => d - 1 - c ≤ i.val)).card = i.val + 1 := by
+    have hsub : (Finset.range d).filter (fun c => d - 1 - c ≤ i.val)
+        = Finset.Ico (d - 1 - i.val) d := by
+      ext c; simp only [Finset.mem_filter, Finset.mem_range, Finset.mem_Ico]
+      have hi : i.val < d := i.isLt
+      omega
+    rw [hsub, Nat.card_Ico]
+    have hi : i.val < d := i.isLt
+    omega
+  rw [hcard, smul_eq_mul, Nat.mul_comm]
+
+/-- Optimality lower bound (the `≥` half of the slot formula): every tuple in
+`TSet q d (k - 1)` has objective at least `Φ_d(M)` (informal.tex Lem. H2-block-min).
+Proof idea: reindex the objective by weight levels and bound each level by the
+greedy bound `slot_value_le`. -/
+theorem slot_lower_bound (q d k : ℕ) (hq : 2 ≤ q) (hk : 0 < k)
+    (m : Fin d → ℕ) (hm : m ∈ TSet q d (k - 1)) :
+    Phi q (k - 1) d (slotLen q d k) ≤ ∑ i : Fin d, (i.val + 1) * m i := by
+  classical
+  obtain ⟨hmpos, hmdvd, hnc⟩ := hm
+  set k1 := k - 1 with hk1
+  set Ls := slotLen q d k with hLs
+  -- carry-free, per position: qdigit k1 e + ∑_i qdigit (m i) e ≤ q-1
+  have hcf : ∀ e, qdigit q k1 e + ∑ i : Fin d, qdigit q (m i) e ≤ q - 1 := by
+    intro e
+    have := hnc e
+    rw [List.map_cons, List.sum_cons, List.map_ofFn, List.sum_ofFn] at this
+    simpa [Function.comp] using this
+  -- rewrite both sides
+  rw [Phi_eq_take_sum, rhs_reindex]
+  apply Finset.sum_le_sum
+  intro c hc
+  simp only [Finset.mem_range] at hc
+  -- the subset of top (c + 1) coordinates and its sum
+  set I : Finset (Fin d) := Finset.univ.filter (fun i : Fin d => d - 1 - c ≤ i.val) with hI
+  set N : ℕ := ∑ i ∈ I, m i with hN
+  -- carry-free for the subfamily
+  have hsubcf : ∀ e, ∑ i ∈ I, qdigit q (m i) e ≤ q - 1 := by
+    intro e
+    refine le_trans (Finset.sum_le_sum_of_subset (Finset.subset_univ I)) ?_
+    have := hcf e; omega
+  -- digit of N
+  have hNdig : ∀ e, qdigit q N e = ∑ i ∈ I, qdigit q (m i) e :=
+    qdigit_sum q hq I m hsubcf
+  -- |I| = c+1
+  have hIcard : I.card = c + 1 := by
+    rw [hI, Finset.card_filter]
+    rw [Fin.sum_univ_eq_sum_range (fun j => if d - 1 - c ≤ j then 1 else 0) d]
+    rw [← Finset.card_filter]
+    have heq : (Finset.range d).filter (fun j => d - 1 - c ≤ j) = Finset.Ico (d - 1 - c) d := by
+      ext j; simp only [Finset.mem_filter, Finset.mem_range, Finset.mem_Ico]; omega
+    rw [heq, Nat.card_Ico]; omega
+  -- apply the bridge
+  refine slot_value_le q d k hq N ((c + 1) * (q - 1)) ?_ ?_ ?_
+  · -- hcarry
+    intro e
+    rw [hNdig e]
+    have hthis := hcf e
+    have hmono : ∑ i ∈ I, qdigit q (m i) e ≤ ∑ i : Fin d, qdigit q (m i) e :=
+      Finset.sum_le_sum_of_subset (Finset.subset_univ I)
+    calc qdigit q k1 e + ∑ i ∈ I, qdigit q (m i) e
+        ≤ qdigit q k1 e + ∑ i : Fin d, qdigit q (m i) e := by
+          exact Nat.add_le_add_left hmono _
+      _ ≤ q - 1 := hthis
+  · -- hm_len
+    have hb := slotList_length_ge q k1 Ls hq
+    have hk1k : k1 + 1 = k := by omega
+    rw [hk1k] at hb
+    have hLval : Ls = k + d * (k + 1) + 1 := by simp [hLs, slotLen]
+    have hdd : d ≤ d * (k + 1) := Nat.le_mul_of_pos_right d (by omega)
+    have hcd : c + 1 ≤ d := by omega
+    calc (c + 1) * (q - 1) = (q - 1) * (c + 1) := by ring
+      _ ≤ (q - 1) * (Ls - k) := Nat.mul_le_mul_left _ (by omega)
+      _ ≤ (slotList q k1 Ls).length := hb
+  · -- hcount
+    have hNexpand : ∑ e ∈ Finset.range (Ls + N + 1), qdigit q N e
+        = ∑ i ∈ I, ∑ e ∈ Finset.range (Ls + N + 1), qdigit q (m i) e := by
+      rw [show (∑ e ∈ Finset.range (Ls + N + 1), qdigit q N e)
+            = ∑ e ∈ Finset.range (Ls + N + 1), ∑ i ∈ I, qdigit q (m i) e from
+          Finset.sum_congr rfl (fun e _ => hNdig e)]
+      rw [Finset.sum_comm]
+    rw [hNexpand]
+    -- each coordinate contributes ≥ q-1
+    have hterm : ∀ i ∈ I, q - 1 ≤ ∑ e ∈ Finset.range (Ls + N + 1), qdigit q (m i) e := by
+      intro i hiI
+      have hmiN : m i ≤ N := by
+        rw [hN]; exact Finset.single_le_sum (fun j _ => Nat.zero_le _) hiI
+      have hmilt : m i < q ^ (Ls + N + 1) := by
+        calc m i ≤ N := hmiN
+          _ < q ^ N := Nat.lt_pow_self (by omega)
+          _ ≤ q ^ (Ls + N + 1) := Nat.pow_le_pow_right (by omega) (by omega)
+      exact digitsum_ge q (m i) (Ls + N + 1) hq (hmdvd i) (hmpos i) hmilt
+    calc (c + 1) * (q - 1) = I.card * (q - 1) := by rw [hIcard]
+      _ = ∑ _i ∈ I, (q - 1) := by rw [Finset.sum_const, smul_eq_mul]
+      _ ≤ ∑ i ∈ I, ∑ e ∈ Finset.range (Ls + N + 1), qdigit q (m i) e :=
+          Finset.sum_le_sum hterm
+
+
+/-- The `f`-th base-`q` digit of a bounded expansion `∑_{e<m} coeff e · q ^ e`
+is `coeff f`. -/
+theorem digit_of_sum_aux (q : ℕ) (hq : 2 ≤ q) (m : ℕ) (coeff : ℕ → ℕ)
+    (hc : ∀ e, e < m → coeff e < q) (f : ℕ) (hf : f < m) :
+    (∑ e ∈ Finset.range m, coeff e * q ^ e) / q ^ f % q = coeff f := by
+  have hqpos : 0 < q := by omega
+  have hsplit : ∑ e ∈ Finset.range m, coeff e * q ^ e
+      = (∑ e ∈ Finset.range f, coeff e * q ^ e) + coeff f * q ^ f
+        + (∑ e ∈ Finset.Ico (f + 1) m, coeff e * q ^ e) := by
+    have h1 : Finset.range m = Finset.range (f + 1) ∪ Finset.Ico (f + 1) m := by
+      ext e
+      simp
+      omega
+    rw [h1, Finset.sum_union (by
+      rw [Finset.range_eq_Ico]; apply Finset.Ico_disjoint_Ico_consecutive)]
+    rw [Finset.sum_range_succ]
+  rw [hsplit]
+  have hlow : ∑ e ∈ Finset.range f, coeff e * q ^ e < q ^ f := by
+    have hb : ∑ e ∈ Finset.range f, coeff e * q ^ e ≤ q ^ f - 1 := by
+      calc ∑ e ∈ Finset.range f, coeff e * q ^ e
+          ≤ ∑ e ∈ Finset.range f, (q - 1) * q ^ e := by
+            apply Finset.sum_le_sum; intro e he
+            apply Nat.mul_le_mul_right; have := hc e (by simp at he; omega); omega
+        _ = (q - 1) * ∑ e ∈ Finset.range f, q ^ e := by rw [Finset.mul_sum]
+        _ = q ^ f - 1 := geom_pred q f (by omega)
+    have : 1 ≤ q ^ f := Nat.one_le_pow _ _ hqpos
+    omega
+  have hhigh : q ^ (f + 1) ∣ ∑ e ∈ Finset.Ico (f + 1) m, coeff e * q ^ e := by
+    apply Finset.dvd_sum; intro e he; simp only [Finset.mem_Ico] at he
+    exact Dvd.dvd.mul_left (pow_dvd_pow q (by omega)) _
+  obtain ⟨t, ht⟩ := hhigh
+  rw [ht]
+  have hpf : 0 < q ^ f := Nat.pow_pos hqpos
+  rw [show (∑ e ∈ Finset.range f, coeff e * q ^ e) + coeff f * q ^ f + q ^ (f + 1)*t
+        = (∑ e ∈ Finset.range f, coeff e * q ^ e) + q ^ f * (coeff f + q*t) by rw [pow_succ]; ring]
+  rw [Nat.add_mul_div_left _ _ hpf, Nat.div_eq_of_lt hlow, Nat.zero_add]
+  rw [Nat.add_mul_mod_self_left]
+  exact Nat.mod_eq_of_lt (hc f hf)
+
+theorem sum_lt_pow_aux (q : ℕ) (hq : 2 ≤ q) (m : ℕ) (coeff : ℕ → ℕ)
+    (hc : ∀ e, e < m → coeff e < q) :
+    (∑ e ∈ Finset.range m, coeff e * q ^ e) < q ^ m := by
+  have hb : ∑ e ∈ Finset.range m, coeff e * q ^ e ≤ q ^ m - 1 := by
+    calc ∑ e ∈ Finset.range m, coeff e * q ^ e
+        ≤ ∑ e ∈ Finset.range m, (q - 1) * q ^ e := by
+          apply Finset.sum_le_sum; intro e he
+          apply Nat.mul_le_mul_right; have := hc e (by simp at he; omega); omega
+      _ = (q - 1) * ∑ e ∈ Finset.range m, q ^ e := by rw [Finset.mul_sum]
+      _ = q ^ m - 1 := geom_pred q m (by omega)
+  have : 1 ≤ q ^ m := Nat.one_le_pow _ _ (by omega)
+  omega
+
+theorem qdigit_le_aux (q k1 e : ℕ) (hq : 2 ≤ q) : qdigit q k1 e ≤ q - 1 := by
+  rw [qdigit_eq _ _ _ hq]; have := Nat.mod_lt (k1 / q ^ e) (by omega : 0 < q); omega
+
+theorem list_map_range_sum (n : ℕ) (g : ℕ → ℕ) :
+    ((List.range n).map g).sum = ∑ i ∈ Finset.range n, g i := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [List.range_succ, List.map_append, List.sum_append, ih, Finset.sum_range_succ]; simp
+
+theorem wsum_eq (q L : ℕ) (hq : 2 ≤ q) (w : List ℕ)
+    (hpow : ∀ x ∈ w, ∃ e, e < L ∧ x = q ^ e) :
+    w.sum = ∑ e ∈ Finset.range L, (w.count (q ^ e)) * q ^ e := by
+  induction w with
+  | nil => simp
+  | cons a t ih =>
+    have hpowt : ∀ x ∈ t, ∃ e, e < L ∧ x = q ^ e := fun x hx => hpow x (by simp [hx])
+    obtain ⟨ea, heaL, haeq⟩ := hpow a (by simp)
+    rw [List.sum_cons, ih hpowt]
+    have hcount : ∀ e, (a :: t).count (q ^ e) = (if e = ea then 1 else 0) + t.count (q ^ e) := by
+      intro e
+      rw [List.count_cons]
+      have heq : (if a = q ^ e then 1 else 0) = (if e = ea then 1 else 0) := by
+        by_cases h : e = ea
+        · subst h; rw [haeq]; simp
+        · rw [if_neg h, if_neg]
+          rw [haeq]
+          intro hcontra
+          exact h (Nat.pow_right_injective hq hcontra.symm)
+      have hbeq : (if (a == q ^ e) = true then 1 else 0) = (if a = q ^ e then 1 else 0) := by
+        simp [beq_iff_eq]
+      omega
+    have hrw : ∑ e ∈ Finset.range L, (a :: t).count (q ^ e) * q ^ e
+        = (∑ e ∈ Finset.range L, (if e = ea then 1 else 0) * q ^ e)
+          + ∑ e ∈ Finset.range L, t.count (q ^ e) * q ^ e := by
+      rw [← Finset.sum_add_distrib]
+      apply Finset.sum_congr rfl
+      intro e _
+      rw [hcount e, Nat.add_mul]
+    have hfirst : ∑ e ∈ Finset.range L, (if e = ea then 1 else 0) * q ^ e = a := by
+      rw [Finset.sum_eq_single ea]
+      · simp [haeq]
+      · intro b _ hb; rw [if_neg hb]; ring
+      · intro hcontra; exact absurd (Finset.mem_range.mpr heaL) hcontra
+    rw [hrw, hfirst]
+
+theorem qdigit_window (q L : ℕ) (hq : 2 ≤ q) (w : List ℕ)
+    (hpow : ∀ x ∈ w, ∃ e, e < L ∧ x = q ^ e)
+    (hlt : ∀ e, w.count (q ^ e) < q) (f : ℕ) :
+    qdigit q w.sum f = if f < L then w.count (q ^ f) else 0 := by
+  rw [qdigit_eq _ _ _ hq, wsum_eq q L hq w hpow]
+  by_cases hf : f < L
+  · rw [if_pos hf]
+    exact digit_of_sum_aux q hq L (fun e => w.count (q ^ e)) (fun e _ => hlt e) f hf
+  · rw [if_neg hf]
+    have hbound : (∑ e ∈ Finset.range L, (w.count (q ^ e)) * q ^ e) < q ^ L :=
+      sum_lt_pow_aux q hq L (fun e => w.count (q ^ e)) (fun e _ => hlt e)
+    have hle : q ^ L ≤ q ^ f := Nat.pow_le_pow_right (by omega) (by omega)
+    rw [Nat.div_eq_of_lt (by omega), Nat.zero_mod]
+
+theorem slotList_pow (q k1 L : ℕ) : ∀ x ∈ slotList q k1 L, ∃ e, e < L ∧ x = q ^ e := by
+  intro x hx
+  unfold slotList at hx
+  rw [List.mem_flatMap] at hx
+  obtain ⟨e, he, hx2⟩ := hx
+  rw [List.mem_replicate] at hx2
+  rw [List.mem_range] at he
+  exact ⟨e, he, hx2.2⟩
+
+theorem slotList_count (q k1 L : ℕ) (hq : 2 ≤ q) (e : ℕ) (he : e < L) :
+    (slotList q k1 L).count (q ^ e) = (q - 1) - qdigit q k1 e := by
+  unfold slotList
+  rw [List.count_flatMap]
+  change ((List.range L).map
+      (List.count (q ^ e) ∘
+        (fun e' => List.replicate ((q - 1) - qdigit q k1 e') (q ^ e')))).sum = _
+  rw [list_map_range_sum]
+  rw [Finset.sum_eq_single e]
+  · simp
+  · intro b _ hb
+    simp only [Function.comp_apply, List.count_replicate]
+    rw [if_neg]
+    simp only [beq_iff_eq]
+    intro hcontra
+    exact hb (Nat.pow_right_injective hq hcontra)
+  · intro hcontra; exact absurd (Finset.mem_range.mpr he) hcontra
+
+theorem take_blocks_count {α : Type*} [BEq α] (L : List α) (n c : ℕ) (x : α) :
+    ∑ s ∈ Finset.range c, ((L.drop (s * n)).take n).count x = (L.take (c * n)).count x := by
+  induction c with
+  | zero => simp
+  | succ c ih =>
+    rw [Finset.sum_range_succ, ih]
+    rw [show (c + 1)*n = c*n + n from by ring, List.take_add, List.count_append]
+
+theorem window_len {α : Type*} (L : List α) (a n : ℕ) (h : a + n ≤ L.length) :
+    ((L.drop a).take n).length = n := by
+  rw [List.length_take, List.length_drop]
+  omega
+
+theorem pow_sum_modEq (q : ℕ) (hq : 2 ≤ q) (w : List ℕ)
+    (hpow : ∀ x ∈ w, ∃ e, x = q ^ e) :
+    w.sum ≡ w.length [MOD (q - 1)] := by
+  induction w with
+  | nil => simp [Nat.ModEq.refl]
+  | cons a t ih =>
+    have hpowt : ∀ x ∈ t, ∃ e, x = q ^ e := fun x hx => hpow x (by simp [hx])
+    obtain ⟨ea, haeq⟩ := hpow a (by simp)
+    rw [List.sum_cons, List.length_cons]
+    have hq1 : q ≡ 1 [MOD (q - 1)] := by
+      have h0 : (q - 1) ≡ 0 [MOD (q - 1)] := (Nat.modEq_zero_iff_dvd).mpr dvd_rfl
+      calc q = (q - 1) + 1 := by omega
+        _ ≡ 0 + 1 [MOD (q - 1)] := Nat.ModEq.add_right 1 h0
+        _ = 1 := by ring
+    have ha1 : a ≡ 1 [MOD (q - 1)] := by
+      rw [haeq]; calc q ^ ea ≡ 1 ^ ea [MOD (q - 1)] := hq1.pow ea
+        _ = 1 := one_pow ea
+    calc a + t.sum ≡ 1 + t.length [MOD (q - 1)] := Nat.ModEq.add ha1 (ih hpowt)
+      _ = t.length + 1 := by ring
+
+/-- Optimality upper bound (the `≤` half of the slot formula): the tuple sending
+the `r`-th smallest block to the coordinate of weight `d-r+1` lies in
+`TSet q d (k - 1)` and has objective exactly `Φ_d(M)`. -/
+theorem slot_upper_bound (q d k : ℕ) (hq : 2 ≤ q) (hk : 0 < k) :
+    sInf {v : ℕ | ∃ m ∈ TSet q d (k - 1), v = ∑ i : Fin d, (i.val + 1) * m i}
+      ≤ Phi q (k - 1) d (slotLen q d k) := by
+  classical
+  set k1 := k - 1 with hk1
+  set L := slotLen q d k with hLdef
+  -- length lower bound
+  have hlen : d * (q - 1) ≤ (slotList q k1 L).length := by
+    have hb := slotList_length_ge q k1 L hq
+    have hk1k : k1 + 1 = k := by omega
+    rw [hk1k] at hb
+    have hLval : L = k + d * (k + 1) + 1 := by simp [hLdef, slotLen]
+    have hdd : d ≤ d * (k + 1) := Nat.le_mul_of_pos_right d (by omega)
+    have hd1 : d ≤ L - k := by omega
+    calc d * (q - 1) = (q - 1) * d := by ring
+      _ ≤ (q - 1) * (L - k) := Nat.mul_le_mul_left _ hd1
+      _ ≤ (slotList q k1 L).length := hb
+  -- the witness
+  set m : Fin d → ℕ := fun i => blockSum q k1 L (d - i.val) with hm
+  -- window for coordinate i
+  have hmwin : ∀ i : Fin d,
+      m i =
+        (((slotList q k1 L).drop ((d - 1 - i.val) * (q - 1))).take (q - 1)).sum := by
+    intro i
+    have hi : i.val < d := i.isLt
+    have hoffeq : (d - i.val) - 1 = d - 1 - i.val := by omega
+    simp only [hm, blockSum, hoffeq]
+  -- offset bound: (d - 1 - i.val)*(q - 1) + (q - 1) ≤ length
+  have hoff : ∀ i : Fin d, (d - 1 - i.val) * (q - 1) + (q - 1) ≤ (slotList q k1 L).length := by
+    intro i
+    have hi : i.val < d := i.isLt
+    calc (d - 1 - i.val) * (q - 1) + (q - 1) = (d - i.val) * (q - 1) := by
+          rw [← Nat.succ_mul]; congr 1; omega
+      _ ≤ d * (q - 1) := Nat.mul_le_mul_right _ (by omega)
+      _ ≤ (slotList q k1 L).length := hlen
+  -- each window is a list of powers q ^ e with e < L
+  have hWpow : ∀ i : Fin d,
+      ∀ x ∈ (((slotList q k1 L).drop ((d - 1 - i.val) * (q - 1))).take (q - 1)),
+        ∃ e, e < L ∧ x = q ^ e := by
+    intro i x hx
+    have hsub : x ∈ slotList q k1 L := by
+      have h1 : x ∈ (slotList q k1 L).drop ((d - 1 - i.val) * (q - 1)) :=
+        List.mem_of_mem_take hx
+      exact List.mem_of_mem_drop h1
+    exact slotList_pow q k1 L x hsub
+  -- window count ≤ slotList count
+  have hWcount : ∀ i : Fin d, ∀ x,
+      (((slotList q k1 L).drop ((d - 1 - i.val) * (q - 1))).take (q - 1)).count x
+        ≤ (slotList q k1 L).count x := by
+    intro i x
+    apply List.Sublist.count_le
+    exact (List.take_sublist _ _).trans (List.drop_sublist _ _)
+  -- window length is q-1
+  have hWlen : ∀ i : Fin d,
+      (((slotList q k1 L).drop ((d - 1 - i.val) * (q - 1))).take (q - 1)).length
+        = q - 1 := by
+    intro i; exact window_len _ _ _ (hoff i)
+  -- carry-free per position e: total count over coordinates ≤ count in slotList
+  have hcountsum : ∀ e,
+      (∑ i : Fin d,
+        (((slotList q k1 L).drop ((d - 1 - i.val) * (q - 1))).take (q - 1)).count
+          (q ^ e))
+      ≤ (slotList q k1 L).count (q ^ e) := by
+    intro e
+    -- reindex i ↦ s = d-1-i.val to range d, use take_blocks_count
+    have hreindex :
+        (∑ i : Fin d,
+          (((slotList q k1 L).drop ((d - 1 - i.val) * (q - 1))).take (q - 1)).count
+            (q ^ e))
+          = ∑ s ∈ Finset.range d,
+              (((slotList q k1 L).drop (s * (q - 1))).take (q - 1)).count (q ^ e) := by
+      rw [Fin.sum_univ_eq_sum_range
+        (fun i =>
+          (((slotList q k1 L).drop ((d - 1 - i) * (q - 1))).take (q - 1)).count
+            (q ^ e)) d]
+      rw [← Finset.sum_range_reflect]
+      apply Finset.sum_congr rfl
+      intro s hs; simp only [Finset.mem_range] at hs
+      have hse : d - 1 - (d - 1 - s) = s := by omega
+      rw [hse]
+    rw [hreindex, take_blocks_count]
+    apply List.Sublist.count_le
+    exact List.take_sublist _ _
+  -- count of any power in slotList is < q
+  have hSltq : ∀ e', (slotList q k1 L).count (q ^ e') < q := by
+    intro e'
+    by_cases he' : e' < L
+    · rw [slotList_count q k1 L hq e' he']; omega
+    · have : (slotList q k1 L).count (q ^ e') = 0 := by
+        rw [List.count_eq_zero]
+        intro hmem
+        obtain ⟨e, heL, hxe⟩ := slotList_pow q k1 L _ hmem
+        have : e' = e := Nat.pow_right_injective hq hxe
+        omega
+      omega
+  -- digit of m i at position e
+  have hmdig : ∀ (i : Fin d) (e : ℕ), qdigit q (m i) e
+      = if e < L then
+          (((slotList q k1 L).drop ((d - 1 - i.val) * (q - 1))).take (q - 1)).count
+            (q ^ e)
+        else 0 := by
+    intro i e
+    rw [hmwin i]
+    refine qdigit_window q L hq _ (hWpow i) ?_ e
+    intro e'
+    exact lt_of_le_of_lt (hWcount i (q ^ e')) (hSltq e')
+  -- membership in TSet
+  have hmem : m ∈ TSet q d k1 := by
+    refine ⟨?_, ?_, ?_⟩
+    · -- 0 < m i
+      intro i
+      rw [hmwin i]
+      have hne : ((slotList q k1 L).drop ((d - 1 - i.val) * (q - 1))).take (q - 1) ≠ [] := by
+        rw [← List.length_pos_iff_ne_nil, hWlen i]; omega
+      obtain ⟨x, hx⟩ := List.exists_mem_of_ne_nil _ hne
+      obtain ⟨e, _, hxe⟩ := hWpow i x hx
+      have hxpos : 0 < x := by rw [hxe]; exact Nat.pow_pos (by omega)
+      exact lt_of_lt_of_le hxpos (List.le_sum_of_mem hx)
+    · -- (q - 1) ∣ m i
+      intro i
+      rw [hmwin i]
+      have hmod := pow_sum_modEq q hq _ (fun x hx => by
+        obtain ⟨e, _, hxe⟩ := hWpow i x hx; exact ⟨e, hxe⟩)
+      rw [hWlen i] at hmod
+      exact (Nat.modEq_zero_iff_dvd).mp (hmod.trans (Nat.modEq_zero_iff_dvd.mpr dvd_rfl))
+    · -- AddNoCarry
+      intro e
+      rw [List.map_cons, List.sum_cons, List.map_ofFn, List.sum_ofFn]
+      simp only [Function.comp]
+      have hsum : ∑ i : Fin d, qdigit q (m i) e
+          ≤ (q - 1) - qdigit q k1 e := by
+        by_cases he : e < L
+        · have heq : ∀ i : Fin d, qdigit q (m i) e
+              =
+                (((slotList q k1 L).drop ((d - 1 - i.val) * (q - 1))).take
+                  (q - 1)).count (q ^ e) := by
+            intro i; rw [hmdig i e, if_pos he]
+          rw [Finset.sum_congr rfl (fun i _ => heq i)]
+          rw [← slotList_count q k1 L hq e he]
+          exact hcountsum e
+        · have hz : ∀ i : Fin d, qdigit q (m i) e = 0 := by
+            intro i; rw [hmdig i e, if_neg he]
+          rw [Finset.sum_congr rfl (fun i _ => hz i), Finset.sum_const, smul_eq_mul, Nat.mul_zero]
+          exact Nat.zero_le _
+      have hk1le : qdigit q k1 e ≤ q - 1 := qdigit_le_aux q k1 e hq
+      omega
+  -- objective equals Phi
+  have hobj : ∑ i : Fin d, (i.val + 1) * m i = Phi q k1 d L := by
+    have hstep : ∑ i : Fin d, (i.val + 1) * m i
+        = ∑ j ∈ Finset.range d, (j + 1) * blockSum q k1 L (d - j) := by
+      rw [← Fin.sum_univ_eq_sum_range (fun j => (j + 1) * blockSum q k1 L (d - j)) d]
+    rw [hstep]
+    unfold Phi
+    rw [← Finset.sum_range_reflect (fun r => (d - r) * blockSum q k1 L (r + 1)) d]
+    apply Finset.sum_congr rfl
+    intro j hj; simp only [Finset.mem_range] at hj
+    have h1 : d - 1 - j + 1 = d - j := by omega
+    have h2 : d - (d - 1 - j) = j + 1 := by omega
+    rw [h1, h2]
+  exact Nat.sInf_le ⟨m, hmem, hobj.symm⟩
+
+/-- **The reciprocal slot formula** `s_d(k) = d·k + Φ_d(M)`. Assembled by
+antisymmetry from `slot_lower_bound` (every value `≥ Φ_d`, hence `sInf ≥ Φ_d`)
+and `slot_upper_bound` (`sInf ≤ Φ_d`). -/
+theorem slot_formula (q d k : ℕ) (hq : 2 ≤ q) (hk : 0 < k) :
+    s q d k = d * k + Phi q (k - 1) d (slotLen q d k) := by
+  unfold s
+  refine congrArg (d * k + ·) (le_antisymm (slot_upper_bound q d k hq hk) ?_)
+  -- sInf ≥ Φ: every element of the value set is ≥ Φ (slot_lower_bound), and the
+  -- set is nonempty (tset_value_nonempty), so its sInf is ≥ Φ.
+  apply le_csInf (tset_value_nonempty q d k hq hk)
+  rintro v ⟨m, hm, rfl⟩
+  exact slot_lower_bound q d k hq hk m hm
+
+/-- (L1) The `d=1` corollary `s_1(k) = k + β₁`: the slot formula at `d=1` gives
+`Φ_1(M) = β₁` (the smallest block sum). -/
+theorem s_one_eq (q k : ℕ) (hq : 2 ≤ q) (hk : 0 < k) :
+    s q 1 k = k + blockSum q (k - 1) (slotLen q 1 k) 1 := by
+  rw [slot_formula q 1 k hq hk]
+  simp [Phi]
+
+/-- Dropping the first `(slotList q k1 p).length + r` slots: the result is a
+flatMap with the slots at positions `< p` removed, `r` removed at position `p`,
+and all positions `> p` intact. -/
+theorem slotList_drop (q k1 p r : ℕ)
+    (hr : r ≤ (q - 1) - qdigit q k1 p) :
+    ∀ Lx, (slotList q k1 Lx).drop ((slotList q k1 p).length + r)
+      = (List.range Lx).flatMap (fun e =>
+          List.replicate (if e < p then 0 else if e = p then ((q - 1)-qdigit q k1 p) - r
+            else (q - 1)-qdigit q k1 e) (q ^ e)) := by
+  intro Lx
+  by_cases hLx : Lx ≤ p
+  · have hlen : (slotList q k1 Lx).length ≤ (slotList q k1 p).length :=
+      slotList_length_mono q k1 hLx
+    rw [List.drop_eq_nil_of_le (by omega)]
+    symm
+    rw [List.flatMap_eq_nil_iff]
+    intro e he; simp only [List.mem_range] at he
+    rw [if_pos (by omega)]; simp
+  · push Not at hLx
+    set g : ℕ → List ℕ := fun e =>
+      List.replicate (if e < p then 0 else if e = p then ((q - 1)-qdigit q k1 p) - r
+        else (q - 1)-qdigit q k1 e) (q ^ e) with hg
+    have hrange :
+        List.range Lx =
+          List.range (p + 1) ++ (List.range (Lx - (p + 1))).map ((p + 1) + ·) := by
+      conv_lhs => rw [show Lx = (p + 1) + (Lx - (p + 1)) by omega]
+      rw [List.range_add]
+    have htail : ((List.range (Lx-(p + 1))).map ((p + 1) + ·)).flatMap
+          (fun e => List.replicate ((q - 1)-qdigit q k1 e) (q ^ e))
+        = ((List.range (Lx-(p + 1))).map ((p + 1) + ·)).flatMap g := by
+      apply List.flatMap_congr
+      intro e he
+      simp only [List.mem_map, List.mem_range] at he
+      obtain ⟨a, _, rfl⟩ := he
+      rw [hg]; simp only
+      rw [if_neg (by omega), if_neg (by omega)]
+    have hLHS :
+        slotList q k1 Lx =
+          (slotList q k1 p ++ List.replicate ((q - 1)-qdigit q k1 p) (q ^ p))
+        ++ ((List.range (Lx-(p + 1))).map ((p + 1) + ·)).flatMap
+            (fun e => List.replicate ((q - 1)-qdigit q k1 e) (q ^ e)) := by
+      conv_lhs => unfold slotList
+      rw [hrange, List.flatMap_append]
+      congr 1
+      rw [← slotList_succ]; rfl
+    have hRHS : (List.range Lx).flatMap g
+        = List.replicate (((q - 1)-qdigit q k1 p) - r) (q ^ p)
+          ++ ((List.range (Lx-(p + 1))).map ((p + 1) + ·)).flatMap g := by
+      rw [hrange, List.flatMap_append]
+      congr 1
+      rw [List.range_succ, List.flatMap_append]
+      have hhead : (List.range p).flatMap g = [] := by
+        rw [List.flatMap_eq_nil_iff]
+        intro e he; simp only [List.mem_range] at he
+        rw [hg]; simp only; rw [if_pos he]; simp
+      rw [hhead, List.nil_append]
+      simp only [List.flatMap_cons, List.flatMap_nil, List.append_nil]
+      rw [hg]; simp
+    rw [hLHS, hRHS, htail]
+    rw [List.drop_append_of_le_length (by simp; omega)]
+    rw [List.drop_append]
+    rw [List.drop_eq_nil_of_le (by omega), List.nil_append]
+    rw [List.drop_replicate]
+    congr 2
+    omega
+
+-- Digit extraction from a base-`q` expansion with bounded coefficients.
+theorem digit_of_sum (q : ℕ) (hq : 2 ≤ q) (m : ℕ) (coeff : ℕ → ℕ)
+    (hc : ∀ e, e < m → coeff e < q) (f : ℕ) (hf : f < m) :
+    (∑ e ∈ Finset.range m, coeff e * q ^ e) / q ^ f % q = coeff f := by
+  have hqpos : 0 < q := by omega
+  have hsplit : ∑ e ∈ Finset.range m, coeff e * q ^ e
+      = (∑ e ∈ Finset.range f, coeff e * q ^ e) + coeff f * q ^ f
+        + (∑ e ∈ Finset.Ico (f + 1) m, coeff e * q ^ e) := by
+    have h1 : Finset.range m = Finset.range (f + 1) ∪ Finset.Ico (f + 1) m := by
+      ext e
+      simp
+      omega
+    rw [h1, Finset.sum_union (by
+      rw [Finset.range_eq_Ico]; apply Finset.Ico_disjoint_Ico_consecutive)]
+    rw [Finset.sum_range_succ]
+  rw [hsplit]
+  have hlow : ∑ e ∈ Finset.range f, coeff e * q ^ e < q ^ f := by
+    have hb : ∑ e ∈ Finset.range f, coeff e * q ^ e ≤ q ^ f - 1 := by
+      calc ∑ e ∈ Finset.range f, coeff e * q ^ e
+          ≤ ∑ e ∈ Finset.range f, (q - 1) * q ^ e := by
+            apply Finset.sum_le_sum; intro e he
+            apply Nat.mul_le_mul_right; have := hc e (by simp at he; omega); omega
+        _ = (q - 1) * ∑ e ∈ Finset.range f, q ^ e := by rw [Finset.mul_sum]
+        _ = q ^ f - 1 := geom_pred q f (by omega)
+    have : 1 ≤ q ^ f := Nat.one_le_pow _ _ hqpos
+    omega
+  have hhigh : q ^ (f + 1) ∣ ∑ e ∈ Finset.Ico (f + 1) m, coeff e * q ^ e := by
+    apply Finset.dvd_sum; intro e he; simp only [Finset.mem_Ico] at he
+    exact Dvd.dvd.mul_left (pow_dvd_pow q (by omega)) _
+  obtain ⟨t, ht⟩ := hhigh
+  rw [ht]
+  have hpf : 0 < q ^ f := Nat.pow_pos hqpos
+  rw [show (∑ e ∈ Finset.range f, coeff e * q ^ e) + coeff f * q ^ f + q ^ (f + 1)*t
+        = (∑ e ∈ Finset.range f, coeff e * q ^ e) + q ^ f * (coeff f + q*t) by rw [pow_succ]; ring]
+  rw [Nat.add_mul_div_left _ _ hpf, Nat.div_eq_of_lt hlow, Nat.zero_add]
+  rw [Nat.add_mul_mod_self_left]
+  exact Nat.mod_eq_of_lt (hc f hf)
+
+-- A bounded base-`q` expansion of length `m` is `< q ^ m`.
+theorem sum_lt_pow (q : ℕ) (hq : 2 ≤ q) (m : ℕ) (coeff : ℕ → ℕ)
+    (hc : ∀ e, e < m → coeff e < q) :
+    (∑ e ∈ Finset.range m, coeff e * q ^ e) < q ^ m := by
+  have hb : ∑ e ∈ Finset.range m, coeff e * q ^ e ≤ q ^ m - 1 := by
+    calc ∑ e ∈ Finset.range m, coeff e * q ^ e
+        ≤ ∑ e ∈ Finset.range m, (q - 1) * q ^ e := by
+          apply Finset.sum_le_sum; intro e he
+          apply Nat.mul_le_mul_right; have := hc e (by simp at he; omega); omega
+      _ = (q - 1) * ∑ e ∈ Finset.range m, q ^ e := by rw [Finset.mul_sum]
+      _ = q ^ m - 1 := geom_pred q m (by omega)
+  have : 1 ≤ q ^ m := Nat.one_le_pow _ _ (by omega)
+  omega
+
+-- A base-`q` digit is at most `q - 1`.
+theorem qdigit_le (q k1 e : ℕ) (hq : 2 ≤ q) : qdigit q k1 e ≤ q - 1 := by
+  rw [qdigit_eq _ _ _ hq]; have := Nat.mod_lt (k1 / q ^ e) (by omega : 0 < q); omega
+
+-- The digits of `β = (slotList q k1 p).sum + r·q ^ p`: slot multiplicities below
+-- `p`, the residual `r` at `p`, and `0` above `p`.
+theorem beta_digit (q k1 p r : ℕ) (hq : 2 ≤ q)
+    (hr : r ≤ (q - 1) - qdigit q k1 p) (f : ℕ) :
+    qdigit q ((slotList q k1 p).sum + r * q ^ p) f
+      = if f < p then (q - 1) - qdigit q k1 f else if f = p then r else 0 := by
+  set β := (slotList q k1 p).sum + r * q ^ p with hβ
+  set bcoeff : ℕ → ℕ := fun e => if e = p then r else (q - 1)-qdigit q k1 e with hbc
+  have hβsum : β = ∑ e ∈ Finset.range (p + 1), bcoeff e * q ^ e := by
+    rw [hβ, slotList_sum, Finset.sum_range_succ]
+    congr 1
+    · apply Finset.sum_congr rfl; intro e he; simp only [Finset.mem_range] at he
+      rw [hbc]; simp only; rw [if_neg (by omega)]
+    · rw [hbc]; simp
+  have hcbound : ∀ e, e < p+1 → bcoeff e < q := by
+    intro e he; rw [hbc]; simp only
+    by_cases h : e = p
+    · rw [if_pos h]; subst h; omega
+    · rw [if_neg h]; omega
+  rw [qdigit_eq _ _ _ hq, hβsum]
+  by_cases hf : f < p+1
+  · rw [digit_of_sum q hq (p + 1) bcoeff hcbound f hf]
+    rw [hbc]; simp only
+    by_cases h : f = p
+    · rw [if_pos h]; subst h; rw [if_neg (by omega), if_pos rfl]
+    · rw [if_neg h]; rw [if_pos (by omega)]
+  · have hlt : (∑ e ∈ Finset.range (p + 1), bcoeff e * q ^ e) < q ^ (p + 1) :=
+      sum_lt_pow q hq (p + 1) bcoeff hcbound
+    have : (∑ e ∈ Finset.range (p + 1), bcoeff e * q ^ e) / q ^ f = 0 := by
+      apply Nat.div_eq_of_lt
+      calc (∑ e ∈ Finset.range (p + 1), bcoeff e * q ^ e) < q ^ (p + 1) := hlt
+        _ ≤ q ^ f := Nat.pow_le_pow_right (by omega) (by omega)
+    rw [this, Nat.zero_mod]
+    rw [if_neg (by omega), if_neg (by omega)]
+
+-- The new slot multiplicity of `k1 + β` at each position: positions `< p` are
+-- spent (multiplicity `0`), position `p` loses `r`, positions `> p` are intact.
+theorem newmult_eq (q k1 p r : ℕ) (hq : 2 ≤ q)
+    (hr : r ≤ (q - 1) - qdigit q k1 p) (e : ℕ) :
+    (q - 1) - qdigit q (k1 + ((slotList q k1 p).sum + r * q ^ p)) e
+      = if e < p then 0
+        else if e = p then ((q - 1)-qdigit q k1 p) - r
+        else (q - 1)-qdigit q k1 e := by
+  set β := (slotList q k1 p).sum + r * q ^ p with hβ
+  have hcf : ∀ f, (k1 / q ^ f % q) + (β / q ^ f % q) ≤ q - 1 := by
+    intro f
+    rw [← qdigit_eq _ _ _ hq, ← qdigit_eq _ _ _ hq]
+    rw [beta_digit q k1 p r hq hr f]
+    have hk := qdigit_le q k1 f hq
+    by_cases h1 : f < p
+    · rw [if_pos h1]; omega
+    · rw [if_neg h1]
+      by_cases h2 : f = p
+      · rw [if_pos h2]; subst h2; omega
+      · rw [if_neg h2]; omega
+  have hadd : qdigit q (k1 + β) e = qdigit q k1 e + qdigit q β e := by
+    rw [qdigit_eq _ _ _ hq, qdigit_eq _ _ _ hq, qdigit_eq _ _ _ hq]
+    exact qdigit_add q k1 β e hq hcf
+  rw [hadd, beta_digit q k1 p r hq hr e]
+  have hk := qdigit_le q k1 e hq
+  by_cases h1 : e < p
+  · rw [if_pos h1, if_pos h1]; omega
+  · rw [if_neg h1, if_neg h1]
+    by_cases h2 : e = p
+    · rw [if_pos h2, if_pos h2]; subst h2; omega
+    · rw [if_neg h2, if_neg h2]; omega
+
+/-- (L2, slot subtraction) The slot list of `k1 + β₁`, where `β₁` is the sum of
+the `q-1` smallest slots of `k1`, equals the slot list of `k1` with its first
+block removed: `M(k1 + β₁) = M(k1) \ B₁`. Adding `β₁` is carry-free and "spends"
+exactly the digit positions occupied by the `q-1` smallest slots. -/
+theorem slot_subtraction (q k1 L₀ : ℕ) (hq : 2 ≤ q)
+    (hβ : (q - 1) ≤ (slotList q k1 L₀).length) :
+    ∀ Lx : ℕ, slotList q (k1 + blockSum q k1 L₀ 1) Lx
+      = (slotList q k1 Lx).drop (q - 1) := by
+  obtain ⟨p, hpL, r, htake, hlen, hr⟩ := slotList_take q k1 L₀ (q - 1) hβ
+  have hβval : blockSum q k1 L₀ 1 = (slotList q k1 p).sum + r * q ^ p := by
+    unfold blockSum
+    simp only [Nat.sub_self, Nat.zero_mul, List.drop_zero]
+    rw [htake, List.sum_append, List.sum_replicate]
+    simp
+  intro Lx
+  rw [hβval]
+  have hnew : slotList q (k1 + ((slotList q k1 p).sum + r * q ^ p)) Lx
+      = (List.range Lx).flatMap (fun e =>
+          List.replicate (if e < p then 0 else if e = p then ((q - 1)-qdigit q k1 p) - r
+            else (q - 1)-qdigit q k1 e) (q ^ e)) := by
+    rw [show slotList q (k1 + ((slotList q k1 p).sum + r * q ^ p)) Lx
+          = (List.range Lx).flatMap (fun e =>
+              List.replicate
+                ((q - 1)-qdigit q (k1 + ((slotList q k1 p).sum + r * q ^ p)) e)
+                (q ^ e)) from rfl]
+    apply List.flatMap_congr
+    intro e _
+    rw [newmult_eq q k1 p r hq hr e]
+  rw [hnew]
+  have hgoal : (slotList q k1 Lx).drop (q - 1)
+      = (slotList q k1 Lx).drop ((slotList q k1 p).length + r) := by rw [hlen]
+  rw [hgoal, slotList_drop q k1 p r hr Lx]
+
+/-- (L2)+(L3) Layer-cake identity linking `Φ_d(M)` at argument `k` to
+`Φ_{d-1}` at argument `s_1(k)` (whose slot set is `M \ B₁`):
+`d·k + Φ_d(M(k - 1)) = (d-1)·s_1(k) + Φ_{d-1}(M(s_1(k)-1)) + s_1(k)`.
+Combines (L1) `s_1(k)=k+β₁`, (L2) slot subtraction `M(s_1(k)-1)=M\B₁`, and
+(L3) `Φ_d(M)=d·β₁+Φ_{d-1}(M\B₁)`; pure block-reindexing algebra. -/
+theorem layer_cake (q d k : ℕ) (hq : 2 ≤ q) (hd : 1 < d) (hk : 0 < k) :
+    d * k + Phi q (k - 1) d (slotLen q d k)
+      = (d - 1) * s q 1 k + Phi q (s q 1 k - 1) (d - 1) (slotLen q (d - 1) (s q 1 k))
+        + s q 1 k := by
+  set k1 := k - 1 with hk1
+  set s1 := s q 1 k with hs1def
+  set L := slotLen q d k with hLdef
+  set L' := slotLen q (d - 1) s1 with hL'def
+  -- A common large truncation length dominating all three.
+  set Lbig := slotLen q d k + slotLen q (d - 1) s1 + slotLen q 1 k + s1 with hLbigdef
+  have hpos : 0 < q - 1 := by omega
+  have hk1k : k1 + 1 = k := by omega
+  -- length lower bounds at the relevant lengths
+  have hlenL : d * (q - 1) ≤ (slotList q k1 L).length := by
+    have hb := slotList_length_ge q k1 L hq
+    rw [hk1k] at hb
+    have hLval : L = k + d * (k + 1) + 1 := by simp [hLdef, slotLen]
+    have hdd : d ≤ d * (k + 1) := Nat.le_mul_of_pos_right d (by omega)
+    have hd1 : d ≤ L - k := by omega
+    calc d * (q - 1) = (q - 1) * d := by ring
+      _ ≤ (q - 1) * (L - k) := Nat.mul_le_mul_left _ hd1
+      _ ≤ (slotList q k1 L).length := hb
+  -- (L1) s1 = k + β, with β = blockSum at length L
+  have hβ_one : blockSum q k1 (slotLen q 1 k) 1 = blockSum q k1 L 1 := by
+    refine (blockSum_Lindep q k1 (slotLen q 1 k) L 1 ?_ ?_ ?_).symm
+    · rw [hLdef]; simp [slotLen]; nlinarith [hk]
+    · omega
+    · have hb := slotList_length_ge q k1 (slotLen q 1 k) hq
+      rw [hk1k] at hb
+      have hge : 1 ≤ slotLen q 1 k - k := by simp [slotLen]; omega
+      calc 1 * (q - 1) = (q - 1) := by ring
+        _ ≤ (q - 1) * (slotLen q 1 k - k) := by nlinarith [hpos]
+        _ ≤ (slotList q k1 (slotLen q 1 k)).length := hb
+  set β := blockSum q k1 L 1 with hβdef
+  have hL1 : s1 = k + β := by
+    rw [hs1def]; rw [s_one_eq q k hq hk, hβ_one]
+  have hsm1 : s1 - 1 = k1 + β := by rw [hL1]; omega
+  -- (L2) slot subtraction: the slot list of (k1+β) is M with its first block dropped.
+  have hL2 : ∀ Lx : ℕ, slotList q (s1 - 1) Lx = (slotList q k1 Lx).drop (q - 1) := by
+    rw [hsm1]
+    refine slot_subtraction q k1 L hq ?_
+    have hd1 : 1 ≤ d := by omega
+    calc q - 1 = 1 * (q - 1) := by ring
+      _ ≤ d * (q - 1) := Nat.mul_le_mul_right _ hd1
+      _ ≤ (slotList q k1 L).length := hlenL
+  -- block-shift: block (r+1) of M(s1-1) = block (r+2) of M(k1)
+  have hshift : ∀ r Lx : ℕ,
+      blockSum q (s1 - 1) Lx (r + 1) = blockSum q k1 Lx (r + 2) := by
+    intro r Lx
+    unfold blockSum
+    rw [hL2 Lx, List.drop_drop]
+    have hidx : q - 1 + (r + 1 - 1) * (q - 1) = (r + 2 - 1) * (q - 1) := by
+      have e1 : r + 1 - 1 = r := by omega
+      have e2 : r + 2 - 1 = r + 1 := by omega
+      rw [e1, e2]; ring
+    rw [hidx]
+  -- length bound for the s1-1 slot list at L'
+  have hlenL' : (d - 1) * (q - 1) ≤ (slotList q (s1 - 1) L').length := by
+    have hb := slotList_length_ge q (s1 - 1) L' hq
+    have hLk : (s1 - 1) + 1 = s1 := by omega
+    rw [hLk] at hb
+    have hL'val : L' = s1 + (d - 1) * (s1 + 1) + 1 := by simp [hL'def, slotLen]
+    have hge : (d - 1) ≤ L' - s1 := by
+      have hdd : (d - 1) ≤ (d - 1) * (s1 + 1) := Nat.le_mul_of_pos_right (d - 1) (by omega)
+      omega
+    calc (d - 1) * (q - 1) = (q - 1) * (d - 1) := by ring
+      _ ≤ (q - 1) * (L' - s1) := Nat.mul_le_mul_left _ hge
+      _ ≤ (slotList q (s1 - 1) L').length := hb
+  have hLLbig : L ≤ Lbig := by rw [hLbigdef, hLdef]; omega
+  have hL'Lbig : L' ≤ Lbig := by rw [hLbigdef, hL'def]; omega
+  -- Phi on the RHS rewritten via block-shift, then L-reconciled to use M(k1) at L
+  have hRHSphi : Phi q (s1 - 1) (d - 1) L'
+      = ∑ r ∈ Finset.range (d - 1), (d - 1 - r) * blockSum q k1 L (r + 2) := by
+    unfold Phi
+    apply Finset.sum_congr rfl
+    intro r hr; simp only [Finset.mem_range] at hr
+    congr 1
+    -- blockSum q (s1-1) L' (r+1) = blockSum q k1 L (r+2)
+    have step1 : blockSum q (s1 - 1) L' (r + 1) = blockSum q (s1 - 1) Lbig (r + 1) := by
+      rw [blockSum_Lindep q (s1 - 1) L' Lbig (r + 1) hL'Lbig (by omega)]
+      calc (r + 1) * (q - 1) ≤ (d - 1) * (q - 1) := by
+            apply Nat.mul_le_mul_right; omega
+        _ ≤ (slotList q (s1 - 1) L').length := hlenL'
+    have step2 : blockSum q (s1 - 1) Lbig (r + 1) = blockSum q k1 Lbig (r + 2) :=
+      hshift r Lbig
+    have step3 : blockSum q k1 Lbig (r + 2) = blockSum q k1 L (r + 2) := by
+      rw [blockSum_Lindep q k1 L Lbig (r + 2) hLLbig (by omega)]
+      calc (r + 2) * (q - 1) ≤ d * (q - 1) := by
+            apply Nat.mul_le_mul_right; omega
+        _ ≤ (slotList q k1 L).length := hlenL
+    rw [step1, step2, step3]
+  -- (L3) split the LHS Phi
+  have hL3 : Phi q k1 d L = d * β
+      + ∑ r ∈ Finset.range (d - 1), (d - 1 - r) * blockSum q k1 L (r + 2) :=
+    Phi_split q k1 d L (by omega)
+  -- assemble
+  rw [hsm1] at hRHSphi ⊢
+  rw [hRHSphi, hL3]
+  -- goal: d*k + (d*β + S) = (d-1)*s1 + S + s1, with s1 = k+β
+  have hkey : d * k + d * β = (d - 1) * s1 + s1 := by
+    have hd1 : d - 1 + 1 = d := by omega
+    calc d * k + d * β = d * (k + β) := by ring
+      _ = d * s1 := by rw [hL1]
+      _ = (d - 1 + 1) * s1 := by rw [hd1]
+      _ = (d - 1) * s1 + s1 := by ring
+  omega
+
+
+/-- Hard direction of the composition identity:
+`s_{d-1}(s_1(k)) + s_1(k) ≤ s_d(k)`. Assembled from the slot formula on `s_d`
+and `s_{d-1}` plus the `layer_cake` reindexing. -/
+theorem comp_id_ge (q : ℕ) (hq : q.Prime) (d k : ℕ) (hd : 1 < d) (hk : 0 < k) :
+    s q (d - 1) (s q 1 k) + s q 1 k ≤ s q d k := by
+  have hq2 : 2 ≤ q := hq.two_le
+  have hs1pos : 0 < s q 1 k := by
+    -- s q 1 k = k + (something), and k > 0
+    have := s_one_eq q k hq2 hk; omega
+  -- slot formula on s_d(k) and on s_{d-1}(s_1(k))
+  have hsd : s q d k = d * k + Phi q (k - 1) d (slotLen q d k) := slot_formula q d k hq2 hk
+  have hsd1 : s q (d - 1) (s q 1 k)
+      = (d - 1) * s q 1 k + Phi q (s q 1 k - 1) (d - 1) (slotLen q (d - 1) (s q 1 k)) :=
+    slot_formula q (d - 1) (s q 1 k) hq2 hs1pos
+  -- assemble via layer-cake
+  rw [hsd, hsd1, layer_cake q d k hq2 hd hk]
+
+/-- Pillar 1, the composition identity: `s_{d-1}(s_1(k)) + s_1(k) = s_d(k)`,
+i.e. `F(0) = s_d(k)`. Antisymmetry of `comp_id_le` and `comp_id_ge`. -/
+theorem composition_identity (q : ℕ) (hq : q.Prime) (d k : ℕ) (hd : 1 < d)
+    (hk : 0 < k) :
+    s q (d - 1) (s q 1 k) + s q 1 k = s q d k := by
+  exact Nat.le_antisymm (comp_id_ge q hq d k hd hk) (comp_id_le q hq d k hd hk)
+
+/-
+Pillar 2 (extraction inequality): put `s1 = k + β` (`s_one_eq`) and `u = β + j`,
+so `s1 + j = k + u` and `(q - 1) ∣ u`. Admissibility `j ∈ J` forces `u` to add to
+`k-1` carry-free (converse Kummer, `dvd_choose_of_carry`). Applying
+`slot_formula` to `s_d(k)` and `s_{d-1}(k+u)`, the goal `s_d(k) < F(j)` reduces
+to the core inequality `Φ_d(M) < d·u + Φ_{d-1}(M\U)` (`extraction_core`),
+strict because `u > β` when `j > 0`.
+-/
+
+-- Helper lemmas for `extraction_core` (the layer-cake / removal-bound argument).
+
+/-- Length of a list of powers `q ^ e` (`e < L`) is the sum of its value-counts. -/
+theorem wlen_eq (q L : ℕ) (hq : 2 ≤ q) (w : List ℕ)
+    (hpow : ∀ x ∈ w, ∃ e, e < L ∧ x = q ^ e) :
+    w.length = ∑ e ∈ Finset.range L, (w.count (q ^ e)) := by
+  induction w with
+  | nil => simp
+  | cons a t ih =>
+    have hpowt : ∀ x ∈ t, ∃ e, e < L ∧ x = q ^ e := fun x hx => hpow x (by simp [hx])
+    obtain ⟨ea, heaL, haeq⟩ := hpow a (by simp)
+    rw [List.length_cons, ih hpowt]
+    have hcount : ∀ e, (a :: t).count (q ^ e) = (if e = ea then 1 else 0) + t.count (q ^ e) := by
+      intro e
+      rw [List.count_cons]
+      have heq : (if a = q ^ e then 1 else 0) = (if e = ea then 1 else 0) := by
+        by_cases h : e = ea
+        · subst h; rw [haeq]; simp
+        · rw [if_neg h, if_neg]
+          rw [haeq]; intro hcontra
+          exact h (Nat.pow_right_injective hq hcontra.symm)
+      have hbeq : (if (a == q ^ e) = true then 1 else 0) = (if a = q ^ e then 1 else 0) := by
+        simp [beq_iff_eq]
+      omega
+    have hrw : ∑ e ∈ Finset.range L, (a :: t).count (q ^ e)
+        = (∑ e ∈ Finset.range L, (if e = ea then 1 else 0))
+          + ∑ e ∈ Finset.range L, t.count (q ^ e) := by
+      rw [← Finset.sum_add_distrib]
+      apply Finset.sum_congr rfl
+      intro e _; rw [hcount e]
+    have hfirst : ∑ e ∈ Finset.range L, (if e = ea then 1 else 0) = 1 := by
+      rw [Finset.sum_eq_single ea]
+      · simp
+      · intro b _ hb; rw [if_neg hb]
+      · intro hcontra; exact absurd (Finset.mem_range.mpr heaL) hcontra
+    rw [hrw, hfirst]; omega
+
+/-- Carry-free digit additivity for two numbers. -/
+theorem qdigit_add2 (q k1 u e : ℕ) (hq : 2 ≤ q)
+    (hcf : ∀ f, qdigit q k1 f + qdigit q u f ≤ q - 1) :
+    qdigit q (k1 + u) e = qdigit q k1 e + qdigit q u e := by
+  rw [qdigit_eq _ _ _ hq, qdigit_eq _ _ _ hq, qdigit_eq _ _ _ hq]
+  apply qdigit_add q k1 u e hq
+  intro f; have := hcf f
+  rw [qdigit_eq _ _ _ hq, qdigit_eq _ _ _ hq] at this; exact this
+
+/-- Slot multiplicity of `k1+u` (carry-free): smaller than `k1`'s by `qdigit u e`. -/
+theorem newmult_gen (q k1 u e : ℕ) (hq : 2 ≤ q)
+    (hcf : ∀ f, qdigit q k1 f + qdigit q u f ≤ q - 1) :
+    (q - 1) - qdigit q (k1 + u) e + qdigit q u e = (q - 1) - qdigit q k1 e := by
+  rw [qdigit_add2 q k1 u e hq hcf]
+  have hk := qdigit_le q k1 e hq
+  have := hcf e
+  omega
+
+/-- Digit sum of `u` over `range L` (with `u < q ^ L`) is the multiset size `m`. -/
+theorem digitsum_eq (q u L : ℕ) (hq : 2 ≤ q) (huL : u < q ^ L) :
+    u = ∑ e ∈ Finset.range L, qdigit q u e * q ^ e := by
+  have h1 : u % q ^ L = ∑ e ∈ Finset.range L, (u / q ^ e % q) * q ^ e := digit_mod q u L
+  rw [Nat.mod_eq_of_lt huL] at h1
+  rw [show (∑ e ∈ Finset.range L, qdigit q u e * q ^ e)
+        = ∑ e ∈ Finset.range L, (u / q ^ e % q) * q ^ e from
+      Finset.sum_congr rfl (fun e _ => by rw [qdigit_eq _ _ _ hq])]
+  exact h1
+
+/-- Removal bound: with `u` adding to `k1` carry-free (so `M' = slotList q (k1+u)`
+is `M = slotList q k1` with a size-`m` submultiset `U` of total value `u` removed),
+the value of the smallest `t+m` slots of `M` is at most the value of the smallest
+`t` slots of `M'` plus `u`. -/
+theorem removal_bound (q k1 u Lbig : ℕ) (hq : 2 ≤ q)
+    (hcf : ∀ f, qdigit q k1 f + qdigit q u f ≤ q - 1)
+    (huL : u < q ^ Lbig)
+    (m : ℕ) (hm : m = ∑ e ∈ Finset.range Lbig, qdigit q u e)
+    (t : ℕ) (ht : t ≤ (slotList q (k1 + u) Lbig).length) :
+    ((slotList q k1 Lbig).take (t + m)).sum
+      ≤ ((slotList q (k1 + u) Lbig).take t).sum + u := by
+  -- length of M ≥ t + m so the take is a genuine count
+  have hMlen : t + m ≤ (slotList q k1 Lbig).length := by
+    rw [slotList_length q k1 Lbig, hm]
+    have hpt : (slotList q (k1 + u) Lbig).length =
+        ∑ e ∈ Finset.range Lbig, ((q - 1) - qdigit q (k1 + u) e) :=
+      slotList_length q (k1 + u) Lbig
+    rw [hpt] at ht
+    have hkey : ∀ e ∈ Finset.range Lbig,
+        ((q - 1) - qdigit q (k1+u) e) + qdigit q u e = (q - 1) - qdigit q k1 e := by
+      intro e _; exact newmult_gen q k1 u e hq hcf
+    calc t + ∑ e ∈ Finset.range Lbig, qdigit q u e
+        ≤ (∑ e ∈ Finset.range Lbig, ((q - 1) - qdigit q (k1+u) e))
+            + ∑ e ∈ Finset.range Lbig, qdigit q u e := by
+          apply Nat.add_le_add_right ht
+      _ = ∑ e ∈ Finset.range Lbig, (((q - 1) - qdigit q (k1+u) e) + qdigit q u e) := by
+          rw [Finset.sum_add_distrib]
+      _ = ∑ e ∈ Finset.range Lbig, ((q - 1) - qdigit q k1 e) := by
+          exact Finset.sum_congr rfl hkey
+  -- prefix structure of the smallest t+m slots of M
+  obtain ⟨p, hpL, r, htake, hlen, hr⟩ := slotList_take q k1 Lbig (t + m) hMlen
+  have hval : ((slotList q k1 Lbig).take (t + m)).sum
+      = (∑ e ∈ Finset.range p, ((q - 1) - qdigit q k1 e) * q ^ e) + r * q ^ p := by
+    rw [htake, List.sum_append, List.sum_replicate, slotList_sum]
+    simp [Nat.mul_comm]
+  rw [hval]
+  -- T' := the t smallest slots of M'
+  set Tp := (slotList q (k1 + u) Lbig).take t with hTp
+  -- candidate selection b e := count of T' at q ^ e plus qdigit u e
+  set bcoef : ℕ → ℕ := fun e => Tp.count (q ^ e) + qdigit q u e with hbcoef
+  -- value of candidate = Tp.sum + u
+  have hTppow : ∀ x ∈ Tp, ∃ e, e < Lbig ∧ x = q ^ e := by
+    intro x hx
+    exact slotList_pow q (k1+u) Lbig x (List.mem_of_mem_take hx)
+  have hcandval : ∑ e ∈ Finset.range Lbig, bcoef e * q ^ e = Tp.sum + u := by
+    have h1 : ∑ e ∈ Finset.range Lbig, Tp.count (q ^ e) * q ^ e = Tp.sum :=
+      (wsum_eq q Lbig hq Tp hTppow).symm
+    have h2 : ∑ e ∈ Finset.range Lbig, qdigit q u e * q ^ e = u :=
+      (digitsum_eq q u Lbig hq huL).symm
+    rw [hbcoef]
+    simp only []
+    rw [show (∑ e ∈ Finset.range Lbig, (Tp.count (q ^ e) + qdigit q u e) * q ^ e)
+          = (∑ e ∈ Finset.range Lbig, Tp.count (q ^ e) * q ^ e)
+            + ∑ e ∈ Finset.range Lbig, qdigit q u e * q ^ e from by
+        rw [← Finset.sum_add_distrib]; apply Finset.sum_congr rfl; intro e _; ring]
+    rw [h1, h2]
+  -- count of candidate = t + m
+  have hTplen : Tp.length = t := by
+    rw [hTp, List.length_take]; omega
+  have hcandcount : ∑ e ∈ Finset.range Lbig, bcoef e = t + m := by
+    rw [hbcoef]; simp only []
+    rw [Finset.sum_add_distrib]
+    rw [← wlen_eq q Lbig hq Tp hTppow, hTplen, ← hm]
+  -- b e ≤ s e := (q - 1) - qdigit q k1 e
+  have hbs : ∀ e, e < Lbig → bcoef e ≤ (q - 1) - qdigit q k1 e := by
+    intro e _
+    rw [hbcoef]; simp only []
+    have hc1 : Tp.count (q ^ e) ≤ (slotList q (k1+u) Lbig).count (q ^ e) :=
+      (List.take_sublist t _).count_le _
+    have hc2 : (slotList q (k1+u) Lbig).count (q ^ e) = (q - 1) - qdigit q (k1+u) e := by
+      by_cases he : e < Lbig
+      · exact slotList_count q (k1+u) Lbig hq e he
+      · rw [List.count_eq_zero.mpr]
+        · have hkk := qdigit_le q (k1+u) e hq; omega
+        · intro hmem
+          obtain ⟨e', he'L, hxe⟩ := slotList_pow q (k1+u) Lbig _ hmem
+          exact absurd (Nat.pow_right_injective hq hxe) (by omega)
+    have hmg := newmult_gen q k1 u e hq hcf
+    omega
+  -- count condition: ∑_{e<p} s_e + r = t + m = ∑_{e<Lbig} b_e
+  have hcountcond : (∑ e ∈ Finset.range p, ((q - 1) - qdigit q k1 e)) + r
+      ≤ ∑ e ∈ Finset.range Lbig, bcoef e := by
+    have hps : ∑ e ∈ Finset.range p, ((q - 1) - qdigit q k1 e) = (slotList q k1 p).length :=
+      (slotList_length q k1 p).symm
+    rw [hps, hcandcount]; omega
+  -- apply greedy_core
+  have hgc := greedy_core q p Lbig hq hpL bcoef (fun e => (q - 1) - qdigit q k1 e) r hbs
+    hcountcond
+  rw [hcandval] at hgc
+  simpa using hgc
+
+/-- Converse Kummer/Lucas: if `k`+`(n - k)` has a carry in base `q` at some
+position (`q ^ i ≤ k%q ^ i + (n - k)%q ^ i`), then `q ∣ C(n,k)`. Proved via
+`Nat.factorization_choose`. -/
+theorem dvd_choose_of_carry (q n k : ℕ) (hq : q.Prime) (hkn : k ≤ n)
+    (hcarry : ∃ i, q ^ i ≤ k % q ^ i + (n - k) % q ^ i) :
+    q ∣ Nat.choose n k := by
+  obtain ⟨i, hi⟩ := hcarry
+  set b := Nat.log q n + 1 with hb
+  have hlogb : Nat.log q n < b := by omega
+  have hpos : 0 < Nat.choose n k := Nat.choose_pos hkn
+  rw [Nat.Prime.dvd_iff_one_le_factorization hq hpos.ne']
+  rw [Nat.factorization_choose hq hkn hlogb]
+  rw [Nat.one_le_iff_ne_zero, Ne, Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+  intro hcon
+  have hi1 : 1 ≤ i := by
+    by_contra h
+    have hi0 : i = 0 := by omega
+    subst hi0
+    simp only [pow_zero, Nat.mod_one] at hi
+    omega
+  have hib : i < b := by
+    by_contra h
+    have hlt : Nat.log q n < i := by omega
+    have hnq : n < q ^ i := Nat.lt_pow_of_log_lt hq.two_le hlt
+    have hk : k % q ^ i = k := Nat.mod_eq_of_lt (by omega)
+    have hnk : (n - k) % q ^ i = n - k := Nat.mod_eq_of_lt (by omega)
+    rw [hk, hnk] at hi
+    omega
+  have hmem : i ∈ Finset.Ico 1 b := Finset.mem_Ico.mpr ⟨hi1, hib⟩
+  exact hcon hmem hi
+
+/-- Carry-free correspondence from admissibility. For `j ∈ Jset q k` set
+`β = blockSum q (k - 1) (slotLen q 1 k) 1` and `u = β + j`. Then `u` adds to `k-1`
+carry-free in base `q`, i.e. per position the digit sum is `≤ q-1`. Uses
+`s_one_eq` (so `s q 1 k - 1 = (k - 1) + β`, hence `s q 1 k + j - 1 = (k - 1) + u`),
+the admissibility `¬ q ∣ C((k - 1)+u, k-1)`, and `dvd_choose_of_carry`. -/
+theorem admissible_carryfree (q : ℕ) (hq : q.Prime) (k : ℕ) (hk : 0 < k)
+    (j : ℕ) (hj : j ∈ Jset q k) :
+    ∀ e, qdigit q (k - 1) e
+        + qdigit q (blockSum q (k - 1) (slotLen q 1 k) 1 + j) e ≤ q - 1 := by
+  have hq2 : 2 ≤ q := hq.two_le
+  obtain ⟨hjdvd, hjnd⟩ := hj
+  set β := blockSum q (k - 1) (slotLen q 1 k) 1 with hβ
+  set k1 := k - 1 with hk1
+  set u := β + j with hu
+  -- Step 2: s q 1 k + j - 1 = k1 + u
+  have hseq : s q 1 k + j - 1 = k1 + u := by
+    rw [s_one_eq q k hq2 hk, ← hβ, hu, hk1]; omega
+  rw [hseq] at hjnd
+  -- Step 3: no carry at any position
+  have hnocarry : ∀ i, k1 % q ^ i + u % q ^ i < q ^ i := by
+    intro i
+    by_contra hc
+    push Not at hc
+    apply hjnd
+    apply dvd_choose_of_carry q (k1 + u) k1 hq (by omega)
+    exact ⟨i, by rw [Nat.add_sub_cancel_left]; exact hc⟩
+  -- Step 4 & 5: bridge to digit-sum bound
+  intro e
+  rw [qdigit_eq _ _ _ hq2, qdigit_eq _ _ _ hq2]
+  -- mod-pow-succ identities
+  have hke : k1 % q ^ (e + 1) = k1 % q ^ e + q ^ e * (k1 / q ^ e % q) := Nat.mod_pow_succ
+  have hue : u % q ^ (e + 1) = u % q ^ e + q ^ e * (u / q ^ e % q) := Nat.mod_pow_succ
+  have hpe : q ^ (e + 1) = q ^ e * q := pow_succ q e
+  have h1 := hnocarry (e + 1)
+  have h0 := hnocarry e
+  have hpos : 0 < q ^ e := pow_pos (by omega : 0 < q) e
+  set da := k1 / q ^ e % q with hda
+  set db := u / q ^ e % q with hdb
+  -- da + db ≤ q - 1
+  by_contra hcon
+  push Not at hcon
+  -- hcon : q - 1 < da + db, so da + db ≥ q
+  have hge : q ≤ da + db := by omega
+  -- (da + db) * q ^ e ≤ k1 % q ^ (e + 1) + u % q ^ (e + 1)
+  have hbound : (da + db) * q ^ e ≤ k1 % q ^ (e + 1) + u % q ^ (e + 1) := by
+    rw [hke, hue]; nlinarith [Nat.zero_le (k1 % q ^ e), Nat.zero_le (u % q ^ e)]
+  have hmul : q * q ^ e ≤ (da + db) * q ^ e := Nat.mul_le_mul_right _ hge
+  have h1' : k1 % q ^ (e + 1) + u % q ^ (e + 1) < q ^ e * q := by rw [← hpe]; exact h1
+  nlinarith [hbound, hmul, h1']
+
+/-- Prefix-sum monotonicity: taking more (nonneg ℕ) elements never decreases the sum. -/
+theorem take_sum_mono (w : List ℕ) {a b : ℕ} (h : a ≤ b) :
+    (w.take a).sum ≤ (w.take b).sum := by
+  have hsplit : w.take b = w.take a ++ (w.take b).drop a := by
+    conv_lhs => rw [← List.take_append_drop a (w.take b)]
+    rw [List.take_take, Nat.min_eq_left h]
+  calc (w.take a).sum ≤ (w.take a).sum + ((w.take b).drop a).sum := Nat.le_add_right _ _
+    _ = (w.take b).sum := by
+        conv_rhs => rw [hsplit]
+        rw [List.sum_append]
+
+/-- `Phi` is independent of the truncation length once it contains the first `d` blocks. -/
+theorem Phi_Lindep (q k1 d L₁ Lbig : ℕ) (h : L₁ ≤ Lbig)
+    (hlen : d * (q - 1) ≤ (slotList q k1 L₁).length) :
+    Phi q k1 d Lbig = Phi q k1 d L₁ := by
+  unfold Phi
+  apply Finset.sum_congr rfl
+  intro r hr; simp only [Finset.mem_range] at hr
+  congr 1
+  apply blockSum_Lindep q k1 L₁ Lbig (r + 1) h (by omega)
+  calc (r + 1) * (q - 1) ≤ d * (q - 1) := Nat.mul_le_mul_right _ (by omega)
+    _ ≤ (slotList q k1 L₁).length := hlen
+
+/-- The core extraction inequality. Let `u` add to `k1 = k-1` carry-free with
+`(q - 1) ∣ u` and `u > β₁` where `β₁ = blockSum q k1 L₀ 1`. Then for truncations
+`L₁`, `L₂` large enough to contain the relevant blocks,
+`Φ_d(M) < d·u + Φ_{d-1}(M\U)`, i.e. `Phi q k1 d L₁ < d*u + Phi q (k1+u) (d-1) L₂`.
+Proof idea: expand both `Phi`s into prefix sums, bound each prefix sum of `M\U`
+below via `removal_bound`, and use `u > β₁` for strictness. -/
+theorem extraction_core (q : ℕ) (hq : 2 ≤ q) (k1 : ℕ) (d : ℕ) (hd : 1 < d)
+    (u : ℕ) (hudvd : (q - 1) ∣ u)
+    (hcf : ∀ e, qdigit q k1 e + qdigit q u e ≤ q - 1)
+    (L₀ L₁ L₂ : ℕ)
+    (hL₀ : (q - 1) ≤ (slotList q k1 L₀).length)
+    (hugt : blockSum q k1 L₀ 1 < u)
+    (hL₁ : d * (q - 1) ≤ (slotList q k1 L₁).length)
+    (hL₂ : (d - 1) * (q - 1) ≤ (slotList q (k1 + u) L₂).length) :
+    Phi q k1 d L₁ < d * u + Phi q (k1 + u) (d - 1) L₂ := by
+  set n := q - 1 with hn
+  -- A common large truncation length dominating everything.
+  set Lbig := L₀ + L₁ + L₂ + u + 1 with hLbig
+  have hL₀big : L₀ ≤ Lbig := by omega
+  have hL₁big : L₁ ≤ Lbig := by omega
+  have hL₂big : L₂ ≤ Lbig := by omega
+  have huLbig : u < q ^ Lbig := by
+    calc u < q ^ u := Nat.lt_pow_self (by omega)
+      _ ≤ q ^ Lbig := Nat.pow_le_pow_right (by omega) (by omega)
+  -- the removed multiset size m = digit sum of u
+  set m := ∑ e ∈ Finset.range Lbig, qdigit q u e with hmdef
+  -- m is a positive multiple of n, write m = ℓ * n
+  have hupos : 0 < u := by omega
+  have hmpos : 0 < m := by
+    rw [hmdef]
+    by_contra hc
+    push Not at hc
+    have hz : ∑ e ∈ Finset.range Lbig, qdigit q u e = 0 := by omega
+    have hu0 : u = 0 := by
+      rw [digitsum_eq q u Lbig hq huLbig]
+      apply Finset.sum_eq_zero
+      intro e he
+      have : qdigit q u e = 0 := Finset.sum_eq_zero_iff.mp hz e he
+      rw [this]; ring
+    omega
+  have hmdvd : n ∣ m := by
+    have hmod : u ≡ m [MOD n] := by
+      rw [hmdef]; conv_lhs => rw [digitsum_eq q u Lbig hq huLbig]
+      exact sum_pow_modEq q Lbig hq (fun e => qdigit q u e)
+    have : n ∣ u := hudvd
+    exact (Nat.modEq_zero_iff_dvd).mp (hmod.symm.trans ((Nat.modEq_zero_iff_dvd).mpr this))
+  obtain ⟨ℓ, hℓ⟩ := hmdvd
+  have hnpos : 0 < n := by omega
+  have hℓpos : 1 ≤ ℓ := by
+    rcases Nat.eq_zero_or_pos ℓ with h | h
+    · rw [h, Nat.mul_zero] at hℓ; omega
+    · exact h
+  -- length lower bound for M' at Lbig
+  have hM'len : (d - 1) * n ≤ (slotList q (k1 + u) Lbig).length :=
+    le_trans hL₂ (slotList_length_mono q (k1+u) hL₂big)
+  -- abbreviations for the prefix sums P j := σ_{j n}(M at Lbig)
+  set P : ℕ → ℕ := fun j => ((slotList q k1 Lbig).take (j * n)).sum with hP
+  set Q : ℕ → ℕ := fun j => ((slotList q (k1 + u) Lbig).take (j * n)).sum with hQ
+  -- Φ_d(M) = ∑_{c<d} P (c + 1)
+  have hPhiM : Phi q k1 d L₁ = ∑ c ∈ Finset.range d, P (c + 1) := by
+    rw [← Phi_Lindep q k1 d L₁ Lbig hL₁big hL₁, Phi_eq_take_sum]
+  -- Φ_{d-1}(M') = ∑_{c<d-1} Q (c + 1)
+  have hPhiM' : Phi q (k1 + u) (d - 1) L₂ = ∑ c ∈ Finset.range (d-1), Q (c + 1) := by
+    rw [← Phi_Lindep q (k1+u) (d-1) L₂ Lbig hL₂big hL₂, Phi_eq_take_sum]
+  -- removal bound per layer: P (c+1+ℓ) ≤ Q (c + 1) + u   for c < d-1
+  have hA1 : ∀ c, c < d - 1 → P (c + 1 + ℓ) ≤ Q (c + 1) + u := by
+    intro c hc
+    have htlen : (c + 1) * n ≤ (slotList q (k1 + u) Lbig).length := by
+      calc (c + 1) * n ≤ (d - 1) * n := Nat.mul_le_mul_right _ (by omega)
+        _ ≤ (slotList q (k1 + u) Lbig).length := hM'len
+    have hrb := removal_bound q k1 u Lbig hq hcf huLbig m hmdef ((c + 1)*n) htlen
+    have hidx : (c + 1) * n + m = (c + 1 + ℓ) * n := by
+      rw [hℓ]; ring
+    rw [hidx] at hrb
+    exact hrb
+  -- monotonicity: P (c+2) ≤ P (c+1+ℓ)  since c+2 ≤ c+1+ℓ (ℓ ≥ 1)
+  have hmono : ∀ c, P (c + 2) ≤ P (c + 1 + ℓ) := by
+    intro c
+    apply take_sum_mono
+    apply Nat.mul_le_mul_right
+    omega
+  -- P 1 = β₁ < u
+  have hP1 : P 1 < u := by
+    have hb1 : P 1 = blockSum q k1 Lbig 1 := by
+      rw [hP]; simp only [Nat.one_mul]
+      unfold blockSum
+      simp only [Nat.sub_self, Nat.zero_mul, List.drop_zero, hn]
+    have hbeq : blockSum q k1 Lbig 1 = blockSum q k1 L₀ 1 := by
+      apply blockSum_Lindep q k1 L₀ Lbig 1 (by omega) (by omega)
+      rw [Nat.one_mul]; exact hL₀
+    rw [hb1, hbeq]; exact hugt
+  -- Step (I): ∑_{c<d-1} P(c+1+ℓ) ≤ Φ'(L₂) + (d-1)*u
+  have hStepI : ∑ c ∈ Finset.range (d-1), P (c + 1 + ℓ)
+      ≤ Phi q (k1 + u) (d - 1) L₂ + (d - 1) * u := by
+    rw [hPhiM']
+    calc ∑ c ∈ Finset.range (d-1), P (c + 1 + ℓ)
+        ≤ ∑ c ∈ Finset.range (d - 1), (Q (c + 1) + u) :=
+          Finset.sum_le_sum (fun c hc => hA1 c (Finset.mem_range.mp hc))
+      _ = (∑ c ∈ Finset.range (d-1), Q (c + 1)) + (d - 1) * u := by
+          rw [Finset.sum_add_distrib, Finset.sum_const, Finset.card_range, smul_eq_mul]
+  -- Step (II): ∑_{c<d} P(c + 1) ≤ ∑_{c<d-1} P(c+1+ℓ) + P 1
+  have hStepII :
+      ∑ c ∈ Finset.range d, P (c + 1) ≤
+        (∑ c ∈ Finset.range (d - 1), P (c + 1 + ℓ)) + P 1 := by
+    -- ∑_{c<d} P(c + 1) = P 1 + ∑_{c<d-1} P(c+2)
+    have hsplitL : ∑ c ∈ Finset.range d, P (c + 1)
+        = P 1 + ∑ c ∈ Finset.range (d-1), P (c + 2) := by
+      obtain ⟨e, rfl⟩ : ∃ e, d = e + 1 := ⟨d - 1, by omega⟩
+      rw [Finset.sum_range_succ']
+      simp only [Nat.add_sub_cancel, Nat.zero_add]
+      rw [Nat.add_comm]
+    rw [hsplitL]
+    have hmonosum :
+        ∑ c ∈ Finset.range (d - 1), P (c + 2) ≤
+          ∑ c ∈ Finset.range (d - 1), P (c + 1 + ℓ) :=
+      Finset.sum_le_sum (fun c _ => hmono c)
+    omega
+  -- Assemble
+  rw [hPhiM]
+  -- d*u + Φ' ≥ u + (∑_{c<d-1} P(c+1+ℓ))  > ∑_{c<d} P(c + 1)
+  have hda : d * u = u + (d - 1) * u := by
+    conv_lhs => rw [show d = (d - 1) + 1 by omega]
+    ring
+  -- combine StepI: Φ' + (d-1)*u ≥ ∑ P(c+1+ℓ)
+  have hkey1 : (∑ c ∈ Finset.range (d - 1), P (c + 1 + ℓ))
+      ≤ Phi q (k1 + u) (d - 1) L₂ + (d - 1) * u := hStepI
+  -- and StepII + hP1
+  have hkey2 : ∑ c ∈ Finset.range d, P (c + 1) < (∑ c ∈ Finset.range (d-1), P (c + 1 + ℓ)) + u := by
+    have := hStepII; omega
+  omega
+
+/-- Pillar 2, the extraction inequality in strict form: for admissible `j > 0`,
+`s_d(k) < F(j)` (informal.tex Lem. lem:H2-extraction). With `u = β₁ + j`,
+admissibility makes `u` carry-free with `k-1`; the slot formula reduces the goal
+to `extraction_core`, strict since `j > 0` gives `u > β₁`. -/
+theorem extraction_strict (q : ℕ) (hq : q.Prime) (d k : ℕ) (hd : 1 < d)
+    (hk : 0 < k) (j : ℕ) (hj : j ∈ Jset q k) (hjpos : 0 < j) :
+    s q d k < F q d k j := by
+  have hq2 : 2 ≤ q := hq.two_le
+  -- abbreviations
+  set s1 := s q 1 k with hs1def
+  set β := blockSum q (k - 1) (slotLen q 1 k) 1 with hβdef
+  -- s_one_eq:  s1 = k + β
+  have hs1eq : s1 = k + β := by rw [hs1def, hβdef]; exact s_one_eq q k hq2 hk
+  have hs1pos : 0 < s1 := by omega
+  set u := β + j with hudef
+  -- n_val = s1 + j = k + u
+  have hnval : s1 + j = k + u := by rw [hs1eq, hudef]; ring
+  have hnvalpos : 0 < s1 + j := by omega
+  -- (q - 1) ∣ u :  (q - 1)∣β  (β is a block sum, divisible) and (q - 1)∣j (admissibility)
+  have hjdvd : (q - 1) ∣ j := hj.1
+  have hβdvd : (q - 1) ∣ β := by
+    have hlen0 : (q - 1) ≤ (slotList q (k - 1) (slotLen q 1 k)).length := by
+      have hb := slotList_length_ge q (k - 1) (slotLen q 1 k) hq2
+      have hsl : slotLen q 1 k - ((k - 1) + 1) = k + 2 := by
+        simp [slotLen]; omega
+      rw [hsl] at hb
+      have : (q - 1) * 1 ≤ (q - 1) * (k + 2) := by
+        apply Nat.mul_le_mul_left; omega
+      omega
+    rw [hβdef, blockSum]
+    set w := ((slotList q (k - 1) (slotLen q 1 k)).drop ((1 - 1) * (q - 1))).take (q - 1) with hwdef
+    have hwlen : w.length = q - 1 := by
+      rw [hwdef]
+      apply window_len
+      simp only [Nat.sub_self, Nat.zero_mul, Nat.zero_add]
+      exact hlen0
+    have hmod := pow_sum_modEq q hq2 w (fun x hx => by
+      rw [hwdef] at hx
+      have h1 : x ∈ (slotList q (k - 1) (slotLen q 1 k)).drop ((1 - 1) * (q - 1)) :=
+        List.mem_of_mem_take hx
+      obtain ⟨e, _, hxe⟩ := slotList_pow q (k - 1) (slotLen q 1 k) x (List.mem_of_mem_drop h1)
+      exact ⟨e, hxe⟩)
+    rw [hwlen] at hmod
+    exact (Nat.modEq_zero_iff_dvd).mp (hmod.trans (Nat.modEq_zero_iff_dvd.mpr dvd_rfl))
+  have hudvd : (q - 1) ∣ u := by rw [hudef]; exact Nat.dvd_add hβdvd hjdvd
+  -- carry-free: `u` adds to `k-1` carry-free  (from admissibility, dvd_choose_of_carry)
+  have hcf : ∀ e, qdigit q (k - 1) e + qdigit q u e ≤ q - 1 := by
+    rw [hudef]; exact admissible_carryfree q hq k hk j hj
+  -- u > β  (since j > 0)
+  have hugt : β < u := by rw [hudef]; omega
+  -- slot formula on both sides
+  have hsd : s q d k = d * k + Phi q (k - 1) d (slotLen q d k) := slot_formula q d k hq2 hk
+  have hFexp : F q d k j
+      = d * (k + u) + Phi q ((k - 1) + u) (d - 1) (slotLen q (d - 1) (s1 + j)) := by
+    have hsd1 : s q (d - 1) (s1 + j)
+        = (d - 1) * (s1 + j)
+          + Phi q (s1 + j - 1) (d - 1) (slotLen q (d - 1) (s1 + j)) :=
+      slot_formula q (d - 1) (s1 + j) hq2 hnvalpos
+    -- s1 + j - 1 = (k - 1) + u
+    have hm1 : s1 + j - 1 = (k - 1) + u := by omega
+    rw [hm1] at hsd1
+    -- F q d k j unfolds to s q (d-1) (s1+j) + s1 + j  (s q 1 k = s1)
+    have hFunf : F q d k j = s q (d - 1) (s1 + j) + s1 + j := by
+      rw [F, ← hs1def]
+    rw [hFunf, hsd1, hnval]
+    -- (d-1)*(k+u) + P + (k+u) = d*(k+u) + P  needs 1 ≤ d
+    have hd1 : (d - 1) * (k + u) + (k + u) = d * (k + u) := by
+      cases d with
+      | zero => omega
+      | succ d' => simp only [Nat.succ_sub_one]; ring
+    omega
+  -- reduce to the core inequality
+  have hβlen : (q - 1) ≤ (slotList q (k - 1) (slotLen q 1 k)).length := by
+    have hb := slotList_length_ge q (k - 1) (slotLen q 1 k) hq2
+    have hsl : slotLen q 1 k - ((k - 1) + 1) = k + 2 := by
+      simp [slotLen]; omega
+    rw [hsl] at hb
+    have : (q - 1) * 1 ≤ (q - 1) * (k + 2) := by
+      apply Nat.mul_le_mul_left; omega
+    omega
+  have hL₁ : d * (q - 1) ≤ (slotList q (k - 1) (slotLen q d k)).length := by
+    have hb := slotList_length_ge q (k - 1) (slotLen q d k) hq2
+    have hsl : slotLen q d k - ((k - 1) + 1) = d * (k + 1) + 1 := by
+      simp [slotLen]; omega
+    rw [hsl] at hb
+    have hge : d ≤ d * (k + 1) + 1 := by
+      have : d * 1 ≤ d * (k + 1) := by apply Nat.mul_le_mul_left; omega
+      omega
+    have : d * (q - 1) ≤ (q - 1) * (d * (k + 1) + 1) := by
+      rw [Nat.mul_comm]
+      apply Nat.mul_le_mul_left; exact hge
+    omega
+  have hL₂ : (d - 1) * (q - 1)
+      ≤ (slotList q ((k - 1) + u) (slotLen q (d - 1) (s1 + j))).length := by
+    have hb := slotList_length_ge q ((k - 1) + u) (slotLen q (d - 1) (s1 + j)) hq2
+    have hsl : slotLen q (d - 1) (s1 + j) - (((k - 1) + u) + 1)
+        = (d - 1) * ((k + u) + 1) + 1 := by
+      simp only [slotLen, ↓reduceIte]
+      rw [hnval]
+      omega
+    rw [hsl] at hb
+    have hge : (d - 1) ≤ (d - 1) * ((k + u) + 1) + 1 := by
+      have : (d - 1) * 1 ≤ (d - 1) * ((k + u) + 1) := by
+        apply Nat.mul_le_mul_left; omega
+      omega
+    have : (d - 1) * (q - 1) ≤ (q - 1) * ((d - 1) * ((k + u) + 1) + 1) := by
+      rw [Nat.mul_comm]
+      apply Nat.mul_le_mul_left; exact hge
+    omega
+  have hcore : Phi q (k - 1) d (slotLen q d k)
+      < d * u + Phi q ((k - 1) + u) (d - 1) (slotLen q (d - 1) (s1 + j)) :=
+    extraction_core q hq2 (k - 1) d hd u hudvd hcf (slotLen q 1 k)
+      (slotLen q d k) (slotLen q (d - 1) (s1 + j)) hβlen hugt hL₁ hL₂
+  -- assemble
+  rw [hsd, hFexp]
+  -- goal: d*k + Phi(M) < d*(k+u) + Phi(M\U);  d*(k+u) = d*k + d*u
+  have : d * (k + u) = d * k + d * u := by ring
+  omega
+
+/-- `F` attains its minimum over `J` uniquely at `j = 0`: for every admissible
+`j ∈ J` with `j > 0` we have `F(0) < F(j)`.
+
+Assembled from `composition_identity` (`F(0) = s_d(k)`) and `extraction_strict`
+(`s_d(k) < F(j)` for admissible `j > 0`). -/
+theorem main (q : ℕ) (hq : q.Prime) (d k : ℕ) (hd : 1 < d) (hk : 0 < k) :
+    ∀ j ∈ Jset q k, 0 < j → F q d k 0 < F q d k j := by
+  intro j hj hjpos
+  -- F(0) = s_{d-1}(s_1(k) + 0) + s_1(k) + 0 = s_{d-1}(s_1(k)) + s_1(k) = s_d(k).
+  have hF0 : F q d k 0 = s q d k := by
+    simp only [F, add_zero]
+    exact composition_identity q hq d k hd hk
+  rw [hF0]
+  exact extraction_strict q hq d k hd hk j hj hjpos
+
+end ZetaH123.H2

--- a/LeanPool/ZetaH123/H3.lean
+++ b/LeanPool/ZetaH123/H3.lean
@@ -1,0 +1,336 @@
+/-
+Copyright (c) 2026 Evan Chen, Kenny Lau, Ken Ono, Jujian Zhang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Evan Chen, Kenny Lau, Ken Ono, Jujian Zhang
+-/
+
+import Mathlib.Algebra.Order.Ring.Star
+import Mathlib.Analysis.Normed.Ring.Lemmas
+import Mathlib.Data.Int.Star
+import Mathlib.Data.List.GetD
+import Mathlib.Data.Nat.Digits.Lemmas
+import Mathlib.Data.Nat.Prime.Defs
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.Order
+import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Push
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Ring.RingNF
+
+/-!
+# H3 for Thakur's hypotheses on power sums
+-/
+
+namespace ZetaH123.H3
+
+/-
+# Problem Description
+
+Fix a prime number `p` and a prime power `q = p ^ f` where `f ≥ 1` is an integer.
+
+## Definition 1 (Carry-free addition in base `p`)
+For nonnegative integers `x_1, ..., x_r`, the addition `x_1 + ... + x_r` *has no
+carries in base `p`* if, at every base-`p` digit position, the corresponding
+base-`p` digits of `x_1, ..., x_r` sum to at most `p - 1`. Writing
+`x_j = ∑_{t ≥ 0} a_{j,t} p ^ t` with `0 ≤ a_{j,t} ≤ p - 1`, the condition is
+`∑_{j=1} ^ r a_{j,t} ≤ p - 1` for every `t ≥ 0`.
+
+## Definition 2 (The set `T_{d,j}`)
+For `d ≥ 1` and `j ≥ 0`, `T_{d,j}` is the set of all `d`-tuples `(m_1, ..., m_d)`
+of integers with: (1) `m_i > 0`; (2) `(q - 1) ∣ m_i`; (3) the addition
+`j + m_1 + ... + m_d` has no carries in base `p` (applied to the `r = d + 1`
+summands `j, m_1, ..., m_d`).
+
+## Definition 3 (The quantities `M_d(j)` and `s_d(k)`)
+The set `T_{d,j}` is nonempty, so the minimum
+`M_d(j) := min_{(m_1,...,m_d) ∈ T_{d,j}} (m_1 + 2 m_2 + ... + d m_d)`
+exists and is attained. For `d ≥ 1` and `k > 0`, `s_d(k) := d k + M_d(k - 1)`.
+
+## Main Statement (Theorem)
+Let `p` be a prime, `q = p ^ f` a prime power (`f ≥ 1`), and `d ≥ 1`, `k > 0`
+integers. If `p ∤ k`, then `s_d(k) < s_d(k + 1)`.
+
+## Remarks
+`T_{d,j}` is nonempty: choosing `m_i = (q - 1) p ^ {f e_i}` for distinct large
+exponents `e_i` gives a carry-free sum, so `M_d(j)` is well defined. The proof
+of the theorem uses that `p ∤ k` implies passing from `k` to `k - 1` only
+decreases the units digit, so `T_{d,k} ⊆ T_{d,k-1}` and hence
+`M_d(k) ≥ M_d(k - 1)`, giving `s_d(k + 1) - s_d(k) ≥ d ≥ 1 > 0`.
+-/
+
+open Finset
+
+-- Main Definition(s)
+
+/-- Definition 1: the addition `j + m_1 + ... + m_d` (the `r = d + 1` summands
+`j, m_1, ..., m_d`) has no carries in base `p`: at every base-`p` digit position
+`t`, the digits sum to at most `p - 1`. We read off the `t`-th base-`p` digit of
+a number `n` as `(Nat.digits p n).getD t 0`. -/
+def NoCarry (p : ℕ) (j : ℕ) (d : ℕ) (m : Fin d → ℕ) : Prop :=
+  ∀ t : ℕ, (Nat.digits p j).getD t 0 + ∑ i, (Nat.digits p (m i)).getD t 0 ≤ p - 1
+
+/-- Definition 2: the set `T_{d,j}` of `d`-tuples `(m_1, ..., m_d)` (encoded as a
+function `Fin d → ℕ`) with each `m_i > 0`, `(q - 1) ∣ m_i`, and `j + m_1 + ... +
+m_d` carry-free in base `p`. -/
+def Tset (p q d j : ℕ) : Set (Fin d → ℕ) :=
+  {m | (∀ i, 0 < m i) ∧ (∀ i, (q - 1) ∣ m i) ∧ NoCarry p j d m}
+
+/-- The objective `m_1 + 2 m_2 + ... + d m_d = ∑_{i} i · m_i` (with `1`-based
+weights; the `i`-th coordinate `m i` is weighted by `i + 1` under `0`-based
+`Fin d` indexing). -/
+def objective (d : ℕ) (m : Fin d → ℕ) : ℕ := ∑ i : Fin d, (i.val + 1) * m i
+
+/-- Definition 3: `M_d(j)` is the minimum of the objective over `T_{d,j}`,
+realized as the infimum of the image of `T_{d,j}` under the objective. Since
+`T_{d,j}` is nonempty (see Remarks) and `ℕ` is well-ordered, this minimum is
+attained. -/
+noncomputable def Md (p q d j : ℕ) : ℕ := sInf (objective d '' Tset p q d j)
+
+/-- Definition 3: `s_d(k) := d k + M_d(k - 1)`. -/
+noncomputable def sd (p q d k : ℕ) : ℕ := d * k + Md p q d (k - 1)
+
+-- Helper lemmas (digit manipulation in base `p`).
+
+/-- The `t`-th base-`p` digit of `n`. -/
+private def dig (p n t : ℕ) : ℕ := n / p ^ t % p
+
+private lemma getD_eq_dig {p : ℕ} (hp : 2 ≤ p) (n t : ℕ) :
+    (Nat.digits p n).getD t 0 = dig p n t :=
+  Nat.getD_digits n t hp
+
+private lemma dig_le {p : ℕ} (hp : 1 ≤ p) (n t : ℕ) : dig p n t ≤ p - 1 := by
+  have := Nat.mod_lt (n / p ^ t) (show 0 < p by omega)
+  unfold dig; omega
+
+private lemma dig_mul_pow_lt {p : ℕ} (hp : 2 ≤ p) (n c t : ℕ) (ht : t < c) :
+    dig p (n * p ^ c) t = 0 := by
+  unfold dig
+  have hdvd : p ^ (t + 1) ∣ n * p ^ c := Dvd.dvd.mul_left (pow_dvd_pow p (by omega)) n
+  obtain ⟨k, hk⟩ := hdvd
+  rw [hk, pow_succ, mul_assoc, Nat.mul_div_cancel_left _ (by positivity),
+    Nat.mul_mod_right]
+
+private lemma dig_mul_pow_ge {p : ℕ} (hp : 2 ≤ p) (n c t : ℕ) (ht : c ≤ t) :
+    dig p (n * p ^ c) t = dig p n (t - c) := by
+  unfold dig
+  have h1 : p ^ t = p ^ c * p ^ (t - c) := by rw [← pow_add]; congr 1; omega
+  rw [h1, ← Nat.div_div_eq_div_mul, Nat.mul_div_cancel _ (by positivity)]
+
+private lemma dig_pred_pow_ge {p : ℕ} (hp : 2 ≤ p) (f t : ℕ) (ht : f ≤ t) :
+    dig p (p ^ f - 1) t = 0 := by
+  unfold dig
+  have hlt : p ^ f - 1 < p ^ t := by
+    have h1 : p ^ f ≤ p ^ t := Nat.pow_le_pow_right (by omega) ht
+    have h2 : 1 ≤ p ^ f := Nat.one_le_pow _ _ (by omega)
+    omega
+  rw [Nat.div_eq_of_lt hlt]; simp
+
+private lemma dig_pred_pow_lt {p : ℕ} (hp : 2 ≤ p) (f t : ℕ) (ht : t < f) :
+    dig p (p ^ f - 1) t = p - 1 := by
+  unfold dig
+  have hdiv : (p ^ f - 1) / p ^ t = p ^ (f - t) - 1 := by
+    have heq : p ^ f = p ^ (f - t) * p ^ t := by rw [← pow_add]; congr 1; omega
+    have hpft : 1 ≤ p ^ (f - t) := Nat.one_le_pow _ _ (by omega)
+    have hpt : 1 ≤ p ^ t := Nat.one_le_pow _ _ (by omega)
+    have hge : p ^ t ≤ p ^ (f - t) * p ^ t := Nat.le_mul_of_pos_left _ (by omega)
+    have hsplit : p ^ f - 1 = (p ^ t - 1) + (p ^ (f - t) - 1) * p ^ t := by
+      rw [heq, Nat.sub_one_mul]; omega
+    rw [hsplit, Nat.add_mul_div_right _ _ (by positivity : 0 < p ^ t),
+      Nat.div_eq_of_lt (by omega : p ^ t - 1 < p ^ t), zero_add]
+  rw [hdiv]
+  have hd : p ∣ p ^ (f - t) := dvd_pow_self p (by omega : f - t ≠ 0)
+  obtain ⟨k, hk⟩ := hd
+  have hpk : 1 ≤ p ^ (f - t) := Nat.one_le_pow _ _ (by omega)
+  have hk1 : 1 ≤ k := by nlinarith [hk, hpk]
+  have hpkmul : p * (k - 1) = p * k - p := by rw [Nat.mul_sub]; ring_nf
+  have hge2 : p ≤ p * k := Nat.le_mul_of_pos_right _ (by omega)
+  rw [hk, show p * k - 1 = (p - 1) + p * (k - 1) by rw [hpkmul]; omega,
+    Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt (by omega : p - 1 < p)]
+
+/-- Digit of the building block `(p ^ f - 1) * p ^ c`: it is `p-1` inside the block
+`[c, c+f)` and `0` outside. -/
+private lemma dig_block {p : ℕ} (hp : 2 ≤ p) (f c t : ℕ) :
+    dig p ((p ^ f - 1) * p ^ c) t = if c ≤ t ∧ t < c + f then p - 1 else 0 := by
+  rcases lt_or_ge t c with hlt | hge
+  · rw [dig_mul_pow_lt hp _ _ _ hlt, if_neg (by omega)]
+  · rw [dig_mul_pow_ge hp _ _ _ hge]
+    rcases lt_or_ge (t - c) f with hin | hout
+    · rw [dig_pred_pow_lt hp _ _ hin, if_pos (by omega)]
+    · rw [dig_pred_pow_ge hp _ _ hout, if_neg (by omega)]
+
+/-- When `p ∤ k` and `k ≥ 1`, every base-`p` digit of `k - 1` is `≤` the
+corresponding digit of `k`. -/
+private lemma dig_pred_le {p : ℕ} (hp : 2 ≤ p) {k : ℕ} (hk : 1 ≤ k)
+    (hpk : ¬ p ∣ k) (t : ℕ) : dig p (k - 1) t ≤ dig p k t := by
+  unfold dig
+  rcases Nat.eq_zero_or_pos t with ht0 | htpos
+  · subst ht0
+    simp only [pow_zero, Nat.div_one]
+    have hkp : k % p ≠ 0 := fun h => hpk (Nat.dvd_of_mod_eq_zero h)
+    have hmod : (k - 1) % p = k % p - 1 := by
+      conv_lhs => rw [show k - 1 = (k % p - 1) + p * (k / p) by
+        have := Nat.div_add_mod k p; omega]
+      rw [Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt]
+      have := Nat.mod_lt k (show 0 < p by omega); omega
+    omega
+  · have hnd : ¬ p ^ t ∣ k := fun h =>
+      hpk (dvd_trans (dvd_pow_self p (by omega : t ≠ 0)) h)
+    have heq : k / p ^ t = (k - 1) / p ^ t := by
+      have hkk : k = (k - 1) + 1 := by omega
+      rw [hkk, Nat.succ_div, if_neg (by rw [← hkk]; exact hnd)]; simp
+    rw [heq]
+
+/-- Auxiliary: nonemptiness of `T_{d,j}`, used by both `main_theorem` and the
+public `Tset_nonempty`. -/
+private lemma Tset_nonempty_aux (p q d j f : ℕ) (hp : p.Prime) (hf : 1 ≤ f)
+    (hq : q = p ^ f) (_hd : 1 ≤ d) : (Tset p q d j).Nonempty := by
+  have hp2 : 2 ≤ p := hp.two_le
+  set L := (Nat.digits p j).length with hL
+  -- witness: m i = (p ^ f - 1) * p ^ (f*(L+i))
+  refine ⟨fun i => (p ^ f - 1) * p ^ (f * (L + i.val)), ?_, ?_, ?_⟩
+  · -- positivity
+    intro i
+    have h1 : 1 ≤ p ^ f - 1 := by
+      have : p ^ 1 ≤ p ^ f := Nat.pow_le_pow_right (by omega) hf
+      simp only [pow_one] at this; omega
+    have h2 : 0 < p ^ (f * (L + i.val)) := by positivity
+    exact Nat.mul_pos (by omega) h2
+  · -- divisibility by q - 1 = p ^ f - 1
+    intro i
+    rw [hq]
+    exact Dvd.intro _ rfl
+  · -- NoCarry
+    intro t
+    rw [getD_eq_dig hp2]
+    have hblock : ∀ i : Fin d,
+        (Nat.digits p ((p ^ f - 1) * p ^ (f * (L + i.val)))).getD t 0
+          = if f * (L + i.val) ≤ t ∧ t < f * (L + i.val) + f then p - 1 else 0 := by
+      intro i
+      rw [getD_eq_dig hp2, dig_block hp2]
+    rw [Finset.sum_congr rfl (fun i _ => hblock i)]
+    -- the sum is ≤ p-1 (at most one block contains t)
+    have hsum : ∑ i : Fin d,
+        (if f * (L + i.val) ≤ t ∧ t < f * (L + i.val) + f then p - 1 else 0) ≤ p - 1 := by
+      by_cases h : ∃ i : Fin d, f * (L + i.val) ≤ t ∧ t < f * (L + i.val) + f
+      · obtain ⟨i0, hi0⟩ := h
+        rw [Finset.sum_eq_single i0]
+        · rw [if_pos hi0]
+        · intro b _ hb
+          rw [if_neg]
+          rintro ⟨hb1, hb2⟩
+          have hfpos : 0 < f := by omega
+          have hle1 : L + b.val ≤ L + i0.val := by
+            by_contra hcon
+            push Not at hcon
+            have : f * (L + i0.val) + f ≤ f * (L + b.val) := by
+              calc f * (L + i0.val) + f = f * (L + i0.val + 1) := by ring
+              _ ≤ f * (L + b.val) := Nat.mul_le_mul_left f (by omega)
+            omega
+          have hle2 : L + i0.val ≤ L + b.val := by
+            by_contra hcon
+            push Not at hcon
+            have : f * (L + b.val) + f ≤ f * (L + i0.val) := by
+              calc f * (L + b.val) + f = f * (L + b.val + 1) := by ring
+              _ ≤ f * (L + i0.val) := Nat.mul_le_mul_left f (by omega)
+            omega
+          exact hb (Fin.ext (by omega))
+        · intro h'; simp at h'
+      · have hz : ∑ i : Fin d,
+            (if f * (L + i.val) ≤ t ∧ t < f * (L + i.val) + f then p - 1 else 0) = 0 := by
+          apply Finset.sum_eq_zero
+          intro i _
+          rw [if_neg]
+          rintro ⟨h1, h2⟩
+          exact h ⟨i, h1, h2⟩
+        rw [hz]; omega
+    -- combine with the j-digit term
+    rcases lt_or_ge t L with htL | htL
+    · -- t < L: all blocks vanish, sum = 0
+      have hzero : ∑ i : Fin d,
+          (if f * (L + i.val) ≤ t ∧ t < f * (L + i.val) + f then p - 1 else 0) = 0 := by
+        apply Finset.sum_eq_zero
+        intro i _
+        rw [if_neg]
+        rintro ⟨h1, h2⟩
+        -- c i = f*(L+i) ≥ f*L ≥ L > t
+        have : L ≤ f * (L + i.val) := by
+          calc L ≤ f * L := Nat.le_mul_of_pos_left L (by omega)
+          _ ≤ f * (L + i.val) := Nat.mul_le_mul_left f (by omega)
+        omega
+      rw [hzero, add_zero]
+      exact dig_le (by omega) j t
+    · -- t ≥ L: j-digit is 0
+      have hj0 : dig p j t = 0 := by
+        have hgd : (Nat.digits p j).getD t 0 = 0 := by
+          rw [List.getD_eq_default]; omega
+        rw [getD_eq_dig hp2] at hgd
+        exact hgd
+      rw [hj0, zero_add]
+      exact hsum
+
+-- Main Statement(s)
+
+/-- **Theorem.** Let `p` be a prime, `q = p ^ f` (`f ≥ 1`), and `d ≥ 1`, `k > 0`.
+If `p ∤ k`, then `s_d(k) < s_d(k + 1)`. -/
+theorem main_theorem (p q d k f : ℕ) (hp : p.Prime) (hf : 1 ≤ f) (hq : q = p ^ f)
+    (hd : 1 ≤ d) (hk : 0 < k) (hpk : ¬ p ∣ k) :
+    sd p q d k < sd p q d (k + 1) := by
+  have hp2 : 2 ≤ p := hp.two_le
+  -- Tset p q d k ⊆ Tset p q d (k - 1)
+  have hsubset : Tset p q d k ⊆ Tset p q d (k - 1) := by
+    rintro m ⟨hpos, hdvd, hnc⟩
+    refine ⟨hpos, hdvd, ?_⟩
+    intro t
+    have hkey := hnc t
+    rw [getD_eq_dig hp2] at hkey ⊢
+    have hdle : dig p (k - 1) t ≤ dig p k t := dig_pred_le hp2 hk hpk t
+    rw [Finset.sum_congr rfl (fun i _ => getD_eq_dig hp2 (m i) t)] at hkey
+    rw [Finset.sum_congr rfl (fun i _ => getD_eq_dig hp2 (m i) t)]
+    omega
+  -- image inclusion
+  have himg : objective d '' Tset p q d k ⊆ objective d '' Tset p q d (k - 1) :=
+    Set.image_mono hsubset
+  -- nonempty image for k
+  have hnek : (objective d '' Tset p q d k).Nonempty :=
+    (Tset_nonempty_aux p q d k f hp hf hq hd).image _
+  -- Md (k - 1) ≤ Md k
+  have hMd : Md p q d (k - 1) ≤ Md p q d k := by
+    obtain ⟨v, hv, hval⟩ := Nat.sInf_mem hnek
+    change sInf (objective d '' Tset p q d (k - 1)) ≤ sInf (objective d '' Tset p q d k)
+    rw [← hval]
+    exact Nat.sInf_le (himg ⟨v, hv, rfl⟩)
+  -- conclude
+  unfold sd
+  simp only [Nat.add_sub_cancel]
+  have hdk : d * k < d * (k + 1) := by
+    have : 0 < d := by omega
+    nlinarith [this]
+  omega
+
+-- Correctness statements characterizing `M_d(j)` as the attained minimum.
+
+/-- Nonemptiness of `T_{d,j}` (Remarks): the minimization defining `M_d(j)` is
+over a nonempty set. -/
+theorem Tset_nonempty (p q d j f : ℕ) (hp : p.Prime) (hf : 1 ≤ f) (hq : q = p ^ f)
+    (hd : 1 ≤ d) : (Tset p q d j).Nonempty :=
+  Tset_nonempty_aux p q d j f hp hf hq hd
+
+/-- `M_d(j)` is attained: there is a tuple in `T_{d,j}` achieving the objective
+value `M_d(j)`. -/
+theorem Md_attained (p q d j f : ℕ) (hp : p.Prime) (hf : 1 ≤ f) (hq : q = p ^ f)
+    (hd : 1 ≤ d) :
+    ∃ m ∈ Tset p q d j, objective d m = Md p q d j := by
+  have hne : (Tset p q d j).Nonempty := Tset_nonempty_aux p q d j f hp hf hq hd
+  have himg : (objective d '' Tset p q d j).Nonempty := hne.image _
+  have hmem : Md p q d j ∈ objective d '' Tset p q d j := Nat.sInf_mem himg
+  obtain ⟨m, hm, hval⟩ := hmem
+  exact ⟨m, hm, hval⟩
+
+/-- `M_d(j)` is a lower bound for the objective on `T_{d,j}`. -/
+theorem Md_le (p q d j f : ℕ) (_hp : p.Prime) (_hf : 1 ≤ f) (_hq : q = p ^ f)
+    (_hd : 1 ≤ d) {m : Fin d → ℕ} (hm : m ∈ Tset p q d j) :
+    Md p q d j ≤ objective d m := by
+  apply Nat.sInf_le
+  exact ⟨m, hm, rfl⟩
+
+end ZetaH123.H3

--- a/LeanPool/ZetaH123/Lem41.lean
+++ b/LeanPool/ZetaH123/Lem41.lean
@@ -1,0 +1,1256 @@
+/-
+Copyright (c) 2026 Evan Chen, Kenny Lau, Ken Ono, Jujian Zhang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Evan Chen, Kenny Lau, Ken Ono, Jujian Zhang
+-/
+
+import Mathlib.Algebra.Order.Ring.Star
+import Mathlib.Analysis.Normed.Ring.Lemmas
+import Mathlib.Data.Int.Star
+import Mathlib.FieldTheory.Finite.Basic
+import Mathlib.Order.CompletePartialOrder
+import Mathlib.RingTheory.Henselian
+import Mathlib.RingTheory.LaurentSeries
+import Mathlib.RingTheory.PowerSeries.Substitution
+import Mathlib.RingTheory.PowerSeries.WellKnown
+import Mathlib.RingTheory.RegularLocalRing.Defs
+import Mathlib.RingTheory.SimpleRing.Principal
+import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.IntervalCases
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Order
+import Mathlib.Tactic.Positivity
+import Mathlib.Tactic.Push
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Ring.RingNF
+import Mathlib.Tactic.Tauto
+
+/-!
+# Lemma 4.1 for Thakur's hypotheses on power sums
+-/
+
+namespace ZetaH123.Lem41
+
+/-
+# Problem Description
+
+Fix a prime `p`, an integer `f ≥ 1`, and the prime power `q = p ^ f`. Let `F_q`
+be the finite field with `q` elements, and let `A := F_q[t]` be the polynomial
+ring in one variable `t`. We work inside the field of formal Laurent series in
+`1/t`,
+  `F_q((1/t)) ⊇ F_q(t)`,
+into which the rational function field `F_q(t)` embeds via expansion of each
+rational function as a Laurent series in the uniformizer `1/t` (an expansion in
+*descending* powers of `t`).
+
+Concretely, for a monic polynomial `a = t ^ d + θ_1 t ^ {d-1} + … + θ_d` and an
+integer `k ≥ 1`, the element `a ^ {-k}` is identified with its expansion
+  `a ^ {-k} = t ^ {-dk} (1 + θ_1 t ^ {-1} + … + θ_d t ^ {-d}) ^ {-k} ∈ F_q((1/t))`.
+
+We fix integers `d ≥ 1` and `k > 0`.
+
+## Main Definitions
+
+* Carry-free addition in base `p`: writing each `x_i` in base `p`, the addition
+  `x_1 + … + x_r` is carry-free if at every digit position the sum of digits is
+  at most `p - 1`.
+* The index set `T_{d,k-1}` of `d`-tuples `(m_1,…,m_d)` with `m_i > 0`,
+  `(q - 1) ∣ m_i`, and the addition `(k - 1) + m_1 + … + m_d` carry-free in base `p`.
+* The weight `w(m) = ∑ i m_i = m_1 + 2 m_2 + … + d m_d`.
+* The power sum `S_d(k) = ∑_{a ∈ A_d ^ +} 1/a ^ k`, over monic polynomials of degree
+  exactly `d`, viewed in `F_q((1/t))`.
+
+## Main Statement
+
+There exist scalars `c_m ∈ F_q ^ ×` (nonzero), one for each `m ∈ T_{d,k-1}`, with
+  `S_d(k) = t ^ {-dk} ∑_{m ∈ T_{d,k-1}} c_m t ^ {-w(m)}`.
+
+Although `T_{d,k-1}` is infinite, the RHS is well defined because only finitely
+many `m` satisfy `w(m) ≤ B` for any bound `B`. The claim is about the
+tuple-indexed family `(c_m)`: distinct tuples may share the same weight, so after
+collecting by power of `t` the coefficient of a given power may be zero in `F_q`
+even though every individual `c_m` is nonzero.
+-/
+
+open Polynomial
+
+/-! ## Encoding of the Laurent field `F_q((1/t))`
+
+We model `F_q((1/t))` by `LaurentSeries Fq = HahnSeries ℤ Fq`, in which the
+formal variable `X` plays the role of the uniformizer `1/t`. Thus `t` corresponds
+to `X⁻¹`, and the coefficient of `Xⁿ` of an element is precisely the coefficient
+of `t ^ {-n}` in its expansion in descending powers of `t`. -/
+
+/-- The `F_q`-algebra embedding `F_q[t] → F_q((1/t))` sending `t ↦ X⁻¹`, i.e. the
+expansion of a polynomial in descending powers of `t`. Since `F_q((1/t))` is a
+field, this extends multiplicatively to inverses, which is how `a ^ {-k}` is
+interpreted below. -/
+noncomputable def phi (Fq : Type) [Field Fq] : Polynomial Fq →ₐ[Fq] LaurentSeries Fq :=
+  Polynomial.aeval ((PowerSeries.X : PowerSeries Fq) : LaurentSeries Fq)⁻¹
+
+-- Main Definition(s)
+
+/-- The `e`-th base-`p` digit of `x`, i.e. `⌊x / p ^ e⌋ mod p`. -/
+def digit (p x e : ℕ) : ℕ := (x / p ^ e) % p
+
+/-- **Definition 1 (Carry-free addition in base `p`).**
+The addition of the nonnegative integers in `xs` is carry-free in base `p` if for
+every digit position `e`, the sum of the `e`-th base-`p` digits is at most
+`p - 1`. -/
+def CarryFree (p : ℕ) (xs : List ℕ) : Prop :=
+  ∀ e : ℕ, (xs.map (fun x => digit p x e)).sum ≤ p - 1
+
+/-- The weight `w(m) = ∑ i (m i) = m_1 + 2 m_2 + … + d m_d`.
+(Here `m : Fin d → ℕ` is `0`-indexed, so the `i`-th coordinate carries the
+multiplier `i + 1`.) -/
+def weight (d : ℕ) (m : Fin d → ℕ) : ℕ := ∑ i : Fin d, (i + 1) * m i
+
+/-- **Definition 2 (The index set `T_{d,k-1}`).**
+The membership predicate for the set of `d`-tuples `(m_1,…,m_d)` (`0`-indexed as
+`m : Fin d → ℕ`) such that:
+1. `m i > 0` for all `i`;
+2. `(q - 1) ∣ m i` for all `i`;
+3. the addition `(k - 1) + m_1 + … + m_d` is carry-free in base `p`. -/
+def Tindex (p q d kk : ℕ) (m : Fin d → ℕ) : Prop :=
+  (∀ i, 0 < m i) ∧
+  (∀ i, (q - 1) ∣ m i) ∧
+  CarryFree p (kk :: List.ofFn m)
+
+/-- The monic polynomial of degree exactly `d` with prescribed lower coefficients
+`θ : Fin d → Fq`, namely `t ^ d + ∑_{i<d} (θ i) t ^ i`. As `θ` ranges over
+`Fin d → Fq` this enumerates the set `A_d ^ +` of monic polynomials of degree `d`
+without repetition (see `monicOf_monic`/`monicOf_natDegree`/`monicOf_injective`).
+-/
+noncomputable def monicOf (Fq : Type) [Field Fq] (d : ℕ) (θ : Fin d → Fq) : Polynomial Fq :=
+  X ^ d + ∑ i : Fin d, C (θ i) * X ^ (i : ℕ)
+
+/-- **Definition 3 (The power sum `S_d(k)`).**
+`S_d(k) = ∑_{a ∈ A_d ^ +} a ^ {-k}`, summed over the monic polynomials of degree `d`
+(parameterized by their lower coefficients `θ : Fin d → Fq`), viewed as an
+element of `F_q((1/t))` via the embedding `phi`. The inverse `(phi a)⁻¹` is taken
+in the Laurent series field, which realizes the expansion of `a ^ {-1}` in
+descending powers of `t`. -/
+noncomputable def Sdk (Fq : Type) [Field Fq] [Fintype Fq] (d k : ℕ) : LaurentSeries Fq :=
+  ∑ θ : Fin d → Fq, (phi Fq (monicOf Fq d θ))⁻¹ ^ k
+
+-- Main Statement(s)
+
+/-! ## The explicit witness family `c_m`
+
+For a tuple `m = (m_1,…,m_d)` with `y := ∑_i m_i`, the witness coefficient is
+  `c_m = (-1) ^ d · (-1) ^ y · C(k+y-1, y) · multinomial(y; m_1,…,m_d)`  (mod `p`),
+where the global factor `(-1) ^ d` comes from `∑_{x∈F_q} x ^ {m_i} = -1` for each of
+the `d` variables. -/
+
+/-- The explicit witness family. For `m : Fin d → ℕ`, with `y = ∑ i, m i`,
+`cwit Fq k m` is the `F_q`-image of the integer
+  `(-1) ^ d · (-1) ^ y · C(k + y - 1, y) · multinomial(y; m)`. -/
+noncomputable def cwit (Fq : Type) [Field Fq] (d k : ℕ) (m : Fin d → ℕ) : Fq :=
+  let y := ∑ i, m i
+  ((((-1) ^ d * (-1) ^ y * (Nat.choose (k + y - 1) y : ℤ)
+        * (Nat.multinomial Finset.univ m : ℤ)) : ℤ) : Fq)
+
+/-! ## Sub-lemmas of the structure theorem
+
+The proof of `main` factors through: L1 (`Sdk_coeff_as_thetasum`), the
+Laurent/multinomial expansion of `coeff n (Sdk)`; L2 (`finField_pow_sum`), the
+finite-field power sum collapsing the `θ`-sum; L3/L4
+(`negChoose_cast_ne_zero_iff`/`multinomial_cast_ne_zero_iff`), Lucas-type
+nonvanishing criteria; L5 (`carryfree_combine`), combining the carry-free
+conditions; then the assembly lemmas `cwit_ne_zero` and `Sdk_coeff_eq_finsum`. -/
+
+/-- **L2 (finite-field power sum).** For a finite field `Fq` and `m : ℕ`,
+`∑_{x∈Fq} x ^ m = -1` if `m > 0 ∧ (q - 1) ∣ m`, and `= 0` otherwise (`0 ^ 0 = 1`). -/
+theorem finField_pow_sum (Fq : Type) [Field Fq] [Fintype Fq] (m : ℕ) :
+    (∑ x : Fq, x ^ m) =
+      if (0 < m ∧ (Fintype.card Fq - 1) ∣ m) then -1 else 0 := by
+  classical
+  have hunits : (∑ x : Fqˣ, (x : Fq) ^ m) = ∑ x : {x : Fq // x ≠ 0}, (x : Fq) ^ m := by
+    exact Fintype.sum_equiv unitsEquivNeZero _ _ (fun x => rfl)
+  have hsplit : (∑ x : Fq, x ^ m) = (0 : Fq) ^ m + ∑ x : {x : Fq // x ≠ 0}, (x : Fq) ^ m := by
+    rw [← Fintype.sum_eq_add_sum_subtype_ne (fun x : Fq => x ^ m) 0]
+  rw [hsplit, ← hunits, FiniteField.sum_pow_units Fq m]
+  rcases Nat.eq_zero_or_pos m with hm | hm
+  · subst hm
+    simp only [pow_zero, lt_irrefl, false_and, if_false]
+    rw [if_pos (dvd_zero _)]
+    ring
+  · rw [zero_pow hm.ne', zero_add]
+    simp only [hm, true_and]
+
+/-- **L3 (Lucas, binomial).** The integer `binom(-k, y) = (-1) ^ y · C(k+y-1, y)`
+has nonzero image in `F_q` (char `p`) iff the addition `(k - 1) + y` is carry-free
+in base `p`, i.e. `CarryFree p [k-1, y]` (Kummer/Lucas). -/
+theorem negChoose_cast_ne_zero_iff (Fq : Type) [Field Fq]
+    (p k : ℕ) (hp : p.Prime) (hchar : CharP Fq p) (hk : 0 < k) (y : ℕ) :
+    (((-1) ^ y * (Nat.choose (k + y - 1) y : ℤ)) : Fq) ≠ 0 ↔
+      CarryFree p [k - 1, y] := by
+  have hp1 : 1 < p := hp.one_lt
+  have step1 : (((-1) ^ y * (Nat.choose (k + y - 1) y : ℤ)) : Fq) ≠ 0 ↔
+      ¬ (p ∣ Nat.choose (k+y-1) y) := by
+    push_cast
+    rw [mul_ne_zero_iff]
+    constructor
+    · rintro ⟨_, h2⟩ hdvd
+      apply h2
+      have : ((Nat.choose (k+y-1) y : ℕ) : Fq) = 0 := by
+        rw [CharP.cast_eq_zero_iff Fq p]; exact hdvd
+      exact this
+    · intro hndvd
+      refine ⟨pow_ne_zero _ (by simp), ?_⟩
+      intro hc
+      apply hndvd
+      rw [← CharP.cast_eq_zero_iff Fq p]
+      exact hc
+  rw [step1]
+  have hkk : k + y - 1 = (k - 1) + y := by omega
+  rw [hkk]
+  set N := (k - 1) + y with hN
+  have hCpos : Nat.choose N y ≠ 0 := (Nat.choose_pos (by omega : y ≤ N)).ne'
+  have step3 : ¬ (p ∣ Nat.choose N y) ↔ (Nat.choose N y).factorization p = 0 := by
+    rw [Nat.factorization_eq_zero_iff]
+    constructor
+    · intro h; right; left; exact h
+    · rintro (h|h|h)
+      · exact absurd hp h
+      · exact h
+      · exact absurd h hCpos
+  rw [step3]
+  set b := Nat.log p N + 1 with hb
+  have hbgt : Nat.log p N < b := by omega
+  have hfact := Nat.factorization_choose' (p := p) (n := k-1) (k := y) hp (by rw [← hN]; exact hbgt)
+  rw [← hN] at hfact
+  rw [hfact]
+  rw [Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+  have bridge : (∀ i ∈ Finset.Ico 1 b, ¬ (p ^ i ≤ y % p ^ i + (k - 1) % p ^ i)) ↔
+      (∀ i, 1 ≤ i → y % p ^ i + (k - 1) % p ^ i < p ^ i) := by
+    constructor
+    · intro Hf i hi
+      by_cases hib : i < b
+      · have := Hf i (Finset.mem_Ico.mpr ⟨hi, hib⟩); omega
+      · push Not at hib
+        have hilog : Nat.log p N < i := lt_of_lt_of_le hbgt hib
+        have hNlt : N < p ^ i := by
+          calc N < p ^ (Nat.log p N + 1) := Nat.lt_pow_succ_log_self hp1 _
+            _ ≤ p ^ i := Nat.pow_le_pow_right (by omega) (by omega)
+        have hy : y < p ^ i := by omega
+        have hk1 : k-1 < p ^ i := by omega
+        rw [Nat.mod_eq_of_lt hy, Nat.mod_eq_of_lt hk1]; omega
+    · intro H i hi hle
+      rw [Finset.mem_Ico] at hi
+      have := H i hi.1; omega
+  rw [bridge]
+  change (∀ i, 1 ≤ i → y % p ^ i + (k - 1) % p ^ i < p ^ i) ↔ CarryFree p [k-1, y]
+  unfold CarryFree digit
+  simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, add_zero]
+  constructor
+  · intro H e
+    have hi := H (e + 1) (by omega)
+    have hpe : 0 < p ^ e := Nat.pow_pos (n := e) (by omega)
+    rw [Nat.mod_pow_succ, Nat.mod_pow_succ, pow_succ] at hi
+    have hae : y % p ^ e < p ^ e := Nat.mod_lt _ hpe
+    have hbe : (k - 1) % p ^ e < p ^ e := Nat.mod_lt _ hpe
+    generalize hA : y % p ^ e = A at *
+    generalize hB : (k - 1) % p ^ e = B at *
+    generalize hu : y / p ^ e % p = u at *
+    generalize hv : (k - 1) / p ^ e % p = v at *
+    set Pe := p ^ e
+    by_contra hcon
+    push Not at hcon
+    have hge : p ≤ v + u := by omega
+    have hmul : Pe * p ≤ Pe * (v + u) := Nat.mul_le_mul_left _ hge
+    have hexp : Pe * (v + u) = Pe * v + Pe * u := by ring
+    omega
+  · intro H
+    have hno : ∀ e, y % p ^ e + (k - 1) % p ^ e < p ^ e := by
+      intro e
+      induction e with
+      | zero => simp [Nat.mod_one]
+      | succ e ih =>
+        have hpe : 0 < p ^ e := Nat.pow_pos (n := e) (by omega)
+        have hda := H e
+        rw [Nat.mod_pow_succ, Nat.mod_pow_succ, pow_succ]
+        generalize hA : y % p ^ e = A at *
+        generalize hB : (k - 1) % p ^ e = B at *
+        generalize hu : y / p ^ e % p = u at *
+        generalize hv : (k - 1) / p ^ e % p = v at *
+        set Pe := p ^ e
+        have h1 : Pe * u + Pe * v = Pe * (u+v) := by ring
+        have h2 : Pe * (u+v) ≤ Pe * (p-1) := Nat.mul_le_mul_left _ (by omega)
+        have h3 : Pe * (p-1) = Pe*p - Pe := by rw [Nat.mul_sub_one]
+        have h4 : Pe ≤ Pe * p := Nat.le_mul_of_pos_right _ (by omega)
+        omega
+    intro i _
+    exact hno i
+
+/-- **L4 (Lucas, multinomial).** With `y = ∑ i, m i`, the multinomial coefficient
+`multinomial(y; m_1,…,m_d)` has nonzero image in `F_q` iff the addition
+`m_1 ⊕ m_2 ⊕ … ⊕ m_d` is carry-free in base `p`, i.e. `CarryFree p (List.ofFn m)`.
+(Telescoping product of binomial-Lucas, informal.tex Lemma 1.6.) -/
+theorem multinomial_cast_ne_zero_iff (Fq : Type) [Field Fq]
+    (p d : ℕ) (hp : p.Prime) (hchar : CharP Fq p) (m : Fin d → ℕ) :
+    ((Nat.multinomial Finset.univ m : ℤ) : Fq) ≠ 0 ↔
+      CarryFree p (List.ofFn m) := by
+  -- Binomial cast characterization (from L3): `C(a+s, a) ≠ 0` in `Fq` iff
+  -- `CarryFree p [a, s]`.
+  have hbinom : ∀ a s : ℕ, ((Nat.choose (a + s) a : ℤ) : Fq) ≠ 0 ↔ CarryFree p [a, s] := by
+    intro a s
+    have h3 := negChoose_cast_ne_zero_iff Fq p (a+1) hp hchar (by omega) s
+    have he1 : (a + 1) + s - 1 = a + s := by omega
+    have he2 : Nat.choose (a + s) s = Nat.choose (a + s) a := by
+      have := Nat.choose_symm (n := a + s) (k := a) (by omega)
+      rw [show a + s - a = s by omega] at this
+      exact this
+    rw [he1, he2] at h3
+    have hsimp : (a + 1) - 1 = a := by omega
+    rw [hsimp] at h3
+    rw [← h3]
+    push_cast
+    have hu : ((-1:Fq)) ^ s ≠ 0 := pow_ne_zero _ (by simp)
+    rw [mul_ne_zero_iff]
+    tauto
+  -- Product of factorials divides factorial of sum (so the list multinomial is an
+  -- integer).
+  have hmultidvd : ∀ L : List ℕ, (L.map Nat.factorial).prod ∣ L.sum.factorial := by
+    intro L
+    induction L with
+    | nil => simp
+    | cons a t ih =>
+      simp only [List.map_cons, List.prod_cons, List.sum_cons]
+      calc a.factorial * (t.map Nat.factorial).prod
+          ∣ a.factorial * t.sum.factorial := Nat.mul_dvd_mul_left _ ih
+        _ ∣ (a + t.sum).factorial := Nat.factorial_mul_factorial_dvd_factorial_add a t.sum
+  -- Recurrence for the list multinomial: peeling off the head gives a binomial
+  -- factor.
+  have hrec : ∀ (a : ℕ) (L : List ℕ),
+      (a + L.sum).factorial / ((a :: L).map Nat.factorial).prod
+        = (a + L.sum).choose a * (L.sum.factorial / (L.map Nat.factorial).prod) := by
+    intro a L
+    have hprodpos : 0 < (L.map Nat.factorial).prod := by
+      apply List.prod_pos
+      intro x hx
+      simp only [List.mem_map] at hx
+      obtain ⟨n, _, rfl⟩ := hx
+      exact Nat.factorial_pos n
+    have key : (a + L.sum).factorial = (a + L.sum).choose a * (a.factorial * L.sum.factorial) := by
+      have h := Nat.add_choose_mul_factorial_mul_factorial L.sum a
+      rw [add_comm L.sum a] at h
+      rw [← h]; ring
+    simp only [List.map_cons, List.prod_cons]
+    rw [key]
+    obtain ⟨c, hc⟩ := hmultidvd L
+    rw [hc]
+    have e1 :
+        (a + L.sum).choose a * (a.factorial * ((L.map Nat.factorial).prod * c))
+            / (a.factorial * (L.map Nat.factorial).prod)
+          = (a + L.sum).choose a * c := by
+      rw [show (a + L.sum).choose a * (a.factorial * ((L.map Nat.factorial).prod * c))
+          = ((a + L.sum).choose a * c) * (a.factorial * (L.map Nat.factorial).prod) by
+        ring]
+      rw [Nat.mul_div_cancel _ (by positivity)]
+    rw [e1, Nat.mul_div_cancel_left _ hprodpos]
+  -- Inlined crux machinery (the `crux_*` lemmas appear later in the file).
+  have crux_div : ∀ (a b : ℕ), 1 < p → (∀ e, digit p a e + digit p b e ≤ p - 1) →
+      ∀ e, (a + b) / p ^ e = a / p ^ e + b / p ^ e := by
+    intro a b hp h e
+    induction e with
+    | zero => simp
+    | succ e ih =>
+      rw [pow_succ, ← Nat.div_div_eq_div_mul, ← Nat.div_div_eq_div_mul, ← Nat.div_div_eq_div_mul]
+      rw [ih]
+      have hdig : (a / p ^ e) % p + (b / p ^ e) % p ≤ p - 1 := h e
+      have key : (a / p ^ e + b / p ^ e)
+          = p * (a / p ^ e / p + b / p ^ e / p)
+            + ((a / p ^ e) % p + (b / p ^ e) % p) := by
+        have ha := Nat.div_add_mod (a / p ^ e) p
+        have hb := Nat.div_add_mod (b / p ^ e) p
+        ring_nf; omega
+      rw [key, Nat.mul_add_div (by omega : 0 < p)]
+      have hz : ((a / p ^ e) % p + (b / p ^ e) % p) / p = 0 := Nat.div_eq_of_lt (by omega)
+      omega
+  have crux_digit_two : ∀ (a b : ℕ), 1 < p → (∀ e, digit p a e + digit p b e ≤ p - 1) →
+      ∀ e, digit p (a + b) e = digit p a e + digit p b e := by
+    intro a b hp h e
+    have hd := crux_div a b hp h e
+    have hb := h e
+    unfold digit at *
+    rw [hd, Nat.add_mod]
+    have h1 : (a / p ^ e) % p % p = (a / p ^ e) % p := Nat.mod_mod_of_dvd _ dvd_rfl
+    have h2 : (b / p ^ e) % p % p = (b / p ^ e) % p := Nat.mod_mod_of_dvd _ dvd_rfl
+    rw [Nat.mod_eq_of_lt (show (a / p ^ e) % p + (b / p ^ e) % p < p by omega)]
+  have crux_list : ∀ (L : List ℕ), (∀ e, (L.map (fun x => digit p x e)).sum ≤ p - 1) →
+      ∀ e, digit p L.sum e = (L.map (fun x => digit p x e)).sum := by
+    intro L
+    rcases Nat.lt_or_ge p 2 with hpp | hpp
+    · interval_cases p
+      · intro h e
+        rcases Nat.eq_zero_or_pos e with he | he
+        · subst he
+          have hd : ∀ x : ℕ, digit 0 x 0 = x := by intro x; unfold digit; simp
+          rw [hd]
+          conv_rhs => rw [show (fun x => digit 0 x 0) = (id : ℕ → ℕ) by funext x; simp [hd]]
+          simp
+        · unfold digit
+          have h0 : (0:ℕ) ^ e = 0 := by simp [Nat.pow_eq_zero]; omega
+          simp only [h0, Nat.div_zero, Nat.zero_mod, List.map_const', List.sum_replicate,
+            smul_eq_mul, mul_zero]
+      · intro h e
+        have hd : ∀ x : ℕ, digit 1 x e = 0 := by intro x; unfold digit; simp [Nat.mod_one]
+        simp [hd]
+    · have hp' : 1 < p := hpp
+      intro h
+      induction L with
+      | nil => intro e; simp [digit]
+      | cons a t ih =>
+        have htail : ∀ e, (t.map (fun x => digit p x e)).sum ≤ p - 1 := by
+          intro e; have := h e; simp only [List.map_cons, List.sum_cons] at this; omega
+        have ihd := ih htail
+        intro e
+        simp only [List.map_cons, List.sum_cons]
+        have hpair : ∀ e, digit p a e + digit p t.sum e ≤ p - 1 := by
+          intro e
+          rw [ihd e]
+          have := h e
+          simp only [List.map_cons, List.sum_cons] at this
+          exact this
+        rw [crux_digit_two a t.sum hp' hpair e, ihd e]
+  -- CarryFree splits over a cons: the head together with the tail-sum.
+  have hcons : ∀ (a : ℕ) (L : List ℕ),
+      (CarryFree p [a, L.sum] ∧ CarryFree p L) ↔ CarryFree p (a :: L) := by
+    intro a L
+    unfold CarryFree
+    simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, add_zero]
+    constructor
+    · rintro ⟨h1, h2⟩ e
+      have hc := crux_list L h2 e
+      have h1e := h1 e
+      rw [hc] at h1e
+      exact h1e
+    · intro h
+      have h2 : ∀ e, (L.map (fun x => digit p x e)).sum ≤ p - 1 := by
+        intro e; have := h e; omega
+      refine ⟨?_, h2⟩
+      intro e
+      have hc := crux_list L h2 e
+      have he := h e
+      rw [← hc] at he
+      exact he
+  -- Main induction on lists: the list multinomial cast is nonzero iff CarryFree.
+  have hmain : ∀ L : List ℕ,
+      (((L.sum.factorial / (L.map Nat.factorial).prod : ℕ) : ℤ) : Fq) ≠ 0 ↔ CarryFree p L := by
+    intro L
+    induction L with
+    | nil =>
+      simp only [List.sum_nil, List.map_nil, List.prod_nil, Nat.factorial_zero]
+      constructor
+      · intro _ e; simp [digit]
+      · intro _; simp
+    | cons a t ih =>
+      have hrr := hrec a t
+      rw [List.sum_cons]
+      have hcast : (((a + t.sum).factorial / ((a :: t).map Nat.factorial).prod : ℕ) : Fq)
+          = ((a + t.sum).choose a : Fq)
+            * ((t.sum.factorial / (t.map Nat.factorial).prod : ℕ) : Fq) := by
+        rw [hrr]; push_cast; ring
+      rw [Int.cast_natCast, hcast]
+      rw [mul_ne_zero_iff]
+      have hb := hbinom a t.sum
+      rw [Int.cast_natCast] at hb
+      rw [hb]
+      rw [show (((t.sum.factorial / (t.map Nat.factorial).prod : ℕ) : Fq))
+          = ((((t.sum.factorial / (t.map Nat.factorial).prod : ℕ) : ℤ)) : Fq) by
+        rw [Int.cast_natCast]] at *
+      rw [ih]
+      rw [hcons a t]
+  -- Reduce `Nat.multinomial Finset.univ m` to the list version over `List.ofFn m`.
+  have hreduce : ((Nat.multinomial Finset.univ m : ℤ) : Fq)
+      = ((((List.ofFn m).sum.factorial
+          / ((List.ofFn m).map Nat.factorial).prod : ℕ) : ℤ) : Fq) := by
+    unfold Nat.multinomial
+    rw [List.sum_ofFn]
+    norm_cast
+    congr 2
+    rw [List.map_ofFn, List.prod_ofFn]
+    rfl
+  rw [hreduce, hmain]
+
+/-- Crux (division form). If, at every base-`p` digit position, the digits of `a`
+and `b` sum to at most `p - 1` (no carry), then dividing by `p ^ e` distributes
+over the sum `a + b`. Requires `1 < p`. -/
+theorem crux_div (p a b : ℕ) (hp : 1 < p)
+    (h : ∀ e, digit p a e + digit p b e ≤ p - 1) :
+    ∀ e, (a + b) / p ^ e = a / p ^ e + b / p ^ e := by
+  intro e
+  induction e with
+  | zero => simp
+  | succ e ih =>
+    rw [pow_succ, ← Nat.div_div_eq_div_mul, ← Nat.div_div_eq_div_mul, ← Nat.div_div_eq_div_mul]
+    rw [ih]
+    have hdig : (a / p ^ e) % p + (b / p ^ e) % p ≤ p - 1 := h e
+    have key : (a / p ^ e + b / p ^ e)
+        = p * (a / p ^ e / p + b / p ^ e / p)
+          + ((a / p ^ e) % p + (b / p ^ e) % p) := by
+      have ha := Nat.div_add_mod (a / p ^ e) p
+      have hb := Nat.div_add_mod (b / p ^ e) p
+      ring_nf; omega
+    rw [key, Nat.mul_add_div (by omega : 0 < p)]
+    have hz : ((a / p ^ e) % p + (b / p ^ e) % p) / p = 0 := Nat.div_eq_of_lt (by omega)
+    omega
+
+/-- Crux (two-summand digit form). Under the no-carry hypothesis, the digit of the
+sum equals the sum of digits at every position. -/
+theorem crux_digit_two (p a b : ℕ) (hp : 1 < p)
+    (h : ∀ e, digit p a e + digit p b e ≤ p - 1) :
+    ∀ e, digit p (a + b) e = digit p a e + digit p b e := by
+  intro e
+  have hd := crux_div p a b hp h e
+  have hb := h e
+  unfold digit at *
+  rw [hd, Nat.add_mod]
+  have h1 : (a / p ^ e) % p % p = (a / p ^ e) % p := Nat.mod_mod_of_dvd _ dvd_rfl
+  have h2 : (b / p ^ e) % p % p = (b / p ^ e) % p := Nat.mod_mod_of_dvd _ dvd_rfl
+  rw [Nat.mod_eq_of_lt (show (a / p ^ e) % p + (b / p ^ e) % p < p by omega)]
+
+/-- Crux (list form, all `p`). If the addition of the entries of `L` is carry-free
+in base `p`, then for every digit position the digit of `L.sum` equals the sum of
+the digits of the entries. (Holds unconditionally for `p ≤ 1`.) -/
+theorem crux_list (p : ℕ) (L : List ℕ)
+    (h : ∀ e, (L.map (fun x => digit p x e)).sum ≤ p - 1) :
+    ∀ e, digit p L.sum e = (L.map (fun x => digit p x e)).sum := by
+  rcases Nat.lt_or_ge p 2 with hp | hp
+  · interval_cases p
+    · intro e
+      rcases Nat.eq_zero_or_pos e with he | he
+      · subst he
+        have hd : ∀ x : ℕ, digit 0 x 0 = x := by intro x; unfold digit; simp
+        rw [hd]
+        conv_rhs => rw [show (fun x => digit 0 x 0) = (id : ℕ → ℕ) by funext x; simp [hd]]
+        simp
+      · unfold digit
+        have h0 : (0:ℕ) ^ e = 0 := by simp [Nat.pow_eq_zero]; omega
+        simp only [h0, Nat.div_zero, Nat.zero_mod, List.map_const', List.sum_replicate,
+          smul_eq_mul, mul_zero]
+    · intro e
+      have hd : ∀ x : ℕ, digit 1 x e = 0 := by intro x; unfold digit; simp [Nat.mod_one]
+      simp [hd]
+  · have hp' : 1 < p := hp
+    induction L with
+    | nil => intro e; simp [digit]
+    | cons a t ih =>
+      have htail : ∀ e, (t.map (fun x => digit p x e)).sum ≤ p - 1 := by
+        intro e; have := h e; simp only [List.map_cons, List.sum_cons] at this; omega
+      have ihd := ih htail
+      intro e
+      simp only [List.map_cons, List.sum_cons]
+      have hpair : ∀ e, digit p a e + digit p t.sum e ≤ p - 1 := by
+        intro e
+        rw [ihd e]
+        have := h e
+        simp only [List.map_cons, List.sum_cons] at this
+        exact this
+      rw [crux_digit_two p a t.sum hp' hpair e, ihd e]
+
+/-- **L5 (carry-free combination).** With `y = ∑ i, m i`, the two carry-free
+conditions `CarryFree p [k-1, y]` (binomial) and `CarryFree p (List.ofFn m)`
+(multinomial) hold simultaneously iff the combined addition is carry-free, i.e.
+`CarryFree p ((k - 1) :: List.ofFn m)`. -/
+theorem carryfree_combine (p kk d : ℕ) (m : Fin d → ℕ) :
+    (CarryFree p [kk, ∑ i, m i] ∧ CarryFree p (List.ofFn m)) ↔
+      CarryFree p (kk :: List.ofFn m) := by
+  have hsum : (List.ofFn m).sum = ∑ i, m i := by rw [List.sum_ofFn]
+  unfold CarryFree
+  simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, add_zero]
+  constructor
+  · rintro ⟨h1, h2⟩ e
+    have hc := crux_list p (List.ofFn m) h2 e
+    rw [hsum] at hc
+    have h1e := h1 e
+    rw [hc] at h1e
+    exact h1e
+  · intro h
+    have h2 : ∀ e, ((List.ofFn m).map (fun x => digit p x e)).sum ≤ p - 1 := by
+      intro e; have := h e; omega
+    refine ⟨?_, h2⟩
+    intro e
+    have hc := crux_list p (List.ofFn m) h2 e
+    rw [hsum] at hc
+    have he := h e
+    rw [← hc] at he
+    exact he
+
+/-! ### L1 helper lemmas (PowerSeries / LaurentSeries infrastructure)
+
+The proof of L1 (`Sdk_coeff_as_thetasum`) is decomposed into helper lemmas H1–H5:
+H1 is the generalized binomial / unit-inverse power-series expansion; H2–H4 are
+the `phi`/`monicOf` → LaurentSeries bridge and the HahnSeries shift; H5 is the
+finite-vs-finsum bookkeeping. -/
+
+/-- **H1 (generalized binomial / unit-inverse power-series expansion).** For a
+power series `g` with zero constant term, the `e`-th coefficient of
+`((1 + g) ^ k)⁻¹` is the finite sum `∑_{y ≤ e} binom(-k, y) · coeff_e (g ^ y)`,
+where `binom(-k, y) = (-1) ^ y · C(k+y-1, y)`. (Only `y ≤ e` contribute since
+`order (g ^ y) ≥ y`.) -/
+theorem coeff_inv_one_add_pow
+    (Fq : Type) [Field Fq] (k e : ℕ) (g : PowerSeries Fq)
+    (hg : PowerSeries.constantCoeff (R := Fq) g = 0) :
+    (PowerSeries.coeff (R := Fq) e) (((1 + g) ^ k)⁻¹) =
+      ∑ y ∈ Finset.range (e + 1),
+        ((-1) ^ y * (Nat.choose (k + y - 1) y : ℤ) : Fq)
+          * (PowerSeries.coeff (R := Fq) e) (g ^ y) := by
+  -- Substitute `X ↦ -g` into `mk_add_choose_mul_one_sub_pow_eq_one`, extract the
+  -- `e`-th coefficient via `coeff_subst'`, and truncate the finsum to `range (e + 1)`.
+  have coeff_pow_high : ∀ d : ℕ, e < d → (PowerSeries.coeff (R := Fq) e) (g ^ d) = 0 := by
+    intro d h
+    apply PowerSeries.coeff_of_lt_order
+    have h1 : 1 ≤ g.order := PowerSeries.one_le_order_iff_constCoeff_eq_zero.mpr hg
+    have h2 : (d : ℕ∞) ≤ (g ^ d).order := by
+      rw [PowerSeries.order_pow]
+      calc (d : ℕ∞) = d • (1 : ℕ∞) := by simp
+        _ ≤ d • g.order := by gcongr
+    calc (e : ℕ∞) < d := by exact_mod_cast h
+      _ ≤ (g ^ d).order := h2
+  have coeff_neg_pow : ∀ d : ℕ,
+      (PowerSeries.coeff (R := Fq) e) ((-g) ^ d)
+        = (-1) ^ d * (PowerSeries.coeff (R := Fq) e) (g ^ d) := by
+    intro d
+    rcases Nat.even_or_odd d with hd | hd
+    · rw [hd.neg_pow, hd.neg_one_pow, one_mul]
+    · rw [hd.neg_pow, hd.neg_one_pow, map_neg, neg_one_mul]
+  rcases Nat.eq_zero_or_pos k with hk | hk
+  · subst hk
+    rw [pow_zero, inv_one]
+    rw [Finset.sum_eq_single 0]
+    · simp
+    · intro y _ hy
+      have hz : Nat.choose (0 + y - 1) y = 0 := Nat.choose_eq_zero_of_lt (by omega)
+      rw [hz]; simp
+    · intro h; simp at h
+  · obtain ⟨k', rfl⟩ := Nat.exists_eq_add_of_lt hk
+    rw [Nat.zero_add] at *
+    have ha : PowerSeries.HasSubst (-g : PowerSeries Fq) := by
+      apply PowerSeries.HasSubst.of_constantCoeff_zero'
+      simp [hg]
+    have hinv : (((1 + g) ^ (k'+1))⁻¹) =
+        PowerSeries.subst (-g) (PowerSeries.mk fun n => ((k' + n).choose k' : Fq)) := by
+      have hkey := PowerSeries.mk_add_choose_mul_one_sub_pow_eq_one Fq k'
+      set S := PowerSeries.substAlgHom (R := Fq) ha with hS
+      have happ := congrArg S hkey
+      rw [map_mul, map_one] at happ
+      have h1 : S ((1 - PowerSeries.X) ^ (k'+1)) = (1 + g) ^ (k'+1) := by
+        rw [map_pow, map_sub, map_one, hS, PowerSeries.coe_substAlgHom,
+          PowerSeries.subst_X ha]
+        ring
+      rw [h1] at happ
+      rw [hS, PowerSeries.coe_substAlgHom] at happ
+      rw [PowerSeries.inv_eq_iff_mul_eq_one]
+      · exact happ
+      · rw [map_pow]; simp [hg]
+    rw [hinv, PowerSeries.coeff_subst' ha]
+    rw [finsum_eq_finsetSum_of_support_subset _ (s := Finset.range (e + 1))]
+    · apply Finset.sum_congr rfl
+      intro d hd
+      rw [PowerSeries.coeff_mk, coeff_neg_pow, smul_eq_mul]
+      have hnat : (k' + d).choose k' = ((k'+1) + d - 1).choose d := by
+        have h : (k'+1) + d - 1 = k' + d := by omega
+        rw [h, Nat.choose_symm_add]
+      rw [hnat]; push_cast; ring
+    · intro d hd
+      simp only [Function.mem_support] at hd
+      rw [Finset.coe_range, Set.mem_Iio]
+      by_contra hcon
+      push Not at hcon
+      apply hd
+      rw [PowerSeries.coeff_mk, coeff_neg_pow, coeff_pow_high d (by omega)]
+      simp
+
+/-- **H2 (`phi (monicOf θ)` made explicit).** `phi (monicOf θ)` equals the shift
+`single (-d) 1` times the coercion of the unit power series
+`1 + ∑_{i<d} θ_i X ^ {d-i}`. (`phi = aeval X⁻¹`, `X⁻¹ = single (-1) 1`; pull out
+`single (-d) 1` and identify the bracket with the coerced power series.) -/
+theorem phi_monicOf_eq (Fq : Type) [Field Fq] (d : ℕ) (θ : Fin d → Fq) :
+    phi Fq (monicOf Fq d θ)
+      = (HahnSeries.single (-(d : ℤ)) 1)
+          * (HahnSeries.ofPowerSeries ℤ Fq
+              (1 + ∑ i : Fin d,
+                (PowerSeries.C (R := Fq) (θ i)) * PowerSeries.X ^ (d - (i : ℕ)))) := by
+  have hpow : ∀ (n : ℕ) (a : ℤ),
+      (HahnSeries.single a (1 : Fq)) ^ n = HahnSeries.single (n * a) 1 := by
+    intro n a
+    induction n with
+    | zero => simp
+    | succ k ih =>
+      rw [pow_succ, ih, HahnSeries.single_mul_single]
+      congr 1 <;> push_cast <;> ring_nf
+  have hXinv :
+      ((PowerSeries.X : PowerSeries Fq) : LaurentSeries Fq)⁻¹ = HahnSeries.single (-1) 1 := by
+    apply inv_eq_of_mul_eq_one_left
+    rw [PowerSeries.coe_X, HahnSeries.single_mul_single]; norm_num
+  have halg : ∀ a : Fq, algebraMap Fq (LaurentSeries Fq) a = HahnSeries.single 0 a := by
+    intro a
+    rw [LaurentSeries.algebraMap_apply, HahnSeries.C_apply]
+  have hofX : ∀ m : ℕ,
+      HahnSeries.ofPowerSeries ℤ Fq (PowerSeries.X ^ m) = HahnSeries.single (m : ℤ) 1 := by
+    intro m
+    rw [map_pow, PowerSeries.coe_X, hpow]; congr 1; simp
+  have hLHSterm : ∀ i : Fin d,
+      (Polynomial.aeval ((HahnSeries.single (-1) 1 : LaurentSeries Fq)))
+          (Polynomial.C (θ i) * Polynomial.X ^ (i : ℕ))
+        = HahnSeries.single (-(i : ℤ)) (θ i) := by
+    intro i
+    rw [map_mul, map_pow, Polynomial.aeval_C, Polynomial.aeval_X, hpow, halg,
+        HahnSeries.single_mul_single]
+    congr 1 <;> ring_nf
+  have hRHSterm : ∀ i : Fin d,
+      (HahnSeries.single (-(d : ℤ)) (1 : Fq)) *
+          (HahnSeries.ofPowerSeries ℤ Fq
+            ((PowerSeries.C (R := Fq) (θ i)) * PowerSeries.X ^ (d - (i : ℕ))))
+        = HahnSeries.single (-(i : ℤ)) (θ i) := by
+    intro i
+    rw [map_mul, hofX, HahnSeries.ofPowerSeries_C, HahnSeries.C_apply,
+        ← mul_assoc, HahnSeries.single_mul_single, HahnSeries.single_mul_single, mul_one, one_mul]
+    congr 1
+    have : (i : ℕ) ≤ d := le_of_lt i.isLt
+    push_cast [Nat.cast_sub this]
+    ring_nf
+  -- LHS transform
+  unfold phi monicOf
+  rw [map_add, map_pow, map_sum, Polynomial.aeval_X, hXinv, hpow,
+      show ((d : ℤ) * (-1)) = -(d : ℤ) by ring]
+  rw [Finset.sum_congr rfl (fun i _ => hLHSterm i)]
+  -- RHS transform
+  rw [map_add, mul_add, map_sum, Finset.mul_sum]
+  rw [Finset.sum_congr rfl (fun i _ => hRHSterm i)]
+  -- now: single(-d)1 + ∑ single(-i)(θi) = single(-d)1 * ofPowerSeries 1 + ∑ single(-i)(θi)
+  congr 1
+  simp
+
+/-- **H3 (inverse `k`-th power as shift × PowerSeries inverse).** From H2: the
+`k`-th power of the inverse is `single (d*k) 1` times the coercion of the
+PowerSeries inverse `((1 + g) ^ k)⁻¹`, where `g = ∑_{i<d} θ_i X ^ {d-i}`. Uses that a
+power series with constant term `1` is a unit, so `(↑u)⁻¹ = ↑(u⁻¹)` in
+`LaurentSeries`. -/
+theorem inv_phi_pow_eq_shift_mul (Fq : Type) [Field Fq] (d k : ℕ) (θ : Fin d → Fq) :
+    (phi Fq (monicOf Fq d θ))⁻¹ ^ k
+      = (HahnSeries.single (d * k : ℤ) 1)
+          * (HahnSeries.ofPowerSeries ℤ Fq
+              (((1 + ∑ i : Fin d,
+                (PowerSeries.C (R := Fq) (θ i)) * PowerSeries.X ^ (d - (i : ℕ))) ^ k)⁻¹)) := by
+  set u : PowerSeries Fq :=
+    1 + ∑ i : Fin d, (PowerSeries.C (R := Fq) (θ i)) * PowerSeries.X ^ (d - (i : ℕ)) with hu
+  -- u has constant term 1, hence is a unit in PowerSeries
+  have hconst : PowerSeries.constantCoeff (R := Fq) u = 1 := by
+    rw [hu]
+    simp only [map_add, map_one, map_sum, map_mul, map_pow, PowerSeries.constantCoeff_X]
+    have : ∀ i : Fin d, (PowerSeries.constantCoeff (R := Fq) (PowerSeries.C (R := Fq) (θ i)))
+        * (0 : Fq) ^ (d - (i : ℕ)) = 0 := by
+      intro i
+      have : d - (i : ℕ) ≠ 0 := by omega
+      rw [zero_pow this, mul_zero]
+    rw [Finset.sum_eq_zero (fun i _ => this i), add_zero]
+  have hunit : IsUnit u := by
+    rw [PowerSeries.isUnit_iff_constantCoeff, hconst]; exact isUnit_one
+  -- the LaurentSeries coercion of u is a unit
+  have hofu_unit : IsUnit (HahnSeries.ofPowerSeries ℤ Fq u) :=
+    hunit.map (HahnSeries.ofPowerSeries ℤ Fq)
+  have hofu_ne : (HahnSeries.ofPowerSeries ℤ Fq u) ≠ 0 := hofu_unit.ne_zero
+  -- single(-d)1 is a unit with inverse single(d)1
+  have hsingle_ne : (HahnSeries.single (-(d : ℤ)) (1 : Fq)) ≠ 0 := by
+    simp
+  have hpow : ∀ (n : ℕ) (a : ℤ),
+      (HahnSeries.single a (1 : Fq)) ^ n = HahnSeries.single (n * a) 1 := by
+    intro n a
+    induction n with
+    | zero => simp
+    | succ m ih =>
+      rw [pow_succ, ih, HahnSeries.single_mul_single]
+      congr 1 <;> push_cast <;> ring_nf
+  -- rewrite phi via H2
+  rw [phi_monicOf_eq, ← hu]
+  rw [mul_inv_rev, mul_pow]
+  -- handle the single factor: (single(-d)1)⁻¹ ^ k = single(d*k)1
+  have hsingle :
+      (HahnSeries.single (-(d : ℤ)) (1 : Fq))⁻¹ ^ k =
+        HahnSeries.single (d * k : ℤ) 1 := by
+    have hinv : (HahnSeries.single (-(d : ℤ)) (1 : Fq))⁻¹ = HahnSeries.single (d : ℤ) 1 := by
+      apply inv_eq_of_mul_eq_one_left
+      rw [HahnSeries.single_mul_single]; norm_num
+    rw [hinv, hpow]; congr 1; ring_nf
+  rw [mul_comm ((HahnSeries.ofPowerSeries ℤ Fq u)⁻¹ ^ k) _, hsingle]
+  congr 1
+  -- ofPS(u)⁻¹ ^ k = ofPS((u ^ k)⁻¹)
+  rw [inv_pow, ← map_pow]
+  -- u ^ k has nonzero constant term, so (u ^ k)⁻¹ * u ^ k = 1 in PowerSeries
+  have hck : PowerSeries.constantCoeff (R := Fq) (u ^ k) ≠ 0 := by
+    rw [map_pow, hconst, one_pow]; exact one_ne_zero
+  apply inv_eq_of_mul_eq_one_left
+  rw [← map_mul, PowerSeries.inv_mul_cancel _ hck, map_one]
+
+/-- **H4 (coefficient of `single s 1 * ↑f`, the Laurent shift).** The `n`-th
+coefficient of `single s 1 * (↑f)` is the `(n-s)`-th PowerSeries coefficient of
+`f` when `n - s ≥ 0`, else `0`. -/
+theorem coeff_single_mul_coe_powerSeries
+    (Fq : Type) [Field Fq] (s : ℤ) (f : PowerSeries Fq) (n : ℤ) :
+    ((HahnSeries.single s 1 * (HahnSeries.ofPowerSeries ℤ Fq f)) : LaurentSeries Fq).coeff n
+      = if _h : 0 ≤ n - s then (PowerSeries.coeff (R := Fq) (n - s).toNat) f else 0 := by
+  rw [HahnSeries.coeff_single_mul, one_mul]
+  split
+  · next _h =>
+    conv_lhs => rw [show (n - s) = ((n - s).toNat : ℤ) by omega]
+    rw [LaurentSeries.coeff_coe_powerSeries]
+  · next h =>
+    rw [HahnSeries.ofPowerSeries_apply, HahnSeries.embDomain_notin_range]
+    rintro ⟨m, hm⟩
+    simp at hm
+    omega
+
+/-- **H5 (per-`θ` coefficient identity).** Assembling H1 (binomial expansion),
+the multinomial theorem (`Finset.sum_pow_eq_sum_piAntidiag` for `g ^ y`), and the
+re-indexing of the `X ^ {d-i}` exponents against `weight d m = ∑ (i+1) m_i`, the
+coefficient of `X ^ n` in `(phi (monicOf θ))⁻¹ ^ k` is the finsum over tuples `m` with
+`d*k + weight(m) = n` of `binom(-k, ∑ m_i)·multinomial·∏ θ_i ^ {m_i}`. -/
+theorem Sdk_coeff_per_theta (Fq : Type) [Field Fq] (d k : ℕ) (θ : Fin d → Fq) (n : ℤ) :
+    ((phi Fq (monicOf Fq d θ))⁻¹ ^ k).coeff n =
+      ∑ᶠ m ∈ {m : Fin d → ℕ | ((d * k : ℕ) + weight d m : ℤ) = n},
+        ((-1) ^ (∑ i, m i) * (Nat.choose (k + (∑ i, m i) - 1) (∑ i, m i) : ℤ)
+            * (Nat.multinomial Finset.univ m : ℤ) : Fq)
+          * ∏ i, (θ (Fin.rev i)) ^ (m i) := by
+  -- The coordinate `θ i` carries X-exponent `d - i`, not `i + 1`, so the correct
+  -- pairing against `m i` (whence `weight`) is `θ (Fin.rev i)`.
+  rw [inv_phi_pow_eq_shift_mul, coeff_single_mul_coe_powerSeries]
+  set g : PowerSeries Fq :=
+    ∑ i : Fin d, (PowerSeries.C (R := Fq) (θ i)) * PowerSeries.X ^ (d - (i : ℕ)) with hgdef
+  have hg : PowerSeries.constantCoeff (R := Fq) g = 0 := by
+    rw [hgdef]
+    simp only [map_sum, map_mul, map_pow, PowerSeries.constantCoeff_X]
+    apply Finset.sum_eq_zero
+    intro i _
+    have : d - (i : ℕ) ≠ 0 := by have := i.isLt; omega
+    rw [zero_pow this, mul_zero]
+  split
+  · next h =>
+    rw [coeff_inv_one_add_pow Fq k _ g hg]
+    -- abbreviate e
+    set e := (n - ↑d * ↑k).toNat with he_def
+    have he : (e : ℤ) = n - ↑d * ↑k := by rw [he_def]; omega
+    -- coeff of g ^ y expansion
+    have hcoeff : ∀ y : ℕ, (PowerSeries.coeff (R := Fq) e) (g ^ y) =
+        ∑ c ∈ (Finset.univ : Finset (Fin d)).piAntidiag y,
+          (Nat.multinomial Finset.univ c : Fq) * (∏ i, (θ i) ^ (c i)) *
+            (if e = (∑ i : Fin d, (d - (i : ℕ)) * c i) then 1 else 0) := by
+      intro y
+      rw [hgdef, Finset.sum_pow_eq_sum_piAntidiag, map_sum]
+      apply Finset.sum_congr rfl
+      intro c hc
+      have hprod :
+          (∏ i : Fin d,
+            ((PowerSeries.C (R:=Fq) (θ i)) * PowerSeries.X ^ (d - (i : ℕ))) ^ (c i))
+            = PowerSeries.C (∏ i : Fin d, (θ i) ^ (c i))
+              * PowerSeries.X ^ (∑ i : Fin d, (d - (i : ℕ)) * c i) := by
+        have step : ∀ i : Fin d,
+            ((PowerSeries.C (R:=Fq) (θ i)) * PowerSeries.X ^ (d - (i : ℕ))) ^ (c i)
+            = PowerSeries.C ((θ i) ^ (c i)) * PowerSeries.X ^ ((d - (i : ℕ)) * c i) := by
+          intro i; rw [mul_pow, ← map_pow, ← pow_mul]
+        rw [Finset.prod_congr rfl (fun i _ => step i),
+            Finset.prod_mul_distrib, ← map_prod, ← Finset.prod_pow_eq_pow_sum]
+      rw [hprod]
+      rw [show ((Nat.multinomial Finset.univ c : PowerSeries Fq))
+          = PowerSeries.C (Nat.multinomial Finset.univ c : Fq) by
+        simp]
+      rw [PowerSeries.coeff_C_mul, PowerSeries.coeff_C_mul, PowerSeries.coeff_X_pow]
+      ring
+    -- reindex inner sum: c ↦ c ∘ rev = m
+    have hreindex : ∀ y : ℕ,
+        (∑ c ∈ (Finset.univ : Finset (Fin d)).piAntidiag y,
+          (Nat.multinomial Finset.univ c : Fq) * (∏ i, (θ i) ^ (c i)) *
+            (if e = (∑ i : Fin d, (d - (i : ℕ)) * c i) then 1 else 0))
+        = ∑ m ∈ (Finset.univ : Finset (Fin d)).piAntidiag y,
+          (Nat.multinomial Finset.univ m : Fq) * (∏ i, (θ (Fin.rev i)) ^ (m i)) *
+            (if e = weight d m then 1 else 0) := by
+      intro y
+      apply Finset.sum_nbij' (fun c => c ∘ Fin.rev) (fun m => m ∘ Fin.rev)
+      · intro c hc
+        rw [Finset.mem_piAntidiag] at hc ⊢
+        exact ⟨by rw [← hc.1]; exact Equiv.sum_comp (Fin.revPerm) c, fun i _ => Finset.mem_univ i⟩
+      · intro m hm
+        rw [Finset.mem_piAntidiag] at hm ⊢
+        exact ⟨by rw [← hm.1]; exact Equiv.sum_comp (Fin.revPerm) m, fun i _ => Finset.mem_univ i⟩
+      · intro c hc; funext i; simp [Function.comp, Fin.rev_rev]
+      · intro m hm; funext i; simp [Function.comp, Fin.rev_rev]
+      · intro c hc
+        have hmult : Nat.multinomial Finset.univ (c ∘ Fin.rev) = Nat.multinomial Finset.univ c := by
+          unfold Nat.multinomial
+          have hs : (∑ i, (c ∘ Fin.rev) i) = ∑ i, c i := Equiv.sum_comp (Fin.revPerm) c
+          have hp : (∏ i, ((c ∘ Fin.rev) i).factorial) = ∏ i, (c i).factorial :=
+            Equiv.prod_comp (Fin.revPerm) (fun i => (c i).factorial)
+          rw [hs, hp]
+        have hprodθ : (∏ i, (θ (Fin.rev i)) ^ ((c ∘ Fin.rev) i)) = ∏ i, (θ i) ^ (c i) := by
+          rw [← Equiv.prod_comp (Fin.revPerm) (fun i => (θ i) ^ (c i))]
+          apply Finset.prod_congr rfl
+          intro j _; simp [Function.comp, Fin.revPerm_apply]
+        have hweight : weight d (c ∘ Fin.rev) = ∑ i : Fin d, (d - (i : ℕ)) * c i := by
+          rw [weight, ← Equiv.sum_comp (Fin.revPerm) (fun i => ((i : ℕ) + 1) * (c ∘ Fin.rev) i)]
+          apply Finset.sum_congr rfl
+          intro j _
+          simp only [Function.comp, Fin.revPerm_apply, Fin.rev_rev]
+          have hjr : ((Fin.rev j : Fin d) : ℕ) = d - 1 - (j : ℕ) := by rw [Fin.val_rev]; omega
+          rw [hjr]
+          have hj : (j : ℕ) < d := j.isLt
+          congr 1; omega
+        rw [hmult, hprodθ, hweight]
+    -- apply reindex
+    rw [Finset.sum_congr rfl (fun y _ => by rw [hcoeff y, hreindex y])]
+    -- define common summand F (RHS)
+    set F : (Fin d → ℕ) → Fq := fun m =>
+      ((-1) ^ (∑ i, m i) * (Nat.choose (k + (∑ i, m i) - 1) (∑ i, m i) : ℤ)
+          * (Nat.multinomial Finset.univ m : ℤ) : Fq) * ∏ i, (θ (Fin.rev i)) ^ (m i) with hF
+    -- carrier finset
+    set FS := (Fintype.piFinset (fun _ : Fin d => Finset.range (e + 1))).filter
+      (fun m => weight d m = e) with hFS
+    have hset : {m : Fin d → ℕ | ((d * k : ℕ) + weight d m : ℤ) = n} = ↑FS := by
+      ext m
+      rw [Finset.mem_coe, hFS, Finset.mem_filter, Fintype.mem_piFinset]
+      simp only [Set.mem_setOf_eq, Finset.mem_range]
+      constructor
+      · intro hm
+        have hw : weight d m = e := by
+          have hcast : ((d * k : ℕ) : ℤ) + (weight d m : ℤ) = n := by exact_mod_cast hm
+          have : (weight d m : ℤ) = (e : ℤ) := by push_cast [he] at hcast ⊢; omega
+          exact_mod_cast this
+        refine ⟨fun i => ?_, hw⟩
+        have hle : m i ≤ weight d m := by
+          rw [weight]
+          calc m i ≤ ((i : ℕ)+1) * m i := by nlinarith [Nat.zero_le (i : ℕ)]
+            _ ≤ ∑ j : Fin d, ((j : ℕ)+1) * m j :=
+              Finset.single_le_sum (f := fun j : Fin d => ((j : ℕ)+1) * m j)
+                (fun j _ => Nat.zero_le _) (Finset.mem_univ i)
+        omega
+      · rintro ⟨_, hw⟩
+        have : (weight d m : ℤ) = (e : ℤ) := by exact_mod_cast hw
+        push_cast [← he, this]
+        omega
+    rw [hset, finsum_mem_coe_finset]
+    -- LHS → fiberwise
+    rw [← Finset.sum_fiberwise_of_maps_to (s := FS) (t := Finset.range (e + 1))
+      (g := fun m => ∑ i, m i) (f := F) ?maps]
+    · -- termwise
+      apply Finset.sum_congr rfl
+      intro y hy
+      rw [Finset.mul_sum]
+      rw [Finset.sum_congr rfl (fun m _ =>
+        show ((-1) ^ y * (Nat.choose (k + y - 1) y : ℤ) : Fq) *
+            ((Nat.multinomial Finset.univ m : Fq) * (∏ i, (θ (Fin.rev i)) ^ (m i)) *
+              (if e = weight d m then 1 else 0))
+          = if e = weight d m then
+              (((-1) ^ y * (Nat.choose (k + y - 1) y : ℤ) : Fq) *
+                ((Nat.multinomial Finset.univ m : Fq) * (∏ i, (θ (Fin.rev i)) ^ (m i)))) else 0 by
+          split_ifs <;> ring)]
+      rw [← Finset.sum_filter]
+      apply Finset.sum_nbij' (fun m => m) (fun m => m)
+      · intro m hm
+        simp only [Finset.mem_filter, Finset.mem_piAntidiag] at hm
+        simp only [hFS, Finset.mem_filter, Fintype.mem_piFinset, Finset.mem_range]
+        obtain ⟨⟨hsum, _⟩, hw⟩ := hm
+        refine ⟨⟨fun i => ?_, ?_⟩, ?_⟩
+        · have hle : m i ≤ weight d m := by
+            rw [weight]
+            calc m i ≤ ((i : ℕ)+1) * m i := by nlinarith [Nat.zero_le (i : ℕ)]
+              _ ≤ ∑ j : Fin d, ((j : ℕ)+1) * m j :=
+                Finset.single_le_sum (f := fun j : Fin d => ((j : ℕ)+1) * m j)
+                  (fun j _ => Nat.zero_le _) (Finset.mem_univ i)
+          omega
+        · omega
+        · exact hsum
+      · intro m hm
+        simp only [hFS, Finset.mem_filter, Fintype.mem_piFinset, Finset.mem_range] at hm
+        simp only [Finset.mem_filter, Finset.mem_piAntidiag]
+        obtain ⟨⟨_, hw⟩, hsum⟩ := hm
+        exact ⟨⟨hsum, fun i _ => Finset.mem_univ i⟩, hw.symm⟩
+      · intro m hm; rfl
+      · intro m hm; rfl
+      · intro m hm
+        simp only [Finset.mem_filter, Finset.mem_piAntidiag] at hm
+        obtain ⟨⟨hsum, _⟩, hw⟩ := hm
+        rw [hF]
+        simp only
+        rw [hsum]
+        push_cast
+        ring
+    case maps =>
+      intro m hm
+      rw [hFS, Finset.mem_filter] at hm
+      rw [Finset.mem_range]
+      show ∑ i, m i < e + 1
+      have hw := hm.2
+      have : ∑ i, m i ≤ weight d m := by
+        rw [weight]
+        apply Finset.sum_le_sum
+        intro i _; nlinarith [Nat.zero_le (i : ℕ), Nat.zero_le (m i)]
+      omega
+  · next h =>
+    -- LHS = 0; show RHS finsum = 0 because index set is empty
+    symm
+    apply finsum_mem_eq_zero_of_forall_eq_zero
+    intro x hx
+    simp only [Set.mem_setOf_eq] at hx
+    exfalso
+    push_cast at hx h
+    omega
+
+/-- **L1 (Laurent/multinomial expansion).** The coefficient of `X ^ n` in `Sdk`
+equals the `θ`-sum of single-monic-polynomial coefficients, each of which is the
+finite tuple-sum of `binom(-k,y)·multinomial(y;m)·∏_i (θ i) ^ {m i}` over tuples `m`
+with `d*k + w(m) = n`. -/
+theorem Sdk_coeff_as_thetasum (Fq : Type) [Field Fq] [Fintype Fq]
+    (d k : ℕ) (n : ℤ) :
+    (Sdk Fq d k).coeff n =
+      ∑ θ : Fin d → Fq,
+        ∑ᶠ m ∈ {m : Fin d → ℕ | ((d * k : ℕ) + weight d m : ℤ) = n},
+          ((-1) ^ (∑ i, m i) * (Nat.choose (k + (∑ i, m i) - 1) (∑ i, m i) : ℤ)
+              * (Nat.multinomial Finset.univ m : ℤ) : Fq)
+            * ∏ i, (θ i) ^ (m i) := by
+  -- Push `coeff n` through the finite `θ`-sum, then apply `Sdk_coeff_per_theta` (H5).
+  unfold Sdk
+  rw [HahnSeries.coeff_sum]
+  rw [Finset.sum_congr rfl (fun θ _ => Sdk_coeff_per_theta Fq d k θ n)]
+  -- Reindex the finite `θ`-sum by `θ ↦ θ ∘ Fin.rev` (a bijection of `Fin d → Fq`),
+  -- which turns `∏ i, (θ (Fin.rev i)) ^ (m i)` into `∏ i, (θ i) ^ (m i)`.
+  apply Fintype.sum_bijective (fun θ : Fin d → Fq => θ ∘ Fin.rev)
+    (Function.Involutive.bijective (fun θ => by funext i; simp [Function.comp]))
+  intro θ
+  rfl
+
+/-- **Assembly (b): nonvanishing of `cwit` on the index set.** For `m ∈ T_{d,k-1}`,
+`cwit Fq d k m ≠ 0`.  From L3, L4, and L5: membership in `Tindex` supplies both
+carry-free conditions, and the global `(-1) ^ d` is a unit. -/
+theorem cwit_ne_zero (Fq : Type) [Field Fq] [Fintype Fq]
+    (p f d k : ℕ) (hp : p.Prime) (_hf : 1 ≤ f) (_hd : 1 ≤ d) (hk : 0 < k)
+    (hchar : CharP Fq p) (_hq : Fintype.card Fq = p ^ f)
+    (m : Fin d → ℕ) (hm : Tindex p (Fintype.card Fq) d (k - 1) m) :
+    cwit Fq d k m ≠ 0 := by
+  obtain ⟨hcf1, hcf2⟩ := (carryfree_combine p (k - 1) d m).mpr hm.2.2
+  have h3 : (((-1) ^ (∑ i, m i) * (Nat.choose (k + (∑ i, m i) - 1) (∑ i, m i) : ℤ)) : Fq) ≠ 0 :=
+    (negChoose_cast_ne_zero_iff Fq p k hp hchar hk (∑ i, m i)).mpr hcf1
+  have h4 : ((Nat.multinomial Finset.univ m : ℤ) : Fq) ≠ 0 :=
+    (multinomial_cast_ne_zero_iff Fq p d hp hchar m).mpr hcf2
+  unfold cwit
+  simp only
+  push_cast
+  push_cast at h3 h4
+  have hsign : ((-1 : Fq)) ^ d ≠ 0 := pow_ne_zero _ (by norm_num)
+  have hcombo := mul_ne_zero (mul_ne_zero hsign h3) h4
+  intro hzero
+  apply hcombo
+  rw [← hzero]
+  ring
+
+/-- **Assembly (c): the coefficient identity** with the explicit witness `cwit`.
+Combines L1 (expansion), L2 (the finite-field power sum collapsing the `θ`-sum to
+`(-1) ^ d` exactly when every `m i > 0 ∧ (q - 1) ∣ m i`), and L3/L4/L5 (a term has
+nonzero coefficient iff `m ∈ Tindex`), regrouped as the finsum of `cwit` over the
+admissible fiber `{m ∈ Tindex | d*k + w(m) = n}`. -/
+theorem Sdk_coeff_eq_finsum (Fq : Type) [Field Fq] [Fintype Fq]
+    (p f d k : ℕ) (hp : p.Prime) (_hf : 1 ≤ f) (_hd : 1 ≤ d) (hk : 0 < k)
+    (hchar : CharP Fq p) (_hq : Fintype.card Fq = p ^ f) (n : ℤ) :
+    (Sdk Fq d k).coeff n =
+      ∑ᶠ m ∈ {m : Fin d → ℕ | Tindex p (Fintype.card Fq) d (k - 1) m ∧
+                ((d * k : ℕ) + weight d m : ℤ) = n}, cwit Fq d k m := by
+  -- Start from L1, swap the `θ`-sum past the finsum; L2 collapses
+  -- `∑_θ ∏_i (θ i) ^ {m i}` to `(-1) ^ d` exactly when conditions (1),(2) of `Tindex`
+  -- hold; condition (3) is automatic since `cwit m = 0` when it fails (L3/L4/L5).
+  classical
+  rw [Sdk_coeff_as_thetasum Fq d k n]
+  -- finite carrier
+  set FS := (Fintype.piFinset (fun _ : Fin d => Finset.range ((n - d*k).toNat + 1))).filter
+    (fun m => ((d * k : ℕ) + weight d m : ℤ) = n) with hFS
+  have hwle : ∀ (m : Fin d → ℕ) (i : Fin d), m i ≤ weight d m := by
+    intro m i
+    rw [weight]
+    calc m i ≤ ((i : ℕ)+1) * m i := by nlinarith [Nat.zero_le (i : ℕ)]
+      _ ≤ ∑ j : Fin d, ((j : ℕ)+1) * m j :=
+        Finset.single_le_sum (f := fun j : Fin d => ((j : ℕ)+1) * m j)
+          (fun j _ => Nat.zero_le _) (Finset.mem_univ i)
+  have hset : {m : Fin d → ℕ | ((d * k : ℕ) + weight d m : ℤ) = n} = ↑FS := by
+    ext m
+    rw [Finset.mem_coe, hFS, Finset.mem_filter, Fintype.mem_piFinset]
+    simp only [Set.mem_setOf_eq, Finset.mem_range]
+    constructor
+    · intro hm
+      refine ⟨fun i => ?_, hm⟩
+      have hcast : ((d * k : ℕ) : ℤ) + (weight d m : ℤ) = n := by exact_mod_cast hm
+      have hle := hwle m i
+      have : (weight d m : ℤ) ≤ (n - d*k) := by push_cast at hcast ⊢; omega
+      have hwn : weight d m ≤ (n - d*k).toNat := by omega
+      omega
+    · rintro ⟨_, hm⟩; exact hm
+  have hsetT : {m : Fin d → ℕ | Tindex p (Fintype.card Fq) d (k - 1) m ∧
+        ((d * k : ℕ) + weight d m : ℤ) = n}
+          = ↑(FS.filter (Tindex p (Fintype.card Fq) d (k - 1))) := by
+    ext m
+    rw [Finset.mem_coe, Finset.mem_filter, hFS, Finset.mem_filter, Fintype.mem_piFinset]
+    simp only [Set.mem_setOf_eq, Finset.mem_range]
+    constructor
+    · rintro ⟨hT, hm⟩
+      refine ⟨⟨fun i => ?_, hm⟩, hT⟩
+      have hcast : ((d * k : ℕ) : ℤ) + (weight d m : ℤ) = n := by exact_mod_cast hm
+      have hle := hwle m i
+      have : (weight d m : ℤ) ≤ (n - d*k) := by push_cast at hcast ⊢; omega
+      have hwn : weight d m ≤ (n - d*k).toNat := by omega
+      omega
+    · rintro ⟨⟨_, hm⟩, hT⟩; exact ⟨hT, hm⟩
+  rw [hsetT, finsum_mem_coe_finset]
+  rw [Finset.sum_congr rfl (fun θ _ => by rw [hset, finsum_mem_coe_finset])]
+  rw [Finset.sum_comm]
+  conv_rhs => rw [Finset.sum_filter]
+  apply Finset.sum_congr rfl
+  intro m hm
+  rw [← Finset.mul_sum]
+  rw [show (∑ θ : Fin d → Fq, ∏ i, (θ i) ^ (m i)) = ∏ i, (∑ x : Fq, x ^ (m i)) from
+    (Fintype.prod_sum fun i j => j ^ m i).symm]
+  rw [show (∏ i, (∑ x : Fq, x ^ (m i))) =
+      if (∀ i, 0 < m i ∧ (Fintype.card Fq - 1) ∣ m i) then (-1:Fq) ^ d else 0 by
+    rw [Finset.prod_congr rfl (fun i _ => finField_pow_sum Fq (m i))]
+    by_cases h : ∀ i, 0 < m i ∧ (Fintype.card Fq - 1) ∣ m i
+    · rw [if_pos h, Finset.prod_congr rfl (fun i _ => if_pos (h i))]; simp [Finset.prod_const]
+    · rw [if_neg h]; push Not at h; obtain ⟨i, hi⟩ := h
+      apply Finset.prod_eq_zero (Finset.mem_univ i); rw [if_neg]; intro hc; exact hi hc.1 hc.2]
+  set y := ∑ i, m i with hy
+  by_cases hcond : ∀ i, 0 < m i ∧ (Fintype.card Fq - 1) ∣ m i
+  · rw [if_pos hcond]
+    by_cases hT : Tindex p (Fintype.card Fq) d (k - 1) m
+    · rw [if_pos hT]; unfold cwit; simp only; push_cast; ring
+    · rw [if_neg hT]
+      have h1 : ∀ i, 0 < m i := fun i => (hcond i).1
+      have h2 : ∀ i, (Fintype.card Fq - 1) ∣ m i := fun i => (hcond i).2
+      have hcf : ¬ CarryFree p ((k - 1) :: List.ofFn m) := fun hc => hT ⟨h1, h2, hc⟩
+      have hsplit : ¬ (CarryFree p [k-1, y] ∧ CarryFree p (List.ofFn m)) :=
+        fun hh => hcf ((carryfree_combine p (k - 1) d m).mp hh)
+      have hBzero : (((-1) ^ y * (Nat.choose (k + y - 1) y : ℤ)
+          * (Nat.multinomial Finset.univ m : ℤ) : Fq)) = 0 := by
+        push_cast
+        rw [not_and_or] at hsplit
+        rcases hsplit with hb | hmm
+        · have hz : ¬ ((((-1) ^ y * (Nat.choose (k + y - 1) y : ℤ)) : Fq) ≠ 0) := by
+            rw [negChoose_cast_ne_zero_iff Fq p k hp hchar hk y]; exact hb
+          push Not at hz; push_cast at hz; rw [hz, zero_mul]
+        · have hz : ¬ (((Nat.multinomial Finset.univ m : ℤ) : Fq) ≠ 0) := by
+            rw [multinomial_cast_ne_zero_iff Fq p d hp hchar m]; exact hmm
+          push Not at hz; push_cast at hz; rw [hz, mul_zero]
+      rw [hBzero, zero_mul]
+  · rw [if_neg hcond]
+    have hT : ¬ Tindex p (Fintype.card Fq) d (k - 1) m :=
+      fun hT => hcond (fun i => ⟨hT.1 i, hT.2.1 i⟩)
+    rw [if_neg hT, mul_zero]
+
+/-- **Theorem.**
+There exists a family of scalars `c_m ∈ F_q` indexed by `d`-tuples `m`, all
+nonzero on the index set `T_{d,k-1}`, such that
+  `S_d(k) = t ^ {-dk} ∑_{m ∈ T_{d,k-1}} c_m t ^ {-w(m)}`.
+
+The identity is expressed coefficient-by-coefficient in `F_q((1/t))`: working with
+the uniformizer `X = 1/t`, the coefficient of `Xⁿ` (equivalently of `t ^ {-n}`) in
+`S_d(k)` equals the sum of `c_m` over the (finite) set of tuples `m ∈ T_{d,k-1}`
+with `d*k + w(m) = n`. This faithfully captures that the right-hand side is a
+formal sum of monomials `t ^ {-w(m)}` indexed by the tuples (with repetition
+allowed): each individual `c_m` is nonzero, while the collected coefficient of a
+given power of `t` may vanish. -/
+theorem main (Fq : Type) [Field Fq] [Fintype Fq]
+    (p f d k : ℕ) (hp : p.Prime) (hf : 1 ≤ f) (hd : 1 ≤ d) (hk : 0 < k)
+    (hchar : CharP Fq p) (hq : Fintype.card Fq = p ^ f) :
+    ∃ c : (Fin d → ℕ) → Fq,
+      (∀ m, Tindex p (Fintype.card Fq) d (k - 1) m → c m ≠ 0) ∧
+      (∀ n : ℤ, (Sdk Fq d k).coeff n =
+        ∑ᶠ m ∈ {m : Fin d → ℕ | Tindex p (Fintype.card Fq) d (k - 1) m ∧
+                  ((d * k : ℕ) + weight d m : ℤ) = n}, c m) := by
+  -- The witness is the explicit family `cwit Fq d k`; its two required properties
+  -- are exactly the assembly lemmas `cwit_ne_zero` and `Sdk_coeff_eq_finsum`.
+  refine ⟨cwit Fq d k, ?_, ?_⟩
+  · intro m hm
+    exact cwit_ne_zero Fq p f d k hp hf hd hk hchar hq m hm
+  · intro n
+    exact Sdk_coeff_eq_finsum Fq p f d k hp hf hd hk hchar hq n
+
+/-! ## Correctness statements for the definitions
+
+The following auxiliary statements pin down that `monicOf` is the intended
+enumeration of the monic polynomials of degree exactly `d`, justifying that
+`Sdk` is the power sum `S_d(k) = ∑_{a ∈ A_d ^ +} a ^ {-k}`. -/
+
+/-- The lower-degree part `∑_{i<d} C(θ i) X ^ i` has degree `< d`. -/
+theorem monicOf_lower_degree (Fq : Type) [Field Fq] (d : ℕ) (θ : Fin d → Fq) :
+    (∑ i : Fin d, C (θ i) * X ^ (i : ℕ)).degree < (d : WithBot ℕ) := by
+  apply lt_of_le_of_lt (degree_sum_le Finset.univ _)
+  rw [Finset.sup_lt_iff (WithBot.bot_lt_coe _)]
+  intro i _
+  apply lt_of_le_of_lt (degree_C_mul_X_pow_le _ _)
+  exact_mod_cast i.isLt
+
+/-- `monicOf` always produces a monic polynomial. -/
+theorem monicOf_monic (Fq : Type) [Field Fq] (d : ℕ) (θ : Fin d → Fq) :
+    (monicOf Fq d θ).Monic := by
+  unfold monicOf
+  have hlt := monicOf_lower_degree Fq d θ
+  apply monic_X_pow_add
+  exact hlt
+
+/-- `monicOf` produces a polynomial of degree exactly `d`. -/
+theorem monicOf_natDegree (Fq : Type) [Field Fq] (d : ℕ) (θ : Fin d → Fq) :
+    (monicOf Fq d θ).natDegree = d := by
+  have hm := monicOf_monic Fq d θ
+  have hlt := monicOf_lower_degree Fq d θ
+  unfold monicOf
+  have hdeg : (X ^ d + ∑ i : Fin d, C (θ i) * X ^ (i : ℕ)).degree = (d : WithBot ℕ) := by
+    rw [degree_add_eq_left_of_degree_lt]
+    · rw [degree_X_pow]
+    · rw [degree_X_pow]; exact hlt
+  exact natDegree_eq_of_degree_eq_some hdeg
+
+/-- The coefficient of `X ^ i` (for `i < d`) in `monicOf θ` is `θ i`. -/
+theorem monicOf_coeff (Fq : Type) [Field Fq] (d : ℕ) (θ : Fin d → Fq)
+    (i : Fin d) : (monicOf Fq d θ).coeff (i : ℕ) = θ i := by
+  unfold monicOf
+  rw [coeff_add, coeff_X_pow]
+  rw [if_neg (by exact Nat.ne_of_lt i.isLt)]
+  rw [zero_add, finsetSum_coeff]
+  rw [Finset.sum_eq_single i]
+  · rw [coeff_C_mul, coeff_X_pow, if_pos rfl, mul_one]
+  · intro j _ hj
+    rw [coeff_C_mul, coeff_X_pow, if_neg, mul_zero]
+    exact fun h => hj (Fin.ext h.symm)
+  · intro h; exact absurd (Finset.mem_univ i) h
+
+/-- Distinct coefficient tuples give distinct polynomials, so the parameterization
+of `A_d ^ +` by `Fin d → Fq` has no repetitions. -/
+theorem monicOf_injective (Fq : Type) [Field Fq] (d : ℕ) :
+    Function.Injective (monicOf Fq d) := by
+  intro θ θ' h
+  funext i
+  have := monicOf_coeff Fq d θ i
+  have h2 := monicOf_coeff Fq d θ' i
+  rw [h] at this
+  rw [this] at h2
+  exact h2
+
+/-- The parameterization is surjective onto `A_d ^ +`: every monic polynomial of
+degree exactly `d` arises as `monicOf` of its lower coefficients. -/
+theorem monicOf_surjective (Fq : Type) [Field Fq] (d : ℕ) (a : Polynomial Fq)
+    (ha : a.Monic) (hdeg : a.natDegree = d) :
+    ∃ θ : Fin d → Fq, monicOf Fq d θ = a := by
+  refine ⟨fun i => a.coeff (i : ℕ), ?_⟩
+  have hsum : a = ∑ i ∈ Finset.range (d + 1), C (a.coeff i) * X ^ i := by
+    conv_lhs => rw [a.as_sum_range' (d + 1) (by rw [hdeg]; omega)]
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [C_mul_X_pow_eq_monomial]
+  have hcoeff_top : a.coeff d = 1 := by
+    have := ha.coeff_natDegree
+    rwa [hdeg] at this
+  have hfin : (∑ i : Fin d, C (a.coeff (i : ℕ)) * X ^ (i : ℕ))
+      = ∑ i ∈ Finset.range d, C (a.coeff i) * X ^ i :=
+    Fin.sum_univ_eq_sum_range (fun i => C (a.coeff i) * X ^ i) d
+  change X ^ d + ∑ i : Fin d, C (a.coeff (i : ℕ)) * X ^ (i : ℕ) = a
+  rw [hfin]
+  conv_rhs => rw [hsum, Finset.sum_range_succ, hcoeff_top, map_one, one_mul]
+  rw [add_comm]
+
+end ZetaH123.Lem41

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -122,6 +122,45 @@ projects:
     msc:
       - "11M06"
       - "11J72"
+  - slug: zeta-h123
+    title: Thakur's hypotheses on power sums of F_q[t]
+    summary: Formalizes four components of Thakur's hypotheses on power sums over finite polynomial rings, including uniqueness and monotonicity results for the carry-free digit optimization problems and the Laurent-series expansion of finite-field power sums.
+    branch: number theory
+    entry_module: LeanPool.ZetaH123
+    authors:
+      - Evan Chen
+      - Kenny Lau
+      - Ken Ono
+      - Jujian Zhang
+    source:
+      title: Thakur's hypotheses on power sums of F_q[t]
+      authors:
+        - Evan Chen
+        - Ken Ono
+      arxiv: "2606.16239"
+      github_repo: AxiomMath/zeta-h123
+    license: MIT
+    status: verified
+    main_declarations:
+      - ZetaH123.H1.main_theorem
+      - ZetaH123.Lem41.main
+    main_results:
+      - declaration: ZetaH123.H1.main_theorem
+        informal: Proves uniqueness of the admissible base-q decomposition maximizing the H1 power-sum weight functional.
+      - declaration: ZetaH123.H2.main
+        informal: Proves the H2 unique-minimizer statement for the recursive digit/carry-free optimization problem defining the values s_d(k).
+      - declaration: ZetaH123.H3.main_theorem
+        informal: Proves the H3 monotonicity statement that s_d(k) is strictly less than s_d(k+1) when p does not divide k.
+      - declaration: ZetaH123.Lem41.main
+        informal: Proves the Lemma 4.1 Laurent-series expansion for S_d(k), with nonzero coefficients indexed by the carry-free tuples.
+    tags:
+      - number-theory
+      - function-fields
+      - zeta-functions
+    msc:
+      - "11M38"
+      - "11T55"
+      - "11G09"
   - slug: bruhat-tits
     title: Formalisation of the Bruhat-Tits Tree
     summary: Formalizes the Bruhat-Tits tree for GL₂ over the fraction field of a discrete valuation ring.


### PR DESCRIPTION
## Summary

- imports the `AxiomMath/zeta-h123` formalization as `LeanPool.ZetaH123`
- adds the H1, H2, H3, and Lemma 4.1 modules under `LeanPool/ZetaH123/`
- registers the project in `LeanPool/projects.yml` and regenerates `LeanPool.lean`

## Validation

- `lake build LeanPool.ZetaH123`
- `lake exe lint-style LeanPool.ZetaH123`
- `lake exe runLinter LeanPool.ZetaH123`
- `lake exe mk_all --check`
- focused Zeta static quality checks for headers, forbidden Lean text, file sizes, and proof sizes
- Zeta project metadata, project card, and main declarations check

The full-pool quality command reaches unrelated declaration checks for existing modules that are not built in this temp worktree; Zeta's declarations check directly.