### PR TITLE
Profile refactor PRs as a base→head compile-cost comparison

### DIFF
--- a/.github/workflows/proof-profile.yml
+++ b/.github/workflows/proof-profile.yml
@@ -5,6 +5,15 @@ name: Proof Profile
 # profile is advisory, so re-run it by hand after a push if you want a fresh
 # one. That on-demand path is what lets an external contributor re-profile
 # their own PR after pushing. workflow_dispatch takes an explicit PR number.
+#
+# Added files get an absolute profile (`lean --profile` + heartbeat counts).
+# Modified files instead get a base→head compile-cost comparison: heartbeats
+# and wall time are measured at the merge base and at the PR head, and the
+# comment reports the deltas. That answers the right question for refactor
+# PRs — "did this golf change compile cost?" — where absolute numbers alone
+# are noise. On PRs that change the toolchain/manifest (or when no warm
+# build cache exists) the comparison is skipped and modified files fall
+# back to the absolute profile.
 on:
   pull_request:
     types: [opened]
@@ -102,6 +111,7 @@ jobs:
           persist-credentials: false
 
       - name: Restore caches
+        id: lake-cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
@@ -131,16 +141,131 @@ jobs:
         id: files
         env:
           BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          CACHE_MATCHED: ${{ steps.lake-cache.outputs.cache-matched-key }}
         run: |
           set -euo pipefail
