### PR TITLE
Stop daily candidate-discovery schedule

### DIFF
--- a/.github/workflows/discovery.yml
+++ b/.github/workflows/discovery.yml
@@ -1,8 +1,6 @@
 name: Candidate Discovery
 
 on:
-  schedule:
-    - cron: "20 14 * * *"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Removes the daily `schedule:` cron from the **Candidate Discovery** workflow (`.github/workflows/discovery.yml`) so it no longer runs every day and auto-commits `Update discovered Lean candidates` to `main`.

`workflow_dispatch` is retained, so the discovery job can still be triggered manually when wanted.

Scheduled workflows only fire from the default branch, so this takes effect once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)