### PR TITLE
Import Sabidussi: compatibility conjecture for Eulerian multigraphs

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -2268,6 +2268,16 @@ import LeanPool.Rupert.SnubCube
 import LeanPool.Rupert.Square
 import LeanPool.Rupert.Tetrahedron
 import LeanPool.Rupert.TriakisTetrahedron
+import LeanPool.Sabidussi
+import LeanPool.Sabidussi.Color
+import LeanPool.Sabidussi.CyclicWord
+import LeanPool.Sabidussi.LocalPattern
+import LeanPool.Sabidussi.LoopGraphBridge
+import LeanPool.Sabidussi.LoopMultigraph
+import LeanPool.Sabidussi.OddBalance
+import LeanPool.Sabidussi.OrdinaryCircuit
+import LeanPool.Sabidussi.Parity
+import LeanPool.Sabidussi.Statement
 import LeanPool.SardMoreira
 import LeanPool.SardMoreira.Chart
 import LeanPool.SardMoreira.ChartEstimates

--- a/LeanPool/Sabidussi.lean
+++ b/LeanPool/Sabidussi.lean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2026 Nikolay Ulyanov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nikolay Ulyanov
+-/
+
+import LeanPool.Sabidussi.Color
+import LeanPool.Sabidussi.CyclicWord
+import LeanPool.Sabidussi.LocalPattern
+import LeanPool.Sabidussi.LoopGraphBridge
+import LeanPool.Sabidussi.LoopMultigraph
+import LeanPool.Sabidussi.OddBalance
+import LeanPool.Sabidussi.OrdinaryCircuit
+import LeanPool.Sabidussi.Parity
+import LeanPool.Sabidussi.Statement
+
+/-!
+# Sabidussi's compatibility conjecture for Eulerian multigraphs
+
+Source: url:https://github.com/gexahedron/sabidussi-lean/blob/032e640df0cc41d4d3d217f7c68628ab19cb3767/sabidussi_proof.pdf
+Authors: Nikolay Ulyanov
+Status: verified
+Main declarations: `Sabidussi.LoopMultigraph.loop_sabidussi_compatibility_ordinary`
+Tags: graph-theory, eulerian-graphs, circuit-decomposition, sabidussi
+MSC: 05C45
+-/

--- a/LeanPool/Sabidussi/Color.lean
+++ b/LeanPool/Sabidussi/Color.lean
@@ -1,0 +1,178 @@
+/-
+Copyright (c) 2026 Nikolay Ulyanov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nikolay Ulyanov
+-/
+import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.Algebra.Field.ZMod
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Tactic.Abel
+import Mathlib.Tactic.FinCases
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.SplitIfs
+
+/-!
+# The four colours used in the Sabidussi proof
+
+This file contains the elementary algebra over `F₂²` used by the proof. We use an explicit
+product so that the three admissible local frames can be given by concrete formulas.
+-/
+
+namespace Sabidussi
+
+open scoped BigOperators
+
+/-- The field with two elements. -/
+abbrev F₂ := ZMod 2
+
+/-- The four-element colour space. -/
+abbrev Color := F₂ × F₂
+
+@[simp]
+theorem F₂_add_self (x : F₂) : x + x = 0 := ZModModule.add_self x
+
+@[simp]
+theorem color_add_self (x : Color) : x + x = 0 := by
+  ext <;> simp
+
+theorem F₂_add_shuffle (a b : F₂) : a + (b + (a + b)) = 0 := by
+  calc
+    a + (b + (a + b)) = (a + a) + (b + b) := by abel
+    _ = 0 := by simp
+
+/-- The alternating form polarizing `quadratic`. -/
+def bracket (x y : Color) : F₂ := x.1 * y.2 + x.2 * y.1
+
+/-- The quadratic form detecting the colour `(1, 1)`. -/
+def quadratic (x : Color) : F₂ := x.1 * x.2
+
+@[simp]
+theorem bracket_apply (x y : Color) : bracket x y = x.1 * y.2 + x.2 * y.1 := rfl
+
+@[simp]
+theorem quadratic_apply (x : Color) : quadratic x = x.1 * x.2 := rfl
+
+theorem bracket_zero_left (x : Color) : bracket 0 x = 0 := by
+  simp [bracket]
+
+theorem bracket_zero_right (x : Color) : bracket x 0 = 0 := by
+  simp [bracket]
+
+theorem bracket_add_left (x y z : Color) :
+    bracket (x + y) z = bracket x z + bracket y z := by
+  simp only [bracket, Prod.fst_add, Prod.snd_add]
+  ring
+
+theorem bracket_add_right (x y z : Color) :
+    bracket x (y + z) = bracket x y + bracket x z := by
+  simp only [bracket, Prod.fst_add, Prod.snd_add]
+  ring
+
+/-- Bracketing with a fixed left argument, as an additive homomorphism. -/
+def bracketRightHom (x : Color) : Color →+ F₂ where
+  toFun := bracket x
+  map_zero' := bracket_zero_right x
+  map_add' := bracket_add_right x
+
+@[simp]
+theorem bracketRightHom_apply (x y : Color) : bracketRightHom x y = bracket x y := rfl
+
+theorem sum_bracket_right {I : Type*} [Fintype I] (x : Color) (f : I → Color) :
+    ∑ i, bracket x (f i) = bracket x (∑ i, f i) := by
+  change ∑ i, bracketRightHom x (f i) = bracketRightHom x (∑ i, f i)
+  exact (map_sum (bracketRightHom x) f Finset.univ).symm
+
+theorem bracket_comm (x y : Color) : bracket x y = bracket y x := by
+  simp [bracket, add_comm, mul_comm]
+
+theorem bracket_self (x : Color) : bracket x x = 0 := by
+  simp [bracket, mul_comm]
+
+theorem quadratic_add (x y : Color) :
+    quadratic (x + y) = quadratic x + quadratic y + bracket x y := by
+  simp only [quadratic, bracket, Prod.fst_add, Prod.snd_add]
+  ring
+
+/-- The three locally admissible difference vectors at a 6-valent vertex. -/
+def tripleDifference (t : Color) : Fin 3 → Color
+  | ⟨0, _⟩ => t
+  | ⟨1, _⟩ => (t.2, t.1 + t.2)
+  | ⟨2, _⟩ => (t.1 + t.2, t.1)
+
+@[simp]
+theorem tripleDifference_zero (t : Color) : tripleDifference t 0 = t := rfl
+
+@[simp]
+theorem tripleDifference_one (t : Color) :
+    tripleDifference t 1 = (t.2, t.1 + t.2) := rfl
+
+@[simp]
+theorem tripleDifference_two (t : Color) :
+    tripleDifference t 2 = (t.1 + t.2, t.1) := rfl
+
+theorem sum_tripleDifference (t : Color) : ∑ i, tripleDifference t i = 0 := by
+  rw [Fin.sum_univ_three]
+  change t + (t.2, t.1 + t.2) + (t.1 + t.2, t.1) = 0
+  ext
+  · change t.1 + t.2 + (t.1 + t.2) = 0
+    exact F₂_add_self (t.1 + t.2)
+  · change t.2 + (t.1 + t.2) + t.1 = 0
+    calc
+      t.2 + (t.1 + t.2) + t.1 = (t.1 + t.1) + (t.2 + t.2) := by abel
+      _ = 0 := by simp
+
+theorem tripleDifference_ne_zero (t : Color) (ht : t ≠ 0) (i : Fin 3) :
+    tripleDifference t i ≠ 0 := by
+  fin_cases i
+  · simpa using ht
+  · intro h
+    apply ht
+    rcases Prod.mk_eq_zero.mp h with ⟨h₂, hsum⟩
+    ext
+    · simpa [h₂] using hsum
+    · exact h₂
+  · intro h
+    apply ht
+    rcases Prod.mk_eq_zero.mp h with ⟨hsum, h₁⟩
+    ext
+    · exact h₁
+    · simpa [h₁] using hsum
+
+/-- At a 4-valent vertex the two local differences coincide. -/
+def doubleDifference (t : Color) : Fin 2 → Color
+  | ⟨0, _⟩ => t
+  | ⟨1, _⟩ => t
+
+theorem sum_doubleDifference (t : Color) : ∑ i, doubleDifference t i = 0 := by
+  rw [Fin.sum_univ_two]
+  exact color_add_self t
+
+theorem doubleDifference_ne_zero (t : Color) (ht : t ≠ 0) (i : Fin 2) :
+    doubleDifference t i ≠ 0 := by
+  fin_cases i <;> exact ht
+
+/-- The local quadratic contribution from two equal nonzero differences vanishes. -/
+theorem double_local_quadratic (t : Color) :
+    (∑ i, quadratic (doubleDifference t i)) +
+      (∑ i, ∑ j,
+        if j < i then bracket (doubleDifference t i) (doubleDifference t j) else 0) = 0 := by
+  simp only [Fin.sum_univ_two, doubleDifference, quadratic, bracket]
+  norm_num
+  ring_nf
+  rw [show (2 : F₂) = 0 from ZMod.natCast_self 2]
+  simp
+
+/-- The local quadratic contribution from the three `tripleDifference`s vanishes. -/
+theorem triple_local_quadratic (t : Color) :
+    (∑ i, quadratic (tripleDifference t i)) +
+      (∑ i, ∑ j,
+        if j < i then bracket (tripleDifference t i) (tripleDifference t j) else 0) = 0 := by
+  simp only [Fin.sum_univ_three, tripleDifference, quadratic, bracket]
+  split_ifs <;> try omega
+  ring_nf
+  rw [show (8 : F₂) = 0 from (show Even 8 by exact ⟨4, rfl⟩).natCast_zmod_two,
+    show (4 : F₂) = 0 from (show Even 4 by exact ⟨2, rfl⟩).natCast_zmod_two]
+  simp
+
+end Sabidussi