-          files=$(git diff --name-only --diff-filter=AM "$BASE_SHA"...HEAD -- LeanPool \
+          added=$(git diff --name-only --diff-filter=A "$BASE_SHA"...HEAD -- LeanPool \
                   | grep '\.lean$' \
                   | tr '\n' ' ' || true)
-          echo "files=$files" >> "$GITHUB_OUTPUT"
+          modified=$(git diff --name-only --diff-filter=M "$BASE_SHA"...HEAD -- LeanPool \
+                     | grep '\.lean$' \
+                     | tr '\n' ' ' || true)
+          files="${added}${modified}"
+          merge_base=$(git merge-base "$BASE_SHA" HEAD)
+          # A base→head comparison is only meaningful when the merge base
+          # compiles with the same toolchain and dependencies as the head,
+          # and only affordable when the restored cache already covers most
+          # of the base build.
+          compare=false
+          compare_note=""
+          if [ -n "$modified" ]; then
+            if ! git diff --quiet "$merge_base" HEAD -- \
+                   lean-toolchain lake-manifest.json lakefile.toml; then
+              compare_note="Base→head comparison skipped: this PR changes the toolchain, manifest, or lakefile, so the two sides would not be comparable."
+            elif [ -z "$CACHE_MATCHED" ]; then
+              compare_note="Base→head comparison skipped: no warm build cache was available to build the base affordably."
+            else
+              compare=true
+            fi
+          fi
+          # Modified files get the cheap base→head heartbeat comparison, so
+          # the expensive serial `lean --profile` pass covers only added
+          # files. Without a comparison, modified files keep the full
+          # absolute treatment.
+          if [ "$compare" = true ]; then
+            profile_files="$added"
+          else
+            profile_files="$files"
+          fi
+          {
+            echo "files=$files"
+            echo "added=$added"
+            echo "modified=$modified"
+            echo "profile_files=$profile_files"
+            echo "compare=$compare"
+            echo "compare_note=$compare_note"
+            echo "merge_base=$merge_base"
+          } >> "$GITHUB_OUTPUT"
           if [ -z "$files" ]; then
             echo "No new or modified Lean files in this diff; profile will no-op."
           else
             echo "Will profile: $files"
+            echo "Compare against merge base $merge_base: $compare"
+          fi
+
+      - name: Write heartbeat measurement helper
+        if: steps.files.outputs.files != ''
+        run: |
+          set -euo pipefail
+          cat > "$RUNNER_TEMP/measure-one.sh" <<'SH'
+          #!/usr/bin/env bash
+          # Measure one file with Mathlib's countHeartbeats linter (which
+          # reports in `set_option maxHeartbeats` units) plus wall time,
+          # into <outdir>/<slugified-path>.log.
+          file="$1"
+          outdir="$2"
+          # The checksum disambiguates paths that collide under `tr` (an
+          # underscore in a directory name vs a slash).
+          slug="$(printf '%s' "$file" | tr '/' '_')_$(printf '%s' "$file" | cksum | cut -d' ' -f1)"
+          {
+            echo "## $file"
+            /usr/bin/time -p "$HOME/.elan/bin/lake" env lean \
+              -Dlinter.countHeartbeats=true \
+              "$file"
+            status=$?
+            if [ "$status" -ne 0 ]; then
+              echo "error: count-heartbeats command exited with status $status"
+            fi
+            echo
+          } > "$outdir/$slug.log" 2>&1
+          SH
+          cat > "$RUNNER_TEMP/measure-heartbeats.sh" <<'SH'
+          #!/usr/bin/env bash
+          # Usage: measure-heartbeats.sh <combined-log> <file>...
+          # Measures files in parallel (they are independent), then stitches
+          # the per-file sections together in input order so the combined
+          # log is deterministic. Parallelism trades some per-file
+          # wall-clock accuracy for hours of runtime on refactor-sized PRs;
+          # heartbeats are unaffected, and both sides of a comparison are
+          # measured the same way.
+          set -euo pipefail
+          out="$1"
+          shift
+          outdir=$(mktemp -d)
+          jobs=$(nproc)
+          if [ "$jobs" -gt 1 ]; then jobs=$((jobs - 1)); fi
+          printf '%s\n' "$@" | xargs -P "$jobs" -I{} \
+            bash "$RUNNER_TEMP/measure-one.sh" {} "$outdir"
+          : > "$out"
+          for file in "$@"; do
+            slug="$(printf '%s' "$file" | tr '/' '_')_$(printf '%s' "$file" | cksum | cut -d' ' -f1)"
+            cat "$outdir/$slug.log" >> "$out"
+          done
+          rm -rf "$outdir"
+          SH
+          chmod +x "$RUNNER_TEMP/measure-one.sh" "$RUNNER_TEMP/measure-heartbeats.sh"
+
+      - name: Measure modified files at the merge base
+        if: steps.files.outputs.compare == 'true'
+        env:
+          MERGE_BASE: ${{ steps.files.outputs.merge_base }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          MODIFIED: ${{ steps.files.outputs.modified }}
+        run: |
+          set -euo pipefail
+          # Whatever happens below, later steps must run against the head.
+          trap 'git checkout -f --detach "$HEAD_SHA"' EXIT
+          # The restored cache was built from the base branch, so building
+          # the merge base first is mostly cache hits; the head build in the
+          # next step then measures exactly the PR's rebuild cost.
+          git checkout -f --detach "$MERGE_BASE"
+          if /usr/bin/time -p ~/.elan/bin/lake build LeanPool 2>&1 \
+               | tee proof-profile-base-build.log; then
+            # shellcheck disable=SC2086 # MODIFIED is a space-separated list on purpose
+            "$RUNNER_TEMP/measure-heartbeats.sh" proof-profile-base-heartbeats.log $MODIFIED \
+              || echo "::warning::Base-side measurement failed; modified files fall back to head-only numbers."
+          else
+            echo "::warning::Base build failed; skipping base-side measurements."
           fi
 
       - name: Build project so profile imports resolve
@@ -150,9 +275,9 @@ jobs:
           /usr/bin/time -p ~/.elan/bin/lake build LeanPool 2>&1 | tee proof-profile-build.log
 
       - name: Profile new and modified files
-        if: steps.files.outputs.files != ''
+        if: steps.files.outputs.profile_files != ''
         env:
-          FILES: ${{ steps.files.outputs.files }}
+          FILES: ${{ steps.files.outputs.profile_files }}
         run: |
           set -euo pipefail
           : > proof-profile.log
@@ -178,30 +303,17 @@ jobs:
           FILES: ${{ steps.files.outputs.files }}
         run: |
           set -euo pipefail
-          : > proof-profile-heartbeats.log
           # shellcheck disable=SC2086 # FILES is a space-separated list on purpose
-          for file in $FILES; do
-            {
-              echo "## $file"
-              # Mathlib's countHeartbeats linter reports in the same units
-              # used by `set_option maxHeartbeats`.
-              set +e
-              /usr/bin/time -p ~/.elan/bin/lake env lean \
-                -Dlinter.countHeartbeats=true \
-                "$file"
-              status=$?
-              set -e
-              if [ "$status" -ne 0 ]; then
-                echo "error: count-heartbeats command exited with status $status"
-              fi
-              echo
-            } >> proof-profile-heartbeats.log 2>&1
-          done
+          "$RUNNER_TEMP/measure-heartbeats.sh" proof-profile-heartbeats.log $FILES
 
       - name: Render profile summary
         if: steps.files.outputs.files != ''
         env:
           BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          ADDED_FILES: ${{ steps.files.outputs.added }}
+          MODIFIED_FILES: ${{ steps.files.outputs.modified }}
+          COMPARE: ${{ steps.files.outputs.compare }}
+          COMPARE_NOTE: ${{ steps.files.outputs.compare_note }}
         run: |
           python3 <<'PY'
           import os
@@ -211,6 +323,7 @@ jobs:
 
           log_path = Path("proof-profile.log")
           heartbeat_log_path = Path("proof-profile-heartbeats.log")
+          base_heartbeat_log_path = Path("proof-profile-base-heartbeats.log")
           build_log_path = Path("proof-profile-build.log")
           rendered_path = Path("proof-profile.md")
           summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
@@ -240,10 +353,12 @@ jobs:
               r"(?:approximately\s+)?(?P<heartbeats>[0-9]+)\s+heartbeats"
           )
 
+
           def format_ms(ms: float) -> str:
               """Format milliseconds with the equivalent seconds."""
 
               return f"{ms:.1f} ms (= {ms / 1000:.2f} s)"
+
 
           def format_seconds(seconds: float | None) -> str:
               """Format an optional wall-clock seconds value."""
@@ -252,15 +367,32 @@ jobs:
                   return "—"
               return f"{seconds:.2f}"
 
+
           def format_heartbeats(heartbeats: float) -> str:
               """Format heartbeats in maxHeartbeats units."""
 
               return f"{heartbeats:,.0f}"
 
+
           def format_int(value: int) -> str:
               """Format an integer with thousands separators."""
 
               return f"{value:,}"
+
+
+          def format_signed(value: float) -> str:
+              """Format a signed heartbeat delta with thousands separators."""
+
+              return f"{value:+,.0f}"
+
+
+          def format_delta_pct(delta: float, base: float) -> str:
+              """Format a delta as a percentage of a base, dash when undefined."""
+
+              if base <= 0:
+                  return "—"
+              return f"{delta / base * 100:+.1f}%"
+
 
           def split_sections(log_text: str) -> list[tuple[str, str]]:
               """Split a profile log into `## <file>` sections."""
@@ -280,6 +412,37 @@ jobs:
               if name is not None:
                   sections.append((name, "\n".join(buf).rstrip()))
               return sections
+
+
+          def parse_heartbeat_sections(log_text: str) -> dict[str, dict[str, float | int | None]]:
+              """Parse a count-heartbeats log into per-file totals."""
+
+              result: dict[str, dict[str, float | int | None]] = {}
+              for fname, body in split_sections(log_text):
+                  heartbeats = 0.0
+                  declarations = 0
+                  errors = 0
+                  wall_seconds = None
+                  for line in body.splitlines():
+                      if "error:" in line:
+                          errors += 1
+                          continue
+                      timing = time_re.match(line.strip())
+                      if timing and timing.group(1) == "real":
+                          wall_seconds = float(timing.group(2))
+                          continue
+                      match = heartbeat_re.search(line)
+                      if match:
+                          heartbeats += float(match.group("heartbeats"))
+                          declarations += 1
+                  result[fname] = {
+                      "heartbeats": heartbeats,
+                      "declarations": declarations,
+                      "errors": errors,
+                      "wall_seconds": wall_seconds,
+                  }
+              return result
+
 
           def changed_loc_by_file(files: list[str]) -> dict[str, int]:
               """Count added LOC in the profiled files from the PR diff."""
@@ -312,9 +475,70 @@ jobs:
                       loc[path] = int(additions)
               return loc
 
-          out = ["## Proof profile (new / modified Lean files)\n\n"]
+
+          def changed_line_stats(files: list[str]) -> dict[str, tuple[int, int]]:
+              """Added/deleted line counts per file from the PR diff."""
+
+              base_sha = os.environ.get("BASE_SHA")
+              stats = {fname: (0, 0) for fname in files}
+              if not base_sha or not files:
+                  return stats
+              try:
+                  output = subprocess.check_output(
+                      [
+                          "git",
+                          "diff",
+                          "--numstat",
+                          "--diff-filter=AM",
+                          f"{base_sha}...HEAD",
+                          "--",
+                          *files,
+                      ],
+                      text=True,
+                  )
+              except subprocess.CalledProcessError:
+                  return stats
+              for line in output.splitlines():
+                  parts = line.split("\t")
+                  if len(parts) < 3:
+                      continue
+                  additions, deletions, path = parts[:3]
+                  if additions.isdigit() and deletions.isdigit() and path in stats:
+                      stats[path] = (int(additions), int(deletions))
+              return stats
+
+
+          added_files = os.environ.get("ADDED_FILES", "").split()
+          modified_files = os.environ.get("MODIFIED_FILES", "").split()
+          compare = os.environ.get("COMPARE", "") == "true"
+          compare_note = os.environ.get("COMPARE_NOTE", "").strip()
+
           log_text = log_path.read_text() if log_path.exists() else ""
-          if not log_text.strip():
+          heartbeat_text = (
+              heartbeat_log_path.read_text(errors="replace")
+              if heartbeat_log_path.exists()
+              else ""
+          )
+          base_heartbeat_text = (
+              base_heartbeat_log_path.read_text(errors="replace")
+              if base_heartbeat_log_path.exists()
+              else ""
+          )
+
+          heartbeat_by_file = parse_heartbeat_sections(heartbeat_text)
+          base_heartbeat_by_file = parse_heartbeat_sections(base_heartbeat_text)
+
+          # A modified file is compared only when both sides were measured; anything
+          # else falls back to the absolute table below.
+          compared = [
+              fname
+              for fname in modified_files
+              if fname in base_heartbeat_by_file and fname in heartbeat_by_file
+          ]
+          compared_set = set(compared)
+
+          out = ["## Proof profile (new / modified Lean files)\n\n"]
+          if not log_text.strip() and not heartbeat_text.strip():
               out.append("_No proof profile output._\n")
               rendered_path.write_text("".join(out))
               summary_path.write_text("".join(out))
@@ -355,91 +579,290 @@ jobs:
                       f"`sys {build_clock['sys']:.2f} s`"
                   )
               out.append(lead + ".\n\n")
