### PR TITLE
Let PR authors trigger `/profile` on their own PR

### DIFF
--- a/.github/workflows/proof-profile.yml
+++ b/.github/workflows/proof-profile.yml
@@ -1,9 +1,10 @@
 name: Proof Profile
 
-# Same triggering model as LLM Review: profile once when a PR is opened, and
-# again on demand when someone comments `/profile` on the PR. No `synchronize`
-# trigger — the profile is advisory, so re-run it by hand after a push if you
-# want a fresh one. workflow_dispatch takes an explicit PR number.
+# Profile once when a PR is opened, and again on demand when the PR author (or
+# anyone with write access) comments `/profile`. No `synchronize` trigger — the
+# profile is advisory, so re-run it by hand after a push if you want a fresh
+# one. That on-demand path is what lets an external contributor re-profile
+# their own PR after pushing. workflow_dispatch takes an explicit PR number.
 on:
   pull_request:
     types: [opened]
@@ -47,16 +48,23 @@ jobs:
     runs-on: ubuntu-latest
     name: Proof profile (advisory)
     # Run on a fresh PR or a workflow_dispatch unconditionally; for issue
-    # comments, only when the body starts with `/profile` AND the commenter
-    # has write access. This job checks out and *runs* the PR's Lean code,
-    # so an untrusted commenter must not be able to trigger it on a fork PR.
+    # comments, only when the body starts with `/profile` AND the commenter is
+    # either the PR author or someone with write access. This job checks out
+    # and *runs* the PR's Lean code, so it stays least-privilege (read-only
+    # token, no secrets) and the workflow definition always comes from the base
+    # default branch (issue_comment context) — the same trust model under which
+    # fork PRs are already auto-profiled on `opened`. Letting the PR author
+    # re-profile their own PR therefore adds no new code-execution surface,
+    # while still barring an arbitrary commenter from triggering a run on
+    # someone else's fork PR.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request != null &&
        startsWith(github.event.comment.body, '/profile') &&
-       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+       (github.event.comment.user.login == github.event.issue.user.login ||
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)))
     steps:
       - name: Resolve PR number, head SHA, base SHA
         id: pr


### PR DESCRIPTION
## Problem

On #246 the author (an external contributor, `authorAssociation: NONE`) commented `/profile` and nothing happened. The `/profile` comment trigger in `proof-profile.yml` was gated to `OWNER`/`MEMBER`/`COLLABORATOR`, so contributors couldn't re-profile their own PRs on demand — despite the README/CONTRIBUTING advertising `/profile` as available to contributors.

## Fix

Allow the `/profile` comment to trigger the profile run when the commenter **is the PR author**, in addition to write-access holders:

```
(github.event.comment.user.login == github.event.issue.user.login ||
 contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
```

## Why this is safe

The profile job *runs* the PR's Lean code, which is why the original gate existed. Letting the PR author trigger it adds **no new code-execution surface**:

- The job runs with a **read-only** token (`contents: read`, `pull-requests: read`) and **no secrets**.
- On an `issue_comment` event the workflow definition always comes from the **base default branch**, so a fork can't alter it.
- This is the *same trust model* under which fork PRs are already auto-profiled on `opened` — and the privileged comment-poster (`proof-profile-comment.yml`, `workflow_run`) never runs PR code.

An arbitrary internet commenter still **cannot** trigger a run on someone else's fork PR — the author check (`comment.user.login == issue.user.login`) and the write-access check are the only two gates. `workflow_dispatch` and the auto-profile-on-open path are unchanged.

Advisory-only workflow; never blocks merge. `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)