--- a/LeanPool/Sabidussi/CyclicWord.lean
+++ b/LeanPool/Sabidussi/CyclicWord.lean
@@ -1,0 +1,640 @@
+/-
+Copyright (c) 2026 Nikolay Ulyanov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nikolay Ulyanov
+-/
+import LeanPool.Sabidussi.LocalPattern
+import LeanPool.Sabidussi.OddBalance
+import LeanPool.Sabidussi.Parity
+import Mathlib.Data.Finset.Sort
+import Mathlib.Logic.Equiv.Fin.Rotate
+import Mathlib.Order.Interval.Finset.Fin
+
+/-!
+# The cyclic-word four-colouring lemma
+
+This file is the combinatorial core of the compatibility proof.  A letter at a position records
+the transition between the preceding and the current gap.  If every letter occurs at least twice,
+the local patterns from `LocalPattern` and the odd balancing theorem produce colours on the gaps
+such that adjacent gaps have different colours and every colour occurs evenly at each letter.
+-/
+
+namespace Sabidussi
+namespace CyclicWord
+
+open scoped BigOperators
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- A nonempty cyclic word, represented with a chosen cut. -/
+structure Word where
+  /-- The word has `n + 1` positions, so it is always nonempty. -/
+  n : ℕ
+  /-- The letter recorded at each position. -/
+  letter : Fin (n + 1) → V
+
+namespace Word
+
+variable (W : Word (V := V))
+
+/-- Positions of the cyclic word. -/
+abbrev Pos := Fin (W.n + 1)
+
+/-- The position immediately preceding `i`, cyclically. -/
+def prev (i : W.Pos) : W.Pos := (finRotate (W.n + 1)).symm i
+
+/-- Occurrences of a letter. -/
+abbrev Occurrence (v : V) := {i : W.Pos // W.letter i = v}
+
+instance (v : V) : Fintype (W.Occurrence v) :=
+  Subtype.fintype fun i : W.Pos ↦ W.letter i = v
+
+/-- The two gap colours incident with an occurrence. -/
+def incidentColor (x : W.Pos → Color) {v : V} (o : W.Occurrence v) (s : Fin 2) : Color :=
+  if s = 0 then x (W.prev o.1) else x o.1
+
+/-- The desired output of the cyclic-word construction. -/
+structure Coloring where
+  /-- The colour assigned to each gap of the cyclic word. -/
+  color : W.Pos → Color
+  /-- Consecutive gaps receive different colours. -/
+  transition_ne : ∀ i, color (W.prev i) ≠ color i
+  /-- Each colour occurs an even number of times among the incidences at every letter. -/
+  color_even : ∀ (v : V) (z : Color),
+    Even (Fintype.card {os : W.Occurrence v × Fin 2 // W.incidentColor color os.1 os.2 = z})
+
+end Word
+
+section LocalPattern
+
+/-- The quadratic contribution of a finite ordered difference pattern. -/
+def localQuadraticContribution (n : ℕ) (c : Fin 3) : F₂ :=
+  (∑ i, quadratic (localDifference n c i)) +
+    ∑ i, ∑ j, if j < i then bracket (localDifference n c i) (localDifference n c j) else 0
+
+private theorem orderedPairSum_succ (k : ℕ) (f : Fin (k + 1) → Color) :
+    (∑ i, ∑ j, if j < i then bracket (f i) (f j) else 0) =
+      (∑ i : Fin k, ∑ j : Fin k,
+        if j < i then bracket (f i.castSucc) (f j.castSucc) else 0) +
+      ∑ j : Fin k, bracket (f (Fin.last k)) (f j.castSucc) := by
+  rw [Fin.sum_univ_castSucc]
+  congr 1
+  · apply Fintype.sum_congr
+    intro i
+    rw [Fin.sum_univ_castSucc]
+    rw [if_neg (not_lt_of_ge (Fin.castSucc_lt_last i).le)]
+    simp
+  · rw [Fin.sum_univ_castSucc]
+    simp
+
+/-- Polarization of `quadratic` over a linearly ordered finite family. -/
+theorem quadratic_sum_fin (k : ℕ) (f : Fin k → Color) :
+    quadratic (∑ i, f i) =
+      (∑ i, quadratic (f i)) +
+        ∑ i, ∑ j, if j < i then bracket (f i) (f j) else 0 := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+      rw [Fin.sum_univ_castSucc, quadratic_add, ih (fun i ↦ f i.castSucc),
+        Fin.sum_univ_castSucc, orderedPairSum_succ]
+      rw [bracket_comm, ← sum_bracket_right]
+      abel
+
+/-- The recursively extended local patterns retain the quadratic cancellation of the pair and
+triple base cases. -/
+theorem localQuadraticContribution_eq_zero (n : ℕ) (c : Fin 3) :
+    localQuadraticContribution n c = 0 := by
+  unfold localQuadraticContribution
+  rw [← quadratic_sum_fin]
+  rw [sum_localDifference_occurrences]
+  rfl
+
+end LocalPattern
+
+namespace Word
+
+section Frames
+
+variable (W : Word (V := V))
+
+/-- An arbitrary enumeration of the occurrences of each letter, used only to transport the
+explicit local patterns. -/
+noncomputable def occurrenceOrderIsoFin
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v)) (v : V) :
+    W.Occurrence v ≃o Fin (Fintype.card (W.Occurrence v) - 2 + 2) :=
+  (Fintype.orderIsoFinOfCardEq (W.Occurrence v)
+    (Nat.sub_add_cancel (hmin v)).symm).symm
+
+/-- The difference at an occurrence for one of the three local choices. -/
+noncomputable def frameDifference
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v))
+    (v : V) (c : Fin 3) (o : W.Occurrence v) : Color :=
+  localDifference (Fintype.card (W.Occurrence v) - 2) c (W.occurrenceOrderIsoFin hmin v o)
+
+omit [Fintype V] in
+theorem frameDifference_ne_zero
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v))
+    (v : V) (c : Fin 3) (o : W.Occurrence v) :
+    W.frameDifference hmin v c o ≠ 0 := by
+  exact localDifference_ne_zero _ _ _
+
+omit [Fintype V] in
+theorem sum_frameDifference_occurrences
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v)) (v : V) (c : Fin 3) :
+    ∑ o, W.frameDifference hmin v c o = 0 := by
+  rw [← (W.occurrenceOrderIsoFin hmin v).symm.toEquiv.sum_comp]
+  simpa [frameDifference] using sum_localDifference_occurrences
+    (Fintype.card (W.Occurrence v) - 2) c
+
+omit [Fintype V] in
+theorem sum_frameDifference_choices
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v))
+    (v : V) (o : W.Occurrence v) :
+    ∑ c, W.frameDifference hmin v c o = 0 := by
+  exact sum_localDifference_choices _ _
+
+omit [Fintype V] in
+theorem frameDifference_localQuadratic
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v)) (v : V) (c : Fin 3) :
+    (∑ o, quadratic (W.frameDifference hmin v c o)) +
+      (∑ o, ∑ p,
+        if p.1 < o.1 then
+          bracket (W.frameDifference hmin v c o) (W.frameDifference hmin v c p)
+        else 0) = 0 := by
+  let k := Fintype.card (W.Occurrence v) - 2
+  let e := W.occurrenceOrderIsoFin hmin v
+  change (∑ o, quadratic (localDifference k c (e o))) +
+      (∑ o, ∑ p,
+        if p.1 < o.1 then bracket (localDifference k c (e o)) (localDifference k c (e p))
+        else 0) = 0
+  have hq :
+      (∑ o, quadratic (localDifference k c (e o))) =
+        ∑ i : Fin (k + 2), quadratic (localDifference k c i) := by
+    apply Fintype.sum_equiv e.toEquiv
+    intro o
+    rfl
+  rw [hq]
+  have hpairs :
+      (∑ o, ∑ p,
+        if p.1 < o.1 then bracket (localDifference k c (e o)) (localDifference k c (e p))
+        else 0) =
+      ∑ i : Fin (k + 2), ∑ j : Fin (k + 2),
+        if j < i then bracket (localDifference k c i) (localDifference k c j) else 0 := by
+    apply Fintype.sum_equiv e.toEquiv
+    intro o
+    apply Fintype.sum_equiv e.toEquiv
+    intro p
+    change (if p < o then _ else _) = (if e p < e o then _ else _)
+    by_cases hpo : p < o
+    · simp [hpo, (e.lt_iff_lt).mpr hpo]
+    · have he : ¬ e p < e o := by simpa using hpo
+      simp [hpo, he]
+  rw [hpairs]
+  exact localQuadraticContribution_eq_zero k c
+
+end Frames
+
+section Interaction
+
+variable (W : Word (V := V))
+
+/-- The ordered interaction between the local patterns at two letters.  The diagonal is set to
+zero because the balancing theorem is phrased on all ordered pairs of letters. -/
+noncomputable def interaction
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v))
+    (v u : V) (cv cu : Fin 3) : F₂ :=
+  if v = u then 0 else
+    ∑ i : W.Occurrence v, ∑ j : W.Occurrence u,
+      if j.1 < i.1 then
+        bracket (W.frameDifference hmin v cv i) (W.frameDifference hmin u cu j)
+      else 0
+
+omit [Fintype V] in
+theorem interaction_symm
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v))
+    (v u : V) (cv cu : Fin 3) :
+    W.interaction hmin v u cv cu = W.interaction hmin u v cu cv := by
+  by_cases hvu : v = u
+  · subst u
+    simp [interaction]
+  · have hswap :
+        (∑ i : W.Occurrence u, ∑ j : W.Occurrence v,
+          if j.1 < i.1 then
+            bracket (W.frameDifference hmin u cu i) (W.frameDifference hmin v cv j)
+          else 0) =
+        ∑ i : W.Occurrence v, ∑ j : W.Occurrence u,
+          if i.1 < j.1 then
+            bracket (W.frameDifference hmin u cu j) (W.frameDifference hmin v cv i)
+          else 0 := by
+      exact Finset.sum_comm
+    have hsum :
+        W.interaction hmin v u cv cu + W.interaction hmin u v cu cv = 0 := by
+      simp only [interaction, if_neg hvu, if_neg (Ne.symm hvu)]
+      rw [hswap, ← Finset.sum_add_distrib]
+      simp_rw [← Finset.sum_add_distrib]
+      calc
+        (∑ i : W.Occurrence v, ∑ j : W.Occurrence u,
+          ((if j.1 < i.1 then
+              bracket (W.frameDifference hmin v cv i) (W.frameDifference hmin u cu j)
+            else 0) +
+           if i.1 < j.1 then
+              bracket (W.frameDifference hmin u cu j) (W.frameDifference hmin v cv i)
+            else 0)) =
+            ∑ i : W.Occurrence v, ∑ j : W.Occurrence u,
+              bracket (W.frameDifference hmin v cv i) (W.frameDifference hmin u cu j) := by
+                apply Fintype.sum_congr
+                intro i
+                apply Fintype.sum_congr
+                intro j
+                have hij : i.1 ≠ j.1 := by
+                  intro h
+                  apply hvu
+                  calc
+                    v = W.letter i.1 := i.2.symm
+                    _ = W.letter j.1 := congrArg W.letter h
+                    _ = u := j.2
+                rcases lt_trichotomy j.1 i.1 with hji | heq | hij'
+                · simp [hji, not_lt_of_ge hji.le]
+                · exact (hij heq.symm).elim
+                · rw [if_neg (not_lt_of_ge hij'.le), if_pos hij', zero_add]
+                  exact bracket_comm _ _
+        _ = ∑ i : W.Occurrence v,
+              bracket (W.frameDifference hmin v cv i)
+                (∑ j : W.Occurrence u, W.frameDifference hmin u cu j) := by
+              apply Fintype.sum_congr
+              intro i
+              exact sum_bracket_right _ _
+        _ = 0 := by rw [W.sum_frameDifference_occurrences hmin u cu]; simp
+    calc
+      W.interaction hmin v u cv cu = W.interaction hmin v u cv cu + 0 := by simp
+      _ = W.interaction hmin v u cv cu +
+          (W.interaction hmin v u cv cu + W.interaction hmin u v cu cv) := by rw [hsum]
+      _ = W.interaction hmin u v cu cv := by
+        rw [← add_assoc, F₂_add_self, zero_add]
+
+omit [Fintype V] in
+theorem sum_interaction_choices
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v))
+    (v u : V) (cv : Fin 3) :
+    ∑ cu, W.interaction hmin v u cv cu = 0 := by
+  by_cases hvu : v = u
+  · subst u
+    simp [interaction]
+  · simp only [interaction, if_neg hvu]
+    rw [Finset.sum_comm]
+    apply Fintype.sum_eq_zero
+    intro i
+    rw [Finset.sum_comm]
+    apply Fintype.sum_eq_zero
+    intro j
+    by_cases hji : j.1 < i.1
+    · simp only [hji, if_pos]
+      calc
+        (∑ cu, bracket (W.frameDifference hmin v cv i)
+            (W.frameDifference hmin u cu j)) =
+            bracket (W.frameDifference hmin v cv i)
+              (∑ cu, W.frameDifference hmin u cu j) := sum_bracket_right _ _
+        _ = 0 := by rw [W.sum_frameDifference_choices hmin u j]; simp
+    · simp [hji]
+
+/-- The odd balancing theorem chooses one local frame at every letter so that every external
+interaction obstruction vanishes. -/
+theorem exists_balanced_choice
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v)) :
+    ∃ choice : V → Fin 3,
+      ∀ v, OddBalance.obstruction (W.interaction hmin) choice v = 0 := by
+  exact OddBalance.exists_balanced (W.interaction hmin)
+    (W.interaction_symm hmin) (W.sum_interaction_choices hmin)
+
+end Interaction
+
+section DifferencesAndPrefixes
+
+variable (W : Word (V := V))
+
+/-- Differences on all positions induced by choices of the local frames. -/
+noncomputable def chosenDifference
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v))
+    (choice : V → Fin 3) (i : W.Pos) : Color :=
+  W.frameDifference hmin (W.letter i) (choice (W.letter i)) ⟨i, rfl⟩
+
+omit [Fintype V] in
+theorem chosenDifference_ne_zero
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v))
+    (choice : V → Fin 3) (i : W.Pos) :
+    W.chosenDifference hmin choice i ≠ 0 := by
+  exact W.frameDifference_ne_zero hmin _ _ _
+
+omit [Fintype V] in
+theorem chosenDifference_at_occurrence
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v))
+    (choice : V → Fin 3) (v : V) (o : W.Occurrence v) :
+    W.chosenDifference hmin choice o.1 = W.frameDifference hmin v (choice v) o := by
+  rcases o with ⟨i, hi⟩
+  subst v
+  rfl
+
+omit [Fintype V] in
+theorem sum_chosenDifference_occurrences
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v))
+    (choice : V → Fin 3) (v : V) :
+    ∑ o : W.Occurrence v, W.chosenDifference hmin choice o.1 = 0 := by
+  calc
+    (∑ o : W.Occurrence v, W.chosenDifference hmin choice o.1) =
+        ∑ o : W.Occurrence v, W.frameDifference hmin v (choice v) o := by
+          apply Fintype.sum_congr
+          rintro ⟨i, hi⟩
+          subst v
+          rfl
+    _ = 0 := W.sum_frameDifference_occurrences hmin v (choice v)
+
+omit [Fintype V] in
+theorem sum_chosenDifference [Finite V]
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v))
+    (choice : V → Fin 3) :
+    ∑ i, W.chosenDifference hmin choice i = 0 := by
+  haveI : Fintype V := Fintype.ofFinite V
+  let e := Equiv.sigmaFiberEquiv W.letter
+  calc
+    (∑ i, W.chosenDifference hmin choice i) =
+        ∑ p : Σ v, W.Occurrence v, W.chosenDifference hmin choice p.2.1 := by
+          symm
+          simpa [e] using e.sum_comp (W.chosenDifference hmin choice)
+    _ = ∑ v, ∑ o : W.Occurrence v, W.chosenDifference hmin choice o.1 := by
+          exact Fintype.sum_sigma _
+    _ = 0 := by
+          apply Fintype.sum_eq_zero
+          exact W.sum_chosenDifference_occurrences hmin choice
+
+/-- Prefix integration of differences, with the cut placed immediately before position zero. -/
+def prefixColor (y : W.Pos → Color) (i : W.Pos) : Color :=
+  ∑ j ∈ Finset.Iic i, y j
+
+omit [DecidableEq V] [Fintype V] in
+theorem prefixColor_transition
+    (y : W.Pos → Color) (htotal : ∑ i, y i = 0) (i : W.Pos) :
+    W.prefixColor y (W.prev i) + W.prefixColor y i = y i := by
+  by_cases hi : i = 0
+  · subst i
+    have hprev : W.prev 0 = Fin.last W.n := by
+      apply (finRotate (W.n + 1)).injective
+      simp [prev]
+    change (∑ j ∈ Finset.Iic (W.prev 0), y j) +
+        (∑ j ∈ Finset.Iic 0, y j) = y 0
+    rw [hprev, show Fin.last W.n = (⊤ : W.Pos) from rfl, Finset.Iic_top]
+    rw [htotal, zero_add]
+    rw [show (0 : W.Pos) = ⊥ from rfl, Finset.Iic_bot]
+    simp
+  · have hprev : W.prev i = i - 1 := by
+      exact finRotate_symm_apply i
+    rw [prefixColor, prefixColor, hprev,
+      Fin.Iic_sub_one_eq_Iio (Fin.pos_iff_ne_zero.mpr hi), Finset.Iic_eq_cons_Iio]
+    rw [Finset.sum_cons]
+    calc
+      (∑ j ∈ Finset.Iio i, y j) + (y i + ∑ j ∈ Finset.Iio i, y j) =
+          ((∑ j ∈ Finset.Iio i, y j) + ∑ j ∈ Finset.Iio i, y j) + y i := by abel
+      _ = y i := by rw [color_add_self, zero_add]
+
+omit [DecidableEq V] [Fintype V] in
+theorem prefixColor_prev_eq_strictPrefix
+    (y : W.Pos → Color) (htotal : ∑ i, y i = 0) (i : W.Pos) :
+    W.prefixColor y (W.prev i) = ∑ j ∈ Finset.Iio i, y j := by
+  by_cases hi : i = 0
+  · subst i
+    have hprev : W.prev 0 = Fin.last W.n := by
+      apply (finRotate (W.n + 1)).injective
+      simp [prev]
+    rw [prefixColor, hprev, show Fin.last W.n = (⊤ : W.Pos) from rfl, Finset.Iic_top]
+    change (∑ j, y j) = ∑ j ∈ Finset.Iio 0, y j
+    rw [htotal]
+    rw [show (0 : W.Pos) = ⊥ from rfl, Finset.Iio_bot]
+    simp
+  · have hprev : W.prev i = i - 1 := finRotate_symm_apply i
+    rw [prefixColor, hprev, Fin.Iic_sub_one_eq_Iio (Fin.pos_iff_ne_zero.mpr hi)]
+
+/-- Contribution of all earlier occurrences of `u` to occurrences of `v`. -/
+def orderedLetterInteraction (y : W.Pos → Color) (v u : V) : F₂ :=
+  ∑ i : W.Occurrence v, ∑ j : W.Occurrence u,
+    if j.1 < i.1 then bracket (y i.1) (y j.1) else 0
+
+/-- Partitioning earlier word positions according to their letter. -/
+theorem sum_orderedLetterInteraction (y : W.Pos → Color) (v : V) :
+    (∑ u, W.orderedLetterInteraction y v u) =
+      ∑ i : W.Occurrence v, ∑ j ∈ Finset.Iio i.1, bracket (y i.1) (y j) := by
+  unfold orderedLetterInteraction
+  rw [Finset.sum_comm]
+  apply Fintype.sum_congr
+  intro i
+  let e := Equiv.sigmaFiberEquiv W.letter
+  calc
+    (∑ u, ∑ j : W.Occurrence u,
+        if j.1 < i.1 then bracket (y i.1) (y j.1) else 0) =
+        ∑ p : Σ u, W.Occurrence u,
+          if p.2.1 < i.1 then bracket (y i.1) (y p.2.1) else 0 := by
+            symm
+            exact Fintype.sum_sigma _
+    _ = ∑ j : W.Pos, if j < i.1 then bracket (y i.1) (y j) else 0 := by
+          apply Fintype.sum_equiv e
+          rintro ⟨u, ⟨j, hj⟩⟩
+          rfl
+    _ = ∑ j ∈ Finset.Iio i.1, bracket (y i.1) (y j) := by
+          rw [← Finset.sum_filter]
+          apply Finset.sum_congr
+          · ext j
+            simp
+          · intro j hj
+            rfl
+
+omit [Fintype V] in
+theorem orderedLetterInteraction_chosen_eq_interaction
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v))
+    (choice : V → Fin 3) {v u : V} (hvu : v ≠ u) :
+    W.orderedLetterInteraction (W.chosenDifference hmin choice) v u =
+      W.interaction hmin v u (choice v) (choice u) := by
+  unfold orderedLetterInteraction interaction
+  rw [if_neg hvu]
+  apply Fintype.sum_congr
+  intro i
+  apply Fintype.sum_congr
+  intro j
+  rw [W.chosenDifference_at_occurrence hmin choice v i,
+    W.chosenDifference_at_occurrence hmin choice u j]
+
+omit [Fintype V] in
+theorem chosen_localQuadratic
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v))
+    (choice : V → Fin 3) (v : V) :
+    (∑ i : W.Occurrence v, quadratic (W.chosenDifference hmin choice i.1)) +
+      W.orderedLetterInteraction (W.chosenDifference hmin choice) v v = 0 := by
+  unfold orderedLetterInteraction
+  simp_rw [W.chosenDifference_at_occurrence hmin choice v]
+  exact W.frameDifference_localQuadratic hmin v (choice v)
+
+theorem chosen_externalInteraction_eq_zero
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v))
+    (choice : V → Fin 3)
+    (hbalanced : ∀ v, OddBalance.obstruction (W.interaction hmin) choice v = 0)
+    (v : V) :
+    ∑ u ∈ Finset.univ.erase v,
+      W.orderedLetterInteraction (W.chosenDifference hmin choice) v u = 0 := by
+  calc
+    (∑ u ∈ Finset.univ.erase v,
+      W.orderedLetterInteraction (W.chosenDifference hmin choice) v u) =
+        ∑ u ∈ Finset.univ.erase v,
+          W.interaction hmin v u (choice v) (choice u) := by
+            apply Finset.sum_congr rfl
+            intro u hu
+            exact W.orderedLetterInteraction_chosen_eq_interaction hmin choice
+              (Ne.symm (Finset.mem_erase.mp hu).1)
+    _ = OddBalance.obstruction (W.interaction hmin) choice v := rfl
+    _ = 0 := hbalanced v
+
+omit [DecidableEq V] [Fintype V] in
+theorem quadratic_prefix_pair
+    (y : W.Pos → Color) (htotal : ∑ i, y i = 0) (i : W.Pos) :
+    quadratic (W.prefixColor y (W.prev i)) + quadratic (W.prefixColor y i) =
+      quadratic (y i) + bracket (y i) (W.prefixColor y (W.prev i)) := by
+  let a := W.prefixColor y (W.prev i)
+  let b := W.prefixColor y i
+  have hab : a + b = y i := W.prefixColor_transition y htotal i
+  have hbracket : bracket a b = bracket (y i) a := by
+    calc
+      bracket a b = bracket b a := bracket_comm _ _
+      _ = bracket (a + b) a := by
+        rw [bracket_add_left, bracket_self, zero_add]
+      _ = bracket (y i) a := by rw [hab]
+  calc
+    quadratic a + quadratic b =
+        (quadratic a + quadratic b + bracket a b) + bracket a b := by
+          symm
+          calc
+            quadratic a + quadratic b + bracket a b + bracket a b =
+                (quadratic a + quadratic b) + (bracket a b + bracket a b) := by abel
+            _ = quadratic a + quadratic b := by rw [F₂_add_self, add_zero]
+    _ = quadratic (a + b) + bracket a b := by rw [quadratic_add]
+    _ = quadratic (y i) + bracket (y i) a := by rw [hab, hbracket]
+
+/-- The balanced interaction equations are exactly the missing quadratic moment at each letter. -/
+theorem quadratic_incident_sum_eq_zero
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v))
+    (choice : V → Fin 3)
+    (hbalanced : ∀ v, OddBalance.obstruction (W.interaction hmin) choice v = 0)
+    (v : V) :
+    let y := W.chosenDifference hmin choice
+    let x := W.prefixColor y
+    ∑ os : W.Occurrence v × Fin 2, quadratic (W.incidentColor x os.1 os.2) = 0 := by
+  dsimp only
+  let y := W.chosenDifference hmin choice
+  let x := W.prefixColor y
+  have htotal : ∑ i, y i = 0 := W.sum_chosenDifference hmin choice
+  have hstrict :
+      (∑ i : W.Occurrence v, bracket (y i.1) (x (W.prev i.1))) =
+        ∑ i : W.Occurrence v, ∑ j ∈ Finset.Iio i.1, bracket (y i.1) (y j) := by
+    apply Fintype.sum_congr
+    intro i
+    rw [show x (W.prev i.1) = ∑ j ∈ Finset.Iio i.1, y j from
+      W.prefixColor_prev_eq_strictPrefix y htotal i.1]
+    change bracketRightHom (y i.1) (∑ j ∈ Finset.Iio i.1, y j) = _
+    exact map_sum (bracketRightHom (y i.1)) y (Finset.Iio i.1)
+  have hsplit :
+      (∑ u, W.orderedLetterInteraction y v u) =
+        (∑ u ∈ Finset.univ.erase v, W.orderedLetterInteraction y v u) +
+          W.orderedLetterInteraction y v v := by
+    exact (Finset.sum_erase_add Finset.univ
+      (fun u ↦ W.orderedLetterInteraction y v u) (Finset.mem_univ v)).symm
+  calc
+    (∑ os : W.Occurrence v × Fin 2, quadratic (W.incidentColor x os.1 os.2)) =
+        ∑ i : W.Occurrence v,
+          (quadratic (x (W.prev i.1)) + quadratic (x i.1)) := by
+            rw [Fintype.sum_prod_type]
+            apply Fintype.sum_congr
+            intro i
+            rw [Fin.sum_univ_two]
+            rfl
+    _ = ∑ i : W.Occurrence v,
+          (quadratic (y i.1) + bracket (y i.1) (x (W.prev i.1))) := by
+            apply Fintype.sum_congr
+            intro i
+            exact W.quadratic_prefix_pair y htotal i.1
+    _ = (∑ i : W.Occurrence v, quadratic (y i.1)) +
+          ∑ i : W.Occurrence v, bracket (y i.1) (x (W.prev i.1)) := by
+            exact Finset.sum_add_distrib
+    _ = (∑ i : W.Occurrence v, quadratic (y i.1)) +
+          ∑ u, W.orderedLetterInteraction y v u := by
+            rw [hstrict, W.sum_orderedLetterInteraction y v]
+    _ = ((∑ i : W.Occurrence v, quadratic (y i.1)) +
+          W.orderedLetterInteraction y v v) +
+          ∑ u ∈ Finset.univ.erase v, W.orderedLetterInteraction y v u := by
+            rw [hsplit]
+            abel
+    _ = 0 := by
+      rw [show (∑ i : W.Occurrence v, quadratic (y i.1)) +
+          W.orderedLetterInteraction y v v = 0 from
+            W.chosen_localQuadratic hmin choice v]
+      rw [show (∑ u ∈ Finset.univ.erase v, W.orderedLetterInteraction y v u) = 0 from
+        W.chosen_externalInteraction_eq_zero hmin choice hbalanced v]
+      simp
+
+omit [Fintype V] in
+theorem incident_sum_eq_zero [Finite V]
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v))
+    (choice : V → Fin 3) (v : V) :
+    let y := W.chosenDifference hmin choice
+    let x := W.prefixColor y
+    ∑ os : W.Occurrence v × Fin 2, W.incidentColor x os.1 os.2 = 0 := by
+  dsimp only
+  let y := W.chosenDifference hmin choice
+  let x := W.prefixColor y
+  have htotal : ∑ i, y i = 0 := W.sum_chosenDifference hmin choice
+  calc
+    (∑ os : W.Occurrence v × Fin 2, W.incidentColor x os.1 os.2) =
+        ∑ i : W.Occurrence v, (x (W.prev i.1) + x i.1) := by
+          rw [Fintype.sum_prod_type]
+          apply Fintype.sum_congr
+          intro i
+          rw [Fin.sum_univ_two]
+          rfl
+    _ = ∑ i : W.Occurrence v, y i.1 := by
+          apply Fintype.sum_congr
+          intro i
+          exact W.prefixColor_transition y htotal i.1
+    _ = 0 := W.sum_chosenDifference_occurrences hmin choice v
+
+omit [Fintype V] in
+/-- Every nonempty cyclic word in which each letter occurs at least twice has the required
+four-colouring of its gaps. -/
+theorem exists_coloring [Finite V]
+    (hmin : ∀ v, 2 ≤ Fintype.card (W.Occurrence v)) : Nonempty W.Coloring := by
+  haveI : Fintype V := Fintype.ofFinite V
+  obtain ⟨choice, hbalanced⟩ := W.exists_balanced_choice hmin
+  let y := W.chosenDifference hmin choice
+  let x := W.prefixColor y
+  have htotal : ∑ i, y i = 0 := W.sum_chosenDifference hmin choice
+  refine ⟨{
+    color := x
+    transition_ne := ?_
+    color_even := ?_ }⟩
+  · intro i hxeq
+    apply W.chosenDifference_ne_zero hmin choice i
+    calc
+      y i = x (W.prev i) + x i := (W.prefixColor_transition y htotal i).symm
+      _ = 0 := by rw [hxeq, color_add_self]
+  · intro v z
+    let f : W.Occurrence v × Fin 2 → Color :=
+      fun os ↦ W.incidentColor x os.1 os.2
+    have hcard : Even (Fintype.card (W.Occurrence v × Fin 2)) := by
+      rw [Fintype.card_prod, Fintype.card_fin]
+      exact ⟨Fintype.card (W.Occurrence v), by omega⟩
+    have hsum : ∑ os, f os = 0 := W.incident_sum_eq_zero hmin choice v
+    have hquad : ∑ os, quadratic (f os) = 0 :=
+      W.quadratic_incident_sum_eq_zero hmin choice hbalanced v
+    have heven := colorFiber_card_even_of_moments f hcard hsum hquad z
+    rw [Fintype.card_subtype]
+    simpa [colorFiber, f] using heven
+
+end DifferencesAndPrefixes
+
+end Word
+
+end CyclicWord
+end Sabidussi

