### PR TITLE
Fix /profile measurement caching: unique save keys, prefix restore

### DIFF
--- a/.github/workflows/proof-profile.yml
+++ b/.github/workflows/proof-profile.yml
@@ -265,16 +265,21 @@ jobs:
       # each side's combined log is cached: re-profiling a PR skips any pass
       # whose inputs did not change (always the base pass, and the head pass
       # too when nothing was pushed since). On a hit, the entire Lean setup
-      # below is skipped as well.
+      # below is skipped as well. The save key is made unique per run and
+      # restores match on the prefix — reusing one fixed key trips the cache
+      # service's "unable to reserve" failure on every save (observed on
+      # both runs that tried), so no measurement ever got cached.
       - name: Restore cached measurements
         id: hb-cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ${{ matrix.log }}
-          key: proof-profile-hb-v2-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml') }}-${{ matrix.ref }}-${{ needs.plan.outputs.modified_hash }}
+          key: proof-profile-hb-v2-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml') }}-${{ matrix.ref }}-${{ needs.plan.outputs.modified_hash }}-${{ github.run_id }}
+          restore-keys: |
+            proof-profile-hb-v2-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml') }}-${{ matrix.ref }}-${{ needs.plan.outputs.modified_hash }}-
 
       - name: Restore caches
-        if: steps.hb-cache.outputs.cache-hit != 'true'
+        if: steps.hb-cache.outputs.cache-matched-key == ''
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
@@ -286,7 +291,7 @@ jobs:
             Lake-${{ runner.os }}-${{ hashFiles('lake-manifest.json') }}-
 
       - name: Install Lean
-        if: steps.hb-cache.outputs.cache-hit != 'true'
+        if: steps.hb-cache.outputs.cache-matched-key == ''
         uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9
         with:
           auto-config: false
@@ -294,7 +299,7 @@ jobs:
           use-mathlib-cache: false
 
       - name: Install Mathlib cache
-        if: steps.hb-cache.outputs.cache-hit != 'true'
+        if: steps.hb-cache.outputs.cache-matched-key == ''
         run: |
           if [ ! -d ".lake/packages/mathlib" ]; then
             ~/.elan/bin/lake exe cache get
@@ -303,7 +308,7 @@ jobs:
           fi
 
       - name: Fetch measurement helpers from the default branch
-        if: steps.hb-cache.outputs.cache-hit != 'true'
+        if: steps.hb-cache.outputs.cache-matched-key == ''
         run: |
           set -euo pipefail
           git show origin/main:scripts/proof-profile/measure-one.sh > "$RUNNER_TEMP/measure-one.sh"
@@ -312,7 +317,7 @@ jobs:
 
       - name: Build the measurement environment at the merge base
         id: base-env
-        if: steps.hb-cache.outputs.cache-hit != 'true'
+        if: steps.hb-cache.outputs.cache-matched-key == ''
         env:
           MERGE_BASE: ${{ needs.plan.outputs.merge_base }}
           BASE_MODULES: ${{ needs.plan.outputs.base_build_modules }}
@@ -352,7 +357,7 @@ jobs:
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ${{ matrix.log }}
-          key: proof-profile-hb-v2-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml') }}-${{ matrix.ref }}-${{ needs.plan.outputs.modified_hash }}
+          key: proof-profile-hb-v2-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml') }}-${{ matrix.ref }}-${{ needs.plan.outputs.modified_hash }}-${{ github.run_id }}
 
       - name: Upload measurements for the report job
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Problem

Every measurement-cache save so far has failed with the Actions cache service's `Failed to save: Unable to reserve cache with key ..., another job may be creating this cache` — observed on both the single-job run (29663806369) and the matrix run (29676965290), on first-ever use of each key. No measurement log was ever cached, so every `/profile` re-run measured from scratch (~70 min per side) instead of the intended minutes.

## Fix

The same pattern the repo's `Lake-` caches already use: append `github.run_id` so every save key is unique (reservation conflicts become impossible), and restore via `restore-keys` prefix so the newest entry for the same (toolchain/manifest/lakefile hash, revision, modified-file-list hash) wins. Skip conditions switch from `cache-hit` (exact-key only — never true with unique keys) to `cache-matched-key`.

`actionlint` clean. Will validate after merge with two `/profile` runs on #246: the first measures fresh and must *save* successfully; the second must *hit* and complete in minutes.

For the record, the matrix run this fix follows up on: 72 min wall (vs 2h25m single-job), heartbeat totals reproduced within 3 HB of 1.7M on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9rUk9sdAd5gqU3nZxqUEL