+              if compared:
+                  out.append(
+                      "_This is the head build on top of a warm base cache, i.e. "
+                      "the cost of rebuilding the modified files and their "
+                      "dependents. The serial per-file sums below are useful for "
+                      "ranking slow files, not as a build budget._\n\n"
+                  )
+              else:
+                  out.append(
+                      "_This is the parallel build wall clock and is the "
+                      "compile-time answer for this PR. The serial per-file "
+                      "sums below are useful for ranking slow files, not as a "
+                      "build budget._\n\n"
+                  )
+
+          if compare_note:
+              out.append(f"_{compare_note}_\n\n")
+          if compare and modified_files and not compared:
               out.append(
-                  "_This is the parallel build wall clock and is the "
-                  "compile-time answer for this PR. The serial per-file "
-                  "sums below are useful for ranking slow files, not as a "
-                  "build budget._\n\n"
+                  "_A base→head comparison was attempted but base-side "
+                  "measurements are unavailable (see the run log); modified "
+                  "files are shown with head-only numbers below._\n\n"
               )
 
-          if not sections:
+
+          def project_of(fname: str) -> str:
+              """Project bucket for a pooled Lean file path."""
+
+              parts = fname.split("/")
+              if len(parts) > 2:
+                  return parts[1]
+              return "(root)"
+
+
+          # ---------------------------------------------------------------------------
+          # Comparison section: compile cost of modified files, base → head.
+          # Heartbeats are deterministic and are the regression signal; wall clock
+          # is measured under parallel load on both sides and is noisy.
+          # ---------------------------------------------------------------------------
+          COMPARISON_FILE_CAP = 50
+          COMPARISON_PROJECT_CAP = 15
+          # A file only counts as cheaper/costlier when its heartbeat delta clears
+          # both an absolute and a relative floor; tiny files otherwise flip
+          # category on single-digit heartbeat changes.
+          CLASSIFY_MIN_HB = 1000
+          CLASSIFY_MIN_PCT = 1.0
+
+          comparison_full: list[str] = []
+          comparison_capped: list[str] = []
+          if compared:
+              line_stats = changed_line_stats(compared)
+              rows = []
+              for fname in compared:
+                  base = base_heartbeat_by_file[fname]
+                  head = heartbeat_by_file[fname]
+                  base_hb = float(base["heartbeats"])
+                  head_hb = float(head["heartbeats"])
+                  delta = head_hb - base_hb
+                  adds, dels = line_stats.get(fname, (0, 0))
+                  rows.append(
+                      {
+                          "fname": fname,
+                          "adds": adds,
+                          "dels": dels,
+                          "base_hb": base_hb,
+                          "head_hb": head_hb,
+                          "delta": delta,
+                          "base_wall": base["wall_seconds"],
+                          "head_wall": head["wall_seconds"],
+                          "base_decls": int(base["declarations"]),
+                          "head_decls": int(head["declarations"]),
+                          "base_errors": int(base["errors"]),
+                          "head_errors": int(head["errors"]),
+                      }
+                  )
+              rows.sort(key=lambda r: (-abs(r["delta"]), r["fname"]))
+
+              total_base_hb = sum(r["base_hb"] for r in rows)
+              total_head_hb = sum(r["head_hb"] for r in rows)
+              total_delta = total_head_hb - total_base_hb
+              total_base_wall = sum(r["base_wall"] or 0.0 for r in rows)
+              total_head_wall = sum(r["head_wall"] or 0.0 for r in rows)
+              total_adds = sum(r["adds"] for r in rows)
+              total_dels = sum(r["dels"] for r in rows)
+              total_base_decls = sum(r["base_decls"] for r in rows)
+              total_head_decls = sum(r["head_decls"] for r in rows)
+              base_error_files = sum(1 for r in rows if r["base_errors"])
+              head_error_files = sum(1 for r in rows if r["head_errors"])
+
+              def classify(row) -> int:
+                  """-1 cheaper, +1 costlier, 0 within noise."""
+
+                  delta = row["delta"]
+                  if abs(delta) < CLASSIFY_MIN_HB:
+                      return 0
+                  if row["base_hb"] <= 0:
+                      return 1 if delta > 0 else 0
+                  if abs(delta) / row["base_hb"] * 100 < CLASSIFY_MIN_PCT:
+                      return 0
+                  return 1 if delta > 0 else -1
+
+              cheaper = sum(1 for r in rows if classify(r) < 0)
+              costlier = sum(1 for r in rows if classify(r) > 0)
+              unchanged = len(rows) - cheaper - costlier
+
+              def comparison_section(cap: int | None) -> list[str]:
+                  s: list[str] = []
+                  s.append("### Compile cost of modified files — base → head\n\n")
+                  s.append(
+                      f"**Heartbeats:** {format_heartbeats(total_base_hb)} → "
+                      f"{format_heartbeats(total_head_hb)} "
+                      f"({format_signed(total_delta)}, "
+                      f"**{format_delta_pct(total_delta, total_base_hb)}**). "
+                      f"**Declarations:** {format_int(total_base_decls)} → "
+                      f"{format_int(total_head_decls)}.\n\n"
+                  )
+                  s.append(
+                      f"**Per-file wall sum:** {total_base_wall:.1f} s → "
+                      f"{total_head_wall:.1f} s "
+                      f"({format_delta_pct(total_head_wall - total_base_wall, total_base_wall)}). "
+                      "_Wall clock is measured under parallel load and is noisy; "
+                      "heartbeats are deterministic and are the regression "
+                      "signal._\n\n"
+                  )
+                  s.append(
+                      f"**Files:** {format_int(len(rows))} compared — "
+                      f"{format_int(cheaper)} cheaper, {format_int(costlier)} "
+                      f"costlier, {format_int(unchanged)} within noise "
+                      f"(threshold: |Δ heartbeats| ≥ {CLASSIFY_MIN_HB:,} "
+                      f"and ≥ {CLASSIFY_MIN_PCT:.0f}%)."
+                  )
+                  if base_error_files or head_error_files:
+                      s.append(
+                          f" **Measurement errors:** {base_error_files} base-side / "
+                          f"{head_error_files} head-side file(s), marked ⚠; their "
+                          "heartbeat counts are partial."
+                      )
+                  s.append("\n\n")
+                  s.append(
+                      "_Base is the merge-base with the target branch; both sides "
+                      "are measured with Mathlib's `linter.countHeartbeats`, in "
+                      "`maxHeartbeats` units. Δ lines counts added/deleted lines "
+                      "from this PR diff._\n\n"
+                  )
+                  s.append(
+                      "| File | Δ lines | HB base | HB head | Δ HB | Δ HB % | "
+                      "Wall base (s) | Wall head (s) |\n"
+                  )
+                  s.append("|---|---:|---:|---:|---:|---:|---:|---:|\n")
+                  shown = rows if cap is None else rows[:cap]
+                  for r in shown:
+                      marker = " ⚠" if r["base_errors"] or r["head_errors"] else ""
+                      s.append(
+                          f"| `{r['fname']}`{marker} | +{r['adds']}/-{r['dels']} | "
+                          f"{format_heartbeats(r['base_hb'])} | "
+                          f"{format_heartbeats(r['head_hb'])} | "
+                          f"{format_signed(r['delta'])} | "
+                          f"{format_delta_pct(r['delta'], r['base_hb'])} | "
+                          f"{format_seconds(r['base_wall'])} | "
+                          f"{format_seconds(r['head_wall'])} |\n"
+                      )
+                  if cap is not None and len(rows) > cap:
+                      hidden = len(rows) - cap
+                      hidden_max = abs(rows[cap]["delta"])
+                      s.append(
+                          f"| _… +{format_int(hidden)} more files, each with a "
+                          f"smaller move (≤ {format_heartbeats(hidden_max)} HB); "
+                          "full table in the run's step summary_ "
+                          "| | | | | | | |\n"
+                      )
+                  s.append(
+                      f"| **Total** | **+{format_int(total_adds)}/-"
+                      f"{format_int(total_dels)}** | "
+                      f"**{format_heartbeats(total_base_hb)}** | "
+                      f"**{format_heartbeats(total_head_hb)}** | "
+                      f"**{format_signed(total_delta)}** | "
+                      f"**{format_delta_pct(total_delta, total_base_hb)}** | "
+                      f"**{total_base_wall:.1f}** | **{total_head_wall:.1f}** |\n"
+                  )
+                  s.append("\n")
+
+                  projects: dict[str, dict[str, float]] = {}
+                  for r in rows:
+                      p = projects.setdefault(
+                          project_of(r["fname"]),
+                          {"files": 0, "base": 0.0, "head": 0.0},
+                      )
+                      p["files"] += 1
+                      p["base"] += r["base_hb"]
+                      p["head"] += r["head_hb"]
+                  if len(projects) > 1:
+                      project_rows = sorted(
+                          projects.items(),
+                          key=lambda kv: -abs(kv[1]["head"] - kv[1]["base"]),
+                      )
+                      shown_projects = project_rows[:COMPARISON_PROJECT_CAP]
+                      s.append(
+                          f"**Per-project compile cost** (top "
+                          f"{len(shown_projects)} of {len(project_rows)} "
+                          "projects by |Δ heartbeats|):\n\n"
+                      )
+                      s.append("| Project | Files | HB base | HB head | Δ HB | Δ HB % |\n")
+                      s.append("|---|---:|---:|---:|---:|---:|\n")
+                      for pname, p in shown_projects:
+                          pdelta = p["head"] - p["base"]
+                          s.append(
+                              f"| `{pname}` | {format_int(int(p['files']))} | "
+                              f"{format_heartbeats(p['base'])} | "
+                              f"{format_heartbeats(p['head'])} | "
+                              f"{format_signed(pdelta)} | "
+                              f"{format_delta_pct(pdelta, p['base'])} |\n"
+                          )
+                      s.append("\n")
+                  return s
+
+              comparison_full = comparison_section(None)
+              comparison_capped = comparison_section(COMPARISON_FILE_CAP)
+
+          out_comment_extra: list[str] = []
+
+          # ---------------------------------------------------------------------------
+          # Absolute section: files without a base side (new files; also every file
+          # when no comparison ran). This is the pre-existing render, restricted to
+          # the non-compared files.
+          # ---------------------------------------------------------------------------
+          absolute_out: list[str] = []
+          # Summary table: cumulative ms = sum over reported phases.
+          # Import-excluded ms keeps the current workflow's signal while
+          # separating repeated import cost from file-local elaboration.
+          profile_by_file = {}
+          phase_totals: dict[str, float] = {}
+          for fname, body in sections:
+              if fname in compared_set:
+                  continue
+              total = 0.0
+              import_ms = 0.0
+              phases = 0
+              errors = 0
+              wall_seconds = None
+              for line in body.splitlines():
+                  if "error:" in line:
+                      errors += 1
+                      continue
+                  timing = time_re.match(line.strip())
+                  if timing and timing.group(1) == "real":
+                      wall_seconds = float(timing.group(2))
+                      continue
+                  m = metric_re.match(line)
+                  if m:
+                      value = float(m.group(2))
+                      if m.group(3) == "s":
+                          value *= 1000
+                      phase = m.group(1).strip()
+                      phase_totals[phase] = phase_totals.get(phase, 0.0) + value
+                      total += value
+                      if phase == "import":
+                          import_ms += value
+                      phases += 1
+              profile_by_file[fname] = {
+                  "total_ms": total,
+                  "local_ms": total - import_ms,
+                  "import_ms": import_ms,
+                  "phases": phases,
+                  "errors": errors,
+                  "wall_seconds": wall_seconds,
+              }
+
+          absolute_heartbeats = {
+              fname: data
+              for fname, data in heartbeat_by_file.items()
+              if fname not in compared_set
+          }
+
+          all_files = sorted(set(profile_by_file) | set(absolute_heartbeats))
+          if not all_files and not compared:
               out.append("_No files profiled._\n")