--- a/LeanPool/Sabidussi/LocalPattern.lean
+++ b/LeanPool/Sabidussi/LocalPattern.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 Nikolay Ulyanov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nikolay Ulyanov
+-/
+import LeanPool.Sabidussi.Color
+
+/-!
+# Local difference patterns
+
+For every number `n + 2` of transition occurrences we construct three admissible local patterns.
+The construction is the degree-splitting step of the manuscript written without changing the
+graph: remove pairs of occurrences recursively, ending with a pair or a triple.
+-/
+
+namespace Sabidussi
+
+open scoped BigOperators
+
+/-- A fixed enumeration of the three nonzero colours. -/
+def choiceColor (c : Fin 3) : Color := tripleDifference (1, 0) c
+
+theorem choiceColor_ne_zero (c : Fin 3) : choiceColor c ≠ 0 := by
+  apply tripleDifference_ne_zero
+  norm_num [Prod.ext_iff]
+
+theorem sum_choiceColor : ∑ c, choiceColor c = 0 := by
+  exact sum_tripleDifference (1, 0)
+
+theorem sum_tripleDifference_choice (i : Fin 3) :
+    ∑ c, tripleDifference (choiceColor c) i = 0 := by
+  fin_cases i <;>
+    simp [Fin.sum_univ_three, choiceColor, tripleDifference, Prod.ext_iff]
+
+/-- Three local patterns on `n + 2` occurrences.  For `2` occurrences the difference is constant;
+for `3` it is the anisotropic triple; every additional pair receives the same nonzero colour and
+is then removed recursively. -/
+def localDifference : (n : ℕ) → Fin 3 → Fin (n + 2) → Color
+  | 0, c => doubleDifference (choiceColor c)
+  | 1, c => tripleDifference (choiceColor c)
+  | n + 2, c =>
+      Fin.cases (choiceColor c) (Fin.cases (choiceColor c) (localDifference n c))
+
+@[simp]
+theorem localDifference_zero (c : Fin 3) :
+    localDifference 0 c = doubleDifference (choiceColor c) := rfl
+
+@[simp]
+theorem localDifference_one (c : Fin 3) :
+    localDifference 1 c = tripleDifference (choiceColor c) := rfl
+
+theorem localDifference_ne_zero (n : ℕ) (c : Fin 3) (i : Fin (n + 2)) :
+    localDifference n c i ≠ 0 := by
+  induction n using Nat.twoStepInduction with
+  | zero => exact doubleDifference_ne_zero _ (choiceColor_ne_zero c) i
+  | one => exact tripleDifference_ne_zero _ (choiceColor_ne_zero c) i
+  | more n ih _ =>
+      refine Fin.cases ?_ (fun j ↦ Fin.cases ?_ (fun k ↦ ih k) j) i
+      · exact choiceColor_ne_zero c
+      · exact choiceColor_ne_zero c
+
+theorem sum_localDifference_occurrences (n : ℕ) (c : Fin 3) :
+    ∑ i, localDifference n c i = 0 := by
+  induction n using Nat.twoStepInduction with
+  | zero => exact sum_doubleDifference (choiceColor c)
+  | one => exact sum_tripleDifference (choiceColor c)
+  | more n ih _ =>
+      rw [Fin.sum_univ_succ, Fin.sum_univ_succ]
+      simp only [localDifference, Fin.cases_zero, Fin.cases_succ]
+      calc
+        choiceColor c + (choiceColor c + ∑ i, localDifference n c i) =
+            (choiceColor c + choiceColor c) + ∑ i, localDifference n c i := by abel
+        _ = 0 := by rw [color_add_self, zero_add, ih]
+
+theorem sum_localDifference_choices (n : ℕ) (i : Fin (n + 2)) :
+    ∑ c, localDifference n c i = 0 := by
+  induction n using Nat.twoStepInduction with
+  | zero => fin_cases i <;> simpa [doubleDifference] using sum_choiceColor
+  | one => exact sum_tripleDifference_choice i
+  | more n ih _ =>
+      refine Fin.cases ?_ (fun j ↦ Fin.cases ?_ (fun k ↦ ih k) j) i
+      · exact sum_choiceColor
+      · exact sum_choiceColor
+
+end Sabidussi

