### PR TITLE
[codex] make project advisory comments nonblocking

### DIFF
--- a/python/lean_pool/pr_advisory.py
+++ b/python/lean_pool/pr_advisory.py
@@ -98,13 +98,29 @@ def run_gh(*args: str, stdin: str | None = None) -> str:
     Returns:
         The command's stdout.
     """
+    command = ["gh", *args]
     result = subprocess.run(
-        ["gh", *args],
-        check=True,
+        command,
         capture_output=True,
         text=True,
         input=stdin,
     )
+    if result.returncode != 0:
+        print(
+            f"GitHub CLI command failed with exit code {result.returncode}: "
+            f"{' '.join(command)}",
+            file=sys.stderr,
+        )
+        if result.stdout:
+            print(result.stdout, file=sys.stderr)
+        if result.stderr:
+            print(result.stderr, file=sys.stderr)
+        raise subprocess.CalledProcessError(
+            result.returncode,
+            command,
+            output=result.stdout,
+            stderr=result.stderr,
+        )
     return result.stdout
 
 
@@ -366,12 +382,22 @@ def main(argv: list[str] | None = None) -> int:
 
     metadata_cache: dict[str, UpstreamMetadata] = {}
     for pr_number in pr_numbers:
-        action = update_pr_advisory(
-            repo_full_name,
-            pr_number,
-            metadata_cache=metadata_cache,
-            dry_run=args.dry_run,
-        )
+        try:
+            action = update_pr_advisory(
+                repo_full_name,
+                pr_number,
+                metadata_cache=metadata_cache,
+                dry_run=args.dry_run,
+            )
+        except subprocess.CalledProcessError as error:
+            print(
+                f"PR #{pr_number}: advisory comment failed; "
+                "continuing because this workflow is non-blocking.",
+                file=sys.stderr,
+            )
+            if error.stderr:
+                print(error.stderr, file=sys.stderr)
+            action = "comment-failed"
         print(f"PR #{pr_number}: {action}")
     return 0
 

--- a/python/tests/test_pr_advisory.py
+++ b/python/tests/test_pr_advisory.py
@@ -16,6 +16,7 @@ from lean_pool.pr_advisory import (
     UpstreamMetadata,
     fetch_upstream_metadata,
     list_open_pr_numbers,
+    main,
     post_sticky_comment,
     project_changes,
     render_comment,
@@ -224,3 +225,35 @@ def test_update_pr_advisory_skips_pr_without_project_changes(
 
     assert action == "skipped"
     assert not posted
+
+
+def test_main_treats_comment_post_failure_as_nonblocking(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """GitHub comment-write failures should not fail the advisory workflow."""
+
+    def fake_update(
+        repo_full_name: str,
+        pr_number: int,
+        *,
+        metadata_cache: dict[str, UpstreamMetadata] | None = None,
+        dry_run: bool = False,
+    ) -> str:
+        assert repo_full_name == "acme/pool"
+        assert pr_number == 7
+        assert not dry_run
+        raise subprocess.CalledProcessError(
+            1,
+            ["gh", "api"],
+            stderr="Resource not accessible by integration\n",
+        )
+
+    monkeypatch.setattr(pr_advisory, "update_pr_advisory", fake_update)
+
+    assert main(["--repo", "acme/pool", "--pr-number", "7"]) == 0
+
+    captured = capsys.readouterr()
+    assert "PR #7: comment-failed" in captured.out
+    assert "continuing because this workflow is non-blocking" in captured.err
+    assert "Resource not accessible by integration" in captured.err


### PR DESCRIPTION
## Summary

Fixes the project advisory comment workflow so a GitHub comment-write failure does not fail CI. The workflow is documented as advisory-only, but PRs without an existing advisory comment were failing when `gh api` could not create the sticky comment.

The change also prints the underlying `gh` stdout/stderr before re-raising, so future failures show the actual GitHub API error rather than only a Python traceback.

## Validation

- `uv run --group test pytest tests/test_pr_advisory.py`
- `uv run ruff check lean_pool/pr_advisory.py tests/test_pr_advisory.py`
- `git diff --check`