### PR TITLE
[codex] import isoperimetric inequality

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -1023,6 +1023,9 @@ import LeanPool.Isoperimetric.Basic
 import LeanPool.Isoperimetric.BrunnMinkowski
 import LeanPool.Isoperimetric.Isoperimetric
 import LeanPool.Isoperimetric.PrekopaLeindler
+import LeanPool.IsoperimetricInequality
+import LeanPool.IsoperimetricInequality.AdolfHurwitzProof
+import LeanPool.IsoperimetricInequality.Basic
 import LeanPool.KrafftSieve
 import LeanPool.KrafftSieve.Basic
 import LeanPool.KrafftSieve.Defs

--- a/LeanPool/IsoperimetricInequality.lean
+++ b/LeanPool/IsoperimetricInequality.lean
@@ -1,0 +1,19 @@
+/-
+Copyright (c) 2026 M. Samarakkody. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: M. Samarakkody
+-/
+
+import LeanPool.IsoperimetricInequality.Basic
+import LeanPool.IsoperimetricInequality.AdolfHurwitzProof
+
+/-!
+# Formalizing the Classical Isoperimetric Inequality
+
+Source: arxiv:2603.14663, doi:10.5281/zenodo.20258500
+Authors: M. Samarakkody
+Status: verified
+Main declarations: `IsoperimetricInequality.isoperimetric_inequality`
+Tags: isoperimetric-inequality, fourier-analysis, geometric-analysis
+MSC: 52A40, 42A16
+-/