-          else:
-              # Summary table: cumulative ms = sum over reported phases.
-              # Import-excluded ms keeps the current workflow's signal while
-              # separating repeated import cost from file-local elaboration.
-              profile_by_file = {}
-              phase_totals: dict[str, float] = {}
-              for fname, body in sections:
-                  total = 0.0
-                  import_ms = 0.0
-                  phases = 0
-                  errors = 0
-                  wall_seconds = None
-                  for line in body.splitlines():
-                      if "error:" in line:
-                          errors += 1
-                          continue
-                      timing = time_re.match(line.strip())
-                      if timing and timing.group(1) == "real":
-                          wall_seconds = float(timing.group(2))
-                          continue
-                      m = metric_re.match(line)
-                      if m:
-                          value = float(m.group(2))
-                          if m.group(3) == "s":
-                              value *= 1000
-                          phase = m.group(1).strip()
-                          phase_totals[phase] = phase_totals.get(phase, 0.0) + value
-                          total += value
-                          if phase == "import":
-                              import_ms += value
-                          phases += 1
-                  profile_by_file[fname] = {
-                      "total_ms": total,
-                      "local_ms": total - import_ms,
-                      "import_ms": import_ms,
-                      "phases": phases,
-                      "errors": errors,
-                      "wall_seconds": wall_seconds,
-                  }
-
-              heartbeat_by_file: dict[str, dict[str, float | int]] = {}
-              heartbeat_text = (
-                  heartbeat_log_path.read_text(errors="replace")
-                  if heartbeat_log_path.exists()
-                  else ""
-              )
-              for fname, body in split_sections(heartbeat_text):
-                  heartbeats = 0.0
-                  declarations = 0
-                  errors = 0
-                  wall_seconds = None
-                  for line in body.splitlines():
-                      if "error:" in line:
-                          errors += 1
-                          continue
-                      timing = time_re.match(line.strip())
-                      if timing and timing.group(1) == "real":
-                          wall_seconds = float(timing.group(2))
-                          continue
-                      match = heartbeat_re.search(line)
-                      if match:
-                          heartbeats += float(match.group("heartbeats"))
-                          declarations += 1
-                  heartbeat_by_file[fname] = {
-                      "heartbeats": heartbeats,
-                      "declarations": declarations,
-                      "errors": errors,
-                      "wall_seconds": wall_seconds,
-                  }
-
-              all_files = sorted(set(profile_by_file) | set(heartbeat_by_file))
+          elif all_files:
+              if compared:
+                  absolute_out.append("### New files — absolute profile\n\n")
               loc_by_file = changed_loc_by_file(all_files)
               summary_rows = []
               for fname in all_files:
                   profile = profile_by_file.get(fname, {})