--- a/LeanPool/Sabidussi/LoopGraphBridge.lean
+++ b/LeanPool/Sabidussi/LoopGraphBridge.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 Nikolay Ulyanov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nikolay Ulyanov
+-/
+import LeanPool.Sabidussi.LoopMultigraph
+import LeanPool.Sabidussi.CyclicWord
+
+/-!
+# From a cyclic word back to a loop-capable endpoint multigraph
+
+The letters are transition vertices and the gaps are labelled edge objects.  Cyclic-word side
+zero denotes the preceding gap, while Euler-tour side zero denotes the current departing
+half-edge; the bridge therefore precomposes occurrence sides with `Fin.rev`.
+-/
+
+namespace Sabidussi
+namespace LoopMultigraph
+
+open Sabidussi
+open scoped BigOperators
+
+variable {V E : Type*} [Fintype V] [Fintype E] [DecidableEq V] [DecidableEq E]
+  {G : LoopMultigraph V E}
+
+/-- The cyclic transition word read from an Euler tour. -/
+def EulerTour.eulerWord (T : G.EulerTour) : Sabidussi.CyclicWord.Word (V := V) where
+  n := T.n
+  letter := T.vertexAt
+
+namespace EulerTour
+
+variable (T : G.EulerTour)
+
+omit [DecidableEq E] [DecidableEq V] in
+@[simp]
+theorem eulerWord_letter (i : T.Pos) : T.eulerWord.letter i = T.vertexAt i := rfl
+
+omit [DecidableEq E] [DecidableEq V] in
+@[simp]
+theorem eulerWord_prev (i : T.Pos) : T.eulerWord.prev i = T.prev i := rfl
+
+/-- Reversal is an equivalence on the two transition sides. -/
+private def revFinTwoEquiv : Fin 2 ≃ Fin 2 :=
+  Fin.rev_involutive.toPerm
+
+/-- Occurrence sides with the cyclic-word convention are exactly the incident half-edges. -/
+def wordOccurrenceSideEquivHalfEdgesAt (v : V) :
+    T.eulerWord.Occurrence v × Fin 2 ≃ G.halfEdgesAt v :=
+  (Equiv.prodCongr (Equiv.refl _) revFinTwoEquiv).trans
+    (T.occurrenceSideEquivHalfEdgesAt v)
+
+omit [DecidableEq E] [DecidableEq V] in
+/-- Under the preceding equivalence, the gap incident with a word-occurrence side is the edge
+underlying the corresponding half-edge. -/
+theorem incidentColor_eq_halfEdgeColor
+    (x : T.eulerWord.Pos → Color) {v : V}
+    (os : T.eulerWord.Occurrence v × Fin 2) :
+    T.eulerWord.incidentColor x os.1 os.2 =
+      x (T.edge.symm ((T.wordOccurrenceSideEquivHalfEdgesAt v os).1.1)) := by
+  rcases os with ⟨o, s⟩
+  fin_cases s
+  · change x (T.prev o.1) = x (T.edge.symm (T.edge (T.prev o.1)))
+    simp
+  · change x o.1 = x (T.edge.symm (T.edge o.1))
+    simp
+
+/-- The coloured occurrence sides of the word and the correspondingly coloured half-edges at a
+vertex are equinumerous. -/
+def coloredOccurrenceSideEquivColoredHalfEdgesAt
+    (C : T.eulerWord.Coloring) (v : V) (z : Color) :
+    {os : T.eulerWord.Occurrence v × Fin 2 //
+      T.eulerWord.incidentColor C.color os.1 os.2 = z} ≃
+    {h : G.halfEdgesAt v // C.color (T.edge.symm h.1.1) = z} :=
+  (T.wordOccurrenceSideEquivHalfEdgesAt v).subtypeEquiv fun os ↦ by
+    rw [T.incidentColor_eq_halfEdgeColor C.color os]
+
+omit [DecidableEq E] in
+private theorem sum_support_edgeIncidence_eq_sum_halfEdgesAt
+    (color : E → Color) (z : Color) (v : V) :
+    (∑ e ∈ (Finset.univ.filter fun e ↦ color e = z), G.edgeIncidence v e) =
+      ∑ h : G.halfEdgesAt v, if color h.1.1 = z then 1 else 0 := by
+  change (∑ e ∈ (Finset.univ.filter fun e ↦ color e = z), G.edgeIncidence v e) =
+    ∑ h : {h : HalfEdge E // G.vertex h = v}, if color h.1.1 = z then 1 else 0
+  rw [← Finset.sum_subtype (Finset.univ.filter fun h : HalfEdge E ↦ G.vertex h = v)
+    (by simp) (fun h : HalfEdge E ↦ if color h.1 = z then (1 : F₂) else 0)]
+  rw [Finset.sum_filter]
+  rw [Finset.sum_filter]
+  rw [Fintype.sum_prod_type]
+  apply Fintype.sum_congr
+  intro e
+  rw [Fin.sum_univ_two]
+  by_cases he : color e = z <;> simp [edgeIncidence, vertex, he]
+
+omit [DecidableEq E] in
+private theorem isEvenEdgeSet_of_coloredHalfEdgesAt_even
+    (color : E → Color)
+    (heven : ∀ (v : V) (z : Color),
+      Even (Fintype.card {h : G.halfEdgesAt v // color h.1.1 = z})) (z : Color) :
+    G.IsEvenEdgeSet (Finset.univ.filter fun e ↦ color e = z) := by
+  intro v
+  rw [sum_support_edgeIncidence_eq_sum_halfEdgesAt color z v]
+  rw [Finset.sum_boole]
+  rw [← Fintype.card_subtype]
+  exact ZMod.natCast_eq_zero_iff_even.mpr (heven v z)
+
+/-- A cyclic-word colouring gives the graph-theoretic compatible four-colouring certificate. -/
+noncomputable def compatibleFourColoringOfWordColoring
+    (C : T.eulerWord.Coloring) : G.CompatibleFourColoring T where
+  color := fun e ↦ C.color (T.edge.symm e)
+  transition_ne := by
+    intro i
+    simpa using C.transition_ne i
+  color_even := by
+    apply isEvenEdgeSet_of_coloredHalfEdgesAt_even
+    intro v z
+    rw [← Fintype.card_congr (T.coloredOccurrenceSideEquivColoredHalfEdgesAt C v z)]
+    exact C.color_even v z
+
+end EulerTour
+
+/-- Sabidussi compatibility for finite endpoint multigraphs, including loops. -/
+theorem loop_sabidussi_compatibility (T : G.EulerTour)
+    (hmin : ∀ v : V, 4 ≤ G.degree v) :
+    ∃ S : G.CircuitDecomposition, S.Compatible T := by
+  have hword : ∀ v : V, 2 ≤ Fintype.card (T.eulerWord.Occurrence v) := by
+    intro v
+    let e : T.eulerWord.Occurrence v ≃ T.Occurrence v := Equiv.refl _
+    rw [Fintype.card_congr e]
+    have hd := hmin v
+    rw [T.degree_eq_two_mul_card_occurrence v] at hd
+    omega
+  obtain ⟨C⟩ := T.eulerWord.exists_coloring hword
+  exact (T.compatibleFourColoringOfWordColoring C).exists_compatible_circuit_decomposition
+
+end LoopMultigraph
+end Sabidussi

--- a/LeanPool/Sabidussi/LoopMultigraph.lean
+++ b/LeanPool/Sabidussi/LoopMultigraph.lean
@@ -1,0 +1,341 @@
+/-
+Copyright (c) 2026 Nikolay Ulyanov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nikolay Ulyanov
+-/
+import LeanPool.Sabidussi.Color
+import LeanPool.Sabidussi.Statement
+import Mathlib.Data.Fin.Rev
+import Mathlib.Logic.Equiv.Fin.Rotate
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Finite.Set
+import Mathlib.Data.Fintype.Sets
+
+/-!
+# Finite endpoint multigraphs with loops
+
+Edges are labelled objects with two numbered half-edges.  The endpoints may coincide, so loops
+are represented without quotienting or special cases.  Degree and parity always count half-edge
+incidences; consequently a loop contributes two incidences at its vertex.
+-/
+
+namespace Sabidussi
+
+open scoped BigOperators
+
+namespace LoopMultigraph
+
+variable {V E : Type*} [Fintype V] [Fintype E]
+
+namespace EulerTour
+
+variable [DecidableEq V] {G : LoopMultigraph V E} (T : G.EulerTour)
+
+/-- The vertex of the transition from the previous edge into edge `i`. -/
+def vertexAt (i : T.Pos) : V := G.endAt (T.edge i) (T.depart i)
+
+/-- The vertex at which edge `i` arrives. -/
+def arrivalAt (i : T.Pos) : V := G.endAt (T.edge i) (Fin.rev (T.depart i))
+
+omit [DecidableEq V] in
+@[simp]
+theorem next_prev (i : T.Pos) : T.next (T.prev i) = i := by
+  simp [next, prev]
+
+omit [DecidableEq V] in
+@[simp]
+theorem prev_next (i : T.Pos) : T.prev (T.next i) = i := by
+  simp [next, prev]
+
+omit [DecidableEq V] in
+theorem arrival_eq_vertexAt_next (i : T.Pos) : T.arrivalAt i = T.vertexAt (T.next i) := by
+  exact T.continuous i
+
+omit [DecidableEq V] in
+theorem arrival_prev_eq_vertexAt (i : T.Pos) : T.arrivalAt (T.prev i) = T.vertexAt i := by
+  simpa [arrivalAt, vertexAt, next, prev] using T.continuous (T.prev i)
+
+/-- Occurrences of `v` in the cyclic transition word. -/
+abbrev Occurrence (v : V) := {i : T.Pos // T.vertexAt i = v}
+
+instance (v : V) : Fintype (T.Occurrence v) :=
+  Subtype.fintype fun i : T.Pos ↦ T.vertexAt i = v
+
+/-- The two edge ends paired at an occurrence of a transition vertex.
+
+Side `0` is the departing end of the current edge; side `1` is the arriving end of the previous
+edge.  The two numbered half-edges remain distinct even when the underlying edge is a loop.
+-/
+def transitionHalfEdge {v : V} (o : T.Occurrence v) : Fin 2 → HalfEdge E
+  | 0 => (T.edge o.1, T.depart o.1)
+  | 1 => (T.edge (T.prev o.1), Fin.rev (T.depart (T.prev o.1)))
+
+omit [DecidableEq V] in
+@[simp]
+theorem vertex_transitionHalfEdge {v : V} (o : T.Occurrence v) (s : Fin 2) :
+    G.vertex (T.transitionHalfEdge o s) = v := by
+  fin_cases s
+  · exact o.2
+  · change T.arrivalAt (T.prev o.1) = v
+    exact (T.arrival_prev_eq_vertexAt o.1).trans o.2
+
+/-- A transition occurrence with a chosen side, mapped to the corresponding incident half-edge. -/
+def occurrenceSideToHalfEdge (v : V) : T.Occurrence v × Fin 2 → G.halfEdgesAt v :=
+  fun os ↦ ⟨T.transitionHalfEdge os.1 os.2, T.vertex_transitionHalfEdge os.1 os.2⟩
+
+/-- The underlying map from a position and transition side to an edge end. -/
+def positionSideToHalfEdge : T.Pos × Fin 2 → HalfEdge E
+  | (i, 0) => (T.edge i, T.depart i)
+  | (i, 1) => (T.edge (T.prev i), Fin.rev (T.depart (T.prev i)))
+
+/-- The inverse map: a departure end belongs to its own position, and an arrival end belongs to
+side `1` of the next position. -/
+def halfEdgeToPositionSide (h : HalfEdge E) : T.Pos × Fin 2 :=
+  let i := T.edge.symm h.1
+  if h.2 = T.depart i then (i, 0) else (T.next i, 1)
+
+private theorem rev_ne_self_fin_two (i : Fin 2) : Fin.rev i ≠ i := by
+  fin_cases i <;> decide
+
+private theorem eq_rev_of_ne_fin_two {i j : Fin 2} (h : i ≠ j) : i = Fin.rev j := by
+  fin_cases i <;> fin_cases j <;> simp_all [Fin.rev]
+
+omit [DecidableEq V] in
+theorem halfEdgeToPositionSide_positionSideToHalfEdge (p : T.Pos × Fin 2) :
+    T.halfEdgeToPositionSide (T.positionSideToHalfEdge p) = p := by
+  rcases p with ⟨i, s⟩
+  fin_cases s
+  · simp [positionSideToHalfEdge, halfEdgeToPositionSide]
+  · simp [positionSideToHalfEdge, halfEdgeToPositionSide, rev_ne_self_fin_two,
+      T.next_prev]
+
+omit [DecidableEq V] in
+theorem positionSideToHalfEdge_halfEdgeToPositionSide (h : HalfEdge E) :
+    T.positionSideToHalfEdge (T.halfEdgeToPositionSide h) = h := by
+  rcases h with ⟨e, j⟩
+  let i : T.Pos := T.edge.symm e
+  by_cases hj : j = T.depart i
+  · subst j
+    simp [halfEdgeToPositionSide, positionSideToHalfEdge, i]
+  · have hrev : j = Fin.rev (T.depart i) := by
+      exact eq_rev_of_ne_fin_two hj
+    subst j
+    simp [halfEdgeToPositionSide, positionSideToHalfEdge, i, rev_ne_self_fin_two,
+      T.prev_next]
+
+/-- Edge positions with a choice of transition side are exactly all edge ends. -/
+def positionSideEquivHalfEdge : T.Pos × Fin 2 ≃ HalfEdge E where
+  toFun := T.positionSideToHalfEdge
+  invFun := T.halfEdgeToPositionSide
+  left_inv := T.halfEdgeToPositionSide_positionSideToHalfEdge
+  right_inv := T.positionSideToHalfEdge_halfEdgeToPositionSide
+
+omit [DecidableEq V] in
+theorem vertex_positionSideToHalfEdge (p : T.Pos × Fin 2) :
+    G.vertex (T.positionSideToHalfEdge p) = T.vertexAt p.1 := by
+  rcases p with ⟨i, s⟩
+  fin_cases s
+  · rfl
+  · change T.arrivalAt (T.prev i) = T.vertexAt i
+    exact T.arrival_prev_eq_vertexAt i
+
+/-- The two sides of all occurrences of `v` are exactly the half-edges incident with `v`. -/
+def occurrenceSideEquivHalfEdgesAt (v : V) : T.Occurrence v × Fin 2 ≃ G.halfEdgesAt v :=
+  (Equiv.prodSubtypeFstEquivSubtypeProd (p := fun i : T.Pos ↦ T.vertexAt i = v)).symm |>.trans
+    (T.positionSideEquivHalfEdge.subtypeEquiv fun p ↦ by
+      change T.vertexAt p.1 = v ↔ G.vertex (T.positionSideToHalfEdge p) = v
+      rw [T.vertex_positionSideToHalfEdge p])
+
+/-- The degree at `v` is twice its number of occurrences in the transition word. -/
+theorem degree_eq_two_mul_card_occurrence (v : V) :
+    G.degree v = 2 * Fintype.card (T.Occurrence v) := by
+  rw [degree, ← Fintype.card_congr (T.occurrenceSideEquivHalfEdgesAt v), Fintype.card_prod]
+  simp [Nat.mul_comm]
+
+end EulerTour
+
+variable {V E : Type*} [Fintype V] [Fintype E] [DecidableEq V] [DecidableEq E]
+  (G : LoopMultigraph V E)
+
+/-- The incidence indicator of an edge at a vertex, with both edge ends counted. -/
+def edgeIncidence (v : V) (e : E) : F₂ :=
+  (if G.endAt e 0 = v then 1 else 0) +
+    (if G.endAt e 1 = v then 1 else 0)
+
+/-- An edge set is even when every vertex has even degree in the induced multigraph. -/
+def IsEvenEdgeSet (F : Finset E) : Prop :=
+  ∀ v : V, ∑ e ∈ F, G.edgeIncidence v e = 0
+
+/-- A (multigraph) cycle is a nonempty inclusion-minimal even edge set.
+
+This includes singleton loops and pairs of parallel non-loop edges. -/
+structure Cycle where
+  /-- The edges of the cycle. -/
+  edges : Finset E
+  /-- A cycle is nonempty. -/
+  nonempty : edges.Nonempty
+  /-- Every vertex has even degree in the cycle. -/
+  even : G.IsEvenEdgeSet edges
+  /-- The edge set is inclusion-minimal among nonempty even edge sets. -/
+  minimal : ∀ D : Finset E, D.Nonempty → D ⊆ edges → G.IsEvenEdgeSet D → D = edges
+
+omit [DecidableEq E] in
+/-- Both incidences of a loop cancel in characteristic two. -/
+theorem singleton_loop_even (e : E) (hloop : G.endAt e 0 = G.endAt e 1) :
+    G.IsEvenEdgeSet {e} := by
+  intro v
+  simp only [Finset.sum_singleton]
+  change (if G.endAt e 0 = v then 1 else 0) +
+      (if G.endAt e 1 = v then 1 else 0) = 0
+  rw [← hloop]
+  exact CharTwo.add_self_eq_zero _
+
+/-- A loop is a one-edge circuit in the minimal-even-set definition. -/
+def loopCycle (e : E) (hloop : G.endAt e 0 = G.endAt e 1) : G.Cycle where
+  edges := {e}
+  nonempty := ⟨e, by simp⟩
+  even := G.singleton_loop_even e hloop
+  minimal := by
+    intro D hDne hDsub _
+    exact hDne.subset_singleton_iff.mp hDsub
+
+private theorem even_sdiff {F D : Finset E} (hDF : D ⊆ F)
+    (hF : G.IsEvenEdgeSet F) (hD : G.IsEvenEdgeSet D) :
+    G.IsEvenEdgeSet (F \ D) := by
+  intro v
+  have hsplit := Finset.sum_sdiff hDF (f := fun e ↦ G.edgeIncidence v e)
+  rw [hD v, hF v] at hsplit
+  simpa using hsplit
+
+/-- Every finite even edge set is an edge-disjoint union of multigraph cycles.  The displayed
+equation records edge multiplicities and is stronger than mere equality of unions. -/
+theorem decompose_even_edge_set (F : Finset E) (hF : G.IsEvenEdgeSet F) :
+    ∃ L : List G.Cycle,
+      ∀ e : E, (L.filter fun C ↦ e ∈ C.edges).length = if e ∈ F then 1 else 0 := by
+  classical
+  revert hF
+  refine Finset.strongInductionOn F ?_
+  intro F ih hF
+  by_cases hne : F.Nonempty
+  · by_cases hmin :
+      (∀ D : Finset E, D.Nonempty → D ⊆ F → G.IsEvenEdgeSet D → D = F)
+    · let C : G.Cycle :=
+        { edges := F
+          nonempty := hne
+          even := hF
+          minimal := hmin }
+      refine ⟨[C], ?_⟩
+      intro e
+      by_cases he : e ∈ F <;> simp [C, he]
+    · push Not at hmin
+      obtain ⟨D, hDne, hDF, hDeven, hDproper⟩ := hmin
+      have hDssub : D ⊂ F := Finset.ssubset_iff_subset_ne.mpr ⟨hDF, hDproper⟩
+      have hRssub : F \ D ⊂ F := by
+        apply Finset.ssubset_iff_subset_ne.mpr
+        refine ⟨Finset.sdiff_subset, ?_⟩
+        intro heq
+        obtain ⟨e, heD⟩ := hDne
+        have : e ∈ F \ D := by simpa [heq] using hDF heD
+        simp [heD] at this
+      obtain ⟨LD, hLD⟩ := ih D hDssub hDeven
+      obtain ⟨LR, hLR⟩ := ih (F \ D) hRssub (G.even_sdiff hDF hF hDeven)
+      refine ⟨LD ++ LR, ?_⟩
+      intro e
+      rw [List.filter_append, List.length_append, hLD e, hLR e]
+      by_cases heD : e ∈ D
+      · have heF : e ∈ F := hDF heD
+        simp [heD, heF]
+      · by_cases heF : e ∈ F <;> simp [heD, heF]
+  · have hzero : F = ∅ := Finset.not_nonempty_iff_eq_empty.mp hne
+    subst F
+    exact ⟨[], by simp⟩
+
+open Sabidussi
+
+variable {V E : Type*} [Fintype V] [Fintype E] [DecidableEq V] [DecidableEq E]
+  (G : LoopMultigraph V E)
+
+/-- A partition of all edge objects into circuits. -/
+structure CircuitDecomposition where
+  /-- The list of circuits partitioning the edges. -/
+  circuits : List G.Cycle
+  /-- Every edge object lies in exactly one circuit. -/
+  coveredOnce : ∀ e : E, (circuits.filter fun C ↦ e ∈ C.edges).length = 1
+
+/-- A circuit decomposition is compatible with an Euler tour when no one circuit contains both
+edge objects of a transition. -/
+def CircuitDecomposition.Compatible {G : LoopMultigraph V E}
+    (S : G.CircuitDecomposition) (T : G.EulerTour) : Prop :=
+  ∀ (i : T.Pos) (C : G.Cycle), C ∈ S.circuits →
+    ¬ (T.edge (T.prev i) ∈ C.edges ∧ T.edge i ∈ C.edges)
+
+/-- The four-colour certificate produced by the cyclic-word part of the proof. -/
+structure CompatibleFourColoring (T : G.EulerTour) where
+  /-- The colour assigned to each edge object. -/
+  color : E → Color
+  /-- Consecutive edges of the tour receive different colours. -/
+  transition_ne : ∀ i : T.Pos, color (T.edge (T.prev i)) ≠ color (T.edge i)
+  /-- Each colour class is an even edge set. -/
+  color_even : ∀ z : Color,
+    G.IsEvenEdgeSet (Finset.univ.filter fun e ↦ color e = z)
+
+namespace CompatibleFourColoring
+
+private theorem filter_flatMap_length {A B : Type*} (p : B → Bool)
+    (f : A → List B) (xs : List A) :
+    ((xs.flatMap f).filter p).length =
+      (xs.map fun x ↦ ((f x).filter p).length).sum := by
+  induction xs with
+  | nil => simp
+  | cons x xs ih => simp [ih]
+
+/-- Every compatible four-colouring yields a compatible circuit decomposition. -/
+theorem exists_compatible_circuit_decomposition
+    {T : G.EulerTour} (K : G.CompatibleFourColoring T) :
+    ∃ S : G.CircuitDecomposition, S.Compatible T := by
+  classical
+  let support : Color → Finset E := fun z ↦ Finset.univ.filter fun e ↦ K.color e = z
+  have hex : ∀ z : Color, ∃ L : List G.Cycle,
+      ∀ e : E, (L.filter fun C ↦ e ∈ C.edges).length =
+        if e ∈ support z then 1 else 0 := by
+    intro z
+    exact G.decompose_even_edge_set (support z) (K.color_even z)
+  choose pieces hpieces using hex
+  have hpiece_subset : ∀ (z : Color) (C : G.Cycle), C ∈ pieces z → C.edges ⊆ support z := by
+    intro z C hC e he
+    by_contra hnot
+    have hzero : ((pieces z).filter fun D ↦ e ∈ D.edges).length = 0 := by
+      simpa [hnot] using hpieces z e
+    have hmem : C ∈ (pieces z).filter fun D ↦ e ∈ D.edges := by
+      simpa using ⟨hC, he⟩
+    have hpos : 0 < ((pieces z).filter fun D ↦ e ∈ D.edges).length :=
+      List.length_pos_iff.mpr (List.ne_nil_of_mem hmem)
+    omega
+  let allPieces : List G.Cycle := Finset.univ.toList.flatMap pieces
+  have hcovered : ∀ e : E,
+      (allPieces.filter fun C ↦ e ∈ C.edges).length = 1 := by
+    intro e
+    change ((Finset.univ.toList.flatMap pieces).filter fun C ↦ e ∈ C.edges).length = 1
+    rw [filter_flatMap_length]
+    simp_rw [hpieces]
+    simp [support]
+  let S : G.CircuitDecomposition :=
+    { circuits := allPieces
+      coveredOnce := hcovered }
+  refine ⟨S, ?_⟩
+  intro i C hC htransition
+  change C ∈ Finset.univ.toList.flatMap pieces at hC
+  rw [List.mem_flatMap] at hC
+  obtain ⟨z, hz, hCz⟩ := hC
+  have hprevSupport := hpiece_subset z C hCz htransition.1
+  have hcurrSupport := hpiece_subset z C hCz htransition.2
+  have hprevColor : K.color (T.edge (T.prev i)) = z := by
+    simpa [support] using hprevSupport
+  have hcurrColor : K.color (T.edge i) = z := by
+    simpa [support] using hcurrSupport
+  exact K.transition_ne i (hprevColor.trans hcurrColor.symm)
+
+end CompatibleFourColoring
+
+end LoopMultigraph
+end Sabidussi

--- a/LeanPool/Sabidussi/OddBalance.lean
+++ b/LeanPool/Sabidussi/OddBalance.lean
@@ -1,0 +1,565 @@
+/-
+Copyright (c) 2026 Nikolay Ulyanov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nikolay Ulyanov
+-/
+import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Logic.Equiv.Prod
+
+/-!
+# The odd balancing theorem
+
+This file proves the parity lemma at the heart of the compatibility argument: for a symmetric,
+row-cancelling interaction `b` over a finite vertex set, the number of frame assignments with no
+obstruction at any vertex is odd, and in particular nonzero. The proof counts frame assignments
+modulo two, expands the count over choices of partner vertices, and cancels the non-covering and
+derangement contributions in pairs.
+-/
+
+open scoped BigOperators
+open Finset
+
+namespace Sabidussi
+
+namespace OddBalance
+
+/-- The field with two elements, used for the parity counting argument. -/
+abbrev F2 := ZMod 2
+
+lemma F2.indicator_zero (a : F2) : (if a = 0 then 1 else 0) = 1 + a := by
+  fin_cases a <;> decide
+
+lemma F2.mul_self (a : F2) : a * a = a := by
+  fin_cases a <;> decide
+
+lemma F2.add_self (a : F2) : a + a = 0 := by
+  fin_cases a <;> decide
+
+section
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- The interaction obstruction at a vertex `v`: the sum over all other vertices `u` of the
+pairwise interaction of the chosen frames at `v` and `u`. -/
+def obstruction (b : V → V → Fin 3 → Fin 3 → F2) (x : V → Fin 3) (v : V) : F2 :=
+  ∑ u ∈ Finset.univ.erase v, b v u (x v) (x u)
+
+/-- The set of frame choices for which every vertex obstruction vanishes. -/
+def solutions (b : V → V → Fin 3 → Fin 3 → F2) : Finset (V → Fin 3) :=
+  Finset.univ.filter fun x => ∀ v, obstruction b x v = 0
+
+lemma cast_solutions_card (b : V → V → Fin 3 → Fin 3 → F2) :
+    ((solutions b).card : F2) =
+      ∑ x : V → Fin 3, ∏ v : V, (1 + obstruction b x v) := by
+  rw [solutions]
+  calc
+    ((Finset.univ.filter fun x : V → Fin 3 =>
+        ∀ v, obstruction b x v = 0).card : F2) =
+        ∑ x : V → Fin 3, if ∀ v, obstruction b x v = 0 then 1 else 0 := by
+          simp [Finset.sum_boole]
+    _ = ∑ x : V → Fin 3, ∏ v : V, (1 + obstruction b x v) := by
+      apply Fintype.sum_congr
+      intro x
+      rw [show (if ∀ v, obstruction b x v = 0 then 1 else 0 : F2) =
+          ∏ v : V, if obstruction b x v = 0 then 1 else 0 by
+            simpa only [Finset.mem_univ, forall_const]
+              using (Finset.prod_boole
+                (s := Finset.univ) (p := fun v : V => obstruction b x v = 0)).symm]
+      congr 1
+      funext v
+      exact F2.indicator_zero _
+
+omit [DecidableEq V] in
+lemma prod_one_add_expand (q : V → F2) :
+    (∏ v : V, (1 + q v)) =
+      ∑ S ∈ Finset.univ.powerset, ∏ v ∈ S, q v := by
+  classical
+  simpa [add_comm] using Finset.prod_add q (fun _ : V => (1 : F2)) Finset.univ
+
+lemma sum_prod_one_add_expand (q : (V → Fin 3) → V → F2) :
+    (∑ x : V → Fin 3, ∏ v : V, (1 + q x v)) =
+      ∑ S ∈ Finset.univ.powerset, ∑ x : V → Fin 3, ∏ v ∈ S, q x v := by
+  simp_rw [prod_one_add_expand]
+  exact Finset.sum_comm
+
+omit [Fintype V] in
+lemma prod_sum_expand (S : Finset V) (t : V → Finset V) (a : V → V → F2) :
+    (∏ v ∈ S, ∑ u ∈ t v, a v u) =
+      ∑ f : (v : {v // v ∈ S}) → {u // u ∈ t v},
+        ∏ v : {v // v ∈ S}, a v (f v) := by
+  rw [Finset.prod_subtype S (fun _ => Iff.rfl)]
+  · simp_rw [Finset.sum_subtype (t _) (fun _ => Iff.rfl)]
+    exact Fintype.prod_sum (fun v : {v // v ∈ S} =>
+      fun u : {u // u ∈ t v} => a v u)
+
+/-- A choice, for each vertex of `S`, of a distinct partner vertex. -/
+abbrev Choice (S : Finset V) :=
+  (v : {v // v ∈ S}) → {u : V // u ≠ v}
+
+/-- The product over `S` of the pairwise interactions along a choice of partners. -/
+def choiceTerm (b : V → V → Fin 3 → Fin 3 → F2) (S : Finset V)
+    (f : Choice S) (x : V → Fin 3) : F2 :=
+  ∏ v : {v // v ∈ S}, b v (f v) (x v) (x (f v))
+
+lemma obstruction_product_expand
+    (b : V → V → Fin 3 → Fin 3 → F2) (S : Finset V) (x : V → Fin 3) :
+    (∏ v ∈ S, obstruction b x v) =
+      ∑ f : Choice S, choiceTerm b S f x := by
+  rw [Finset.prod_subtype S (fun _ => Iff.rfl)]
+  · have hsum (v : V) :
+        (∑ u ∈ Finset.univ.erase v, b v u (x v) (x u)) =
+          ∑ u : {u : V // u ≠ v}, b v u (x v) (x u) := by
+      exact Finset.sum_subtype (Finset.univ.erase v) (by simp)
+        (fun u => b v u (x v) (x u))
+    simp_rw [obstruction, hsum]
+    exact Fintype.prod_sum (fun v : {v // v ∈ S} =>
+      fun u : {u : V // u ≠ v} => b v u (x v) (x u))
+
+/-- The sum over all frame assignments of the choice term of a fixed choice of partners. -/
+def totalChoiceTerm (b : V → V → Fin 3 → Fin 3 → F2)
+    (S : Finset V) (f : Choice S) : F2 :=
+  ∑ x : V → Fin 3, choiceTerm b S f x
+
+lemma sum_obstruction_product_expand
+    (b : V → V → Fin 3 → Fin 3 → F2) (S : Finset V) :
+    (∑ x : V → Fin 3, ∏ v ∈ S, obstruction b x v) =
+      ∑ f : Choice S, totalChoiceTerm b S f := by
+  simp_rw [obstruction_product_expand]
+  exact Finset.sum_comm
+
+lemma sum_fun_split_at {A M : Type*} [Fintype A] [AddCommMonoid M]
+    (w : V) (F : (V → A) → M) :
+    (∑ x : V → A, F x) =
+      ∑ a : A, ∑ y : ({v : V // v ≠ w} → A),
+        F ((Equiv.funSplitAt w A).symm (a, y)) := by
+  calc
+    (∑ x : V → A, F x) =
+        ∑ p : A × ({v : V // v ≠ w} → A),
+          F ((Equiv.funSplitAt w A).symm p) := by
+            apply Fintype.sum_equiv (Equiv.funSplitAt w A)
+            intro x
+            exact congrArg F ((Equiv.funSplitAt w A).symm_apply_apply x).symm
+    _ = _ := Fintype.sum_prod_type _
+
+lemma Fintype.prod_eq_mul_mul_prod_compl_pair {M : Type*} [CommMonoid M]
+    {ι : Type*} [Fintype ι] [DecidableEq ι] (a b : ι) (h : a ≠ b) (g : ι → M) :
+    (∏ i, g i) = g a * g b * ∏ i ∈ ({a, b} : Finset ι)ᶜ, g i := by
+  rw [Fintype.prod_eq_mul_prod_compl a]
+  rw [Finset.prod_eq_mul_prod_sdiff_singleton_of_mem (by simpa using h.symm)]
+  have hset : ({a} : Finset ι)ᶜ \ {b} = ({a, b} : Finset ι)ᶜ := by
+    ext i
+    simp only [Finset.mem_sdiff, Finset.mem_compl, Finset.mem_singleton,
+      Finset.mem_insert, not_or]
+  rw [hset, mul_assoc]
+
+lemma totalChoiceTerm_eq_zero_of_source_leaf
+    (b : V → V → Fin 3 → Fin 3 → F2)
+    (hsymm : ∀ v u a c, b v u a c = b u v c a)
+    (hrow : ∀ v u a, ∑ c : Fin 3, b v u a c = 0)
+    (S : Finset V) (f : Choice S) (v₀ : {v // v ∈ S}) (w : V)
+    (hw : (v₀ : V) = w) (hnotTarget : ∀ v, (f v : V) ≠ w) :
+    totalChoiceTerm b S f = 0 := by
+  rw [totalChoiceTerm, sum_fun_split_at w]
+  rw [Finset.sum_comm]
+  apply Fintype.sum_eq_zero
+  intro y
+  let x₀ : V → Fin 3 := (Equiv.funSplitAt w (Fin 3)).symm (0, y)
+  let C : F2 := ∏ v ∈ ({v₀} : Finset {v // v ∈ S})ᶜ,
+    b v (f v) (x₀ v) (x₀ (f v))
+  have hfactor (a : Fin 3) :
+      choiceTerm b S f ((Equiv.funSplitAt w (Fin 3)).symm (a, y)) =
+        b w (f v₀) a (y ⟨f v₀, hnotTarget v₀⟩) * C := by
+    rw [choiceTerm, Fintype.prod_eq_mul_prod_compl v₀]
+    congr 1
+    · simp [Equiv.funSplitAt_symm_apply, hw, hnotTarget]
+    · apply Finset.prod_congr rfl
+      intro v hv
+      have hvne : v ≠ v₀ := by simpa using hv
+      have hvw : (v : V) ≠ w := by
+        intro h
+        apply hvne
+        apply Subtype.ext
+        simpa [hw] using h
+      simp [x₀, Equiv.funSplitAt_symm_apply, hvw, hnotTarget]
+  simp_rw [hfactor]
+  rw [← Finset.sum_mul]
+  suffices (∑ a : Fin 3, b w (f v₀) a (y ⟨f v₀, hnotTarget v₀⟩)) = 0 by
+    rw [this, zero_mul]
+  calc
+    (∑ a : Fin 3, b w (f v₀) a (y ⟨f v₀, hnotTarget v₀⟩)) =
+        ∑ a : Fin 3, b (f v₀) w (y ⟨f v₀, hnotTarget v₀⟩) a := by
+          apply Fintype.sum_congr
+          intro a
+          exact hsymm _ _ _ _
+    _ = 0 := hrow (f v₀) w (y ⟨f v₀, hnotTarget v₀⟩)
+
+lemma totalChoiceTerm_eq_zero_of_target_leaf
+    (b : V → V → Fin 3 → Fin 3 → F2)
+    (hrow : ∀ v u a, ∑ c : Fin 3, b v u a c = 0)
+    (S : Finset V) (f : Choice S) (v₀ : {v // v ∈ S}) (w : V)
+    (hw : (f v₀ : V) = w) (hnotSource : ∀ v, (v : V) ≠ w)
+    (huniqueTarget : ∀ v, (f v : V) = w → v = v₀) :
+    totalChoiceTerm b S f = 0 := by
+  rw [totalChoiceTerm, sum_fun_split_at w]
+  rw [Finset.sum_comm]
+  apply Fintype.sum_eq_zero
+  intro y
+  let x₀ : V → Fin 3 := (Equiv.funSplitAt w (Fin 3)).symm (0, y)
+  let C : F2 := ∏ v ∈ ({v₀} : Finset {v // v ∈ S})ᶜ,
+    b v (f v) (x₀ v) (x₀ (f v))
+  have hfactor (a : Fin 3) :
+      choiceTerm b S f ((Equiv.funSplitAt w (Fin 3)).symm (a, y)) =
+        b v₀ w (y ⟨v₀, hnotSource v₀⟩) a * C := by
+    rw [choiceTerm, Fintype.prod_eq_mul_prod_compl v₀]
+    congr 1
+    · simp [Equiv.funSplitAt_symm_apply, hw, hnotSource]
+    · apply Finset.prod_congr rfl
+      intro v hv
+      have hvne : v ≠ v₀ := by simpa using hv
+      have hfw : (f v : V) ≠ w := by
+        intro h
+        exact hvne (huniqueTarget v h)
+      simp [x₀, Equiv.funSplitAt_symm_apply, hnotSource]
+  simp_rw [hfactor]
+  rw [← Finset.sum_mul]
+  rw [hrow, zero_mul]
+
+lemma totalChoiceTerm_eq_zero_of_twoCycle
+    (b : V → V → Fin 3 → Fin 3 → F2)
+    (hsymm : ∀ v u a c, b v u a c = b u v c a)
+    (hrow : ∀ v u a, ∑ c : Fin 3, b v u a c = 0)
+    (S : Finset V) (f : Choice S) (v₀ v₁ : {v // v ∈ S})
+    (hne : v₀ ≠ v₁)
+    (hf₀ : (f v₀ : V) = v₁) (hf₁ : (f v₁ : V) = v₀)
+    (_hu₀ : ∀ v, (f v : V) = v₀ → v = v₁)
+    (hu₁ : ∀ v, (f v : V) = v₁ → v = v₀) :
+    totalChoiceTerm b S f = 0 := by
+  have hvne : (v₀ : V) ≠ v₁ := by
+    intro h
+    exact hne (Subtype.ext h)
+  rw [totalChoiceTerm, sum_fun_split_at (v₁ : V)]
+  rw [Finset.sum_comm]
+  apply Fintype.sum_eq_zero
+  intro y
+  let x₀ : V → Fin 3 := (Equiv.funSplitAt (v₁ : V) (Fin 3)).symm (0, y)
+  let C : F2 := ∏ v ∈ ({v₀, v₁} : Finset {v // v ∈ S})ᶜ,
+    b v (f v) (x₀ v) (x₀ (f v))
+  have hfactor (a : Fin 3) :
+      choiceTerm b S f ((Equiv.funSplitAt (v₁ : V) (Fin 3)).symm (a, y)) =
+        b v₀ v₁ (y ⟨v₀, hvne⟩) a * C := by
+    rw [choiceTerm, Fintype.prod_eq_mul_mul_prod_compl_pair v₀ v₁ hne]
+    have hfac₀ :
+        b v₀ (f v₀)
+          ((Equiv.funSplitAt (v₁ : V) (Fin 3)).symm (a, y) v₀)
+          ((Equiv.funSplitAt (v₁ : V) (Fin 3)).symm (a, y) (f v₀)) =
+          b v₀ v₁ (y ⟨v₀, hvne⟩) a := by
+      simp [Equiv.funSplitAt_symm_apply, hf₀, hvne]
+    have hfac₁ :
+        b v₁ (f v₁)
+          ((Equiv.funSplitAt (v₁ : V) (Fin 3)).symm (a, y) v₁)
+          ((Equiv.funSplitAt (v₁ : V) (Fin 3)).symm (a, y) (f v₁)) =
+          b v₀ v₁ (y ⟨v₀, hvne⟩) a := by
+      rw [hsymm]
+      simp [Equiv.funSplitAt_symm_apply, hf₁, hvne]
+    rw [hfac₀, hfac₁, F2.mul_self]
+    congr 1
+    apply Finset.prod_congr rfl
+    intro v hv
+    have hvpair : v ≠ v₀ ∧ v ≠ v₁ := by simpa using hv
+    have hv₀ : v ≠ v₀ := hvpair.1
+    have hv₁ : v ≠ v₁ := hvpair.2
+    have hvw : (v : V) ≠ v₁ := by
+      intro h
+      exact hv₁ (Subtype.ext h)
+    have hfw : (f v : V) ≠ v₁ := by
+      intro h
+      exact hv₀ (hu₁ v h)
+    simp [x₀, Equiv.funSplitAt_symm_apply, hvw, hfw]
+  simp_rw [hfactor]
+  rw [← Finset.sum_mul]
+  rw [hrow, zero_mul]
+
+/-- A derangement of the vertices of `S`: a fixed-point-free permutation. -/
+def Derangement (S : Finset V) :=
+  {σ : Equiv.Perm {v // v ∈ S} // ∀ v, σ v ≠ v}
+
+noncomputable instance Derangement.instFintype (S : Finset V) : Fintype (Derangement S) :=
+  Fintype.ofInjective
+    (fun d : Derangement S => (d.1 : {v // v ∈ S} → {v // v ∈ S})) <| by
+      intro d e h
+      apply Subtype.ext
+      apply Equiv.ext
+      exact congrFun h
+
+/-- The choice of partners induced by a derangement: each vertex is sent to its image. -/
+def Derangement.choice {S : Finset V} (d : Derangement S) : Choice S :=
+  fun v => ⟨d.1 v, by
+    intro h
+    exact d.2 v (Subtype.ext h)⟩
+
+/-- The inverse derangement. -/
+def Derangement.inv {S : Finset V} (d : Derangement S) : Derangement S :=
+  ⟨d.1.symm, fun v h => d.2 v <| by
+    calc
+      d.1 v = d.1 (d.1.symm v) := congrArg d.1 h.symm
+      _ = v := d.1.apply_symm_apply v⟩
+
+omit [DecidableEq V] [Fintype V] in
+lemma Derangement.inv_inv {S : Finset V} (d : Derangement S) : d.inv.inv = d := by
+  apply Subtype.ext
+  exact d.1.symm_symm
+
+omit [DecidableEq V] [Fintype V] in
+lemma choiceTerm_derangement_inv
+    (b : V → V → Fin 3 → Fin 3 → F2)
+    (hsymm : ∀ v u a c, b v u a c = b u v c a)
+    (S : Finset V) (d : Derangement S) (x : V → Fin 3) :
+    choiceTerm b S d.inv.choice x = choiceTerm b S d.choice x := by
+  rw [choiceTerm, choiceTerm]
+  calc
+    (∏ v : {v // v ∈ S},
+        b v (d.inv.choice v) (x v) (x (d.inv.choice v))) =
+        ∏ v : {v // v ∈ S},
+          b (d.1.symm v) v (x (d.1.symm v)) (x v) := by
+            apply Fintype.prod_congr
+            intro v
+            exact hsymm _ _ _ _
+    _ = ∏ v : {v // v ∈ S}, b v (d.choice v) (x v) (x (d.choice v)) := by
+      simpa [Derangement.choice, Derangement.inv] using
+        (d.1.symm.prod_comp (fun v : {v // v ∈ S} =>
+          b v (d.1 v) (x v) (x (d.1 v))))
+
+lemma totalChoiceTerm_derangement_inv
+    (b : V → V → Fin 3 → Fin 3 → F2)
+    (hsymm : ∀ v u a c, b v u a c = b u v c a)
+    (S : Finset V) (d : Derangement S) :
+    totalChoiceTerm b S d.inv.choice = totalChoiceTerm b S d.choice := by
+  apply Fintype.sum_congr
+  intro x
+  exact choiceTerm_derangement_inv b hsymm S d x
+
+lemma totalChoiceTerm_eq_zero_of_derangement_inv_eq_self
+    (b : V → V → Fin 3 → Fin 3 → F2)
+    (hsymm : ∀ v u a c, b v u a c = b u v c a)
+    (hrow : ∀ v u a, ∑ c : Fin 3, b v u a c = 0)
+    (S : Finset V) (hS : S.Nonempty) (d : Derangement S) (hd : d.inv = d) :
+    totalChoiceTerm b S d.choice = 0 := by
+  let v₀ : {v // v ∈ S} := ⟨hS.choose, hS.choose_spec⟩
+  let v₁ : {v // v ∈ S} := d.1 v₀
+  have hne : v₀ ≠ v₁ := (d.2 v₀).symm
+  have hsigma : d.1.symm = d.1 := congrArg Subtype.val hd
+  have hcycle : d.1 v₁ = v₀ := by
+    have h := d.1.symm_apply_apply v₀
+    rw [hsigma] at h
+    exact h
+  apply totalChoiceTerm_eq_zero_of_twoCycle b hsymm hrow S d.choice v₀ v₁ hne
+  · rfl
+  · exact congrArg Subtype.val hcycle
+  · intro v hv
+    apply d.1.injective
+    calc
+      d.1 v = v₀ := Subtype.ext hv
+      _ = d.1 v₁ := hcycle.symm
+  · intro v hv
+    apply d.1.injective
+    calc
+      d.1 v = v₁ := Subtype.ext hv
+      _ = d.1 v₀ := rfl
+
+/-- A choice of partners whose image covers every vertex of `S`. -/
+def CoveredChoice (S : Finset V) :=
+  {f : Choice S // ∀ w : {w // w ∈ S}, ∃ v, (f v : V) = w}
+
+noncomputable instance CoveredChoice.instFintype (S : Finset V) :
+    Fintype (CoveredChoice S) :=
+  Fintype.ofInjective (fun f : CoveredChoice S => f.1) Subtype.val_injective
+
+/-- A covering choice of partners is a bijection, hence a derangement. -/
+noncomputable def CoveredChoice.toDerangement {S : Finset V}
+    (c : CoveredChoice S) : Derangement S := by
+  let r : {w // w ∈ S} → {v // v ∈ S} := fun w => Classical.choose (c.2 w)
+  have hr (w : {w // w ∈ S}) : (c.1 (r w) : V) = w :=
+    Classical.choose_spec (c.2 w)
+  have rinj : Function.Injective r := by
+    intro w z h
+    apply Subtype.ext
+    calc
+      (w : V) = c.1 (r w) := (hr w).symm
+      _ = c.1 (r z) := by rw [h]
+      _ = z := hr z
+  have rsurj : Function.Surjective r :=
+    (Finite.injective_iff_surjective.mp rinj)
+  have hmem (v : {v // v ∈ S}) : (c.1 v : V) ∈ S := by
+    obtain ⟨w, rfl⟩ := rsurj v
+    rw [hr]
+    exact w.2
+  let g : {v // v ∈ S} → {v // v ∈ S} := fun v => ⟨c.1 v, hmem v⟩
+  have gsurj : Function.Surjective g := by
+    intro w
+    obtain ⟨v, hv⟩ := c.2 w
+    exact ⟨v, Subtype.ext hv⟩
+  let σ : Equiv.Perm {v // v ∈ S} :=
+    Equiv.ofBijective g ((Fintype.bijective_iff_surjective_and_card g).2 ⟨gsurj, rfl⟩)
+  exact ⟨σ, fun v hv => (c.1 v).2 <| by
+    have := congrArg Subtype.val hv
+    exact this⟩
+
+/-- The covering choice of partners underlying a derangement. -/
+def Derangement.toCoveredChoice {S : Finset V} (d : Derangement S) : CoveredChoice S :=
+  ⟨d.choice, fun w => ⟨d.1.symm w, by
+    exact congrArg Subtype.val (d.1.apply_symm_apply w)⟩⟩
+
+omit [DecidableEq V] in
+lemma CoveredChoice.toDerangement_choice {S : Finset V} (c : CoveredChoice S) :
+    c.toDerangement.choice = c.1 := by
+  funext v
+  apply Subtype.ext
+  rfl
+
+omit [DecidableEq V] [Fintype V] in
+lemma Derangement.choice_injective {S : Finset V} :
+    Function.Injective (fun d : Derangement S => d.choice) := by
+  intro d e h
+  apply Subtype.ext
+  apply Equiv.ext
+  intro v
+  apply Subtype.ext
+  simpa [Derangement.choice] using congrArg Subtype.val (congrFun h v)
+
+/-- Covering choices of partners and derangements are in bijection. -/
+noncomputable def coveredChoiceEquivDerangement (S : Finset V) :
+    CoveredChoice S ≃ Derangement S where
+  toFun := CoveredChoice.toDerangement
+  invFun := Derangement.toCoveredChoice
+  left_inv c := by
+    apply Subtype.ext
+    exact CoveredChoice.toDerangement_choice c
+  right_inv d := by
+    apply Derangement.choice_injective
+    exact CoveredChoice.toDerangement_choice d.toCoveredChoice
+
+lemma sum_derangement_totalChoiceTerm_eq_zero
+    (b : V → V → Fin 3 → Fin 3 → F2)
+    (hsymm : ∀ v u a c, b v u a c = b u v c a)
+    (hrow : ∀ v u a, ∑ c : Fin 3, b v u a c = 0)
+    (S : Finset V) (hS : S.Nonempty) :
+    (∑ d : Derangement S, totalChoiceTerm b S d.choice) = 0 := by
+  classical
+  apply Finset.sum_involution (s := Finset.univ)
+    (f := fun d : Derangement S => totalChoiceTerm b S d.choice)
+    (g := fun d _ => d.inv)
+  · intro d _
+    rw [totalChoiceTerm_derangement_inv b hsymm S d]
+    exact F2.add_self _
+  · intro d _ hdne hinv
+    apply hdne
+    exact totalChoiceTerm_eq_zero_of_derangement_inv_eq_self
+      b hsymm hrow S hS d hinv
+  · simp
+  · intro d _
+    exact Derangement.inv_inv d
+
+lemma sum_coveredChoice_totalChoiceTerm_eq_zero
+    (b : V → V → Fin 3 → Fin 3 → F2)
+    (hsymm : ∀ v u a c, b v u a c = b u v c a)
+    (hrow : ∀ v u a, ∑ c : Fin 3, b v u a c = 0)
+    (S : Finset V) (hS : S.Nonempty) :
+    (∑ c : CoveredChoice S, totalChoiceTerm b S c.1) = 0 := by
+  calc
+    (∑ c : CoveredChoice S, totalChoiceTerm b S c.1) =
+        ∑ d : Derangement S, totalChoiceTerm b S d.choice := by
+          apply Fintype.sum_equiv (coveredChoiceEquivDerangement S)
+          intro c
+          change totalChoiceTerm b S c.1 =
+            totalChoiceTerm b S c.toDerangement.choice
+          exact congrArg (totalChoiceTerm b S)
+            (CoveredChoice.toDerangement_choice c).symm
+    _ = 0 := sum_derangement_totalChoiceTerm_eq_zero b hsymm hrow S hS
+
+lemma sum_choice_totalChoiceTerm_eq_zero
+    (b : V → V → Fin 3 → Fin 3 → F2)
+    (hsymm : ∀ v u a c, b v u a c = b u v c a)
+    (hrow : ∀ v u a, ∑ c : Fin 3, b v u a c = 0)
+    (S : Finset V) (hS : S.Nonempty) :
+    (∑ f : Choice S, totalChoiceTerm b S f) = 0 := by
+  classical
+  let covers : Choice S → Prop := fun f =>
+    ∀ w : {w // w ∈ S}, ∃ v, (f v : V) = w
+  have hgood :
+      (∑ f ∈ Finset.univ.filter covers, totalChoiceTerm b S f) = 0 := by
+    calc
+      (∑ f ∈ Finset.univ.filter covers, totalChoiceTerm b S f) =
+          ∑ c : CoveredChoice S, totalChoiceTerm b S c.1 := by
+            exact Finset.sum_subtype (Finset.univ.filter covers) (by
+              intro f
+              simp [covers]) (fun f => totalChoiceTerm b S f)
+      _ = 0 := sum_coveredChoice_totalChoiceTerm_eq_zero b hsymm hrow S hS
+  have hbad :
+      (∑ f ∈ Finset.univ.filter (fun f => ¬covers f), totalChoiceTerm b S f) = 0 := by
+    apply Finset.sum_eq_zero
+    intro f hf
+    have hn : ¬covers f := (Finset.mem_filter.mp hf).2
+    simp only [covers, not_forall, not_exists] at hn
+    obtain ⟨w, hw⟩ := hn
+    exact totalChoiceTerm_eq_zero_of_source_leaf b hsymm hrow S f w w rfl hw
+  calc
+    (∑ f : Choice S, totalChoiceTerm b S f) =
+        (∑ f ∈ Finset.univ.filter covers, totalChoiceTerm b S f) +
+          ∑ f ∈ Finset.univ.filter (fun f => ¬covers f), totalChoiceTerm b S f := by
+            exact (Finset.sum_filter_add_sum_filter_not Finset.univ covers
+              (fun f => totalChoiceTerm b S f)).symm
+    _ = 0 := by rw [hgood, hbad, add_zero]
+
+lemma sum_obstruction_product_eq_zero
+    (b : V → V → Fin 3 → Fin 3 → F2)
+    (hsymm : ∀ v u a c, b v u a c = b u v c a)
+    (hrow : ∀ v u a, ∑ c : Fin 3, b v u a c = 0)
+    (S : Finset V) (hS : S.Nonempty) :
+    (∑ x : V → Fin 3, ∏ v ∈ S, obstruction b x v) = 0 := by
+  rw [sum_obstruction_product_expand]
+  exact sum_choice_totalChoiceTerm_eq_zero b hsymm hrow S hS
+
+lemma sum_one_fin3_assignments : (∑ _x : V → Fin 3, (1 : F2)) = 1 := by
+  simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fun,
+    Fintype.card_fin, nsmul_eq_mul, mul_one, Nat.cast_pow, Nat.cast_ofNat]
+  rw [show (3 : F2) = 1 by decide]
+  simp
+
+theorem cast_solutions_card_eq_one
+    (b : V → V → Fin 3 → Fin 3 → F2)
+    (hsymm : ∀ v u a c, b v u a c = b u v c a)
+    (hrow : ∀ v u a, ∑ c : Fin 3, b v u a c = 0) :
+    ((solutions b).card : F2) = 1 := by
+  rw [cast_solutions_card]
+  rw [sum_prod_one_add_expand]
+  rw [Finset.sum_eq_single ∅]
+  · simpa using (sum_one_fin3_assignments (V := V))
+  · intro S hSpow hSne
+    apply sum_obstruction_product_eq_zero b hsymm hrow S
+    simpa only [Finset.nonempty_iff_ne_empty] using hSne
+  · simp
+
+theorem solutions_card_odd
+    (b : V → V → Fin 3 → Fin 3 → F2)
+    (hsymm : ∀ v u a c, b v u a c = b u v c a)
+    (hrow : ∀ v u a, ∑ c : Fin 3, b v u a c = 0) :
+    Odd (solutions b).card :=
+  ZMod.natCast_eq_one_iff_odd.mp (cast_solutions_card_eq_one b hsymm hrow)
+
+/-- A symmetric row-cancelling interaction has a balanced choice at every vertex. -/
+theorem exists_balanced
+    (b : V → V → Fin 3 → Fin 3 → F2)
+    (hsymm : ∀ v u a c, b v u a c = b u v c a)
+    (hrow : ∀ v u a, ∑ c : Fin 3, b v u a c = 0) :
+    ∃ x : V → Fin 3, ∀ v, obstruction b x v = 0 := by
+  have hpos : 0 < (solutions b).card := (solutions_card_odd b hsymm hrow).pos
+  obtain ⟨x, hx⟩ := Finset.card_pos.mp hpos
+  refine ⟨x, ?_⟩
+  simpa [solutions] using hx
+
+end
+
+end OddBalance
+
+end Sabidussi

--- a/LeanPool/Sabidussi/OrdinaryCircuit.lean
+++ b/LeanPool/Sabidussi/OrdinaryCircuit.lean
@@ -1,0 +1,454 @@
+/-
+Copyright (c) 2026 Nikolay Ulyanov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nikolay Ulyanov
+-/
+import LeanPool.Sabidussi.LoopGraphBridge
+import Mathlib.LinearAlgebra.Dimension.Constructions
+import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+import Mathlib.LinearAlgebra.Matrix.ToLin
+
+/-!
+# Ordinary circuits in endpoint multigraphs
+
+This file relates the binary ``minimal even edge set`` notion used by the colouring proof to
+the usual graph-theoretic notion of a circuit.  Connectivity below is phrased directly in terms
+of chains of incident labelled edges; in particular it does not mention parity or minimality.
+Loops and parallel edges need no exceptional representation.
+-/
+
+namespace Sabidussi
+namespace LoopMultigraph
+
+open scoped BigOperators
+
+variable {V E : Type*} [Fintype V] [Fintype E] [DecidableEq V] [DecidableEq E]
+  (G : LoopMultigraph V E)
+
+omit [DecidableEq E] in
+@[simp]
+theorem mem_edgeSupport_iff {F : Finset E} {v : V} :
+    v ∈ G.edgeSupport F ↔ ∃ e ∈ F, ∃ i : Fin 2, G.endAt e i = v := by
+  simp [edgeSupport]
+
+omit [DecidableEq E] in
+private theorem degreeIn_eq_sum_indicator (F : Finset E) (v : V) :
+    G.degreeIn F v = ∑ e ∈ F, ∑ i : Fin 2, if G.endAt e i = v then 1 else 0 := by
+  simp only [degreeIn, Finset.card_filter, Finset.sum_product]
+
+omit [DecidableEq E] in
+theorem degreeIn_cast (F : Finset E) (v : V) :
+    (G.degreeIn F v : F₂) = ∑ e ∈ F, G.edgeIncidence v e := by
+  rw [G.degreeIn_eq_sum_indicator]
+  simp only [edgeIncidence, Nat.cast_sum, Nat.cast_ite, Nat.cast_one, Nat.cast_zero]
+  congr with e
+  rw [Fin.sum_univ_two]
+
+omit [DecidableEq E] in
+theorem isEvenEdgeSet_iff_even_degree (F : Finset E) :
+    G.IsEvenEdgeSet F ↔ ∀ v : V, Even (G.degreeIn F v) := by
+  constructor
+  · intro h v
+    rw [← ZMod.natCast_eq_zero_iff_even, G.degreeIn_cast]
+    exact h v
+  · intro h v
+    rw [← G.degreeIn_cast, ZMod.natCast_eq_zero_iff_even]
+    exact h v
+
+omit [DecidableEq E] in
+theorem degreeIn_pos_iff_mem_edgeSupport (F : Finset E) (v : V) :
+    0 < G.degreeIn F v ↔ v ∈ G.edgeSupport F := by
+  rw [degreeIn, Finset.card_pos, G.mem_edgeSupport_iff]
+  constructor
+  · rintro ⟨⟨e, i⟩, hh⟩
+    have hh' := Finset.mem_filter.mp hh
+    have heF : e ∈ F := (Finset.mem_product.mp hh'.1).1
+    have hend : G.endAt e i = v := hh'.2
+    exact ⟨e, heF, i, hend⟩
+  · rintro ⟨e, heF, i, hend⟩
+    refine ⟨⟨e, i⟩, Finset.mem_filter.mpr ⟨?_, hend⟩⟩
+    exact Finset.mem_product.mpr ⟨heF, Finset.mem_univ i⟩
+
+omit [DecidableEq E] in
+/-- The degree-sum formula, valid without excluding loops: each labelled edge has exactly two
+numbered ends. -/
+theorem sum_degreeIn (F : Finset E) :
+    ∑ v : V, G.degreeIn F v = 2 * F.card := by
+  have h := Finset.card_eq_sum_card_fiberwise
+    (f := fun h : E × Fin 2 ↦ G.endAt h.1 h.2)
+    (s := F ×ˢ (Finset.univ : Finset (Fin 2))) (t := Finset.univ) (by simp)
+  simpa only [degreeIn, Finset.card_product, Finset.card_univ, Fintype.card_fin,
+    Nat.mul_comm] using h.symm
+
+omit [DecidableEq E] in
+private theorem incident_of_edgeIncidence_ne_zero {v : V} {e : E}
+    (h : G.edgeIncidence v e ≠ 0) : ∃ i : Fin 2, G.endAt e i = v := by
+  by_contra hn
+  push Not at hn
+  simp [edgeIncidence, hn] at h
+
+omit [DecidableEq E] [DecidableEq V] in
+private theorem adjacent_of_incident {d e : E} {v : V} {i j : Fin 2}
+    (hd : G.endAt d i = v) (he : G.endAt e j = v) : G.EdgeAdjacent d e := by
+  exact ⟨i, j, hd.trans he.symm⟩
+
+omit [DecidableEq E] in
+/-- Inclusion-minimal even edge sets are connected in the ordinary edge-chain sense. -/
+theorem Cycle.edgeConnected (C : G.Cycle) : G.EdgeConnected C.edges := by
+  classical
+  obtain ⟨root, hroot⟩ := C.nonempty
+  let R : E → E → Prop := fun x y ↦
+    x ∈ C.edges ∧ y ∈ C.edges ∧ G.EdgeAdjacent x y
+  let D : Finset E := C.edges.filter fun e ↦ Relation.ReflTransGen R root e
+  have hrootD : root ∈ D := by
+    exact Finset.mem_filter.mpr ⟨hroot, Relation.ReflTransGen.refl⟩
+  have hDne : D.Nonempty := ⟨root, hrootD⟩
+  have hDsub : D ⊆ C.edges := Finset.filter_subset _ _
+  have hDeven : G.IsEvenEdgeSet D := by
+    intro v
+    by_cases hincident : ∃ d ∈ D, ∃ i : Fin 2, G.endAt d i = v
+    · rw [← C.even v]
+      apply Finset.sum_subset hDsub
+      intro e heF heD
+      by_contra hinc
+      obtain ⟨j, hej⟩ := G.incident_of_edgeIncidence_ne_zero hinc
+      obtain ⟨d, hdD, i, hdi⟩ := hincident
+      have hdmem := (Finset.mem_filter.mp hdD).1
+      have hdreach := (Finset.mem_filter.mp hdD).2
+      have hstep : R d e :=
+        ⟨hdmem, heF, G.adjacent_of_incident hdi hej⟩
+      have hereach : Relation.ReflTransGen R root e := hdreach.tail hstep
+      exact heD (Finset.mem_filter.mpr ⟨heF, hereach⟩)
+    · apply Finset.sum_eq_zero
+      intro e heD
+      have hnend : ∀ i : Fin 2, G.endAt e i ≠ v := by
+        intro i hi
+        exact hincident ⟨e, heD, i, hi⟩
+      simp [edgeIncidence, hnend]
+  have hDF : D = C.edges := C.minimal D hDne hDsub hDeven
+  refine ⟨root, hroot, ?_⟩
+  intro e heF
+  have heD : e ∈ D := hDF.symm ▸ heF
+  exact (Finset.mem_filter.mp heD).2
+
+private theorem F₂_eq_zero_or_one (x : F₂) : x = 0 ∨ x = 1 := by
+  fin_cases x
+  · exact Or.inl rfl
+  · exact Or.inr rfl
+
+/-- The vertex-edge incidence matrix of an edge set, with rows restricted to its support. -/
+noncomputable def incidenceMatrix (F : Finset E) :
+    Matrix (↑(G.edgeSupport F)) (↑F) F₂ :=
+  fun v e ↦ G.edgeIncidence v.1 e.1
+
+/-- The incidence matrix as a linear map over `F₂`. -/
+noncomputable def incidenceMap (F : Finset E) :
+    (↑F → F₂) →ₗ[F₂] (↑(G.edgeSupport F) → F₂) :=
+  (G.incidenceMatrix F).mulVecLin
+
+omit [DecidableEq E] in
+@[simp]
+theorem incidenceMap_apply (F : Finset E) (x : ↑F → F₂)
+    (v : ↑(G.edgeSupport F)) :
+    G.incidenceMap F x v = ∑ e : ↑F, G.edgeIncidence v.1 e.1 * x e := by
+  rfl
+
+/-- Extend a coefficient vector on a subtype by zero to all labelled edges. -/
+private noncomputable def vectorCoeff (F : Finset E) (x : ↑F → F₂) (e : E) : F₂ :=
+  if h : e ∈ F then x ⟨e, h⟩ else 0
+
+/-- Edges on which a binary coefficient vector is one. -/
+private noncomputable def selectedEdges (F : Finset E) (x : ↑F → F₂) : Finset E :=
+  F.filter fun e ↦ vectorCoeff F x e = 1
+
+omit [Fintype E] in
+private theorem selectedEdges_subset (F : Finset E) (x : ↑F → F₂) :
+    selectedEdges F x ⊆ F := Finset.filter_subset _ _
+
+private theorem sum_selectedEdges (F : Finset E) (x : ↑F → F₂) (v : V) :
+    ∑ e ∈ selectedEdges F x, G.edgeIncidence v e =
+      ∑ e : ↑F, G.edgeIncidence v e.1 * x e := by
+  classical
+  rw [selectedEdges, Finset.sum_filter, ← Finset.sum_attach]
+  apply Finset.sum_congr rfl
+  intro e _
+  simp only [vectorCoeff, dif_pos e.2]
+  rcases F₂_eq_zero_or_one (x e) with hx | hx
+  · simp [hx]
+  · simp [hx]
+
+private def oneVector (F : Finset E) : ↑F → F₂ := fun _ ↦ 1
+
+omit [DecidableEq E] [Fintype E] in
+private theorem oneVector_ne_zero {F : Finset E} (hF : F.Nonempty) :
+    oneVector F ≠ 0 := by
+  obtain ⟨e, he⟩ := hF
+  intro h
+  have := congr_fun h (⟨e, he⟩ : ↑F)
+  simp [oneVector] at this
+
+omit [DecidableEq E] in
+private theorem Cycle.oneVector_mem_incidenceKer (C : G.Cycle) :
+    oneVector C.edges ∈ LinearMap.ker (G.incidenceMap C.edges) := by
+  rw [LinearMap.mem_ker]
+  funext v
+  rw [G.incidenceMap_apply]
+  calc
+    (∑ e : ↑C.edges, G.edgeIncidence v.1 e.1 * oneVector C.edges e) =
+        ∑ e : ↑C.edges, G.edgeIncidence v.1 e.1 := by simp [oneVector]
+    _ = ∑ e ∈ C.edges, G.edgeIncidence v.1 e := by
+      rw [← Finset.attach_eq_univ]
+      exact Finset.sum_attach C.edges (fun e ↦ G.edgeIncidence v.1 e)
+    _ = 0 := C.even v.1
+
+private theorem selectedEdges_even_of_mem_ker {F : Finset E} (x : ↑F → F₂)
+    (hx : x ∈ LinearMap.ker (G.incidenceMap F)) :
+    G.IsEvenEdgeSet (selectedEdges F x) := by
+  classical
+  intro v
+  by_cases hv : v ∈ G.edgeSupport F
+  · have hx0 : G.incidenceMap F x ⟨v, hv⟩ = 0 := by
+      have hmap : G.incidenceMap F x = 0 := LinearMap.mem_ker.mp hx
+      exact congr_fun hmap ⟨v, hv⟩
+    rw [G.sum_selectedEdges]
+    simpa [G.incidenceMap_apply, mul_comm] using hx0
+  · apply Finset.sum_eq_zero
+    intro e heD
+    have heF : e ∈ F := selectedEdges_subset F x heD
+    have hnend : ∀ i : Fin 2, G.endAt e i ≠ v := by
+      intro i hi
+      exact hv (G.mem_edgeSupport_iff.mpr ⟨e, heF, i, hi⟩)
+    simp [edgeIncidence, hnend]
+
+omit [DecidableEq E] in
+private theorem Cycle.incidenceKer_eq_span_oneVector (C : G.Cycle) :
+    LinearMap.ker (G.incidenceMap C.edges) =
+      Submodule.span F₂ ({oneVector C.edges} : Set (↑C.edges → F₂)) := by
+  classical
+  apply le_antisymm
+  · intro x hx
+    let D := selectedEdges C.edges x
+    have hDsub : D ⊆ C.edges := selectedEdges_subset C.edges x
+    have hDeven : G.IsEvenEdgeSet D := G.selectedEdges_even_of_mem_ker x hx
+    by_cases hDne : D.Nonempty
+    · have hDF : D = C.edges := C.minimal D hDne hDsub hDeven
+      have hxone : x = oneVector C.edges := by
+        funext e
+        have heD : e.1 ∈ D := hDF.symm ▸ e.2
+        have hcoeff := (Finset.mem_filter.mp heD).2
+        simpa [D, selectedEdges, vectorCoeff, e.2, oneVector] using hcoeff
+      rw [hxone]
+      exact Submodule.mem_span_singleton_self (R := F₂) (oneVector C.edges)
+    · have hDempty : D = ∅ := Finset.not_nonempty_iff_eq_empty.mp hDne
+      have hxzero : x = 0 := by
+        funext e
+        have heNotD : e.1 ∉ D := by simp [hDempty]
+        have hcoeff : vectorCoeff C.edges x e.1 ≠ 1 := by
+          simpa [D, selectedEdges, e.2] using heNotD
+        rcases F₂_eq_zero_or_one (x e) with he | he
+        · exact he
+        · exfalso
+          apply hcoeff
+          simpa [vectorCoeff, e.2] using he
+      rw [hxzero]
+      exact (Submodule.span F₂ ({oneVector C.edges} : Set (↑C.edges → F₂))).zero_mem
+  · apply Submodule.span_le.mpr
+    intro x hx
+    rw [Set.mem_singleton_iff.mp hx]
+    exact C.oneVector_mem_incidenceKer
+
+omit [DecidableEq E] in
+private theorem Cycle.finrank_incidenceKer (C : G.Cycle) :
+    Module.finrank F₂ (LinearMap.ker (G.incidenceMap C.edges)) = 1 := by
+  rw [C.incidenceKer_eq_span_oneVector]
+  exact finrank_span_singleton (oneVector_ne_zero C.nonempty)
+
+private def coordinateSum {J : Type*} [Fintype J] : (J → F₂) →ₗ[F₂] F₂ where
+  toFun x := ∑ j, x j
+  map_add' x y := by simp [Finset.sum_add_distrib]
+  map_smul' c x := by
+    simp only [smul_eq_mul, RingHom.id_apply]
+    change (∑ j, c * x j) = c * ∑ j, x j
+    exact (Finset.mul_sum Finset.univ x c).symm
+
+private theorem coordinateSum_surjective {J : Type*} [Fintype J] [Nonempty J] :
+    Function.Surjective (coordinateSum (J := J)) := by
+  classical
+  intro c
+  let j₀ : J := Classical.choice inferInstance
+  refine ⟨Pi.single j₀ c, ?_⟩
+  simp [coordinateSum, j₀]
+
+private theorem coordinateSum_ker_finrank {J : Type*} [Fintype J] [Nonempty J] :
+    Module.finrank F₂ (LinearMap.ker (coordinateSum (J := J))) + 1 = Fintype.card J := by
+  have hrange : LinearMap.range (coordinateSum (J := J)) = ⊤ :=
+    LinearMap.range_eq_top_of_surjective _ coordinateSum_surjective
+  have h := LinearMap.finrank_range_add_finrank_ker (coordinateSum (J := J))
+  rw [hrange] at h
+  simpa [Module.finrank_pi, Module.finrank_self, add_comm] using h
+
+omit [DecidableEq E] in
+private theorem sum_endpoint_indicator (F : Finset E) {e : E} (he : e ∈ F) (i : Fin 2) :
+    (∑ v : ↑(G.edgeSupport F),
+      if G.endAt e i = v.1 then (1 : F₂) else 0) = 1 := by
+  classical
+  let w : ↑(G.edgeSupport F) :=
+    ⟨G.endAt e i, G.mem_edgeSupport_iff.mpr ⟨e, he, i, rfl⟩⟩
+  simpa only [w, Subtype.ext_iff] using
+    (Fintype.sum_ite_eq w (fun _ : ↑(G.edgeSupport F) ↦ (1 : F₂)))
+
+omit [DecidableEq E] in
+private theorem sum_edgeIncidence_support (F : Finset E) {e : E} (he : e ∈ F) :
+    ∑ v : ↑(G.edgeSupport F), G.edgeIncidence v.1 e = 0 := by
+  simp only [edgeIncidence, Finset.sum_add_distrib]
+  rw [G.sum_endpoint_indicator F he 0, G.sum_endpoint_indicator F he 1]
+  exact CharTwo.add_self_eq_zero 1
+
+omit [DecidableEq E] in
+private theorem Cycle.support_nonempty (C : G.Cycle) : Nonempty ↑(G.edgeSupport C.edges) := by
+  obtain ⟨e, he⟩ := C.nonempty
+  exact ⟨⟨G.endAt e 0, G.mem_edgeSupport_iff.mpr ⟨e, he, 0, rfl⟩⟩⟩
+
+omit [DecidableEq E] in
+/-- A minimal nonzero binary-even family has at most as many edges as supported vertices.
+This is the rank-nullity step in the standard proof that a binary cycle is 2-regular. -/
+private theorem Cycle.card_edges_le_card_support (C : G.Cycle) :
+    C.edges.card ≤ (G.edgeSupport C.edges).card := by
+  let S := ↑(G.edgeSupport C.edges)
+  let A := G.incidenceMap C.edges
+  let σ : (S → F₂) →ₗ[F₂] F₂ := coordinateSum
+  letI : Nonempty S := C.support_nonempty
+  have hrange : LinearMap.range A ≤ LinearMap.ker σ := by
+    rintro y ⟨x, rfl⟩
+    rw [LinearMap.mem_ker]
+    change ∑ v : S, G.incidenceMap C.edges x v = 0
+    simp_rw [G.incidenceMap_apply]
+    rw [Finset.sum_comm]
+    apply Finset.sum_eq_zero
+    intro e _
+    rw [← Finset.sum_mul, G.sum_edgeIncidence_support C.edges e.2]
+    simp
+  have hle : Module.finrank F₂ (LinearMap.range A) ≤
+      Module.finrank F₂ (LinearMap.ker σ) := Submodule.finrank_mono hrange
+  have hrank := LinearMap.finrank_range_add_finrank_ker A
+  have hker := C.finrank_incidenceKer
+  have hσ := coordinateSum_ker_finrank (J := S)
+  change Module.finrank F₂ (LinearMap.ker A) = 1 at hker
+  change Module.finrank F₂ (LinearMap.ker σ) + 1 = Fintype.card S at hσ
+  rw [hker, Module.finrank_pi] at hrank
+  have hrank' : Module.finrank F₂ (LinearMap.range A) + 1 = C.edges.card := by
+    simpa using hrank
+  have hσ' : Module.finrank F₂ (LinearMap.ker σ) + 1 =
+      (G.edgeSupport C.edges).card := by
+    simpa using hσ
+  omega
+
+omit [DecidableEq E] in
+/-- Every supported vertex of a binary cycle has ordinary degree exactly two. -/
+theorem Cycle.degree_eq_two (C : G.Cycle) {v : V}
+    (hv : v ∈ G.edgeSupport C.edges) : G.degreeIn C.edges v = 2 := by
+  have heven : ∀ w : V, Even (G.degreeIn C.edges w) :=
+    (G.isEvenEdgeSet_iff_even_degree C.edges).mp C.even
+  have hge : ∀ w ∈ G.edgeSupport C.edges, 2 ≤ G.degreeIn C.edges w := by
+    intro w hw
+    have hpos : 0 < G.degreeIn C.edges w :=
+      (G.degreeIn_pos_iff_mem_edgeSupport C.edges w).mpr hw
+    obtain ⟨k, hk⟩ := heven w
+    omega
+  have hsum : ∑ w ∈ G.edgeSupport C.edges, G.degreeIn C.edges w =
+      2 * C.edges.card := by
+    rw [← G.sum_degreeIn]
+    apply Finset.sum_subset (Finset.subset_univ _)
+    intro w _ hw
+    have hnpos : ¬ 0 < G.degreeIn C.edges w := by
+      intro hp
+      exact hw ((G.degreeIn_pos_iff_mem_edgeSupport C.edges w).mp hp)
+    omega
+  have hlower : 2 * (G.edgeSupport C.edges).card ≤
+      ∑ w ∈ G.edgeSupport C.edges, G.degreeIn C.edges w := by
+    have h := Finset.sum_le_sum (fun w hw ↦ hge w hw)
+    simpa [Nat.mul_comm] using h
+  have hcard : C.edges.card = (G.edgeSupport C.edges).card := by
+    have hle := C.card_edges_le_card_support
+    omega
+  have hsumeq : (∑ _w ∈ G.edgeSupport C.edges, 2) =
+      ∑ w ∈ G.edgeSupport C.edges, G.degreeIn C.edges w := by
+    calc
+      (∑ _w ∈ G.edgeSupport C.edges, 2) =
+          (G.edgeSupport C.edges).card * 2 := by simp
+      _ = 2 * C.edges.card := by omega
+      _ = ∑ w ∈ G.edgeSupport C.edges, G.degreeIn C.edges w := hsum.symm
+  exact ((Finset.sum_eq_sum_iff_of_le (fun w hw ↦ hge w hw)).mp hsumeq v hv).symm
+
+/-- Regard a minimal nonempty binary-even edge set as an ordinary connected 2-regular circuit. -/
+def Cycle.toOrdinaryCircuit (C : G.Cycle) : G.OrdinaryCircuit where
+  edges := C.edges
+  nonempty := C.nonempty
+  connected := C.edgeConnected
+  twoRegular := fun _ hv ↦ Cycle.degree_eq_two G C hv
+
+omit [DecidableEq E] in
+@[simp]
+theorem Cycle.toOrdinaryCircuit_edges (C : G.Cycle) :
+    C.toOrdinaryCircuit.edges = C.edges := rfl
+
+omit [DecidableEq E] in
+/-- An ordinary circuit is an even edge set (including the singleton-loop case). -/
+theorem OrdinaryCircuit.even (C : G.OrdinaryCircuit) : G.IsEvenEdgeSet C.edges := by
+  rw [G.isEvenEdgeSet_iff_even_degree]
+  intro v
+  by_cases hv : v ∈ G.edgeSupport C.edges
+  · rw [C.twoRegular v hv]
+    exact ⟨1, by omega⟩
+  · have hnpos : ¬ 0 < G.degreeIn C.edges v := by
+      intro hp
+      exact hv ((G.degreeIn_pos_iff_mem_edgeSupport C.edges v).mp hp)
+    have hz : G.degreeIn C.edges v = 0 := Nat.eq_zero_of_not_pos hnpos
+    rw [hz]
+    exact Even.zero
+
+/-- Mapping cycles to ordinary circuits does not change edge multiplicities. -/
+private theorem filter_map_toOrdinaryCircuit_length (L : List G.Cycle) (e : E) :
+    ((L.map (Cycle.toOrdinaryCircuit G)).filter fun C ↦ e ∈ C.edges).length =
+      (L.filter fun C ↦ e ∈ C.edges).length := by
+  induction L with
+  | nil => simp
+  | cons C L ih =>
+      by_cases he : e ∈ C.edges <;> simp [he, Cycle.toOrdinaryCircuit, ih]
+
+/-- The existing minimal-even-set decomposition can therefore be read as a decomposition into
+ordinary connected 2-regular circuits. -/
+theorem decompose_even_edge_set_ordinary (F : Finset E) (hF : G.IsEvenEdgeSet F) :
+    ∃ L : List G.OrdinaryCircuit,
+      ∀ e : E, (L.filter fun C ↦ e ∈ C.edges).length = if e ∈ F then 1 else 0 := by
+  obtain ⟨L, hL⟩ := G.decompose_even_edge_set F hF
+  refine ⟨L.map (Cycle.toOrdinaryCircuit G), ?_⟩
+  intro e
+  rw [filter_map_toOrdinaryCircuit_length, hL e]
+
+/-- Transport a decomposition from the minimal-even representation to ordinary circuits. -/
+def CircuitDecomposition.toOrdinary (S : G.CircuitDecomposition) :
+    G.OrdinaryCircuitDecomposition where
+  circuits := S.circuits.map (Cycle.toOrdinaryCircuit G)
+  coveredOnce := by
+    intro e
+    rw [filter_map_toOrdinaryCircuit_length, S.coveredOnce e]
+
+theorem CircuitDecomposition.compatible_toOrdinary {T : G.EulerTour}
+    {S : G.CircuitDecomposition} (h : S.Compatible T) : S.toOrdinary.Compatible T := by
+  intro i C hC
+  change C ∈ S.circuits.map (Cycle.toOrdinaryCircuit G) at hC
+  rw [List.mem_map] at hC
+  obtain ⟨D, hD, rfl⟩ := hC
+  exact h i D hD
+
+/-- Sabidussi compatibility with the conclusion expressed using ordinary connected 2-regular
+circuits rather than minimal binary-even edge sets. -/
+theorem loop_sabidussi_compatibility_ordinary {G : LoopMultigraph V E} (T : G.EulerTour)
+    (hmin : ∀ v : V, 4 ≤ G.degree v) :
+    ∃ S : G.OrdinaryCircuitDecomposition, S.Compatible T := by
+  obtain ⟨S, hS⟩ := loop_sabidussi_compatibility T hmin
+  exact ⟨S.toOrdinary, CircuitDecomposition.compatible_toOrdinary G hS⟩
+
+end LoopMultigraph
+end Sabidussi

--- a/LeanPool/Sabidussi/Parity.lean
+++ b/LeanPool/Sabidussi/Parity.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2026 Nikolay Ulyanov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nikolay Ulyanov
+-/
+import LeanPool.Sabidussi.Color
+
+/-!
+# Parity algebra for the four-colour argument
+
+This file records the two finite characteristic-two calculations used after the local choices
+have been balanced: polarization of the quadratic form along an ordered word, and recovery of
+the parity of all four colour classes from its linear and quadratic moments.
+-/
+
+namespace Sabidussi
+
+open scoped BigOperators
+
+/-- The sum of the bracket over all ordered pairs of positions, each pair occurring with its
+smaller position second. -/
+def orderedPairBracket {n : ℕ} (f : Fin n → Color) : F₂ :=
+  ∑ i, ∑ j, if j < i then bracket (f i) (f j) else 0
+
+private theorem orderedPairBracket_inner_castSucc {n : ℕ} (f : Fin (n + 1) → Color)
+    (i : Fin n) :
+    (∑ j : Fin (n + 1),
+        if j < i.castSucc then bracket (f i.castSucc) (f j) else 0) =
+      ∑ j : Fin n, if j < i then bracket (f i.castSucc) (f j.castSucc) else 0 := by
+  rw [Fin.sum_univ_castSucc]
+  have hnlt : ¬ Fin.last n < i.castSucc := (Fin.castSucc_lt_last i).asymm
+  rw [if_neg hnlt, add_zero]
+  simp
+
+private theorem orderedPairBracket_inner_last {n : ℕ} (f : Fin (n + 1) → Color) :
+    (∑ j : Fin (n + 1),
+        if j < Fin.last n then bracket (f (Fin.last n)) (f j) else 0) =
+      ∑ j : Fin n, bracket (f j.castSucc) (f (Fin.last n)) := by
+  calc
+    _ = ∑ j : Fin n, bracket (f (Fin.last n)) (f j.castSucc) := by
+      rw [Fin.sum_univ_castSucc]
+      simp
+    _ = _ := by
+      apply Finset.sum_congr rfl
+      intro j _
+      exact bracket_comm _ _
+
+/-- Adding the last position adds precisely its brackets with all earlier positions. -/
+theorem orderedPairBracket_succ {n : ℕ} (f : Fin (n + 1) → Color) :
+    orderedPairBracket f =
+      orderedPairBracket (fun i : Fin n ↦ f i.castSucc) +
+        bracket (∑ i : Fin n, f i.castSucc) (f (Fin.last n)) := by
+  unfold orderedPairBracket
+  rw [Fin.sum_univ_castSucc]
+  congr 1
+  · apply Finset.sum_congr rfl
+    intro i _
+    exact orderedPairBracket_inner_castSucc f i
+  · rw [orderedPairBracket_inner_last]
+    let g : Color →+ F₂ :=
+      { toFun := fun x ↦ bracket x (f (Fin.last n))
+        map_zero' := bracket_zero_left _
+        map_add' := fun x y ↦ bracket_add_left x y _ }
+    change (∑ i : Fin n, g (f i.castSucc)) = g (∑ i : Fin n, f i.castSucc)
+    exact (map_sum g (fun i : Fin n ↦ f i.castSucc) Finset.univ).symm
+
+/-- Polarization of `quadratic` along a finite linearly ordered word. -/
+theorem quadratic_sum_fin : ∀ {n : ℕ} (f : Fin n → Color),
+    quadratic (∑ i, f i) = (∑ i, quadratic (f i)) + orderedPairBracket f
+  | 0, f => by simp [orderedPairBracket, quadratic]
+  | n + 1, f => by
+    rw [Fin.sum_univ_castSucc, quadratic_add,
+      quadratic_sum_fin (fun i : Fin n ↦ f i.castSucc), orderedPairBracket_succ,
+      Fin.sum_univ_castSucc]
+    abel
+
+/-- The positions carrying a specified colour. -/
+def colorFiber {I : Type*} [Fintype I] (f : I → Color) (c : Color) :
+    Finset I :=
+  Finset.univ.filter fun i ↦ f i = c
+
+theorem cast_colorFiber_card {I : Type*} [Fintype I]
+    (f : I → Color) (c : Color) :
+    ((colorFiber f c).card : F₂) = ∑ i, if f i = c then 1 else 0 := by
+  symm
+  simp [colorFiber]
+
+private theorem colorIndicator_eq_product (x c : Color) :
+    (if x = c then 1 else 0 : F₂) =
+      (1 + x.1 + c.1) * (1 + x.2 + c.2) := by
+  rcases x with ⟨a, b⟩
+  rcases c with ⟨u, v⟩
+  fin_cases a <;> fin_cases b <;> fin_cases u <;> fin_cases v <;> decide
+
+private theorem colorIndicator_eq_moments (x c : Color) :
+    (if x = c then 1 else 0 : F₂) =
+      (1 + c.1) * (1 + c.2) + (1 + c.2) * x.1 +
+        (1 + c.1) * x.2 + quadratic x := by
+  rw [colorIndicator_eq_product]
+  simp only [quadratic]
+  ring
+
+private def colorFstHom : Color →+ F₂ where
+  toFun := Prod.fst
+  map_zero' := rfl
+  map_add' := fun _ _ ↦ rfl
+
+private def colorSndHom : Color →+ F₂ where
+  toFun := Prod.snd
+  map_zero' := rfl
+  map_add' := fun _ _ ↦ rfl
+
+/-- In an even finite family of four colours, vanishing of the two linear moments and of the
+quadratic moment is equivalent to every colour occurring evenly.  This is the forward direction
+needed in the Sabidussi argument. -/
+theorem colorFiber_card_even_of_moments {I : Type*} [Fintype I]
+    (f : I → Color) (hcard : Even (Fintype.card I))
+    (hsum : ∑ i, f i = 0) (hquadratic : ∑ i, quadratic (f i) = 0) (c : Color) :
+    Even (colorFiber f c).card := by
+  have hfst : ∑ i, (f i).1 = 0 := by
+    calc
+      ∑ i, (f i).1 = colorFstHom (∑ i, f i) := by
+        simp [colorFstHom]
+      _ = 0 := by rw [hsum]; rfl
+  have hsnd : ∑ i, (f i).2 = 0 := by
+    calc
+      ∑ i, (f i).2 = colorSndHom (∑ i, f i) := by
+        simp [colorSndHom]
+      _ = 0 := by rw [hsum]; rfl
+  have hcardF₂ : (Fintype.card I : F₂) = 0 :=
+    ZMod.natCast_eq_zero_iff_even.mpr hcard
+  change ∑ i, (f i).1 * (f i).2 = 0 at hquadratic
+  apply ZMod.natCast_eq_zero_iff_even.mp
+  rw [cast_colorFiber_card]
+  simp_rw [colorIndicator_eq_moments]
+  simp only [Finset.sum_add_distrib]
+  rw [Finset.sum_const, nsmul_eq_mul, ← Finset.mul_sum, ← Finset.mul_sum]
+  simp [hcardF₂, hfst, hsnd, hquadratic]
+
+end Sabidussi

--- a/LeanPool/Sabidussi/Statement.lean
+++ b/LeanPool/Sabidussi/Statement.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 Nikolay Ulyanov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Nikolay Ulyanov
+-/
+import Mathlib.Data.Fin.Rev
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Finset.Prod
+import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Fintype.Prod
+import Mathlib.Data.Fintype.Sets
+import Mathlib.Logic.Equiv.Fin.Rotate
+import Mathlib.Logic.Relation
+
+/-!
+# Trusted statement layer for Sabidussi compatibility
+
+This module contains only the public data and predicates occurring in the headline theorem. It is
+the trusted import boundary for `leanprover/comparator`; proof modules build on it, but it does not
+import them.
+-/
+
+namespace Sabidussi
+
+/-- A finite labelled endpoint multigraph. Parallel edges and loops are allowed. -/
+structure LoopMultigraph (V E : Type*) [Fintype V] [Fintype E] where
+  /-- The two numbered endpoints of each labelled edge. -/
+  endAt : E → Fin 2 → V
+
+namespace LoopMultigraph
+
+variable {V E : Type*} [Fintype V] [Fintype E] [DecidableEq V]
+
+/-- A labelled edge together with one of its two numbered ends. -/
+abbrev HalfEdge (E : Type*) := E × Fin 2
+
+/-- The endpoint vertex of a half-edge. -/
+def vertex (G : LoopMultigraph V E) (h : HalfEdge E) : V := G.endAt h.1 h.2
+
+/-- Half-edges incident with a vertex. A loop contributes both of its numbered ends. -/
+def halfEdgesAt (G : LoopMultigraph V E) (v : V) :=
+  {h : HalfEdge E // G.vertex h = v}
+
+instance (G : LoopMultigraph V E) (v : V) : Fintype (G.halfEdgesAt v) :=
+  Subtype.fintype fun h : HalfEdge E ↦ G.vertex h = v
+
+/-- Degree counted in half-edge incidences. -/
+def degree (G : LoopMultigraph V E) (v : V) : ℕ :=
+  Fintype.card (G.halfEdgesAt v)
+
+variable {V E : Type*} [Fintype V] [Fintype E]
+
+/-- A nonempty closed Euler tour using every labelled edge exactly once. -/
+structure EulerTour (G : LoopMultigraph V E) where
+  /-- The edge positions are `Fin (n + 1)`. -/
+  n : ℕ
+  /-- Every edge object occurs at exactly one position. -/
+  edge : Fin (n + 1) ≃ E
+  /-- The end from which the edge at a position is traversed. -/
+  depart : Fin (n + 1) → Fin 2
+  /-- The arrival end at a position is the departure vertex at the next position. -/
+  continuous : ∀ i,
+    G.endAt (edge i) (Fin.rev (depart i)) =
+      G.endAt (edge (finRotate (n + 1) i)) (depart (finRotate (n + 1) i))
+
+namespace EulerTour
+
+variable [DecidableEq V] {G : LoopMultigraph V E} (T : G.EulerTour)
+
+/-- Positions in the cyclic edge word. -/
+abbrev Pos := Fin (T.n + 1)
+
+/-- The next edge position. -/
+def next (i : T.Pos) : T.Pos := finRotate (T.n + 1) i
+
+/-- The previous edge position. -/
+def prev (i : T.Pos) : T.Pos := (finRotate (T.n + 1)).symm i
+
+end EulerTour
+
+variable {V E : Type*} [Fintype V] [Fintype E] [DecidableEq V] [DecidableEq E]
+  (G : LoopMultigraph V E)
+
+/-- The ordinary natural-number degree of `v` in an edge set. Edge ends are counted, so this
+definition also has the standard behavior for multigraphs. -/
+def degreeIn (F : Finset E) (v : V) : ℕ :=
+  ((F ×ˢ (Finset.univ : Finset (Fin 2))).filter fun h ↦ G.endAt h.1 h.2 = v).card
+
+/-- Two labelled edges meet if some numbered end of one has the same endpoint as some numbered
+end of the other. An edge meets itself, and parallel edges meet at both endpoints. -/
+def EdgeAdjacent (e f : E) : Prop :=
+  ∃ i j : Fin 2, G.endAt e i = G.endAt f j
+
+/-- Edge-chain connectivity of a nonempty edge-supported subgraph. -/
+def EdgeConnected (F : Finset E) : Prop :=
+  ∃ root ∈ F, ∀ e ∈ F,
+    Relation.ReflTransGen
+      (fun x y : E ↦ x ∈ F ∧ y ∈ F ∧ G.EdgeAdjacent x y) root e
+
+/-- The vertices incident with at least one edge of `F`. -/
+def edgeSupport (F : Finset E) : Finset V :=
+  Finset.univ.filter fun v ↦ ∃ e ∈ F, ∃ i : Fin 2, G.endAt e i = v
+
+/-- An ordinary circuit: a nonempty connected edge-supported subgraph in which every supported
+vertex has degree two. -/
+structure OrdinaryCircuit where
+  /-- The edges of the circuit. -/
+  edges : Finset E
+  /-- An ordinary circuit is nonempty. -/
+  nonempty : edges.Nonempty
+  /-- The circuit is edge-connected. -/
+  connected : G.EdgeConnected edges
+  /-- Every supported vertex has ordinary degree two. -/
+  twoRegular : ∀ v : V, v ∈ G.edgeSupport edges → G.degreeIn edges v = 2
+
+/-- A partition of all labelled edges into ordinary connected 2-regular circuits. -/
+structure OrdinaryCircuitDecomposition where
+  /-- The list of ordinary circuits partitioning the edges. -/
+  circuits : List G.OrdinaryCircuit
+  /-- Every labelled edge lies in exactly one circuit. -/
+  coveredOnce : ∀ e : E, (circuits.filter fun C ↦ e ∈ C.edges).length = 1
+
+/-- Compatibility stated for ordinary circuits. -/
+def OrdinaryCircuitDecomposition.Compatible {G : LoopMultigraph V E}
+    (S : G.OrdinaryCircuitDecomposition) (T : G.EulerTour) : Prop :=
+  ∀ (i : T.Pos) (C : G.OrdinaryCircuit), C ∈ S.circuits →
+    ¬ (T.edge (T.prev i) ∈ C.edges ∧ T.edge i ∈ C.edges)
+
+end LoopMultigraph
+end Sabidussi

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -4638,3 +4638,46 @@ projects:
       - "11R06"
       - "11C08"
       - "20F55"
+  - slug: sabidussi
+    title: "Sabidussi's compatibility conjecture for Eulerian multigraphs"
+    summary: >-
+      Formalizes Sabidussi's compatibility conjecture for finite labelled endpoint multigraphs
+      with loops and parallel edges, where a loop contributes two half-edge incidences to the
+      degree of its vertex. Given an Euler tour and minimum degree at least four, the main theorem
+      constructs a partition of all edges into nonempty, edge-connected, 2-regular ordinary
+      circuits such that consecutive edges of the Euler tour never lie in the same circuit. The
+      proof runs a four-colour (F_2^2) algebra over the cyclic transition word, uses an odd
+      balancing parity lemma to choose compatible local frames, and transports the resulting
+      colouring back to a compatible ordinary circuit decomposition.
+    branch: graph theory
+    entry_module: LeanPool.Sabidussi
+    authors:
+      - Nikolay Ulyanov
+    source:
+      title: "Graph Puzzles III.1: A proof of Sabidussi's compatibility conjecture"
+      authors:
+        - Nikolay Ulyanov
+      url: "https://github.com/gexahedron/sabidussi-lean/blob/032e640df0cc41d4d3d217f7c68628ab19cb3767/sabidussi_proof.pdf"
+      github_repo: gexahedron/sabidussi-lean
+    license: Apache-2.0
+    status: verified
+    provenance: AI
+    main_declarations:
+      - Sabidussi.LoopMultigraph.loop_sabidussi_compatibility_ordinary
+    main_results:
+      - declaration: Sabidussi.LoopMultigraph.loop_sabidussi_compatibility_ordinary
+        informal: >-
+          For any finite endpoint multigraph with an Euler tour and minimum degree at least four,
+          the edges partition into ordinary, nonempty, connected, 2-regular circuits that are
+          compatible with the tour: no circuit contains two consecutive tour edges.
+      - declaration: Sabidussi.LoopMultigraph.loop_sabidussi_compatibility
+        informal: >-
+          The same compatibility statement phrased with the intrinsic even-edge-set circuit
+          decomposition, from which the ordinary-circuit form is derived.
+    tags:
+      - graph-theory
+      - eulerian-graphs
+      - circuit-decomposition
+      - sabidussi
+    msc:
+      - "05C45"


### PR DESCRIPTION
## What this proves

Imports [`gexahedron/sabidussi-lean`](https://github.com/gexahedron/sabidussi-lean), a Lean 4 formalization of **Sabidussi's compatibility conjecture** for finite labelled endpoint multigraphs. Loops and parallel edges are allowed, and a loop contributes two half-edge incidences to the degree of its vertex.

The public endpoint is

```lean
Sabidussi.LoopMultigraph.loop_sabidussi_compatibility_ordinary
```

Given an Euler tour `T` of the multigraph and the hypothesis that every vertex has degree at least four, it constructs a partition of all edges into **ordinary circuits** — each nonempty, edge-connected, and 2-regular on its support — such that consecutive edges of the Euler tour never lie in the same circuit. The proof runs a four-colour (`F₂²`) algebra over the cyclic transition word, uses an odd balancing parity lemma to select compatible local frames, and transports the colouring back to a compatible ordinary circuit decomposition.

## Provenance

**AI.** The bundled manuscript (`sabidussi_proof.pdf`) and the repository's `formalization.yaml` record that the mathematical proof is "entirely due to GPT 5.6 Pro" and the writeup was prepared with Codex (GPT 5.6 Sol); the project ships an OpenAI Comparator one-shot verification harness. The card is registered with `provenance: AI`.

## Author / licensing

- Upstream author: **Nikolay Ulyanov** (GitHub [@gexahedron](https://github.com/gexahedron), ulyanick@gmail.com).
- The author agreed to inclusion by email (2026-07-19) and added the Apache-2.0 license for this import.
- Upstream repo: `gexahedron/sabidussi-lean`, vendored at commit `da2f6ff7a7c7cc04e9ad34a53c3b6b8a18bd9ffa` (branch `main`).

## Import / port notes

- Vendored the proven library (`Sabidussi/` tree) as `LeanPool/Sabidussi/**` with entry module `LeanPool/Sabidussi.lean`; re-rooted `import Sabidussi.X` → `import LeanPool.Sabidussi.X`. The comparator scaffolding (`Challenge.lean`, `Solution.lean`, `Audit.lean`, `comparator/`) was **not** vendored — `Challenge.lean` contains a `sorry` placeholder by design, and the headline theorem lives in the library itself.
- Ported Lean **v4.31.0 → v4.32.0-rc1**. Main fixes: added the specific-import block lost when replacing `import Mathlib` / `import Mathlib.Tactic` (notably `Mathlib.Algebra.Field.ZMod`, without which the `ZMod 2` field / `finrank` lemmas hit a `whnf` heartbeat timeout); silenced the strict pool linters (`unusedSectionVars`, `unusedDecidableInType`, `unusedFintypeInType`) via `omit … in` and, where a proof genuinely needs finiteness, `[Finite V]` + `Fintype.ofFinite`; focused the extra `Fintype`-instance goal that v4.32 `Finset.prod_subtype` now leaves; docstrings, `simpNF` / `unusedArguments` / `unnecessarySimpa` cleanups.
- A per-declaration name diff (upstream vs vendored, filtering `inst*`) shows **no dropped or renamed declarations**.

## Gates (all green locally)

- `lake build LeanPool.Sabidussi` — 0 warnings
- `lake exe runLinter LeanPool.Sabidussi` — passed
- `lake exe lint-style LeanPool.Sabidussi` — passed
- `lake exe mk_all --check` — passed
- `lean_pool.quality` — passed (Sabidussi card)
- `#print axioms` on `loop_sabidussi_compatibility_ordinary` and `loop_sabidussi_compatibility` → `{propext, Classical.choice, Quot.sound}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDRfjJLhVEoZ9WQaYwGUgC