--- a/LeanPool/IsoperimetricInequality/AdolfHurwitzProof.lean
+++ b/LeanPool/IsoperimetricInequality/AdolfHurwitzProof.lean
@@ -1,0 +1,689 @@
+/-
+Copyright (c) 2026 M. Samarakkody. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: M. Samarakkody
+-/
+
+import LeanPool.IsoperimetricInequality.Basic
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Topology.Basic
+import Mathlib.Analysis.Calculus.Deriv.Basic
+import Mathlib.Analysis.Calculus.Deriv.Comp
+import Mathlib.Analysis.Calculus.Deriv.Mul
+import Mathlib.Analysis.Calculus.FDeriv.WithLp
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Tactic.Ring
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
+
+/-!
+# Adolf Hurwitz's Proof of the Isoperimetric Inequality
+
+This file formalizes Adolf Hurwitz's 1902 proof of the classical isoperimetric inequality
+in the plane: among all simple closed curves of a given perimeter, the circle encloses the
+maximum area.
+
+## Proof outline
+
+Given a simple closed C¹ curve `γ` of length `L`, we reparametrize it over `[0, 2π]` via
+  `f(θ) = x(Lθ/(2π))`,  `g(θ) = y(Lθ/(2π))`.
+
+The proof proceeds as follows:
+1. **Area formula**: Express the enclosed area using the shoelace formula and reparametrize
+   to get `area = (1/2) ∫₀²π (f g' - g f') dθ`.
+2. **IBP**: Integration by parts shows `∫ f g' = -∫ g f'`, simplifying the area to
+   `area = ∫₀²π f g' dθ`.
+3. **AM-GM inequality**: Pointwise `2 f g' ≤ f² + (g')²` gives
+   `area ≤ (1/2) ∫₀²π (f² + (g')²) dθ`.
+4. **Wirtinger's inequality**: Since `f` has zero mean (centroid at origin), Parseval's
+   theorem from `IsoperimetricInequality.Basic` gives `∫ f² ≤ ∫ (f')²`, upgrading step 3 to
+   `area ≤ (1/2) ∫₀²π ((f')² + (g')²) dθ`.
+5. **Arc-length constraint** (to be completed): Under arc-length parametrization,
+   `(f')² + (g')² = (L/(2π))²` everywhere, so
+   `∫₀²π ((f')² + (g')²) dθ = L²/(2π)`, yielding `area ≤ L²/(4π)`,
+   with equality iff `γ` is a circle.
+
+## Main declarations
+
+- `SimpleClosedC1Curve`: structure for simple closed C¹ curves parametrized over `[0, L]`
+- `area_parametrized`: shoelace area formula in terms of `f`, `g`
+- `IBP_to_fParm_gParm`: integration by parts for `∫ f g'`
+- `area_simplified`: area equals `∫ f g' dθ`
+- `fParm_gParm_ineq`: AM-GM pointwise inequality
+- `area_inequality`: area bounded by `(1/2) ∫ (f² + (g')²) dθ`
+- `apply_Wirtingers_ineq`: Wirtinger's inequality `∫ f² ≤ ∫ (f')²` for zero-mean `f`
+- `addition_ineq`: combines AM-GM and Wirtinger to give `area ≤ (1/2) ∫ ((f')² + (g')²) dθ`
+- `apply_fParm_gParm_deriv_sq_sum`: arc-length constraint gives `area ≤ (1/2) ∫₀²π L²/(4π²) dθ`
+- `isoperimetric_inequality`: the main result `area ≤ L²/(4π)`
+-/
+
+namespace IsoperimetricInequality
+
+/-- A simple closed C¹ curve in ℝⁿ, parametrized over [0, L] where L is the arc length. -/
+structure SimpleClosedC1Curve (n : ℕ) where
+  /-- The parametrization map. -/
+  curve : ℝ → EuclideanSpace ℝ (Fin n)
+  /-- The period (arc length) of the curve. -/
+  length : ℝ
+  /-- The period is positive. -/
+  length_pos : 0 < length
+  /-- The curve is continuous. -/
+  continuous : Continuous curve
+  /-- The curve is C¹: a derivative exists at every point. -/
+  has_deriv : ∀ t : ℝ, ∃ f : EuclideanSpace ℝ (Fin n), HasDerivAt curve f t
+  /-- The curve is closed: its endpoints coincide. -/
+  closed : curve 0 = curve length
+  /-- The curve is L-periodic. -/
+  periodic : ∀ t : ℝ, curve (t + length) = curve t
+  /-- The curve is simple: injective on the open interval (0, L). -/
+  simple : ∀ t s : ℝ, t ∈ Set.Ioo 0 length → s ∈ Set.Ioo 0 length → curve t = curve s → t = s
+
+/-- The arc length of `γ` over the interval `[a, b]`. -/
+noncomputable def arcLength {n : ℕ} (γ : SimpleClosedC1Curve n) (a b : ℝ) : ℝ :=
+  ∫ t in a..b, ‖deriv γ.curve t‖
+
+/-- The total perimeter of `γ`: arc length over one period `[0, L]`. -/
+noncomputable def perimeter {n : ℕ} (γ : SimpleClosedC1Curve n) : ℝ :=
+  arcLength γ 0 γ.length
+
+/-- A curve is arc-length parametrized if it has unit speed.
+    Since the parameter runs over [0, L], this means ‖γ'(t)‖ = 1 everywhere. -/
+def IsArcLengthParametrized {n : ℕ} (γ : SimpleClosedC1Curve n) : Prop :=
+  ∀ t : ℝ, ‖deriv γ.curve t‖ = 1
+
+/-- The x-coordinate of a planar curve at parameter `s`. -/
+noncomputable def xCoord (γ : SimpleClosedC1Curve 2) (s : ℝ) : ℝ :=
+  γ.curve s 0
+
+/-- The y-coordinate of a planar curve at parameter `s`. -/
+noncomputable def yCoord (γ : SimpleClosedC1Curve 2) (s : ℝ) : ℝ :=
+  γ.curve s 1
+
+/-- Reparametrized x-coordinate: f(θ) = x(Lθ/(2π)) for θ ∈ [0, 2π] -/
+noncomputable def fParm (γ : SimpleClosedC1Curve 2) (θ : ℝ) : ℝ :=
+  xCoord γ (γ.length * θ / (2 * Real.pi))
+
+/-- Reparametrized y-coordinate: g(θ) = y(Lθ/(2π)) for θ ∈ [0, 2π] -/
+noncomputable def gParm (γ : SimpleClosedC1Curve 2) (θ : ℝ) : ℝ :=
+  yCoord γ (γ.length * θ / (2 * Real.pi))
+
+/-- fParm is 2π-periodic. -/
+lemma fParm_periodic (γ : SimpleClosedC1Curve 2) (θ : ℝ) :
+    fParm γ (θ + 2 * Real.pi) = fParm γ θ := by
+  simp only [fParm, xCoord]
+  have h : γ.length * (θ + 2 * Real.pi) / (2 * Real.pi) =
+           γ.length * θ / (2 * Real.pi) + γ.length := by
+    field_simp
+  rw [h, γ.periodic]
+
+/-- gParm is 2π-periodic. -/
+lemma gParm_periodic (γ : SimpleClosedC1Curve 2) (θ : ℝ) :
+    gParm γ (θ + 2 * Real.pi) = gParm γ θ := by
+      simp only [gParm, yCoord]
+      have h : γ.length * (θ + 2 * Real.pi) / (2 * Real.pi) =
+               γ.length * θ / (2 * Real.pi) + γ.length := by
+                field_simp
+      rw [h, γ.periodic]
+
+
+/-- The x-coordinate function is differentiable; its derivative at `t` is the 0th component
+    of the curve's velocity vector at `t`. -/
+lemma xCoord_hasDerivAt (γ : SimpleClosedC1Curve 2) (t : ℝ) :
+    HasDerivAt (xCoord γ) ((γ.has_deriv t).choose 0) t := by
+  set f := (γ.has_deriv t).choose
+  have hf := (γ.has_deriv t).choose_spec
+  have hFD : HasFDerivAt (fun v : EuclideanSpace ℝ (Fin 2) => v 0)
+      (PiLp.proj (𝕜 := ℝ) 2 (fun _ : Fin 2 => ℝ) 0) (γ.curve t) :=
+    PiLp.hasFDerivAt_apply (𝕜 := ℝ) 2 (γ.curve t) 0
+  have hcomp := HasFDerivAt.comp_hasDerivAt t hFD hf
+  exact hcomp.congr_of_eventuallyEq (Filter.Eventually.of_forall (by intro y; rfl))
+
+/-- The y-coordinate function is differentiable; its derivative at `t` is the 1st component
+    of the curve's velocity vector at `t`. -/
+lemma yCoord_hasDerivAt (γ : SimpleClosedC1Curve 2) (t : ℝ) :
+    HasDerivAt (yCoord γ) ((γ.has_deriv t).choose 1) t := by
+  set f := (γ.has_deriv t).choose
+  have hf := (γ.has_deriv t).choose_spec
+  have hFD : HasFDerivAt (fun v : EuclideanSpace ℝ (Fin 2) => v 1)
+      (PiLp.proj (𝕜 := ℝ) 2 (fun _ : Fin 2 => ℝ) 1) (γ.curve t) :=
+    PiLp.hasFDerivAt_apply (𝕜 := ℝ) 2 (γ.curve t) 1
+  have hcomp := HasFDerivAt.comp_hasDerivAt t hFD hf
+  exact hcomp.congr_of_eventuallyEq (Filter.Eventually.of_forall (by intro y; rfl))
+
+/-- The derivative of fParm by the chain rule:
+    (fParm γ)'(θ) = (xCoord γ)'(γ.length · θ / (2π)) · γ.length / (2π) -/
+lemma fParm_deriv (γ : SimpleClosedC1Curve 2) (θ : ℝ) :
+    deriv (fParm γ) θ =
+      deriv (xCoord γ) (γ.length * θ / (2 * Real.pi)) * (γ.length / (2 * Real.pi)) := by
+  have hx := (xCoord_hasDerivAt γ (γ.length * θ / (2 * Real.pi))).differentiableAt
+  have hinner : HasDerivAt (fun t => γ.length * t / (2 * Real.pi)) (γ.length / (2 * Real.pi)) θ :=
+  by
+    have heq : (fun t : ℝ => γ.length * t / (2 * Real.pi)) =
+               fun t => t * (γ.length / (2 * Real.pi)) := by
+      ext t; rw [mul_comm, mul_div_assoc]
+    rw [heq]
+    have hid : HasDerivAt (fun t : ℝ => t) 1 θ := hasDerivAt_id θ
+    have h := HasDerivAt.mul_const hid (γ.length / (2 * Real.pi))
+    simpa using h
+  have hg : HasDerivAt (xCoord γ) (deriv (xCoord γ) (γ.length * θ / (2 * Real.pi)))
+      (γ.length * θ / (2 * Real.pi)) := hx.hasDerivAt
+  have hcomp : HasDerivAt (xCoord γ ∘ fun t => γ.length * t / (2 * Real.pi))
+      (deriv (xCoord γ) (γ.length * θ / (2 * Real.pi)) * (γ.length / (2 * Real.pi))) θ :=
+    HasDerivAt.comp θ hg hinner
+  exact HasDerivAt.deriv hcomp
+
+/-- The derivative of gParm by the chain rule:
+    (gParm γ)'(θ) = (yCoord γ)'(γ.length · θ / (2π)) · γ.length / (2π) -/
+lemma gParm_deriv (γ : SimpleClosedC1Curve 2) (θ : ℝ) :
+    deriv (gParm γ) θ =
+      deriv (yCoord γ) (γ.length * θ / (2 * Real.pi)) * (γ.length / (2 * Real.pi)) := by
+  have hy := (yCoord_hasDerivAt γ (γ.length * θ / (2 * Real.pi))).differentiableAt
+  have hinner :
+  HasDerivAt (fun t => γ.length * t / (2 * Real.pi)) (γ.length / (2 * Real.pi)) θ := by
+    have heq : (fun t : ℝ => γ.length * t / (2 * Real.pi)) =
+               fun t => t * (γ.length / (2 * Real.pi)) := by
+      ext t; rw [mul_comm, mul_div_assoc]
+    rw [heq]
+    have hid : HasDerivAt (fun t : ℝ => t) 1 θ := hasDerivAt_id θ
+    have h := HasDerivAt.mul_const hid (γ.length / (2 * Real.pi))
+    simpa using h
+  have hg : HasDerivAt (yCoord γ) (deriv (yCoord γ) (γ.length * θ / (2 * Real.pi)))
+      (γ.length * θ / (2 * Real.pi)) := hy.hasDerivAt
+  have hcomp : HasDerivAt (yCoord γ ∘ fun t => γ.length * t / (2 * Real.pi))
+      (deriv (yCoord γ) (γ.length * θ / (2 * Real.pi)) * (γ.length / (2 * Real.pi))) θ :=
+    HasDerivAt.comp θ hg hinner
+  exact HasDerivAt.deriv hcomp
+
+/-- The sum of squared derivatives of the reparametrized coordinates equals the sum of squared
+    derivatives of the original coordinates, scaled by `(L / 2π)²`. -/
+lemma fParm_gParm_deriv_sq_sum (γ : SimpleClosedC1Curve 2) (θ : ℝ) :
+    deriv (fParm γ) θ ^ 2 + deriv (gParm γ) θ ^ 2 =
+      (deriv (xCoord γ) (γ.length * θ / (2 * Real.pi)) ^ 2 +
+       deriv (yCoord γ) (γ.length * θ / (2 * Real.pi)) ^ 2) *
+      (γ.length / (2 * Real.pi)) ^ 2 := by
+  rw [fParm_deriv, gParm_deriv]
+  ring
+
+/-- Under arc-length parametrization, the sum of squares of coordinate derivatives equals 1,
+    because the speed ‖γ'(t)‖ = 1 and the two components square-sum to the squared norm. -/
+lemma due_to_arc_length_parametrization (γ : SimpleClosedC1Curve 2)
+    (h : IsArcLengthParametrized γ) (θ : ℝ) :
+    deriv (xCoord γ) (γ.length * θ / (2 * Real.pi)) ^ 2 +
+    deriv (yCoord γ) (γ.length * θ / (2 * Real.pi)) ^ 2 = 1 := by
+  set t := γ.length * θ / (2 * Real.pi)
+  have hxd := (xCoord_hasDerivAt γ t).deriv
+  have hyd := (yCoord_hasDerivAt γ t).deriv
+  have hchoose : deriv γ.curve t = (γ.has_deriv t).choose :=
+    (γ.has_deriv t).choose_spec.deriv
+  have hnorm : ‖(γ.has_deriv t).choose‖ = 1 := by rw [← hchoose]; exact h t
+  rw [hxd, hyd]
+  have hsq : (γ.has_deriv t).choose 0 ^ 2 + (γ.has_deriv t).choose 1 ^ 2 =
+      ‖(γ.has_deriv t).choose‖ ^ 2 := by
+    rw [EuclideanSpace.norm_sq_eq]
+    simp [Fin.sum_univ_two, Real.norm_eq_abs, sq_abs]
+  rw [hsq, hnorm, one_pow]
+
+/-- Under arc-length parametrization, the sum of squared derivatives of the reparametrized
+    coordinates is the constant `(L / 2π)²`. -/
+lemma fParm_gParm_deriv_eq_sum_const (γ : SimpleClosedC1Curve 2)
+    (h : IsArcLengthParametrized γ) (θ : ℝ) :
+    deriv (fParm γ) θ ^ 2 + deriv (gParm γ) θ ^ 2 = (γ.length / (2 * Real.pi)) ^ 2 := by
+  rw [fParm_gParm_deriv_sq_sum]
+  rw [due_to_arc_length_parametrization γ h]
+  ring
+
+
+/-- The signed area enclosed by `γ` between parameters `a` and `b`,
+    computed via the shoelace formula: 1/2 ∫ (x · y' - y · x') dt. -/
+noncomputable def area (γ : SimpleClosedC1Curve 2)
+  (a b : ℝ) : ℝ :=
+  (1/2)*∫ t in a..b, (γ.curve t 0 * deriv γ.curve t 1 - γ.curve t 1 * deriv γ.curve t 0)
+
+
+/-- x'(s) = (2π/L) f'(θ), where θ = 2π·s/L -/
+lemma xPrime_s (γ : SimpleClosedC1Curve 2) (s : ℝ) :
+    deriv (xCoord γ) s =
+      (2 * Real.pi) / γ.length * deriv (fParm γ) (2 * Real.pi * s / γ.length) := by
+  have hpi : (0 : ℝ) < 2 * Real.pi := by positivity
+  have hL : (0 : ℝ) < γ.length := γ.length_pos
+  have h := fParm_deriv γ (2 * Real.pi * s / γ.length)
+  have hsimp : γ.length * (2 * Real.pi * s / γ.length) / (2 * Real.pi) = s := by
+    field_simp
+  rw [hsimp] at h
+  rw [h]
+  field_simp [hL.ne', hpi.ne']
+
+/-- y'(s) = (2π/L) g'(θ), where θ = 2π·s/L -/
+lemma yPrime_s (γ : SimpleClosedC1Curve 2) (s : ℝ) :
+    deriv (yCoord γ) s =
+      (2 * Real.pi) / γ.length * deriv (gParm γ) (2 * Real.pi * s / γ.length) := by
+    have hpi : (0 : ℝ) < 2 * Real.pi := by positivity
+    have hL : (0 : ℝ) < γ.length := γ.length_pos
+    have h := gParm_deriv γ (2 * Real.pi * s / γ.length)
+    have hsimp : γ.length * (2 * Real.pi * s / γ.length) / (2 * Real.pi) = s := by
+      field_simp
+    rw [hsimp] at h
+    rw [h]
+    field_simp [hL.ne', hpi.ne']
+
+/-- area = (1/2)∫₀²π f(θ)g'(θ) - g(θ)f'(θ) dθ -/
+lemma area_parametrized (γ : SimpleClosedC1Curve 2) :
+    area γ 0 γ.length =
+      (1 / 2) * ∫ t in (0 : ℝ)..(2 * Real.pi),
+        fParm γ t * deriv (gParm γ) t - gParm γ t * deriv (fParm γ) t := by
+  unfold area
+  have hL : (0 : ℝ) < γ.length := γ.length_pos
+  have hpi : (0 : ℝ) < 2 * Real.pi := by positivity
+  have key : (1/2) * ∫ s in (0 : ℝ)..γ.length,
+    (xCoord γ s * deriv (yCoord γ) s - yCoord γ s * deriv (xCoord γ) s) =
+    (1/2) * ∫ t in (0 : ℝ)..(2*Real.pi),
+    fParm γ t * deriv (gParm γ) t - gParm γ t * deriv (fParm γ) t := by
+      have xeq : ∀ s, xCoord γ s = fParm γ (2 * Real.pi * s / γ.length) := fun s ↦ by
+        simp only [fParm, xCoord]
+        have heq : γ.length * (2 * Real.pi * s / γ.length) / (2 * Real.pi) = s := by
+         field_simp [hL.ne']
+        rw [heq]
+      have yeq : ∀ s, yCoord γ s = gParm γ (2 * Real.pi * s / γ.length) := fun s ↦ by
+        simp only [gParm, yCoord]
+        have heq : γ.length * (2 * Real.pi * s / γ.length) / (2 * Real.pi) = s := by
+          field_simp [hL.ne']
+        rw [heq]
+      simp_rw [xeq, yeq, xPrime_s, yPrime_s]
+      have hπL_ne : γ.length ≠ 0 := hL.ne'
+      have h2π_ne : (2 : ℝ) * Real.pi ≠ 0 := hpi.ne'
+      have hscale : (2 * Real.pi / γ.length) ≠ 0 := div_ne_zero h2π_ne hπL_ne
+      -- factor (2π/L) out of each integrand term
+      have factor : ∀ s : ℝ,
+          fParm γ (2 * Real.pi * s / γ.length) *
+            (2 * Real.pi / γ.length * deriv (gParm γ) (2 * Real.pi * s / γ.length)) -
+          gParm γ (2 * Real.pi * s / γ.length) *
+            (2 * Real.pi / γ.length * deriv (fParm γ) (2 * Real.pi * s / γ.length)) =
+          (2 * Real.pi / γ.length) *
+            (fParm γ (2 * Real.pi / γ.length * s) * deriv (gParm γ) (2 * Real.pi / γ.length * s) -
+             gParm γ (2 * Real.pi / γ.length * s) * deriv (fParm γ) (2 * Real.pi / γ.length * s)) :=
+        fun s => by rw [show 2 * Real.pi * s / γ.length =
+        2 * Real.pi / γ.length * s from by ring]; ring
+      congr 1
+      simp_rw [factor, intervalIntegral.integral_const_mul]
+      -- use smul_integral_comp_mul_left with named args to pin down f exactly
+      have key3 := intervalIntegral.smul_integral_comp_mul_left
+        (f := fun t : ℝ => fParm γ t * deriv (gParm γ) t - gParm γ t * deriv (fParm γ) t)
+        (a := (0 : ℝ)) (b := γ.length) (2 * Real.pi / γ.length)
+      rw [mul_zero, show (2 * Real.pi / γ.length) * γ.length = 2 * Real.pi from by
+        field_simp] at key3
+      exact key3
+  -- connect the outer goal (uses .ofLp and deriv γ.curve) to key (uses xCoord/yCoord)
+  have hxd : ∀ t : ℝ, deriv (xCoord γ) t = (deriv γ.curve t) 0 := fun t => by
+    rw [(xCoord_hasDerivAt γ t).deriv, (γ.has_deriv t).choose_spec.deriv]
+  have hyd : ∀ t : ℝ, deriv (yCoord γ) t = (deriv γ.curve t) 1 := fun t => by
+    rw [(yCoord_hasDerivAt γ t).deriv, (γ.has_deriv t).choose_spec.deriv]
+  have eq1 : (1/2) * ∫ t in (0:ℝ)..γ.length,
+      ((γ.curve t).ofLp 0 * (deriv γ.curve t).ofLp 1 -
+       (γ.curve t).ofLp 1 * (deriv γ.curve t).ofLp 0) =
+    (1/2) * ∫ s in (0:ℝ)..γ.length,
+      (xCoord γ s * deriv (yCoord γ) s - yCoord γ s * deriv (xCoord γ) s) := by
+    congr 1
+    apply intervalIntegral.integral_congr
+    intro t _
+    simp only [xCoord, yCoord, hxd, hyd]
+  rw [eq1]
+  exact key
+
+/-- IBP to prove ∫₀²π f(θ) g'(θ) dθ = -∫₀²π g(θ) f'(θ) dθ -/
+lemma IBP_to_fParm_gParm (γ : SimpleClosedC1Curve 2)
+    (hdc : Continuous (deriv γ.curve)) :
+    ∫ t in (0 : ℝ)..(2 * Real.pi), fParm γ t * deriv (gParm γ) t =
+      -∫ t in (0 : ℝ)..(2 * Real.pi), gParm γ t * deriv (fParm γ) t := by
+  -- Step 1: HasDerivAt for fParm γ at every point (chain rule)
+  have hfHD : ∀ t : ℝ, HasDerivAt (fParm γ) (deriv (fParm γ) t) t := fun t => by
+    rw [fParm_deriv]
+    have hinner : HasDerivAt (fun θ : ℝ => γ.length * θ / (2 * Real.pi))
+        (γ.length / (2 * Real.pi)) t := by
+      have heq : (fun θ : ℝ => γ.length * θ / (2 * Real.pi)) =
+                 fun θ => θ * (γ.length / (2 * Real.pi)) := by ext θ; ring
+      rw [heq]; simpa using (hasDerivAt_id t).mul_const (γ.length / (2 * Real.pi))
+    exact HasDerivAt.comp t
+      (xCoord_hasDerivAt γ _).differentiableAt.hasDerivAt hinner
+  -- Step 2: HasDerivAt for gParm γ at every point (chain rule)
+  have hgHD : ∀ t : ℝ, HasDerivAt (gParm γ) (deriv (gParm γ) t) t := fun t => by
+    rw [gParm_deriv]
+    have hinner : HasDerivAt (fun θ : ℝ => γ.length * θ / (2 * Real.pi))
+        (γ.length / (2 * Real.pi)) t := by
+      have heq : (fun θ : ℝ => γ.length * θ / (2 * Real.pi)) =
+                 fun θ => θ * (γ.length / (2 * Real.pi)) := by ext θ; ring
+      rw [heq]; simpa using (hasDerivAt_id t).mul_const (γ.length / (2 * Real.pi))
+    exact HasDerivAt.comp t
+      (yCoord_hasDerivAt γ _).differentiableAt.hasDerivAt hinner
+  -- Step 3: HasDerivAt for the product t ↦ fParm γ t * gParm γ t (product rule)
+  have hprodHD : ∀ t ∈ Set.uIcc (0 : ℝ) (2 * Real.pi),
+      HasDerivAt (fun t => fParm γ t * gParm γ t)
+        (deriv (fParm γ) t * gParm γ t + fParm γ t * deriv (gParm γ) t) t :=
+    fun t _ => (hfHD t).mul (hgHD t)
+  -- Step 4: Express coordinate derivatives in terms of deriv γ.curve
+  have hxd : ∀ t : ℝ, deriv (xCoord γ) t = (deriv γ.curve t) 0 := fun t => by
+    rw [(xCoord_hasDerivAt γ t).deriv, (γ.has_deriv t).choose_spec.deriv]
+  have hyd : ∀ t : ℝ, deriv (yCoord γ) t = (deriv γ.curve t) 1 := fun t => by
+    rw [(yCoord_hasDerivAt γ t).deriv, (γ.has_deriv t).choose_spec.deriv]
+  -- Step 5: Continuity of coordinate projections (PiLp projections are CLMs)
+  have eval0 : Continuous (fun v : EuclideanSpace ℝ (Fin 2) => v 0) :=
+    (PiLp.proj (𝕜 := ℝ) 2 (fun _ : Fin 2 => ℝ) 0).continuous
+  have eval1 : Continuous (fun v : EuclideanSpace ℝ (Fin 2) => v 1) :=
+    (PiLp.proj (𝕜 := ℝ) 2 (fun _ : Fin 2 => ℝ) 1).continuous
+  -- Step 6: Continuity of the reparametrization θ ↦ L·θ/(2π)
+  have hlinear : Continuous (fun θ : ℝ => γ.length * θ / (2 * Real.pi)) := by fun_prop
+  -- Step 7: Continuity of fParm γ and gParm γ
+  have hf_cont : Continuous (fParm γ) := by
+    have heq : fParm γ = (fun v : EuclideanSpace ℝ (Fin 2) => v 0) ∘ γ.curve ∘
+               (fun θ => γ.length * θ / (2 * Real.pi)) := by
+      ext θ; simp [fParm, xCoord, Function.comp]
+    rw [heq]; exact eval0.comp (γ.continuous.comp hlinear)
+  have hg_cont : Continuous (gParm γ) := by
+    have heq : gParm γ = (fun v : EuclideanSpace ℝ (Fin 2) => v 1) ∘ γ.curve ∘
+               (fun θ => γ.length * θ / (2 * Real.pi)) := by
+      ext θ; simp [gParm, yCoord, Function.comp]
+    rw [heq]; exact eval1.comp (γ.continuous.comp hlinear)
+  -- Step 8: Continuity of deriv (fParm γ) and deriv (gParm γ)
+  have hdf_cont : Continuous (fun θ => deriv (fParm γ) θ) := by
+    have heq : (fun θ => deriv (fParm γ) θ) =
+               fun θ => (deriv γ.curve (γ.length * θ / (2 * Real.pi))) 0 *
+                        (γ.length / (2 * Real.pi)) := by
+      ext θ; rw [fParm_deriv, hxd]
+    rw [heq]; exact (eval0.comp (hdc.comp hlinear)).mul continuous_const
+  have hdg_cont : Continuous (fun θ => deriv (gParm γ) θ) := by
+    have heq : (fun θ => deriv (gParm γ) θ) =
+               fun θ => (deriv γ.curve (γ.length * θ / (2 * Real.pi))) 1 *
+                        (γ.length / (2 * Real.pi)) := by
+      ext θ; rw [gParm_deriv, hyd]
+    rw [heq]; exact (eval1.comp (hdc.comp hlinear)).mul continuous_const
+  -- Step 9: Integrability from continuity on compact intervals
+  have hint1 : IntervalIntegrable (fun t => deriv (fParm γ) t * gParm γ t)
+      MeasureTheory.volume 0 (2 * Real.pi) :=
+    (hdf_cont.mul hg_cont).intervalIntegrable _ _
+  have hint2 : IntervalIntegrable (fun t => fParm γ t * deriv (gParm γ) t)
+      MeasureTheory.volume 0 (2 * Real.pi) :=
+    (hf_cont.mul hdg_cont).intervalIntegrable _ _
+  have hint : IntervalIntegrable
+      (fun t => deriv (fParm γ) t * gParm γ t + fParm γ t * deriv (gParm γ) t)
+      MeasureTheory.volume 0 (2 * Real.pi) := hint1.add hint2
+  -- Step 10: FTC — ∫₀²π (fg)' = fg(2π) - fg(0)
+  have ftc := intervalIntegral.integral_eq_sub_of_hasDerivAt hprodHD hint
+  -- Step 11: Boundary term vanishes by 2π-periodicity of f and g
+  have hf2π : fParm γ (2 * Real.pi) = fParm γ 0 := by
+    have h := fParm_periodic γ 0; simp only [zero_add] at h; exact h
+  have hg2π : gParm γ (2 * Real.pi) = gParm γ 0 := by
+    have h := gParm_periodic γ 0; simp only [zero_add] at h; exact h
+  rw [hf2π, hg2π, sub_self] at ftc
+  -- ftc : ∫ (f'g + fg') = 0
+  -- Step 12: Split the integral of the sum
+  rw [intervalIntegral.integral_add hint1 hint2] at ftc
+  -- ftc : ∫ f'g + ∫ fg' = 0
+  -- Step 13: Solve for ∫ fg' and rewrite using commutativity of multiplication
+  have key : ∫ t in (0:ℝ)..(2 * Real.pi), fParm γ t * deriv (gParm γ) t =
+             -(∫ t in (0:ℝ)..(2 * Real.pi), deriv (fParm γ) t * gParm γ t) := by linarith
+  rw [key]
+  congr 1
+  apply intervalIntegral.integral_congr
+  intro t _; ring
+
+/-- area = ∫ 0 2π f(θ) g'(θ) dθ -/
+lemma area_simplified (γ : SimpleClosedC1Curve 2)
+    (hdc : Continuous (deriv γ.curve)) :
+    area γ 0 γ.length = ∫ t in (0 : ℝ)..(2 * Real.pi), fParm γ t * (deriv (gParm γ) t) := by
+  rw [area_parametrized]
+  have ibp := IBP_to_fParm_gParm γ hdc
+  -- Re-establish continuity facts needed for integrability
+  have hlinear : Continuous (fun θ : ℝ => γ.length * θ / (2 * Real.pi)) := by fun_prop
+  have eval0 : Continuous (fun v : EuclideanSpace ℝ (Fin 2) => v 0) :=
+    (PiLp.proj (𝕜 := ℝ) 2 (fun _ : Fin 2 => ℝ) 0).continuous
+  have eval1 : Continuous (fun v : EuclideanSpace ℝ (Fin 2) => v 1) :=
+    (PiLp.proj (𝕜 := ℝ) 2 (fun _ : Fin 2 => ℝ) 1).continuous
+  have hxd : ∀ t : ℝ, deriv (xCoord γ) t = (deriv γ.curve t) 0 := fun t => by
+    rw [(xCoord_hasDerivAt γ t).deriv, (γ.has_deriv t).choose_spec.deriv]
+  have hyd : ∀ t : ℝ, deriv (yCoord γ) t = (deriv γ.curve t) 1 := fun t => by
+    rw [(yCoord_hasDerivAt γ t).deriv, (γ.has_deriv t).choose_spec.deriv]
+  have hf_cont : Continuous (fParm γ) := by
+    have heq : fParm γ = (fun v : EuclideanSpace ℝ (Fin 2) => v 0) ∘ γ.curve ∘
+               (fun θ => γ.length * θ / (2 * Real.pi)) := by
+      ext θ; simp [fParm, xCoord, Function.comp]
+    rw [heq]; exact eval0.comp (γ.continuous.comp hlinear)
+  have hg_cont : Continuous (gParm γ) := by
+    have heq : gParm γ = (fun v : EuclideanSpace ℝ (Fin 2) => v 1) ∘ γ.curve ∘
+               (fun θ => γ.length * θ / (2 * Real.pi)) := by
+      ext θ; simp [gParm, yCoord, Function.comp]
+    rw [heq]; exact eval1.comp (γ.continuous.comp hlinear)
+  have hdf_cont : Continuous (fun θ => deriv (fParm γ) θ) := by
+    have heq : (fun θ => deriv (fParm γ) θ) =
+               fun θ => (deriv γ.curve (γ.length * θ / (2 * Real.pi))) 0 *
+                        (γ.length / (2 * Real.pi)) := by
+      ext θ; rw [fParm_deriv, hxd]
+    rw [heq]; exact (eval0.comp (hdc.comp hlinear)).mul continuous_const
+  have hdg_cont : Continuous (fun θ => deriv (gParm γ) θ) := by
+    have heq : (fun θ => deriv (gParm γ) θ) =
+               fun θ => (deriv γ.curve (γ.length * θ / (2 * Real.pi))) 1 *
+                        (γ.length / (2 * Real.pi)) := by
+      ext θ; rw [gParm_deriv, hyd]
+    rw [heq]; exact (eval1.comp (hdc.comp hlinear)).mul continuous_const
+  -- Integrability of fg' and gf'
+  have hint_fg' : IntervalIntegrable (fun t => fParm γ t * deriv (gParm γ) t)
+      MeasureTheory.volume 0 (2 * Real.pi) :=
+    (hf_cont.mul hdg_cont).intervalIntegrable _ _
+  have hint_gf' : IntervalIntegrable (fun t => gParm γ t * deriv (fParm γ) t)
+      MeasureTheory.volume 0 (2 * Real.pi) :=
+    (hg_cont.mul hdf_cont).intervalIntegrable _ _
+  -- Split ∫ (fg' - gf') = ∫ fg' - ∫ gf', then use IBP: ∫ fg' = -∫ gf'
+  rw [intervalIntegral.integral_sub hint_fg' hint_gf']
+  linarith
+
+/-- 2f(θ)g'(θ) ≤ (f(θ))^2 + (g'(θ))^2 -/
+lemma fParm_gParm_ineq (γ : SimpleClosedC1Curve 2) (θ : ℝ) :
+    2 * fParm γ θ * deriv (gParm γ) θ ≤ (fParm γ θ)^2 + (deriv (gParm γ) θ)^2 := by
+  have h : 0 ≤ (fParm γ θ - deriv (gParm γ) θ)^2 := sq_nonneg _
+  nlinarith [h]
+
+/-- area ≤ (1/2) * ∫0 2π ((f(θ))^2 + (g'(θ))^2) dθ -/
+lemma area_inequality (γ : SimpleClosedC1Curve 2)
+    (hdc : Continuous (deriv γ.curve)) :
+    area γ 0 γ.length ≤
+      (1/2) * ∫ t in (0 : ℝ)..(2 * Real.pi), ((fParm γ t)^2 + (deriv (gParm γ) t)^2) := by
+  rw [area_simplified γ hdc]
+  -- Continuity facts needed for integrability
+  have hlinear : Continuous (fun θ : ℝ => γ.length * θ / (2 * Real.pi)) := by fun_prop
+  have eval0 : Continuous (fun v : EuclideanSpace ℝ (Fin 2) => v 0) :=
+    (PiLp.proj (𝕜 := ℝ) 2 (fun _ : Fin 2 => ℝ) 0).continuous
+  have eval1 : Continuous (fun v : EuclideanSpace ℝ (Fin 2) => v 1) :=
+    (PiLp.proj (𝕜 := ℝ) 2 (fun _ : Fin 2 => ℝ) 1).continuous
+  have hyd : ∀ t : ℝ, deriv (yCoord γ) t = (deriv γ.curve t) 1 := fun t => by
+    rw [(yCoord_hasDerivAt γ t).deriv, (γ.has_deriv t).choose_spec.deriv]
+  have hf_cont : Continuous (fParm γ) := by
+    have heq : fParm γ = (fun v : EuclideanSpace ℝ (Fin 2) => v 0) ∘ γ.curve ∘
+               (fun θ => γ.length * θ / (2 * Real.pi)) := by
+      ext θ; simp [fParm, xCoord, Function.comp]
+    rw [heq]; exact eval0.comp (γ.continuous.comp hlinear)
+  have hdg_cont : Continuous (fun θ => deriv (gParm γ) θ) := by
+    have heq : (fun θ => deriv (gParm γ) θ) =
+               fun θ => (deriv γ.curve (γ.length * θ / (2 * Real.pi))) 1 *
+                        (γ.length / (2 * Real.pi)) := by
+      ext θ; rw [gParm_deriv, hyd]
+    rw [heq]; exact (eval1.comp (hdc.comp hlinear)).mul continuous_const
+  -- Integrability of lhs and rhs integrands
+  have hint_lhs : IntervalIntegrable (fun t => fParm γ t * deriv (gParm γ) t)
+      MeasureTheory.volume 0 (2 * Real.pi) :=
+    (hf_cont.mul hdg_cont).intervalIntegrable _ _
+  have hint_rhs : IntervalIntegrable
+      (fun t => (1 / 2) * ((fParm γ t)^2 + (deriv (gParm γ) t)^2))
+      MeasureTheory.volume 0 (2 * Real.pi) :=
+    (continuous_const.mul ((hf_cont.pow 2).add (hdg_cont.pow 2))).intervalIntegrable _ _
+  -- Pointwise: fg' ≤ (1/2)(f² + g'²) follows from fParm_gParm_ineq
+  have hpw : ∀ t ∈ Set.Icc (0 : ℝ) (2 * Real.pi),
+      fParm γ t * deriv (gParm γ) t ≤ (1 / 2) * ((fParm γ t)^2 + (deriv (gParm γ) t)^2) :=
+    fun t _ => by linarith [fParm_gParm_ineq γ t]
+  -- ∫ fg' ≤ ∫ (1/2)(f² + g'²) by integral_mono_on
+  have hmono := intervalIntegral.integral_mono_on (by positivity) hint_lhs hint_rhs hpw
+  -- Pull 1/2 out: ∫ (1/2)(f² + g'²) = (1/2) * ∫ (f² + g'²) via integral_smul
+  have heq : ∫ t in (0 : ℝ)..(2 * Real.pi),
+        (1 / 2 : ℝ) * ((fParm γ t)^2 + (deriv (gParm γ) t)^2) =
+      (1 / 2) * ∫ t in (0 : ℝ)..(2 * Real.pi), ((fParm γ t)^2 + (deriv (gParm γ) t)^2) := by
+    have h : (fun t => (1 / 2 : ℝ) * ((fParm γ t)^2 + (deriv (gParm γ) t)^2)) =
+             (fun t => (1 / 2 : ℝ) • ((fParm γ t)^2 + (deriv (gParm γ) t)^2)) := by
+      ext t; simp [smul_eq_mul]
+    rw [h, intervalIntegral.integral_smul, smul_eq_mul]
+  linarith
+
+/-- Apply Wirtinger's Inequality: for a 2π-periodic function with zero mean (a₀ = 0),
+    the Parseval and Wirtinger integral formulas imply ∫₀²π f² ≤ ∫₀²π (f')².
+    This follows from comparing the Fourier coefficient sums:
+    ∑ₙ (aₙ² + bₙ²) ≤ ∑ₙ n²(aₙ² + bₙ²) since n ≥ 1 for all n : ℕ+. -/
+lemma apply_Wirtingers_ineq (γ : SimpleClosedC1Curve 2)
+    -- Fourier coefficients for fParm γ (with a 0 = 0 encoding zero mean)
+    (a b : ℕ → ℝ)
+    -- Parseval identity: ∫₀²π (fParm γ)² = π · ∑ₙ≥1 (aₙ² + bₙ²)
+    -- (zero mean / a₀ = 0 is implicit here — the constant term is absent)
+    (h_parseval : ∫ t in (0 : ℝ)..(2 * Real.pi), (fParm γ t) ^ 2 =
+        Real.pi * ∑' n : ℕ+, ((a n) ^ 2 + (b n) ^ 2))
+    -- Wirtinger identity (Parseval applied to f'): ∫₀²π (fParm γ')² = π · ∑ₙ≥1 n²(aₙ² + bₙ²)
+    (h_wirtinger : ∫ t in (0 : ℝ)..(2 * Real.pi), (deriv (fParm γ) t) ^ 2 =
+        Real.pi * ∑' n : ℕ+, ((n : ℝ) ^ 2 * ((a n) ^ 2 + (b n) ^ 2)))
+    -- Summability of n²(aₙ² + bₙ²) (needed for tsum comparison)
+    (hsum : Summable (fun n : ℕ+ => (n : ℝ) ^ 2 * ((a n) ^ 2 + (b n) ^ 2))) :
+    ∫ t in (0 : ℝ)..(2 * Real.pi), (fParm γ t) ^ 2 ≤
+      ∫ t in (0 : ℝ)..(2 * Real.pi), (deriv (fParm γ) t) ^ 2 := by
+  rw [h_parseval, h_wirtinger]
+  -- It suffices to compare ∑ (aₙ² + bₙ²) ≤ ∑ n²(aₙ² + bₙ²)
+  apply mul_le_mul_of_nonneg_left _ (le_of_lt Real.pi_pos)
+  -- Pointwise: aₙ² + bₙ² ≤ n²(aₙ² + bₙ²), since n² ≥ 1 for n : ℕ+
+  have hpw : ∀ n : ℕ+, (a n) ^ 2 + (b n) ^ 2 ≤ (n : ℝ) ^ 2 * ((a n) ^ 2 + (b n) ^ 2) :=
+      fun n => by
+    have hn_nat : (1 : ℕ) ≤ n := Nat.succ_le_of_lt n.2
+    have hn : (1 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn_nat
+    have hnn : (0 : ℝ) ≤ (a n) ^ 2 + (b n) ^ 2 := by positivity
+    calc (a n) ^ 2 + (b n) ^ 2
+        = 1 * ((a n) ^ 2 + (b n) ^ 2) := (one_mul _).symm
+      _ ≤ (n : ℝ) ^ 2 * ((a n) ^ 2 + (b n) ^ 2) := by
+          apply mul_le_mul_of_nonneg_right _ hnn
+          nlinarith [sq_nonneg ((n : ℝ) - 1)]
+  -- Summability of left side follows from right side via domination
+  have hsum_left : Summable (fun n : ℕ+ => (a n) ^ 2 + (b n) ^ 2) :=
+    Summable.of_nonneg_of_le (fun n => by positivity) hpw hsum
+  exact hsum_left.tsum_le_tsum hpw hsum
+
+/-- Combining `area_inequality` (AM-GM) and `apply_Wirtingers_ineq` (Wirtinger):
+    the enclosed area is bounded by (1/2) times the integral of the sum of squared
+    reparametrized velocities. -/
+lemma addition_ineq (γ : SimpleClosedC1Curve 2)
+    (hdc : Continuous (deriv γ.curve))
+    -- Fourier coefficients and Parseval/Wirtinger hypotheses for fParm γ
+    (a b : ℕ → ℝ)
+    (h_parseval : ∫ t in (0 : ℝ)..(2 * Real.pi), (fParm γ t) ^ 2 =
+        Real.pi * ∑' n : ℕ+, ((a n) ^ 2 + (b n) ^ 2))
+    (h_wirtinger : ∫ t in (0 : ℝ)..(2 * Real.pi), (deriv (fParm γ) t) ^ 2 =
+        Real.pi * ∑' n : ℕ+, ((n : ℝ) ^ 2 * ((a n) ^ 2 + (b n) ^ 2)))
+    (hsum : Summable (fun n : ℕ+ => (n : ℝ) ^ 2 * ((a n) ^ 2 + (b n) ^ 2))) :
+    area γ 0 γ.length ≤
+      (1/2) * ∫ t in (0 : ℝ)..(2 * Real.pi),
+        ((deriv (fParm γ) t)^2 + (deriv (gParm γ) t)^2) := by
+  -- Rebuild continuity facts needed for integrability
+  have hlinear : Continuous (fun θ : ℝ => γ.length * θ / (2 * Real.pi)) := by fun_prop
+  have eval0 : Continuous (fun v : EuclideanSpace ℝ (Fin 2) => v 0) :=
+    (PiLp.proj (𝕜 := ℝ) 2 (fun _ : Fin 2 => ℝ) 0).continuous
+  have eval1 : Continuous (fun v : EuclideanSpace ℝ (Fin 2) => v 1) :=
+    (PiLp.proj (𝕜 := ℝ) 2 (fun _ : Fin 2 => ℝ) 1).continuous
+  have hxd : ∀ t : ℝ, deriv (xCoord γ) t = (deriv γ.curve t) 0 := fun t => by
+    rw [(xCoord_hasDerivAt γ t).deriv, (γ.has_deriv t).choose_spec.deriv]
+  have hyd : ∀ t : ℝ, deriv (yCoord γ) t = (deriv γ.curve t) 1 := fun t => by
+    rw [(yCoord_hasDerivAt γ t).deriv, (γ.has_deriv t).choose_spec.deriv]
+  have hf_cont : Continuous (fParm γ) := by
+    have heq : fParm γ = (fun v : EuclideanSpace ℝ (Fin 2) => v 0) ∘ γ.curve ∘
+               (fun θ => γ.length * θ / (2 * Real.pi)) := by
+      ext θ; simp [fParm, xCoord, Function.comp]
+    rw [heq]; exact eval0.comp (γ.continuous.comp hlinear)
+  have hdf_cont : Continuous (fun θ => deriv (fParm γ) θ) := by
+    have heq : (fun θ => deriv (fParm γ) θ) =
+               fun θ => (deriv γ.curve (γ.length * θ / (2 * Real.pi))) 0 *
+                        (γ.length / (2 * Real.pi)) := by ext θ; rw [fParm_deriv, hxd]
+    rw [heq]; exact (eval0.comp (hdc.comp hlinear)).mul continuous_const
+  have hdg_cont : Continuous (fun θ => deriv (gParm γ) θ) := by
+    have heq : (fun θ => deriv (gParm γ) θ) =
+               fun θ => (deriv γ.curve (γ.length * θ / (2 * Real.pi))) 1 *
+                        (γ.length / (2 * Real.pi)) := by ext θ; rw [gParm_deriv, hyd]
+    rw [heq]; exact (eval1.comp (hdc.comp hlinear)).mul continuous_const
+  -- Integrability of each squared term
+  have hint_f2 : IntervalIntegrable (fun t => (fParm γ t)^2)
+      MeasureTheory.volume 0 (2 * Real.pi) := (hf_cont.pow 2).intervalIntegrable _ _
+  have hint_dg2 : IntervalIntegrable (fun t => (deriv (gParm γ) t)^2)
+      MeasureTheory.volume 0 (2 * Real.pi) := (hdg_cont.pow 2).intervalIntegrable _ _
+  have hint_df2 : IntervalIntegrable (fun t => (deriv (fParm γ) t)^2)
+      MeasureTheory.volume 0 (2 * Real.pi) := (hdf_cont.pow 2).intervalIntegrable _ _
+  -- Step 1: area ≤ (1/2) * ∫ (f² + (g')²)   [area_inequality + AM-GM]
+  -- Step 2: ∫ f² ≤ ∫ (f')²                   [apply_Wirtingers_ineq]
+  -- Step 3: add ∫ (g')² to both sides of Step 2
+  have h_wirtingers := apply_Wirtingers_ineq γ a b h_parseval h_wirtinger hsum
+  have h_int_ineq : ∫ t in (0:ℝ)..(2*Real.pi), ((fParm γ t)^2 + (deriv (gParm γ) t)^2) ≤
+                    ∫ t in (0:ℝ)..(2*Real.pi), ((deriv (fParm γ) t)^2 + (deriv (gParm γ) t)^2) := by
+    rw [intervalIntegral.integral_add hint_f2 hint_dg2,
+        intervalIntegral.integral_add hint_df2 hint_dg2]
+    linarith
+  calc area γ 0 γ.length
+      ≤ (1/2) * ∫ t in (0:ℝ)..(2*Real.pi), ((fParm γ t)^2 + (deriv (gParm γ) t)^2) :=
+          area_inequality γ hdc
+    _ ≤ (1/2) * ∫ t in (0:ℝ)..(2*Real.pi), ((deriv (fParm γ) t)^2 + (deriv (gParm γ) t)^2) :=
+          mul_le_mul_of_nonneg_left h_int_ineq (by norm_num)
+
+
+/-- **Isoperimetric bound**: under arc-length parametrization, the area is at most
+    `(1/2) * ∫₀²π (L/(2π))² dθ = L²/(4π)`.
+    This combines `addition_ineq` (Wirtinger + AM-GM) with the arc-length constraint
+    `(f')² + (g')² = (L/(2π))²` from `fParm_gParm_deriv_sq_sum`. -/
+lemma apply_fParm_gParm_deriv_sq_sum (γ : SimpleClosedC1Curve 2)
+    (hdc : Continuous (deriv γ.curve))
+    (h_arc : IsArcLengthParametrized γ)
+    (a b : ℕ → ℝ)
+    (h_parseval : ∫ t in (0 : ℝ)..(2 * Real.pi), (fParm γ t) ^ 2 =
+        Real.pi * ∑' n : ℕ+, ((a n) ^ 2 + (b n) ^ 2))
+    (h_wirtinger : ∫ t in (0 : ℝ)..(2 * Real.pi), (deriv (fParm γ) t) ^ 2 =
+        Real.pi * ∑' n : ℕ+, ((n : ℝ) ^ 2 * ((a n) ^ 2 + (b n) ^ 2)))
+    (hsum : Summable (fun n : ℕ+ => (n : ℝ) ^ 2 * ((a n) ^ 2 + (b n) ^ 2))) :
+    area γ 0 γ.length ≤
+      (1/2) * ∫ _ in (0 : ℝ)..(2 * Real.pi), (γ.length ^ 2 / (4 * (Real.pi) ^ 2)) := by
+  calc area γ 0 γ.length
+      ≤ (1/2) * ∫ t in (0:ℝ)..(2 * Real.pi),
+            ((deriv (fParm γ) t) ^ 2 + (deriv (gParm γ) t) ^ 2) :=
+          addition_ineq γ hdc a b h_parseval h_wirtinger hsum
+    _ = (1/2) * ∫ t in (0:ℝ)..(2 * Real.pi), (γ.length ^ 2 / (4 * Real.pi ^ 2)) := by
+          congr 1
+          apply intervalIntegral.integral_congr
+          intro t _
+          -- fParm_gParm_deriv_sq_sum: (f')²+(g')² = (x'²+y'²) * (L/(2π))²
+          have hsq := fParm_gParm_deriv_sq_sum γ t
+          -- due_to_arc_length_parametrization: x'²+y'² = 1
+          have harc := due_to_arc_length_parametrization γ h_arc t
+          -- combine: (f')²+(g')² = (L/(2π))² = L²/(4π²)
+          rw [harc, one_mul] at hsq
+          exact hsq.trans (by ring)
+
+
+/-- **Isoperimetric Inequality** (Adolf Hurwitz, 1902): for any simple closed C¹ curve of
+    length `L = γ.length`, the enclosed area satisfies `area ≤ L² / (4π)`.
+    Combines `apply_fParm_gParm_deriv_sq_sum` (which gives `area ≤ (1/2) ∫₀²π L²/(4π²) dθ`)
+    with evaluation of the constant integral: `(1/2) · L²/(4π²) · 2π = L²/(4π)`. -/
+theorem isoperimetric_inequality (γ : SimpleClosedC1Curve 2)
+    (hdc : Continuous (deriv γ.curve))
+    (h_arc : IsArcLengthParametrized γ)
+    (a b : ℕ → ℝ)
+    (h_parseval : ∫ t in (0 : ℝ)..(2 * Real.pi), (fParm γ t) ^ 2 =
+        Real.pi * ∑' n : ℕ+, ((a n) ^ 2 + (b n) ^ 2))
+    (h_wirtinger : ∫ t in (0 : ℝ)..(2 * Real.pi), (deriv (fParm γ) t) ^ 2 =
+        Real.pi * ∑' n : ℕ+, ((n : ℝ) ^ 2 * ((a n) ^ 2 + (b n) ^ 2)))
+    (hsum : Summable (fun n : ℕ+ => (n : ℝ) ^ 2 * ((a n) ^ 2 + (b n) ^ 2))) :
+    area γ 0 γ.length ≤ γ.length ^ 2 / (4 * Real.pi) := by
+  calc area γ 0 γ.length
+      ≤ (1/2) * ∫ _ in (0 : ℝ)..(2 * Real.pi), (γ.length ^ 2 / (4 * (Real.pi) ^ 2)) :=
+          apply_fParm_gParm_deriv_sq_sum γ hdc h_arc a b h_parseval h_wirtinger hsum
+    _ = γ.length ^ 2 / (4 * Real.pi) := by
+          rw [intervalIntegral.integral_const, smul_eq_mul]
+          -- ∫ _ in 0..(2π), c = (2π - 0) * c = 2π * c
+          -- (1/2) * (2π * (L²/(4π²))) = L²/(4π)
+          have hpi : Real.pi ≠ 0 := Real.pi_ne_zero
+          field_simp
+          ring
+
+end IsoperimetricInequality

--- a/LeanPool/IsoperimetricInequality/Basic.lean
+++ b/LeanPool/IsoperimetricInequality/Basic.lean
@@ -1,0 +1,694 @@
+/-
+Copyright (c) 2026 M. Samarakkody. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: M. Samarakkody
+-/
+
+import Mathlib.Analysis.Fourier.FourierTransform
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Topology.Algebra.InfiniteSum.Basic
+import Mathlib.Topology.Algebra.InfiniteSum.Ring
+import Mathlib.Topology.Algebra.InfiniteSum.Constructions
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
+import Mathlib.MeasureTheory.Integral.DominatedConvergence
+import Mathlib.Analysis.BoundedVariation
+import Mathlib.Analysis.Normed.Lp.lpSpace
+import Mathlib.Analysis.Normed.Group.FunctionSeries
+import Mathlib.Analysis.Calculus.UniformLimitsDeriv
+
+/-!
+# The Isoperimetric Inequality
+
+This file formalises basic properties of classical Fourier series needed on the way to
+the isoperimetric inequality.  In particular we prove:
+
+* **Parseval's theorem** – `Parsevals_thm`
+* **Wirtinger's inequality** – `Wirtingers_inequality`
+
+## Main results
+
+### Parseval's theorem (`Parsevals_thm`)
+Given a Fourier series `f(x) = a₀/2 + ∑_{n≥1} (aₙ cos(nx) + bₙ sin(nx))`,
+under suitable integrability and summability hypotheses,
+```
+(1/π) ∫_{-π}^{π} f(x)² dx = (1/2) a₀² + ∑_{n≥1} (aₙ² + bₙ²).
+```
+
+### Wirtinger's inequality (`Wirtingers_inequality`)
+Given the same Fourier series, the Parseval identity applied to the derivative series yields
+```
+(1/π) ∫_{-π}^{π} (f'(x))² dx = ∑_{n≥1} n² (aₙ² + bₙ²).
+```
+This is the continuous analogue of the discrete Wirtinger inequality, and reflects that
+differentiation weights each Fourier mode by its frequency `n`.
+
+## Notation
+
+Throughout, `a : ℕ → ℝ` and `b : ℕ → ℝ` are the cosine and sine Fourier coefficients,
+and the series is indexed over `ℕ+` (positive natural numbers).
+-/
+
+open Real
+open scoped BigOperators Topology MeasureTheory Filter
+
+namespace IsoperimetricInequality
+
+noncomputable section
+
+-- The Fourier coefficients
+variable (a : ℕ → ℝ) (b : ℕ → ℝ)
+
+/-- The classical Fourier series as a function of `x`:
+`f(x) = a₀/2 + ∑_{n=1}^∞ (aₙ cos(nx) + bₙ sin(nx))`. -/
+def fourierSeries (x : ℝ) : ℝ :=
+    (1/2) * a 0 + ∑' n : ℕ+, (a n * cos (n * x) + b n * sin (n * x))
+
+/-- The `N`-th partial sum of the Fourier series:
+`S_N(x) = a₀/2 + ∑_{n=1}^N (aₙ cos(nx) + bₙ sin(nx))`. -/
+def fourierPartialSum (x : ℝ) (N : ℕ) : ℝ :=
+  (1/2) * a 0 + ∑ n ∈ Finset.range N, (a (n + 1) * cos ((n + 1 : ℝ) * x)
+  + b (n + 1) * sin ((n + 1 : ℝ) * x))
+
+
+/-- The oscillatory sum part of the Fourier series (without the constant term):
+`S(x) = ∑_{n=1}^∞ (aₙ cos(nx) + bₙ sin(nx))`. -/
+def fourierSum (x : ℝ) : ℝ :=
+    ∑' n : ℕ+, (a n * cos (n * x) + b n * sin (n * x))
+
+/-- The Fourier series decomposes as `f(x) = a₀/2 + S(x)`,
+where `S(x)` is the oscillatory sum part. -/
+lemma fourierSeries_eq (x : ℝ) :
+  fourierSeries a b x = (1/2) * a 0 + fourierSum a b x := by rfl
+
+
+/-- Expansion of `(f(x))²` as `(a₀/2)² + a₀·S(x) + S(x)²`,
+where `S(x) = fourierSum a b x`. -/
+lemma fourierSeries_sq (x : ℝ) :
+  --(hsum : Summable fun n : ℕ+ => (a n * cos (n * x) + b n * sin (n * x))) :
+  (fourierSeries a b x)^2 = (a 0)^2 / 4 +
+  a 0 * (∑' n : ℕ+ , (a n * cos (n * x) + b n * sin (n * x))) +
+  (∑' n : ℕ+ , (a n * cos (n * x) + b n * sin (n * x)))^2 := by
+  unfold fourierSeries
+  ring
+
+/-- Expands `(∑ aₙ cos(nx) + bₙ sin(nx))²` into
+`(∑ aₙ cos)² + 2·(∑ aₙ cos)(∑ bₙ sin) + (∑ bₙ sin)²`
+using linearity of the infinite sum. -/
+lemma expand_square (x : ℝ)
+    (hc : Summable fun n : ℕ+ => a n * cos (n * x))
+    (hs : Summable fun n : ℕ+ => b n * sin (n * x)) :
+    (∑' n : ℕ+, (a n * cos (n * x) + b n * sin (n * x)))^2 =
+    (∑' n : ℕ+, a n * cos (n * x))^2 +
+    2 * (∑' n : ℕ+, a n * cos (n * x)) * (∑' n : ℕ+, b n * sin (n * x)) +
+    (∑' n : ℕ+, b n * sin (n * x))^2 := by
+  rw [hc.tsum_add hs]
+  ring
+
+/-- Expands the square of the sine partial sum into a double sum:
+`(∑ bₙ sin(nx))² = ∑ₙ ∑ₘ bₙ bₘ sin(nx) sin(mx)`. -/
+lemma expand_sin_sq (x : ℝ)
+    (hs : Summable fun n : ℕ+ => b n * sin (n * x))
+    -- The product family (n,m) ↦ bₙ sin(nx) · bₘ sin(mx) is summable
+    (hprod : Summable fun z : ℕ+ × ℕ+ =>
+      (b z.1 * sin (z.1 * x)) * (b z.2 * sin (z.2 * x)))
+    -- Each inner sum is summable (needed for converting paired → iterated tsum)
+    (hinner : ∀ n : ℕ+, Summable fun m : ℕ+ =>
+      (b n * sin (n * x)) * (b m * sin (m * x))) :
+    (∑' n : ℕ+, b n * sin (n * x))^2 =
+    ∑' n : ℕ+, ∑' m : ℕ+, b n * b m * sin (n * x) * sin (m * x) := by
+  -- Step 1: Rewrite x² as x * x
+  rw [sq]
+  -- Step 2: Product of tsums → tsum over pairs
+  rw [hs.tsum_mul_tsum hs hprod]
+  -- Step 3: Paired tsum → iterated tsum
+  rw [hprod.tsum_prod' hinner]
+  -- Step 4: Show the terms match pointwise
+  congr 1; ext n; congr 1; ext m
+  ring
+
+/-- Expands the square of the cosine partial sum into a double sum:
+`(∑ aₙ cos(nx))² = ∑ₙ ∑ₘ aₙ aₘ cos(nx) cos(mx)`. -/
+lemma expand_cos_sq (x : ℝ)
+    (hs1 : Summable fun n : ℕ+ => a n * cos (n * x))
+    -- The product family (n,m) ↦ aₙ cos(nx) · aₘ cos(mx) is summable
+    (hprod1 : Summable fun z : ℕ+ × ℕ+ =>
+      (a z.1 * cos (z.1 * x)) * (a z.2 * cos (z.2 * x)))
+    -- Each inner sum is summable (needed for converting paired → iterated tsum)
+    (hinner : ∀ n : ℕ+, Summable fun m : ℕ+ =>
+      (a n * cos (n * x)) * (a m * cos (m * x))) :
+    (∑' n : ℕ+, a n * cos (n * x))^2 =
+    ∑' n : ℕ+, ∑' m : ℕ+, a n * a m * cos (n * x) * cos (m * x) := by
+  -- Step 1: Rewrite x² as x * x
+  rw [sq]
+  -- Step 2: Product of tsums → tsum over pairs
+  rw [hs1.tsum_mul_tsum hs1 hprod1]
+  -- Step 3: Paired tsum → iterated tsum
+  rw [hprod1.tsum_prod' hinner]
+  -- Step 4: Show the terms match pointwise
+  congr 1; ext n; congr 1; ext m
+  ring
+
+
+/-- Full expansion of `(f(x))²` into a constant term, cross terms, and double sums,
+combining `fourierSeries_sq`, `expand_square`, `expand_cos_sq`, and `expand_sin_sq`. -/
+theorem fourier_series_sq_expanded (x : ℝ)
+    (hc : Summable fun n : ℕ+ => a n * cos (n * x))
+    (hs : Summable fun n : ℕ+ => b n * sin (n * x))
+    (hprod_cos : Summable fun z : ℕ+ × ℕ+ =>
+      (a z.1 * cos (z.1 * x)) * (a z.2 * cos (z.2 * x)))
+    (hinner_cos : ∀ n : ℕ+, Summable fun m : ℕ+ =>
+      (a n * cos (n * x)) * (a m * cos (m * x)))
+    (hprod_sin : Summable fun z : ℕ+ × ℕ+ =>
+      (b z.1 * sin (z.1 * x)) * (b z.2 * sin (z.2 * x)))
+    (hinner_sin : ∀ n : ℕ+, Summable fun m : ℕ+ =>
+      (b n * sin (n * x)) * (b m * sin (m * x))) :
+    (fourierSeries a b x)^2 = (a 0)^2 / 4 +
+    a 0 * (∑' n : ℕ+, (a n * cos (n * x) + b n * sin (n * x))) +
+    ((∑' n : ℕ+, ∑' m : ℕ+, a n * a m * cos (n * x) * cos (m * x)) +
+    2 * (∑' n : ℕ+, a n * cos (n * x)) * (∑' n : ℕ+, b n * sin (n * x)) +
+    (∑' n : ℕ+, ∑' m : ℕ+, b n * b m * sin (n * x) * sin (m * x))) := by
+  -- Step 1: Expand (a₀/2 + S)² into a₀²/4 + a₀·S + S²
+  rw [fourierSeries_sq]
+  -- Step 2: Expand S² into C² + 2·C·S_sin + S_sin²
+  rw [expand_square a b x hc hs]
+  -- Step 3: Expand C² into double sum
+  rw [expand_cos_sq a x hc hprod_cos hinner_cos]
+  -- Step 4: Expand S_sin² into double sum
+  rw [expand_sin_sq b x hs hprod_sin hinner_sin]
+
+/-- `∫_{-π}^{π} (1/4) a₀² dx = (1/2) a₀² π`. -/
+lemma integration_of_const :
+    ∫ _x in (-π)..π, (1 / 4) * (a 0)^2 = (1 / 2) * (a 0)^2 * π := by
+  rw [intervalIntegral.integral_const]
+  simp [smul_eq_mul]
+  ring
+
+/-- `∫_{-π}^{π} cos(n·x) dx = 0` for any positive integer `n : ℕ+`. -/
+private lemma integral_cos_pnat (n : ℕ+) :
+    ∫ x in (-π)..π, cos ((n : ℝ) * x) = 0 := by
+  have hn : (n : ℝ) ≠ 0 := by exact_mod_cast n.pos.ne'
+  have h_sin : sin ((n : ℝ) * π) = 0 := by exact_mod_cast sin_nat_mul_pi (n : ℕ)
+  have key : (n : ℝ) * ∫ x in (-π)..π, cos ((n : ℝ) * x) = 0 := by
+    rw [intervalIntegral.mul_integral_comp_mul_left, integral_cos]
+    simp [mul_neg, sin_neg, h_sin]
+  exact (mul_eq_zero.mp key).resolve_left hn
+
+/-- `∫_{-π}^{π} sin(n·x) dx = 0` for any positive integer `n : ℕ+`. -/
+private lemma integral_sin_pnat (n : ℕ+) :
+    ∫ x in (-π)..π, sin ((n : ℝ) * x) = 0 := by
+  have hn : (n : ℝ) ≠ 0 := by exact_mod_cast n.pos.ne'
+  have key : (n : ℝ) * ∫ x in (-π)..π, sin ((n : ℝ) * x) = 0 := by
+    rw [intervalIntegral.mul_integral_comp_mul_left, integral_sin]
+    simp [mul_neg, cos_neg]
+  exact (mul_eq_zero.mp key).resolve_left hn
+
+/-- Orthogonality of individual Fourier terms:
+`∫_{-π}^{π} (aₙ cos(nx) + bₙ sin(nx)) dx = 0` for each `n : ℕ+`. -/
+private lemma integral_fourierTerm (n : ℕ+) :
+    ∫ x in (-π)..π, (a n * cos ((n : ℝ) * x) + b n * sin ((n : ℝ) * x)) = 0 := by
+  have hc : Continuous (fun x => a n * cos ((n : ℝ) * x)) :=
+    continuous_const.mul (continuous_cos.comp (continuous_const.mul continuous_id))
+  have hs : Continuous (fun x => b n * sin ((n : ℝ) * x)) :=
+    continuous_const.mul (continuous_sin.comp (continuous_const.mul continuous_id))
+  rw [intervalIntegral.integral_add (hc.intervalIntegrable (-π) π) (hs.intervalIntegrable (-π) π),
+      intervalIntegral.integral_const_mul, intervalIntegral.integral_const_mul,
+      integral_cos_pnat n, integral_sin_pnat n, mul_zero, mul_zero, add_zero]
+
+/-- The cross term integrates to zero over `[-π, π]`:
+`∫_{-π}^{π} a₀ · (∑_{n≥1} aₙ cos(nx) + bₙ sin(nx)) dx = 0`. -/
+lemma integration_of_cos_sin
+    (hF_int : ∀ n : ℕ+, IntervalIntegrable
+      (fun x => a n * cos ((n : ℕ+) * x) + b n * sin ((n : ℕ+) * x))
+      MeasureTheory.volume (-π) π)
+    (hF_sum : Summable (fun n : ℕ+ =>
+      ∫ x in (-π)..π, ‖a n * cos ((n : ℕ+) * x) + b n * sin ((n : ℕ+) * x)‖)) :
+    ∫ x in (-π)..π, a 0 * fourierSum a b x = 0 := by
+  -- Factor out the constant a 0
+  rw [intervalIntegral.integral_const_mul]
+  -- It suffices to show ∫ fourierSum = 0
+  suffices h : ∫ x in (-π)..π, fourierSum a b x = 0 by simp [h]
+  simp only [fourierSum]
+  -- Interchange ∫ and ∑' (by summability of norms via dominated convergence)
+  have hswap : ∫ x in (-π)..π,
+        ∑' n : ℕ+, (a n * cos ((n : ℕ+) * x) + b n * sin ((n : ℕ+) * x)) =
+        ∑' n : ℕ+, ∫ x in (-π)..π,
+          (a n * cos ((n : ℕ+) * x) + b n * sin ((n : ℕ+) * x)) := by
+    have h_le : (-π : ℝ) ≤ π := by linarith [Real.pi_pos]
+    -- Convert interval integrals to restricted integrals over Ioc (-π) π
+    simp_rw [intervalIntegral.integral_of_le h_le]
+    symm
+    -- Apply integral_tsum_of_summable_integral_norm with μ = volume.restrict (Ioc (-π) π)
+    apply MeasureTheory.integral_tsum_of_summable_integral_norm
+    · intro n; exact (hF_int n).1
+    · simp_rw [← intervalIntegral.integral_of_le h_le]; exact hF_sum
+  rw [hswap]
+  -- Each term integrates to zero by orthogonality of trig functions
+  simp_rw [integral_fourierTerm a b, tsum_zero]
+
+/-- Orthogonality of cosines: `∫_{-π}^{π} cos(nx) cos(mx) dx = 0` for `n ≠ m`. -/
+lemma integration_cos_cos_zero (n m : ℕ+) (h : n ≠ m) :
+    ∫ x in (-π)..π, cos (n  * x) * cos (m * x) = 0 := by
+  -- (n-m) ≠ 0 in ℝ
+  have hnm_ne : (n : ℝ) - m ≠ 0 := sub_ne_zero.mpr (by exact_mod_cast h)
+  -- sin((n-m)π) = 0  (integer multiple of π)
+  have hnm_sin : sin (((n : ℝ) - m) * π) = 0 := by
+    rw [sub_mul, sin_sub]
+    have h1 : sin ((n : ℝ) * π) = 0 := by exact_mod_cast sin_nat_mul_pi (n : ℕ)
+    have h2 : sin ((m : ℝ) * π) = 0 := by exact_mod_cast sin_nat_mul_pi (m : ℕ)
+    simp [h1, h2]
+  -- ∫ cos((n-m)x) = 0
+  have int_nm : ∫ x in (-π)..π, cos (((n : ℝ) - m) * x) = 0 := by
+    have key : ((n : ℝ) - m) * ∫ x in (-π)..π, cos (((n : ℝ) - m) * x) = 0 := by
+      rw [intervalIntegral.mul_integral_comp_mul_left, integral_cos]
+      simp [mul_neg, sin_neg, hnm_sin]
+    exact (mul_eq_zero.mp key).resolve_left hnm_ne
+  -- ∫ cos((n+m)x) = 0  (n+m : ℕ+ so use integral_cos_pnat)
+  have int_np : ∫ x in (-π)..π, cos (((n : ℝ) + m) * x) = 0 := by
+    have h_cast : ((n : ℝ) + m) = ((n + m : ℕ+) : ℝ) := by push_cast; ring
+    rw [h_cast]; exact integral_cos_pnat (n + m)
+  -- Product-to-sum: cos(nx)cos(mx) = ½cos((n-m)x) + ½cos((n+m)x)
+  have prod_sum : ∀ x : ℝ, cos ((n : ℝ) * x) * cos ((m : ℝ) * x) =
+      (1/2) * cos (((n : ℝ) - m) * x) + (1/2) * cos (((n : ℝ) + m) * x) := fun x => by
+    have h1 := cos_sub ((n : ℝ) * x) ((m : ℝ) * x)
+    have h2 := cos_add ((n : ℝ) * x) ((m : ℝ) * x)
+    simp only [← sub_mul, ← add_mul] at h1 h2
+    linarith
+  simp_rw [prod_sum]
+  have hc1 : IntervalIntegrable (fun x => (1/2 : ℝ) * cos (((n : ℝ) - m) * x))
+      MeasureTheory.volume (-π) π := by
+    apply Continuous.intervalIntegrable; fun_prop
+  have hc2 : IntervalIntegrable (fun x => (1/2 : ℝ) * cos (((n : ℝ) + m) * x))
+      MeasureTheory.volume (-π) π := by
+    apply Continuous.intervalIntegrable; fun_prop
+  rw [intervalIntegral.integral_add hc1 hc2,
+      intervalIntegral.integral_const_mul, intervalIntegral.integral_const_mul,
+      int_nm, int_np]; simp
+
+/-- Orthogonality of sines: `∫_{-π}^{π} sin(nx) sin(mx) dx = 0` for `n ≠ m`. -/
+lemma integration_sin_sin_zero (n m : ℕ+) (h : n ≠ m) :
+    ∫ x in (-π)..π, sin (n  * x) * sin (m * x) = 0 := by
+  -- (n-m) ≠ 0 in ℝ
+  have hnm_ne : (n : ℝ) - m ≠ 0 := sub_ne_zero.mpr (by exact_mod_cast h)
+  -- sin((n-m)π) = 0  (integer multiple of π)
+  have hnm_sin : sin (((n : ℝ) - m) * π) = 0 := by
+    rw [sub_mul, sin_sub]
+    have h1 : sin ((n : ℝ) * π) = 0 := by exact_mod_cast sin_nat_mul_pi (n : ℕ)
+    have h2 : sin ((m : ℝ) * π) = 0 := by exact_mod_cast sin_nat_mul_pi (m : ℕ)
+    simp [h1, h2]
+  -- sin((n+m)x) = 0 (integer multiple of π)
+  have hnm1_sin : sin (((n : ℝ) + m) * π) = 0 := by
+    rw [add_mul, sin_add]
+    have h1 : sin ((n : ℝ) * π) = 0 := by exact_mod_cast sin_nat_mul_pi (n : ℕ)
+    have h2 : sin ((m : ℝ) * π) = 0 := by exact_mod_cast sin_nat_mul_pi (m : ℕ)
+    simp [h1, h2]
+  -- ∫ cos((n-m)x) = 0
+  have int_nm : ∫ x in (-π)..π, cos (((n : ℝ) - m) * x) = 0 := by
+    have key : ((n : ℝ) - m) * ∫ x in (-π)..π, cos (((n : ℝ) - m) * x) = 0 := by
+      rw [intervalIntegral.mul_integral_comp_mul_left, integral_cos]
+      simp [mul_neg, sin_neg, hnm_sin]
+    exact (mul_eq_zero.mp key).resolve_left hnm_ne
+  -- ∫ cos((n+m)x) = 0  (n+m : ℕ+ so use integral_cos_pnat)
+  have int_np : ∫ x in (-π)..π, cos (((n : ℝ) + m) * x) = 0 := by
+    have h_cast : ((n : ℝ) + m) = ((n + m : ℕ+) : ℝ) := by push_cast; ring
+    rw [h_cast]; exact integral_cos_pnat (n + m)
+  -- Product-to-sum: sin(nx)sin(mx) = ½cos((n-m)x) - ½cos((n+m)x)
+  have prod_sum : ∀ x : ℝ, sin ((n : ℝ) * x) * sin ((m : ℝ) * x) =
+      (1/2) * cos (((n : ℝ) - m) * x) - (1/2) * cos (((n : ℝ) + m) * x) := fun x => by
+    have h1 := cos_sub ((n : ℝ) * x) ((m : ℝ) * x)
+    have h2 := cos_add ((n : ℝ) * x) ((m : ℝ) * x)
+    simp only [← sub_mul, ← add_mul] at h1 h2
+    linarith
+  simp_rw [prod_sum]
+  have hc1 : IntervalIntegrable (fun x => (1/2 : ℝ) * cos (((n : ℝ) - m) * x))
+      MeasureTheory.volume (-π) π := by
+    apply Continuous.intervalIntegrable; fun_prop
+  have hc2 : IntervalIntegrable (fun x => (1/2 : ℝ) * cos (((n : ℝ) + m) * x))
+      MeasureTheory.volume (-π) π := by
+    apply Continuous.intervalIntegrable; fun_prop
+  rw [intervalIntegral.integral_sub hc1 hc2,
+      intervalIntegral.integral_const_mul, intervalIntegral.integral_const_mul,
+      int_nm, int_np]; simp
+
+/-- Cross orthogonality: `∫_{-π}^{π} cos(nx) sin(mx) dx = 0` for `n ≠ m`. -/
+lemma integration_sin_cos_zero (n m : ℕ+) (h : n ≠ m) :
+    ∫ x in (-π)..π, cos (n * x) * sin (m * x) = 0 := by
+  have hnm_ne : (n : ℝ) - m ≠ 0 := sub_ne_zero.mpr (by exact_mod_cast h)
+  -- ∫ sin((n-m)x) = 0
+  have int_sin_nm : ∫ x in (-π)..π, sin (((n : ℝ) - m) * x) = 0 := by
+    have key : ((n : ℝ) - m) * ∫ x in (-π)..π, sin (((n : ℝ) - m) * x) = 0 := by
+      rw [intervalIntegral.mul_integral_comp_mul_left, integral_sin]
+      simp [mul_neg, cos_neg]
+    exact (mul_eq_zero.mp key).resolve_left hnm_ne
+  -- ∫ sin((n+m)x) = 0
+  have int_sin_np : ∫ x in (-π)..π, sin (((n : ℝ) + m) * x) = 0 := by
+    have h_cast : ((n : ℝ) + m) = ((n + m : ℕ+) : ℝ) := by push_cast; ring
+    rw [h_cast]; exact integral_sin_pnat (n + m)
+  -- Product-to-sum: cos(nx)sin(mx) = ½sin((n+m)x) - ½sin((n-m)x)
+  have prod_sum : ∀ x : ℝ, cos ((n : ℝ) * x) * sin ((m : ℝ) * x) =
+      (1/2) * sin (((n : ℝ) + m) * x) - (1/2) * sin (((n : ℝ) - m) * x) := fun x => by
+    have h1 := sin_add ((n : ℝ) * x) ((m : ℝ) * x)
+    have h2 := sin_sub ((n : ℝ) * x) ((m : ℝ) * x)
+    simp only [← add_mul, ← sub_mul] at h1 h2
+    linarith
+  simp_rw [prod_sum]
+  have hc1 : IntervalIntegrable (fun x => (1/2 : ℝ) * sin (((n : ℝ) + m) * x))
+      MeasureTheory.volume (-π) π := by
+    apply Continuous.intervalIntegrable; fun_prop
+  have hc2 : IntervalIntegrable (fun x => (1/2 : ℝ) * sin (((n : ℝ) - m) * x))
+      MeasureTheory.volume (-π) π := by
+    apply Continuous.intervalIntegrable; fun_prop
+  rw [intervalIntegral.integral_sub hc1 hc2,
+      intervalIntegral.integral_const_mul, intervalIntegral.integral_const_mul,
+      int_sin_np, int_sin_nm]; simp
+
+/-- Self-orthogonality of cosines:
+`∫_{-π}^{π} cos(nx) cos(mx) dx = π` when `n = m`. -/
+lemma integration_cos_cos_pi (n m : ℕ+) (h : n = m) :
+    ∫ x in (-π)..π, cos (n * x) * cos (m * x) = π := by
+  subst h
+  -- cos²(nx) = ½(1 + cos(2nx))
+  have half_angle : ∀ x : ℝ,  cos ((n : ℝ) * x) * cos ((n : ℝ) * x) =
+      1/2 + (1/2) * cos ((2 * (n : ℝ)) * x) := fun x => by
+    have h := cos_sq ((n : ℝ) * x)
+    rw [sq, show 2 * ((n : ℝ) * x) = 2 * (n : ℝ) * x from by ring] at h
+    linarith
+  simp_rw [half_angle]
+  -- ∫ cos(2nx) = 0 since 2n : ℕ+
+  have int_cos2n : ∫ x in (-π)..π, (1/2 : ℝ) * cos ((2 * (n : ℝ)) * x) = 0 := by
+    have h_cast : 2 * (n : ℝ) = ((2 * n : ℕ+) : ℝ) := by push_cast; ring
+    rw [intervalIntegral.integral_const_mul, h_cast, integral_cos_pnat]
+    simp
+  have hc1 : IntervalIntegrable (fun _ => (1/2 : ℝ)) MeasureTheory.volume (-π) π :=
+    intervalIntegrable_const
+  have hc2 : IntervalIntegrable (fun x => (1/2 : ℝ) * cos ((2 * (n : ℝ)) * x))
+      MeasureTheory.volume (-π) π := by
+    apply Continuous.intervalIntegrable; fun_prop
+  rw [intervalIntegral.integral_add hc1 hc2, intervalIntegral.integral_const, int_cos2n]
+  simp only [smul_eq_mul, sub_neg_eq_add, add_zero]
+  linarith
+
+
+/-- Self-orthogonality of sines:
+`∫_{-π}^{π} sin(nx) sin(mx) dx = π` when `n = m`. -/
+lemma integration_sin_sin_pi (n m : ℕ+) (h : n = m) :
+    ∫ x in (-π)..π, sin (n * x) * sin (m * x) = π := by
+  subst h
+  -- sin(nx)sin(nx) = ½(1 - cos(2nx))
+  have half_angle : ∀ x : ℝ, sin ((n : ℝ) * x) * sin ((n : ℝ) * x) =
+      1/2 - (1/2) * cos ((2 * (n : ℝ)) * x) := fun x => by
+    have h1 := sin_sq_add_cos_sq ((n : ℝ) * x)
+    have h2 := cos_sq ((n : ℝ) * x)
+    rw [show 2 * ((n : ℝ) * x) = 2 * (n : ℝ) * x from by ring] at h2
+    rw [← sq]
+    linarith
+  simp_rw [half_angle]
+  -- ∫ cos(2nx) = 0 since 2n : ℕ+
+  have int_cos2n : ∫ x in (-π)..π, (1/2 : ℝ) * cos ((2 * (n : ℝ)) * x) = 0 := by
+    have h_cast : 2 * (n : ℝ) = ((2 * n : ℕ+) : ℝ) := by push_cast; ring
+    rw [intervalIntegral.integral_const_mul, h_cast, integral_cos_pnat]
+    simp
+  have hc1 : IntervalIntegrable (fun _ => (1/2 : ℝ)) MeasureTheory.volume (-π) π :=
+    intervalIntegrable_const
+  have hc2 : IntervalIntegrable (fun x => (1/2 : ℝ) * cos ((2 * (n : ℝ)) * x))
+      MeasureTheory.volume (-π) π := by
+    apply Continuous.intervalIntegrable; fun_prop
+  rw [intervalIntegral.integral_sub hc1 hc2, intervalIntegral.integral_const, int_cos2n]
+  simp only [smul_eq_mul, sub_neg_eq_add, sub_zero]
+  linarith
+
+/-- **Parseval's theorem**: Given square-integrability and suitable summability hypotheses,
+`(1/π) ∫_{-π}^{π} f(x)² dx = (1/2) a₀² + ∑_{n≥1} (aₙ² + bₙ²)`. -/
+theorem Parsevals_thm
+    -- Integrability of a₀·S(x) over [-π, π]
+    (hfS_int : IntervalIntegrable (fun x => a 0 * fourierSum a b x)
+      MeasureTheory.volume (-π) π)
+    -- Integrability of S(x)² over [-π, π]
+    (hfSq_int : IntervalIntegrable (fun x => (fourierSum a b x)^2)
+      MeasureTheory.volume (-π) π)
+    -- Each Fourier term is integrable
+    (hF_int : ∀ n : ℕ+, IntervalIntegrable
+      (fun x => a n * cos ((n : ℕ+) * x) + b n * sin ((n : ℕ+) * x))
+      MeasureTheory.volume (-π) π)
+    -- L¹ summability (for integral/sum interchange in cross term)
+    (hF_sum : Summable (fun n : ℕ+ =>
+      ∫ x in (-π)..π, ‖a n * cos ((n : ℕ+) * x) + b n * sin ((n : ℕ+) * x)‖))
+    -- ∫ S(x)² = π · ∑ₙ (aₙ² + bₙ²)  (orthogonality of the Fourier basis)
+    (h_int_sq : ∫ x in (-π)..π, (fourierSum a b x)^2 =
+      π * ∑' n : ℕ+, ((a n)^2 + (b n)^2)) :
+    (1/π) * ∫ x in (-π)..π, (fourierSeries a b x)^2 =
+    (1/2) * (a 0)^2 + ∑' n : ℕ+, ((a n)^2 + (b n)^2) := by
+  -- Step 1: pointwise expand f(x)² = (a₀/2)² + a₀·S(x) + S(x)²
+  have hpt : ∀ x : ℝ, (fourierSeries a b x)^2 =
+      (1/4 : ℝ) * (a 0)^2 + a 0 * fourierSum a b x + (fourierSum a b x)^2 := fun x => by
+    simp only [fourierSeries_eq]; ring
+  simp_rw [hpt]
+  -- Step 2: establish integrability of the sub-expressions
+  have h_const_int : IntervalIntegrable (fun _ : ℝ => (1 / 4 : ℝ) * (a 0) ^ 2)
+      MeasureTheory.volume (-π) π := intervalIntegrable_const
+  have h_sum_int : IntervalIntegrable
+      (fun x => (1 / 4 : ℝ) * (a 0) ^ 2 + a 0 * fourierSum a b x)
+      MeasureTheory.volume (-π) π := h_const_int.add hfS_int
+  -- Step 3: split the integral linearly into three pieces
+  rw [intervalIntegral.integral_add h_sum_int hfSq_int,
+      intervalIntegral.integral_add h_const_int hfS_int]
+  -- Step 3: evaluate each piece
+  --   ∫ (1/4)·a₀²  = (1/2)·a₀²·π   (integration_of_const)
+  --   ∫ a₀·S(x)    = 0              (orthogonality, integration_of_cos_sin)
+  --   ∫ S(x)²      = π·∑ₙ(aₙ²+bₙ²) (h_int_sq)
+  rw [integration_of_const, integration_of_cos_sin a b hF_int hF_sum, h_int_sq]
+  -- Step 4: arithmetic — (1/π)·((1/2)·a₀²·π + 0 + π·∑…) = (1/2)·a₀² + ∑…
+  simp only [add_zero]
+  have hpi : (π : ℝ) ≠ 0 := Real.pi_ne_zero
+  field_simp [hpi]
+
+
+/-- Each Fourier term is bounded in norm:
+`‖aₙ cos(nx) + bₙ sin(nx)‖ ≤ ‖aₙ‖ + ‖bₙ‖` for all `x : ℝ`. -/
+lemma term_bound (n : ℕ) (x : ℝ) :
+    ‖a (n + 1) * cos ((n + 1 : ℝ) * x) + b (n + 1) * sin ((n + 1 : ℝ) * x)‖
+    ≤ ‖a (n + 1)‖ + ‖b (n + 1)‖ := by
+  calc ‖a (n + 1) * cos ((n + 1 : ℝ) * x) + b (n + 1) * sin ((n + 1 : ℝ) * x)‖
+      ≤ ‖a (n + 1) * cos ((n + 1 : ℝ) * x)‖ + ‖b (n + 1) * sin ((n + 1 : ℝ) * x)‖ :=
+        norm_add_le _ _
+    _ = ‖a (n + 1)‖ * ‖cos ((n + 1 : ℝ) * x)‖ + ‖b (n + 1)‖ * ‖sin ((n + 1 : ℝ) * x)‖ := by
+        simp [norm_mul]
+    _ ≤ ‖a (n + 1)‖ * 1 + ‖b (n + 1)‖ * 1 := by
+        gcongr
+        · exact abs_cos_le_one _
+        · exact abs_sin_le_one _
+    _ = ‖a (n + 1)‖ + ‖b (n + 1)‖ := by ring
+
+/-- **Weierstrass M-test for Fourier series**: If `∑ (‖aₙ‖ + ‖bₙ‖)` converges, then the
+Fourier partial sums converge uniformly to `fourierSeries a b` on all of `ℝ`. -/
+lemma fourierSeries_uniformlyConvergence
+    (hsumab : Summable (fun n => ‖a n‖ + ‖b n‖)) :
+    TendstoUniformly
+      (fun N x => fourierPartialSum a b x N)
+      (fourierSeries a b)
+      Filter.atTop := by
+  unfold fourierPartialSum
+  -- Summability of the shifted bound sequence
+  have hshift : Summable (fun n => ‖a (n + 1)‖ + ‖b (n + 1)‖) :=
+    summable_pnat_iff_summable_succ.mp (summable_pnat_iff_summable_nat.mpr hsumab)
+  -- Weierstrass M-test: partial sums converge uniformly to the ℕ-indexed tsum
+  have hcore := tendstoUniformly_tsum_nat hshift (term_bound a b)
+  -- Use metric characterisation: reduce to dist bound on partial sums
+  rw [Metric.tendstoUniformly_iff]
+  intro ε hε
+  filter_upwards [(Metric.tendstoUniformly_iff.mp hcore) ε hε] with N hN
+  intro x
+  -- fourierSeries a b x = 1/2 * a 0 + ∑' n : ℕ, f(n+1)   (reindex ℕ+ → ℕ)
+  have heq : fourierSeries a b x =
+      1 / 2 * a 0 + ∑' n : ℕ, (a (n + 1) * cos ((↑n + 1) * x)
+      + b (n + 1) * sin ((↑n + 1) * x)) := by
+    simp only [fourierSeries]
+    congr 1
+    -- reindex: ∑' n : ℕ+, f n = ∑' n : ℕ, f (succPNat n)
+    rw [← Equiv.tsum_eq Equiv.pnatEquivNat.symm]
+    congr 1; ext n
+    simp [Nat.succPNat, Nat.cast_succ]
+  rw [heq, dist_add_left]
+  exact hN x
+
+
+/-- If `∑ (‖aₙ‖ + ‖bₙ‖)` converges, then the Fourier series `fourierSeries a b` is
+continuous on all of `ℝ`. -/
+lemma fourierSeries_continuous
+    (hsumab : Summable (fun n => ‖a n‖ + ‖b n‖)) :
+    Continuous (fourierSeries a b) := by
+  apply (fourierSeries_uniformlyConvergence a b hsumab).continuous
+  apply Filter.Eventually.frequently
+  apply Filter.eventually_atTop.mpr
+  refine ⟨0, fun N _ => ?_⟩
+  unfold fourierPartialSum
+  apply Continuous.add continuous_const
+  apply continuous_finsetSum
+  intro n _
+  exact (continuous_const.mul (continuous_cos.comp (continuous_const.mul continuous_id))).add
+        (continuous_const.mul (continuous_sin.comp (continuous_const.mul continuous_id)))
+
+/-- The Fourier series `f(x) = (1/2)a₀ + ∑ (aₙ cos nx + bₙ sin nx)`
+is integrable on `[-π, π]` whenever `∑ (‖aₙ‖ + ‖bₙ‖)` converges. -/
+lemma fourierSeries_integrable (hsumab : Summable (fun n => ‖a n‖ + ‖b n‖)) :
+  IntervalIntegrable (fourierSeries a b)
+    MeasureTheory.volume (-Real.pi) Real.pi := by
+      exact (fourierSeries_continuous a b hsumab).continuousOn
+      |>.intervalIntegrable_of_Icc (by linarith [Real.pi_pos])
+
+/-- The formal derivative series: `d/dx [aₙ cos nx + bₙ sin nx] = -n aₙ sin nx + n bₙ cos nx`. -/
+noncomputable def fourierDeriv (a b : ℕ → ℝ) (x : ℝ) :=
+  ∑' n , (- n * a n * sin (n * x) + n * b n * cos (n * x))
+
+
+/-- If `∑ n * (‖aₙ‖ + ‖bₙ‖)` converges, then the derivative series is summable at each `x`. -/
+lemma fourierDeriv_summable (hab' : Summable (fun n : ℕ => (n : ℝ) * (‖a n‖ + ‖b n‖))) (x : ℝ) :
+    Summable (fun n : ℕ => -(n : ℝ) * a n * sin (↑n * x) + ↑n * b n * cos (↑n * x)) := by
+  exact Summable.of_norm_bounded hab' fun (n : ℕ) => by
+    calc ‖-(n : ℝ) * a n * sin (↑n * x) + ↑n * b n * cos (↑n * x)‖
+        ≤ ‖-(n : ℝ) * a n * sin (↑n * x)‖ + ‖↑n * b n * cos (↑n * x)‖ := norm_add_le _ _
+      _ = ↑n * ‖a n‖ * ‖sin (↑n * x)‖ + ↑n * ‖b n‖ * ‖cos (↑n * x)‖ := by
+            simp [norm_mul, norm_neg]
+      _ ≤ ↑n * ‖a n‖ * 1 + ↑n * ‖b n‖ * 1 := by
+            gcongr
+            · exact abs_sin_le_one _
+            · exact abs_cos_le_one _
+      _ = ↑n * (‖a n‖ + ‖b n‖) := by ring
+
+/-- If `∑ n * (‖aₙ‖ + ‖bₙ‖)` converges, the partial sums of the derivative series converge
+uniformly to `fourierDeriv a b` (Weierstrass M-test applied to the derivative). -/
+lemma fourierDeriv_uniformConvergence
+    (hab' : Summable (fun n : ℕ => (n : ℝ) * (‖a n‖ + ‖b n‖))) :
+    TendstoUniformly
+      (fun N x => ∑ n ∈ Finset.range N,
+        (-(n : ℝ) * a n * sin (n * x) + (n : ℝ) * b n * cos (n * x)))
+      (fourierDeriv a b)
+      Filter.atTop := by
+  change TendstoUniformly
+    (fun N x => ∑ n ∈ Finset.range N,
+      (-(n : ℝ) * a n * sin ((n : ℝ) * x) + (n : ℝ) * b n * cos ((n : ℝ) * x)))
+    (fun x => ∑' n : ℕ, (-(n : ℝ) * a n * sin ((n : ℝ) * x) + (n : ℝ) * b n * cos ((n : ℝ) * x)))
+    Filter.atTop
+  apply tendstoUniformly_tsum_nat hab'
+  intro n x
+  calc ‖-(n : ℝ) * a n * sin ((n : ℝ) * x) + (n : ℝ) * b n * cos ((n : ℝ) * x)‖
+      ≤ ‖-(n : ℝ) * a n * sin ((n : ℝ) * x)‖ + ‖(n : ℝ) * b n * cos ((n : ℝ) * x)‖ :=
+          norm_add_le _ _
+    _ = ↑n * ‖a n‖ * ‖sin ((n : ℝ) * x)‖ + ↑n * ‖b n‖ * ‖cos ((n : ℝ) * x)‖ := by
+          simp [norm_mul, norm_neg]
+    _ ≤ ↑n * ‖a n‖ * 1 + ↑n * ‖b n‖ * 1 := by
+          gcongr
+          · exact abs_sin_le_one _
+          · exact abs_cos_le_one _
+    _ = ↑n * (‖a n‖ + ‖b n‖) := by ring
+
+/-- Each Fourier term is differentiable:
+`d/dx [aₙ cos(nx) + bₙ sin(nx)] = -n aₙ sin(nx) + n bₙ cos(nx)`. -/
+lemma hasDerivAt_term (n : ℕ) (x : ℝ) :
+    HasDerivAt
+      (fun x => a n * cos (n * x) + b n * sin (n * x))
+      (-(n : ℝ) * a n * sin (n * x) + (n : ℝ) * b n * cos (n * x))
+      x := by
+  have h1 : HasDerivAt (fun x => a n * cos (n * x))
+                       (-(n : ℝ) * a n * sin (n * x)) x := by
+    have := ((hasDerivAt_id x).const_mul (n : ℝ)).cos
+    simp at this
+    exact this.const_mul (a n) |>.congr_deriv (by ring)
+  have h2 : HasDerivAt (fun x => b n * sin (n * x))
+                       ((n : ℝ) * b n * cos (n * x)) x := by
+    have := ((hasDerivAt_id x).const_mul (n : ℝ)).sin
+    simp at this
+    exact this.const_mul (b n) |>.congr_deriv (by ring)
+  exact h1.add h2
+
+/-- The `N`-th partial sum is differentiable, with derivative equal to the partial sum of
+term-wise derivatives. -/
+lemma hasDerivAt_partialSum (N : ℕ) (x : ℝ) :
+    HasDerivAt
+      (fun x => fourierPartialSum a b x N)
+      (∑ n ∈ Finset.range N,
+        (-(↑(n + 1) : ℝ) * a (n + 1) * sin (↑(n + 1) * x)
+          + ↑(n + 1) * b (n + 1) * cos (↑(n + 1) * x)))
+      x := by
+  unfold fourierPartialSum
+  -- Strip the constant: reduces goal to HasDerivAt (fun x => ∑ ...) (∑ ...) x
+  apply HasDerivAt.const_add
+  -- HasDerivAt.sum produces: HasDerivAt (∑ n ∈ s, fun x => f n x) D p  (Pi.sum form)
+  have hsum : HasDerivAt
+      (∑ n ∈ Finset.range N,
+        fun x => a (n + 1) * cos ((↑(n + 1) : ℝ) * x) + b (n + 1) * sin ((↑(n + 1) : ℝ) * x))
+      (∑ n ∈ Finset.range N,
+        (-(↑(n + 1) : ℝ) * a (n + 1) * sin ((↑(n + 1) : ℝ) * x)
+          + ↑(n + 1) * b (n + 1) * cos ((↑(n + 1) : ℝ) * x)))
+      x :=
+    HasDerivAt.sum fun n _ => hasDerivAt_term a b (n + 1) x
+  -- Bridge the form: goal has `fun x => ∑ ...`, hsum has `∑ n, fun x => ...`.
+  exact hsum.congr_of_eventuallyEq
+    (Filter.Eventually.of_forall (by intro y; simp [Finset.sum_apply, Nat.cast_succ]))
+
+/-- Term-by-term differentiation: `HasDerivAt (fourierSeries a b) (fourierDeriv a b x) x`
+whenever `∑ n * (‖aₙ‖ + ‖bₙ‖)` and `∑ (‖aₙ‖ + ‖bₙ‖)` both converge. -/
+lemma fourierSeries_hasDerivAt (hab' : Summable (fun n : ℕ => (n : ℝ) * (‖a n‖ + ‖b n‖)))
+    (hab : Summable (fun n => ‖a n‖ + ‖b n‖)) (x : ℝ) :
+    HasDerivAt (fourierSeries a b) (fourierDeriv a b x) x := by
+  -- Uniform convergence of the (n+1)-shifted derivative partial sums.
+  -- Key identity: ∑ n ∈ range N, D(n+1, x) = ∑ n ∈ range (N+1), D(n, x)
+  -- since D(0, x) = 0 (via Finset.sum_range_succ'). The N ↦ N+1 shift
+  -- preserves atTop convergence via Filter.Tendsto.eventually.
+  have hderiv_unif : TendstoUniformly
+      (fun N x => ∑ n ∈ Finset.range N,
+        (-(↑(n + 1) : ℝ) * a (n + 1) * sin (↑(n + 1) * x)
+          + ↑(n + 1) * b (n + 1) * cos (↑(n + 1) * x)))
+      (fourierDeriv a b) Filter.atTop := by
+    have key : ∀ N x,
+        ∑ n ∈ Finset.range N,
+          (-(↑(n + 1) : ℝ) * a (n + 1) * sin (↑(n + 1) * x)
+            + ↑(n + 1) * b (n + 1) * cos (↑(n + 1) * x)) =
+        ∑ n ∈ Finset.range (N + 1),
+          (-(↑n : ℝ) * a n * sin (↑n * x) + ↑n * b n * cos (↑n * x)) :=
+      fun N x => by symm; rw [Finset.sum_range_succ']; simp
+    simp_rw [key]
+    exact fun u hu =>
+      (Filter.tendsto_atTop_atTop.mpr fun M => ⟨M - 1, fun N hN => by omega⟩).eventually
+        (fourierDeriv_uniformConvergence a b hab' u hu)
+  exact hasDerivAt_of_tendstoUniformly hderiv_unif
+    (Filter.Eventually.of_forall (hasDerivAt_partialSum a b))
+    (fun y => (fourierSeries_uniformlyConvergence a b hab).tendsto_at y) x
+
+/-- If `∑ n * (‖aₙ‖ + ‖bₙ‖)` and `∑ (‖aₙ‖ + ‖bₙ‖)` both converge, then the Fourier series
+`fourierSeries a b` is differentiable on all of `ℝ`, with derivative `fourierDeriv a b`. -/
+lemma fourierSeries_differentiable (hab' : Summable (fun n : ℕ => (n : ℝ) * (‖a n‖ + ‖b n‖)))
+  (hab : Summable (fun n => ‖a n‖ + ‖b n‖)) :
+    Differentiable ℝ (fourierSeries a b) :=
+  fun x => (fourierSeries_hasDerivAt a b hab' hab x).differentiableAt
+
+/-- The derivative of the Fourier series equals the ℕ⁺-indexed derivative series. -/
+lemma FourierSerise_derivative (hab' : Summable (fun n : ℕ => (n : ℝ) * (‖a n‖ + ‖b n‖)))
+  (hab : Summable (fun n => ‖a n‖ + ‖b n‖))
+  (x : ℝ) :
+    deriv (fourierSeries a b) x =
+      ∑' n : ℕ+, (-(a n) * (n : ℝ) * Real.sin ((n : ℝ) * x) +
+      b n * (n : ℝ) * Real.cos ((n : ℝ) * x)) := by
+  rw [(fourierSeries_hasDerivAt a b hab' hab x).deriv]
+  simp only [fourierDeriv]
+  rw [(fourierDeriv_summable a b hab' x).tsum_eq_zero_add]
+  simp only [Nat.cast_zero, neg_zero, zero_mul, zero_add]
+  rw [← Equiv.tsum_eq Equiv.pnatEquivNat.symm]
+  congr 1; ext n
+  simp [Nat.succPNat, Nat.cast_succ]
+  ring
+
+/-- **Wirtinger's inequality**: `(1/pi) * int (f'(x))^2 = sum n^2 * (a n^2 + b n^2)`.
+The integral formula `h_int_sq` is the Parseval identity for the derivative series,
+mirroring the `h_int_sq` hypothesis in `Parsevals_thm`. -/
+theorem Wirtingers_inequality
+    (h_int_sq : ∫ x in (-π)..π, (deriv (fourierSeries a b) x) ^ 2 =
+        π * ∑' n : ℕ+, ((n : ℝ) ^ 2 * ((a n) ^ 2 + (b n) ^ 2))) :
+    (1/π) * ∫ x in (-π)..π, (deriv (fourierSeries a b) x) ^ 2 =
+        ∑' n : ℕ+, ((n : ℝ)^2 * ((a n)^2 + (b n)^2)) := by
+  rw [h_int_sq]
+  field_simp [Real.pi_ne_zero]
+
+end
+
+end IsoperimetricInequality

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -679,6 +679,35 @@ projects:
       - "28A75"
       - "52A40"
       - "49Q20"
+  - slug: isoperimetricinequality
+    title: Formalizing the Classical Isoperimetric Inequality
+    summary: Formalizes Adolf Hurwitz's Fourier-series proof of the planar isoperimetric inequality, including Parseval's theorem, Wirtinger's inequality, a shoelace-style area formula, and the final area-perimeter bound for arc-length parametrized simple closed curves.
+    branch: geometric analysis
+    entry_module: LeanPool.IsoperimetricInequality
+    authors:
+      - M. Samarakkody
+    source:
+      arxiv: "2603.14663"
+      doi: "10.5281/zenodo.20258500"
+      github_repo: mirajcs/IsoperimetricInequality
+    license: MIT
+    status: verified
+    main_declarations:
+      - IsoperimetricInequality.isoperimetric_inequality
+    main_results:
+      - declaration: IsoperimetricInequality.Parsevals_thm
+        informal: Proves a Parseval identity for the square integral of a Fourier series in terms of its cosine and sine coefficients.
+      - declaration: IsoperimetricInequality.Wirtingers_inequality
+        informal: Derives Wirtinger's inequality from the Parseval identity for the derivative Fourier series.
+      - declaration: IsoperimetricInequality.isoperimetric_inequality
+        informal: Proves Adolf Hurwitz's planar isoperimetric area bound for an arc-length parametrized simple closed curve.
+    tags:
+      - isoperimetric-inequality
+      - fourier-analysis
+      - geometric-analysis
+    msc:
+      - "52A40"
+      - "42A16"
   - slug: leancomplexanalysis
     title: Formalized Complex Analysis in Lean
     summary: Formalizes Poisson integral formulas on the unit disc and arbitrary centered discs, Herglotz–Riesz representation, and Harnack's inequality on the unit disc, plus infrastructure for univalent function classes S and Σ.


### PR DESCRIPTION
## Summary
- imports `mirajcs/IsoperimetricInequality` under `LeanPool.IsoperimetricInequality`
- ports the Fourier/Wirtinger and Adolf Hurwitz isoperimetric proof files to the current Lean Pool toolchain
- registers the project metadata in `LeanPool/projects.yml` and regenerates `LeanPool.lean`

## Verification
- `lake exe mk_all --check`
- `lake build LeanPool.IsoperimetricInequality`
- `lake build LeanPool`
- `lake exe lint-style LeanPool.IsoperimetricInequality`
- `lake exe runLinter LeanPool.IsoperimetricInequality`
- `cd python && uv run python -m lean_pool.quality --repo ..`
- `git diff --check`

<!-- project-advisory-rerun: 2026-06-28 after-pr-239 -->