-                  heartbeat = heartbeat_by_file.get(fname, {})
+                  heartbeat = absolute_heartbeats.get(fname, {})
                   summary_rows.append(
                       (
                           fname,
@@ -466,35 +889,37 @@ jobs:
               total_errors = sum(r[8] for r in summary_rows)
               total_declarations = sum(r[9] for r in summary_rows)
               file_count = len(summary_rows)
-              out.append(
+              absolute_out.append(
                   f"**Total heartbeats:** {format_heartbeats(total_heartbeats)} "
                   f"maxHeartbeats units across {file_count} file"
                   f"{'' if file_count == 1 else 's'} "
                   f"({format_int(total_loc)} added LOC).\n\n"
               )
-              out.append(
+              absolute_out.append(
                   f"**Sum of `lean --profile`:** {format_ms(total_ms)}. "
                   f"**Import-excluded time:** {format_ms(total_local_ms)}.\n\n"
               )
-              out.append(
+              absolute_out.append(
                   f"**Count-heartbeats wall-clock total:** {total_wall_seconds:.2f} s. "
                   f"Repeated import cost inside `lean --profile`: "
                   f"{format_ms(total_import_ms)}.\n\n"
               )
-              out.append(
+              absolute_out.append(
                   "_Heartbeat values come from Mathlib's `linter.countHeartbeats` "
-                  "and are already in `maxHeartbeats` units._\n\n"
+                  "and are already in `maxHeartbeats` units. Per-file wall "
+                  "clocks are measured under parallel load and are noisier "
+                  "than heartbeats._\n\n"
               )
-              out.append(
+              absolute_out.append(
                   "_LOC counts added lines in the profiled Lean files from "
                   "this PR diff._\n\n"
               )
-              out.append(
+              absolute_out.append(
                   "| File | LOC | Heartbeats (maxHB) | Count wall (s) | "
                   "`lean --profile` (s) | Without import (s) | "
                   "Import (s) | Decls | Errors |\n"
               )
-              out.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+              absolute_out.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|\n")
               for (
                   fname,
                   loc,
@@ -507,7 +932,7 @@ jobs:
                   errors,
                   declarations,
               ) in summary_rows:
-                  out.append(
+                  absolute_out.append(
                       f"| `{fname}` | {format_int(loc)} | "
                       f"{format_heartbeats(heartbeats)} | "
                       f"{format_seconds(wall_seconds)} | {total / 1000:.2f} | "
@@ -516,7 +941,7 @@ jobs:
                   )
               # Total row in the same table so any single file's cumulative
               # time can be compared against the whole at a glance.
-              out.append(
+              absolute_out.append(
                   f"| **Total** | **{format_int(total_loc)}** "
                   f"| **{format_heartbeats(total_heartbeats)}** "
                   f"| **{total_wall_seconds:.2f}** | **{total_ms / 1000:.2f}** "
@@ -524,19 +949,22 @@ jobs:
                   f"| **{total_import_ms / 1000:.2f}** "
                   f"| **{total_declarations}** | **{total_errors}** |\n"
               )
-              out.append("\n")
+              absolute_out.append("\n")
 
               phase_rows = sorted(phase_totals.items(), key=lambda row: -row[1])
-              out.append("### Aggregate phase totals\n\n")
-              out.append("| Phase | Time |\n")
-              out.append("|---|---:|\n")
+              absolute_out.append("### Aggregate phase totals\n\n")
+              absolute_out.append("| Phase | Time |\n")
+              absolute_out.append("|---|---:|\n")
               for phase, ms in phase_rows[:12]:
-                  out.append(f"| `{phase}` | {format_ms(ms)} |\n")
-              out.append("\n")
+                  absolute_out.append(f"| `{phase}` | {format_ms(ms)} |\n")
+              absolute_out.append("\n")
 
+          if all_files or compared:
+              # The lake-build ranking covers every changed module — compared and
+              # absolute alike — since the head build rebuilds both kinds.
               changed_modules = {
                   fname.removesuffix(".lean").replace("/", ".")
-                  for fname, *_ in summary_rows
+                  for fname in set(all_files) | compared_set
               }
               changed_build_times = {
                   module: seconds
@@ -544,30 +972,34 @@ jobs:
                   if module in changed_modules
               }
               if changed_build_times:
-                  out.append("### Slowest changed modules (from `lake build`)\n\n")
-                  out.append("| Changed module | Lake time |\n")
-                  out.append("|---|---:|\n")
+                  absolute_out.append("### Slowest changed modules (from `lake build`)\n\n")
+                  absolute_out.append("| Changed module | Lake time |\n")
+                  absolute_out.append("|---|---:|\n")
                   for module, seconds in sorted(
                       changed_build_times.items(), key=lambda row: -row[1]
                   )[:12]:
-                      out.append(f"| `{module}` | {seconds:.2f} s |\n")
-                  out.append("\n")
+                      absolute_out.append(f"| `{module}` | {seconds:.2f} s |\n")
+                  absolute_out.append("\n")
 
               # Full per-file output, collapsed by default so the comment
               # stays scannable when many files are profiled.
-              out.append("<details><summary>Per-file `lean --profile` output</summary>\n\n")
-              for fname, body in sections:
-                  out.append(f"#### `{fname}`\n\n")
-                  out.append("```text\n")
-                  out.append(body if body.strip() else "(empty)")
-                  out.append("\n```\n\n")
-              out.append("</details>\n")
+              if sections:
+                  absolute_out.append(
+                      "<details><summary>Per-file `lean --profile` output</summary>\n\n"
+                  )
+                  for fname, body in sections:
+                      absolute_out.append(f"#### `{fname}`\n\n")
+                      absolute_out.append("```text\n")
+                      absolute_out.append(body if body.strip() else "(empty)")
+                      absolute_out.append("\n```\n\n")
+                  absolute_out.append("</details>\n")
 
-              out.append(
+              out_comment_extra.append(
                   "\n_Advisory only — never blocks merge. "
                   f"[Full log]({run_url}) uploaded as the `proof-profile` "
                   "artifact._\n"
               )
+
 
           def bound_comment(text, limit):
               """Trim a rendered profile to fit GitHub's comment size cap.
@@ -638,12 +1070,16 @@ jobs:
                   out_text = assemble(n)
               return out_text
 
-          rendered = "".join(out)
+
+          rendered_full = "".join(out + comparison_full + absolute_out + out_comment_extra)
+          rendered_comment = "".join(
+              out + comparison_capped + absolute_out + out_comment_extra
+          )
 
           # The full render always goes to the job step summary (~1 MB limit)
           # and the raw logs to the `proof-profile` artifact.
           with summary_path.open("a") as f:
-              f.write(rendered)
+              f.write(rendered_full)
 
           # A PR comment body is capped by GitHub at 65536 characters. On large
           # PRs (hundreds of changed files) the full render blows past that and
@@ -651,10 +1087,9 @@ jobs:
           # comment to the headline paragraphs, the hottest table rows, and the
           # small aggregate sections; the dropped per-file dump stays available
           # in full in the step summary above and in the artifact.
-          comment = rendered
-          if len(comment) > 62000:
-              comment = bound_comment(rendered, 62000)
-          rendered_path.write_text(comment)
+          if len(rendered_comment) > 62000:
+              rendered_comment = bound_comment(rendered_comment, 62000)
+          rendered_path.write_text(rendered_comment)
           PY
 
       # A `pull_request` run from a fork gets a read-only GITHUB_TOKEN and
@@ -693,4 +1128,6 @@ jobs:
             proof-profile.log
             proof-profile-heartbeats.log
             proof-profile-build.log
+            proof-profile-base-heartbeats.log
+            proof-profile-base-build.log
           if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This file is a concatenation of README.md and CONTRIBUTING.md.
 Lean Pool sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and [`merely-true`](https://github.com/merely-true/merely-true), preserving Lean 4 formalizations that don't fit mathlib's scope. Instead of mathlib's high-bar human review, it relies on deterministic linters and LLM judgment, so it can grow faster while staying `sorry`-free and pinned to the latest Mathlib. See [`MOTIVATION.md`](MOTIVATION.md) for the why, and browse the API docs at <https://vilin97.github.io/lean-pool/>.
 
 <!-- BEGIN STATS -->
-**92** formalization projects · **637,028** lines of Lean
+**123** formalization projects · **882,817** lines of Lean
 <!-- END STATS -->
 
 <sub>(stats above are refreshed automatically by [`readme-stats.yml`](.github/workflows/readme-stats.yml) — edit [`python/lean_pool/stats.py`](python/lean_pool/stats.py), not the numbers)</sub>
@@ -55,7 +55,7 @@ There are two paths:
 - **Propose a repo.** Open an issue with the GitHub URL and a maintainer can import it. Repos that Reservoir does not index can be added to [`candidates/manual.txt`](candidates/manual.txt).
 - **Open a content PR.** Add your project under `LeanPool/<YourProject>/`, register it in [`LeanPool/projects.yml`](LeanPool/projects.yml), and regenerate the index with `lake exe mk_all`.
 
-Either way the result must pass CI (build, linters, and quality checks — see [Linting and testing](#linting-and-testing)) and an [LLM review](.github/REVIEW_RULES.md) of fit and significance. Accepted projects must be `sorry`-free, introduce no axioms beyond `Classical.choice`/`propext`/`Quot.sound`, and avoid `unsafe`/`partial`. (Proof profiling via `/profile` is available but informational, not a gate.)
+Either way the result must pass CI (build, linters, and quality checks — see [Linting and testing](#linting-and-testing)) and an [LLM review](.github/REVIEW_RULES.md) of fit and significance. Accepted projects must be `sorry`-free, introduce no axioms beyond `Classical.choice`/`propext`/`Quot.sound`, and avoid `unsafe`/`partial`. (Proof profiling via `/profile` is available but informational, not a gate: added files get an absolute profile, while modified files get a base→head compile-cost comparison — useful for checking that a refactor doesn't regress compile time.)
 
 ## Dev setup
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This file is a concatenation of README.md and CONTRIBUTING.md.
 Lean Pool sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and [`merely-true`](https://github.com/merely-true/merely-true), preserving Lean 4 formalizations that don't fit mathlib's scope. Instead of mathlib's high-bar human review, it relies on deterministic linters and LLM judgment, so it can grow faster while staying `sorry`-free and pinned to the latest Mathlib. See [`MOTIVATION.md`](MOTIVATION.md) for the why, and browse the API docs at <https://vilin97.github.io/lean-pool/>.
 
 <!-- BEGIN STATS -->
-**92** formalization projects · **637,028** lines of Lean
+**123** formalization projects · **882,817** lines of Lean
 <!-- END STATS -->
 
 <sub>(stats above are refreshed automatically by [`readme-stats.yml`](.github/workflows/readme-stats.yml) — edit [`python/lean_pool/stats.py`](python/lean_pool/stats.py), not the numbers)</sub>
@@ -55,7 +55,7 @@ There are two paths:
 - **Propose a repo.** Open an issue with the GitHub URL and a maintainer can import it. Repos that Reservoir does not index can be added to [`candidates/manual.txt`](candidates/manual.txt).
 - **Open a content PR.** Add your project under `LeanPool/<YourProject>/`, register it in [`LeanPool/projects.yml`](LeanPool/projects.yml), and regenerate the index with `lake exe mk_all`.
 
-Either way the result must pass CI (build, linters, and quality checks — see [Linting and testing](#linting-and-testing)) and an [LLM review](.github/REVIEW_RULES.md) of fit and significance. Accepted projects must be `sorry`-free, introduce no axioms beyond `Classical.choice`/`propext`/`Quot.sound`, and avoid `unsafe`/`partial`. (Proof profiling via `/profile` is available but informational, not a gate.)
+Either way the result must pass CI (build, linters, and quality checks — see [Linting and testing](#linting-and-testing)) and an [LLM review](.github/REVIEW_RULES.md) of fit and significance. Accepted projects must be `sorry`-free, introduce no axioms beyond `Classical.choice`/`propext`/`Quot.sound`, and avoid `unsafe`/`partial`. (Proof profiling via `/profile` is available but informational, not a gate: added files get an absolute profile, while modified files get a base→head compile-cost comparison — useful for checking that a refactor doesn't regress compile time.)
 
 ## Dev setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ There are two paths:
 - **Propose a repo.** Open an issue with the GitHub URL and a maintainer can import it. Repos that Reservoir does not index can be added to [`candidates/manual.txt`](candidates/manual.txt).
 - **Open a content PR.** Add your project under `LeanPool/<YourProject>/`, register it in [`LeanPool/projects.yml`](LeanPool/projects.yml), and regenerate the index with `lake exe mk_all`.
 
-Either way the result must pass CI (build, linters, and quality checks — see [Linting and testing](#linting-and-testing)) and an [LLM review](.github/REVIEW_RULES.md) of fit and significance. Accepted projects must be `sorry`-free, introduce no axioms beyond `Classical.choice`/`propext`/`Quot.sound`, and avoid `unsafe`/`partial`. (Proof profiling via `/profile` is available but informational, not a gate.)
+Either way the result must pass CI (build, linters, and quality checks — see [Linting and testing](#linting-and-testing)) and an [LLM review](.github/REVIEW_RULES.md) of fit and significance. Accepted projects must be `sorry`-free, introduce no axioms beyond `Classical.choice`/`propext`/`Quot.sound`, and avoid `unsafe`/`partial`. (Proof profiling via `/profile` is available but informational, not a gate: added files get an absolute profile, while modified files get a base→head compile-cost comparison — useful for checking that a refactor doesn't regress compile time.)
 
 ## Dev setup
 


### PR DESCRIPTION
## Problem

`/profile` was built for new project imports: it profiles every changed file absolutely. Running it on a refactor answers the wrong question. On #246 (`tryAtEachStep simp_all` golf, 1,153 modified files) it produced a 5h57m run — a hair under the 6-hour job kill limit — and a wall of absolute numbers that says nothing about whether the golf regressed compile time.

## Fix

`/profile` now detects the kind of change per file (same command, no new slash command needed):

- **Added files** keep today's absolute profile (`lean --profile` + heartbeat counts).
- **Modified files** get a **base→head compile-cost comparison** (same idea as leanprover-community/physlib#1356): heartbeats and wall time are measured at the merge base and at the PR head, and the comment reports the deltas — totals with %, top-50 per-file movers by |Δ heartbeats|, a per-project rollup, and error-flagged (⚠) rows.

Mechanics:

- The **merge base is built first**: the restored cache comes from the base branch, so that build is mostly cache hits — and the head build afterwards then measures exactly the PR's rebuild cost.
- **Heartbeat passes run in parallel** (`nproc`−1) on both sides. Heartbeats (Mathlib's `linter.countHeartbeats`) are deterministic and are the regression signal; wall clocks are measured identically on both sides and labeled noisy. This turns #246's ~6 h run into an estimated ~3.5 h *including* the base side.
- The expensive serial `lean --profile` pass covers **only added files** when a comparison runs.
- The comparison is **skipped** (modified files fall back to the absolute profile, as before) when the PR touches `lean-toolchain`/`lake-manifest.json`/`lakefile.toml` (sides wouldn't be comparable — e.g. version bumps) or when no warm build cache exists (base build unaffordable). The comment says why.
- Comment stays small by construction (capped tables); the full per-file table lands in the step summary and the raw logs (now including the base side) in the `proof-profile` artifact.

## Verification

- Ran the workflow's actual render heredoc against #246's real run logs:
  - absolute path renders **byte-identically** to the current renderer (modulo one new wall-clock explainer line);
  - refactor mode renders a 9 KB comment from the 1,153-file log pair (synthesized base side), with sane movers/rollup/⚠ handling;
  - mixed added+modified mode renders both sections.
- Extracted the heredoc helper scripts and exercised them with a stub `lake`: parallel execution, input-order stitching, error capture, and slug-collision disambiguation all verified.
- `actionlint` + `shellcheck` clean.

Advisory-only workflow; never blocks merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9rUk9sdAd5gqU3nZxqUEL