### PR TITLE
Add LehmerE10: Lehmer's polynomial and the E10 Coxeter element

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -1474,6 +1474,17 @@ import LeanPool.LeanQuantumAlg.Util.FinPow
 import LeanPool.LeanQuantumAlg.Util.HilbertSchmidt
 import LeanPool.LeanQuantumAlg.Util.Polynomial
 import LeanPool.LeanQuantumAlg.Util.TrigPolynomial
+import LeanPool.LehmerE10
+import LeanPool.LehmerE10.CoxeterE8
+import LeanPool.LehmerE10.CyclotomicKill
+import LeanPool.LehmerE10.Defs
+import LeanPool.LehmerE10.Ergodic
+import LeanPool.LehmerE10.Kronecker
+import LeanPool.LehmerE10.Mahler
+import LeanPool.LehmerE10.Main
+import LeanPool.LehmerE10.SalemSymmetry
+import LeanPool.LehmerE10.TraceQuintic
+import LeanPool.LehmerE10.UnitCircleFactors
 import LeanPool.Lentil
 import LeanPool.Lentil.Basic
 import LeanPool.Lentil.Expr

--- a/LeanPool/LehmerE10.lean
+++ b/LeanPool/LehmerE10.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2026 Dillon Ryan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dillon Ryan
+-/
+
+import LeanPool.LehmerE10.Defs
+import LeanPool.LehmerE10.Main
+
+/-!
+# Lehmer's polynomial and the E10 Coxeter element
+
+The root module: `LehmerE10.main_theorem` — Lehmer's polynomial is
+irreducible over ℤ, and it is the characteristic polynomial of a Coxeter
+element of the E₁₀ Weyl group.
+-/
+
+namespace LehmerE10
+
+/-- **The claim.**  (i) Lehmer's polynomial is irreducible over ℤ, and (ii) the
+characteristic polynomial of a Coxeter element of the E₁₀ Weyl group is Lehmer's
+polynomial (McMullen, *Coxeter groups, Salem numbers and the Hilbert metric*,
+Publ. Math. IHÉS 95, 2002). -/
+theorem main_theorem :
+    Irreducible lehmerPolynomial ∧ coxeterE10.charpoly = lehmerPolynomial :=
+  ⟨lehmer_irreducible, coxeter_charpoly_lehmer⟩
+
+#print axioms main_theorem
+
+end LehmerE10

--- a/LeanPool/LehmerE10.lean
+++ b/LeanPool/LehmerE10.lean
@@ -8,6 +8,17 @@ import LeanPool.LehmerE10.Defs
 import LeanPool.LehmerE10.Main
 
 /-!
+# Lehmer's Polynomial and the E10 Coxeter Element
+
+Source: url:https://github.com/dillon-11/lehmer-E10
+Authors: Dillon Ryan
+Status: verified
+Main declarations: `LehmerE10.main_theorem`
+Tags: number-theory, mahler-measure, salem-numbers, coxeter-groups
+MSC: 11R06, 11C08, 20F55
+-/
+
+/-!
 # Lehmer's polynomial and the E10 Coxeter element
 
 The root module: `LehmerE10.main_theorem` — Lehmer's polynomial is
@@ -24,7 +35,5 @@ Publ. Math. IHÉS 95, 2002). -/
 theorem main_theorem :
     Irreducible lehmerPolynomial ∧ coxeterE10.charpoly = lehmerPolynomial :=
   ⟨lehmer_irreducible, coxeter_charpoly_lehmer⟩
-
-#print axioms main_theorem
 
 end LehmerE10

--- a/LeanPool/LehmerE10/CoxeterE8.lean
+++ b/LeanPool/LehmerE10/CoxeterE8.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 Dillon Ryan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dillon Ryan
+-/
+
+import LeanPool.LehmerE10.Defs
+import LeanPool.LehmerE10.Mahler
+import Mathlib.GroupTheory.OrderOfElement
+
+/-!
+# the finite contrast: the E₈ Coxeter element has order 30.
+The E-series Coxeter elements cross a phase boundary at rank 10.  For the *finite* root
+system E₈ the Coxeter element is torsion — its order is the Coxeter number `h = 30`, and
+its spectrum consists of the primitive 30th roots of unity (the exponents of E₈ are
+exactly the totatives of 30).  Two ranks later, at the hyperbolic E₁₀, the Coxeter
+element is a Salem matrix of infinite order (`coxeterE10_infinite_order`) whose spectral
+radius is Lehmer's number.
+This file pins the finite side by kernel computation, in the same simple-reflection
+convention as `Defs.lean`:
+* `coxeterE8_pow_thirty` : `coxeterE8 ^ 30 = 1`;
+* `orderOf_coxeterE8` : the order is exactly `30` (no proper power at `30/2, 30/3, 30/5`
+  is the identity).
+So the pair (E₈, E₁₀) realizes both sides of Kronecker's dichotomy for integer matrices:
+spectrum on the unit circle ⟹ roots of unity ⟹ finite order, versus one eigenvalue off
+the circle ⟹ infinite order — with Lehmer's number as the first exit.
+-/
+
+open Matrix
+
+namespace LehmerE10
+
+/-- The Cartan matrix of **E₈**: nodes `0–6` form an A₇ chain and node `7` is attached to
+node `2` — the same labelling convention as `cartanE10`, truncated to the finite diagram
+(arm lengths `2, 1, 4` off the branch node `2`). -/
+def cartanE8 : Matrix (Fin 8) (Fin 8) ℤ :=
+  !![ 2, -1,  0,  0,  0,  0,  0,  0;
+     -1,  2, -1,  0,  0,  0,  0,  0;
+      0, -1,  2, -1,  0,  0,  0, -1;
+      0,  0, -1,  2, -1,  0,  0,  0;
+      0,  0,  0, -1,  2, -1,  0,  0;
+      0,  0,  0,  0, -1,  2, -1,  0;
+      0,  0,  0,  0,  0, -1,  2,  0;
+      0,  0, -1,  0,  0,  0,  0,  2]
+
+/-- The simple reflection `sᵢ` of the E₈ Weyl group on the root lattice:
+`(sᵢ)ⱼₖ = δⱼₖ − δⱼᵢ aᵢₖ`. -/
+def simpleReflectionE8 (i : Fin 8) : Matrix (Fin 8) (Fin 8) ℤ :=
+  Matrix.of fun j k => (if j = k then 1 else 0) - (if j = i then cartanE8 i k else 0)
+
+/-- A Coxeter element of the E₈ Weyl group: the product `s₀ s₁ ⋯ s₇`. -/
+def coxeterE8 : Matrix (Fin 8) (Fin 8) ℤ :=
+  ((List.finRange 8).map simpleReflectionE8).prod
+
+/-- The Coxeter element `s₀ s₁ ⋯ s₇`, evaluated (kernel computation below). -/
+def coxeterE8Mat : Matrix (Fin 8) (Fin 8) ℤ :=
+  !![ 0, 0, 1, 0, 0, 0, -1, -1;
+      1, 0, 1, 0, 0, 0, -1, -1;
+      0, 1, 1, 0, 0, 0, -1, -1;
+      0, 0, 1, 0, 0, 0, -1,  0;
+      0, 0, 0, 1, 0, 0, -1,  0;
+      0, 0, 0, 0, 1, 0, -1,  0;
+      0, 0, 0, 0, 0, 1, -1,  0;
+      0, 0, 1, 0, 0, 0,  0, -1]
+
+theorem coxeterE8_eq : coxeterE8 = coxeterE8Mat := by decide
+
+/-- `coxeterE8 ^ 30 = 1`: the E₈ Coxeter element is torsion, of order dividing the
+Coxeter number `h = 30`.  Kernel computation, staged as `((c⁵)³)²`. -/
+theorem coxeterE8_pow_thirty : coxeterE8 ^ 30 = 1 := by
+  rw [coxeterE8_eq, show (30 : ℕ) = 5 * 3 * 2 from by norm_num, pow_mul, pow_mul]
+  decide
+
+/-- **The order of the E₈ Coxeter element is exactly the Coxeter number 30**: the powers
+`30/2 = 15`, `30/3 = 10`, `30/5 = 6` are not the identity (kernel computations), so no
+proper divisor of `30` kills it. -/
+theorem orderOf_coxeterE8 : orderOf coxeterE8 = 30 := by
+  refine orderOf_eq_of_pow_and_pow_div_prime (by norm_num) coxeterE8_pow_thirty ?_
+  intro p hp hdvd
+  have h2p : 2 ≤ p := hp.two_le
+  have hle : p ≤ 30 := Nat.le_of_dvd (by norm_num) hdvd
+  interval_cases p <;>
+    first
+      | (rw [coxeterE8_eq, show (30 : ℕ) / 2 = 5 * 3 from by norm_num, pow_mul]; decide)
+      | (rw [coxeterE8_eq, show (30 : ℕ) / 3 = 5 * 2 from by norm_num, pow_mul]; decide)
+      | (rw [coxeterE8_eq, show (30 : ℕ) / 5 = 3 * 2 from by norm_num, pow_mul]; decide)
+      | exact absurd hdvd (by decide)
+      | exact absurd hp (by decide)
+
+end LehmerE10
+
+#print axioms LehmerE10.coxeterE8_pow_thirty
+#print axioms LehmerE10.orderOf_coxeterE8

--- a/LeanPool/LehmerE10/CoxeterE8.lean
+++ b/LeanPool/LehmerE10/CoxeterE8.lean
@@ -88,6 +88,3 @@ theorem orderOf_coxeterE8 : orderOf coxeterE8 = 30 := by
       | exact absurd hp (by decide)
 
 end LehmerE10
-
-#print axioms LehmerE10.coxeterE8_pow_thirty
-#print axioms LehmerE10.orderOf_coxeterE8

--- a/LeanPool/LehmerE10/CyclotomicKill.lean
+++ b/LeanPool/LehmerE10/CyclotomicKill.lean
@@ -32,7 +32,6 @@ open Polynomial
 
 instance : Fact (Nat.Prime 1291) := ⟨witness_1291_prime⟩
 
-set_option maxRecDepth 40000 in
 /-- 2 has order exactly 1290 = 2·3·5·43 in (ℤ/1291)ˣ — certified by Fermat plus the
     four maximal-divisor refusals (kernel bignum arithmetic). -/
 theorem orderOf_two_mod_1291 : orderOf (2 : ZMod 1291) = 1290 := by
@@ -58,10 +57,10 @@ theorem orderOf_two_mod_1291 : orderOf (2 : ZMod 1291) = 1290 := by
       · exact Or.inr (Or.inr (Or.inl ((Nat.prime_dvd_prime_iff_eq hp (by norm_num)).mp h)))
       · exact Or.inr (Or.inr (Or.inr ((Nat.prime_dvd_prime_iff_eq hp (by norm_num)).mp h)))
     rcases hcase with rfl | rfl | rfl | rfl
-    · decide  -- p = 2 : 2^645 ≠ 1
-    · decide  -- p = 3 : 2^430 ≠ 1
-    · decide  -- p = 5 : 2^258 ≠ 1
-    · decide  -- p = 43 : 2^30 ≠ 1
+    · decide +kernel  -- p = 2 : 2^645 ≠ 1
+    · decide +kernel  -- p = 3 : 2^430 ≠ 1
+    · decide +kernel  -- p = 5 : 2^258 ≠ 1
+    · decide +kernel  -- p = 43 : 2^30 ≠ 1
 
 /-! ### LEG (a): the uniform cyclotomic kill. -/
 
@@ -111,8 +110,7 @@ theorem no_cyclotomic_divisor {k : ℕ} (hk : 1 ≤ k) :
   -- totient divisibility: 336 = φ(1290) ∣ φ(k) ≤ 10
   have h336 : (336 : ℕ) ∣ k.totient := by
     have := Nat.totient_dvd_of_dvd hord
-    rwa [show Nat.totient 1290 = 336 from by
-      set_option maxRecDepth 40000 in decide] at this
+    rwa [show Nat.totient 1290 = 336 from by decide +kernel] at this
   have hpos : 0 < k.totient := Nat.totient_pos.mpr (by omega)
   have := Nat.le_of_dvd hpos h336
   omega

--- a/LeanPool/LehmerE10/CyclotomicKill.lean
+++ b/LeanPool/LehmerE10/CyclotomicKill.lean
@@ -162,14 +162,14 @@ theorem charpoly_eq_lehmer_of_irreducible {M : Matrix (Fin 10) (Fin 10) ℤ}
       rw [hLg, ← hlead, Polynomial.C_1, mul_one]
   -- charpoly: monic, degree 10, divisible by the degree-10 monic minpoly ⟹ equal
   have hchdeg : Cq.charpoly.natDegree = 10 := by
-    simpa using Cq.charpoly_natDegree_eq_dim
+    simp
   have hchmonic : Cq.charpoly.Monic := Cq.charpoly_monic
   have hdvd : Lq ∣ Cq.charpoly := hmin_eq ▸ hminC
   obtain ⟨u, hu⟩ := hdvd
   have hudeg : u.natDegree = 0 := by
     have h0 : Cq.charpoly ≠ 0 := hchmonic.ne_zero
     have := congrArg Polynomial.natDegree hu
-    rw [Polynomial.natDegree_mul hLmonic.ne_zero (by rintro rfl; simp at hu; exact h0 hu),
+    rw [Polynomial.natDegree_mul hLmonic.ne_zero (by rintro rfl; rw [mul_zero] at hu; exact h0 hu),
       hchdeg, hLdeg] at this
     omega
   have hulead : u.leadingCoeff = 1 := by

--- a/LeanPool/LehmerE10/CyclotomicKill.lean
+++ b/LeanPool/LehmerE10/CyclotomicKill.lean
@@ -21,7 +21,7 @@ argument, using that 2 is a primitive root mod `1291 = L(2)` (order 1290):
 `charpoly_eq_lehmer_of_irreducible`: if `L` is irreducible over ℚ, then any 10×10
 integer matrix annihilated by `L` has characteristic polynomial `L` (over ℚ), via
 Cayley–Hamilton + minimal-polynomial divisibility + degree count.
-No `sorry`; no axioms beyond `propext`, `Classical.choice`, `Quot.sound`.
+Axiom footprint: `propext`, `Classical.choice`, `Quot.sound` only.
 -/
 
 namespace LehmerE10

--- a/LeanPool/LehmerE10/CyclotomicKill.lean
+++ b/LeanPool/LehmerE10/CyclotomicKill.lean
@@ -1,0 +1,187 @@
+/-
+Copyright (c) 2026 Dillon Ryan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dillon Ryan
+-/
+
+import LeanPool.LehmerE10.Kronecker
+import Mathlib.RingTheory.Polynomial.Cyclotomic.Eval
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Basic
+import Mathlib.FieldTheory.Minpoly.Field
+
+/-!
+# no cyclotomic polynomial divides Lehmer's polynomial, and the
+characteristic-polynomial identity conditional on irreducibility.
+`no_cyclotomic_divisor`: no cyclotomic polynomial divides `L`.  One uniform
+argument, using that 2 is a primitive root mod `1291 = L(2)` (order 1290):
+  Φ_k ∣ L  ⟹  Φ_k(2) ∣ L(2) = 1291 (prime), and |Φ_k(2)| ≥ 2 (Mathlib's
+  `sub_one_lt_natAbs_cyclotomic_eval`)  ⟹  |Φ_k(2)| = 1291  ⟹  1291 ∣ 2^k − 1
+  ⟹  1290 = ord₁₂₉₁(2) ∣ k  ⟹  336 = φ(1290) ∣ φ(k)  (`totient_dvd_of_dvd`)
+  — but Φ_k ∣ L forces φ(k) = deg Φ_k ≤ 10.  Contradiction.  (k = 1: L(1) = −1.)
+`charpoly_eq_lehmer_of_irreducible`: if `L` is irreducible over ℚ, then any 10×10
+integer matrix annihilated by `L` has characteristic polynomial `L` (over ℚ), via
+Cayley–Hamilton + minimal-polynomial divisibility + degree count.
+No `sorry`; no axioms beyond `propext`, `Classical.choice`, `Quot.sound`.
+-/
+
+namespace LehmerE10
+
+open Polynomial
+
+/-! ### The primitive-root certificate: ord₁₂₉₁(2) = 1290. -/
+
+instance : Fact (Nat.Prime 1291) := ⟨witness_1291_prime⟩
+
+set_option maxRecDepth 40000 in
+/-- 2 has order exactly 1290 = 2·3·5·43 in (ℤ/1291)ˣ — certified by Fermat plus the
+    four maximal-divisor refusals (kernel bignum arithmetic). -/
+theorem orderOf_two_mod_1291 : orderOf (2 : ZMod 1291) = 1290 := by
+  apply orderOf_eq_of_pow_and_pow_div_prime (by norm_num)
+  · have h := ZMod.pow_card_sub_one_eq_one (p := 1291) (a := 2) (by decide)
+    simpa using h
+  · intro p hp hdvd
+    -- p prime ∣ 1290 = 2·3·5·43 ⟹ p ∈ {2,3,5,43}, by the prime-divisor chain
+    have hc1 : p = 2 ∨ p ∣ 645 := by
+      rcases (Nat.Prime.dvd_mul hp).mp (show p ∣ 2 * 645 from hdvd) with h | h
+      · exact Or.inl ((Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp h)
+      · exact Or.inr h
+    have hcase : p = 2 ∨ p = 3 ∨ p = 5 ∨ p = 43 := by
+      rcases hc1 with h | h645
+      · exact Or.inl h
+      have hc2 : p = 3 ∨ p ∣ 215 := by
+        rcases (Nat.Prime.dvd_mul hp).mp (show p ∣ 3 * 215 from h645) with h | h
+        · exact Or.inl ((Nat.prime_dvd_prime_iff_eq hp (by norm_num)).mp h)
+        · exact Or.inr h
+      rcases hc2 with h | h215
+      · exact Or.inr (Or.inl h)
+      rcases (Nat.Prime.dvd_mul hp).mp (show p ∣ 5 * 43 from h215) with h | h
+      · exact Or.inr (Or.inr (Or.inl ((Nat.prime_dvd_prime_iff_eq hp (by norm_num)).mp h)))
+      · exact Or.inr (Or.inr (Or.inr ((Nat.prime_dvd_prime_iff_eq hp (by norm_num)).mp h)))
+    rcases hcase with rfl | rfl | rfl | rfl
+    · decide  -- p = 2 : 2^645 ≠ 1
+    · decide  -- p = 3 : 2^430 ≠ 1
+    · decide  -- p = 5 : 2^258 ≠ 1
+    · decide  -- p = 43 : 2^30 ≠ 1
+
+/-! ### LEG (a): the uniform cyclotomic kill. -/
+
+/-- **NO CYCLOTOMIC DIVIDES LEHMER (proven)** — the uniform 1291 argument. -/
+theorem no_cyclotomic_divisor {k : ℕ} (hk : 1 ≤ k) :
+    ¬ (cyclotomic k ℤ ∣ lehmerPolynomial) := by
+  intro hdvd
+  rcases Nat.eq_or_lt_of_le hk with h1 | h2
+  · -- k = 1 : X − 1 ∣ L would force L(1) = 0, but L(1) = −1
+    have : (cyclotomic 1 ℤ).eval 1 ∣ lehmerPolynomial.eval 1 := eval_dvd (h1 ▸ hdvd)
+    rw [cyclotomic_one, lehmer_eval_one] at this
+    simp at this
+  -- k ≥ 2
+  have hφ10 : k.totient ≤ 10 := by
+    have := Polynomial.natDegree_le_of_dvd hdvd lehmerPolynomial_ne_zero
+    rwa [natDegree_cyclotomic, lehmerPolynomial_natDegree] at this
+  -- Φ_k(2) divides the prime 1291 and exceeds 1 in absolute value
+  have hdvd1291 : (cyclotomic k ℤ).eval 2 ∣ 1291 := by
+    have := eval_dvd (x := (2 : ℤ)) hdvd
+    rwa [lehmer_eval_two] at this
+  have hgt1 : 1 < ((cyclotomic k ℤ).eval 2).natAbs := by
+    have h := Polynomial.sub_one_lt_natAbs_cyclotomic_eval (n := k) (q := 2) h2 (by norm_num)
+    simpa using h
+  have habs : ((cyclotomic k ℤ).eval 2).natAbs = 1291 := by
+    have hdvdN : ((cyclotomic k ℤ).eval 2).natAbs ∣ 1291 := by
+      have := Int.natAbs_dvd_natAbs.mpr hdvd1291
+      simpa using this
+    rcases (Nat.Prime.eq_one_or_self_of_dvd witness_1291_prime _ hdvdN) with h | h
+    · omega
+    · exact h
+  -- hence 1291 ∣ 2^k − 1
+  have hdvd2k : (1291 : ℤ) ∣ 2 ^ k - 1 := by
+    have hΦdvd : (cyclotomic k ℤ).eval 2 ∣ (2 : ℤ) ^ k - 1 := by
+      have := eval_dvd (x := (2 : ℤ)) (cyclotomic.dvd_X_pow_sub_one k ℤ)
+      simpa using this
+    have := Int.natAbs_dvd.mpr hΦdvd
+    rwa [habs] at this
+  -- pass to ZMod 1291: 2^k = 1, so 1290 ∣ k
+  have hzmod : (2 : ZMod 1291) ^ k = 1 := by
+    have h0 : ((2 ^ k - 1 : ℤ) : ZMod 1291) = 0 :=
+      (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mpr hdvd2k
+    push_cast at h0
+    linear_combination h0
+  have hord : (1290 : ℕ) ∣ k := by
+    have := orderOf_dvd_of_pow_eq_one hzmod
+    rwa [orderOf_two_mod_1291] at this
+  -- totient divisibility: 336 = φ(1290) ∣ φ(k) ≤ 10
+  have h336 : (336 : ℕ) ∣ k.totient := by
+    have := Nat.totient_dvd_of_dvd hord
+    rwa [show Nat.totient 1290 = 336 from by
+      set_option maxRecDepth 40000 in decide] at this
+  have hpos : 0 < k.totient := Nat.totient_pos.mpr (by omega)
+  have := Nat.le_of_dvd hpos h336
+  omega
+
+/-! ### The charpoly identity, conditional on irreducibility. -/
+
+/-- If Lehmer's polynomial is irreducible over ℚ, then any 10×10 integer matrix it
+    annihilates has characteristic polynomial `L` over ℚ.
+    (Cayley–Hamilton gives minpoly ∣ charpoly; annihilation gives minpoly ∣ L;
+    irreducibility forces minpoly = L; degree 10 monic on both sides closes it.) -/
+theorem charpoly_eq_lehmer_of_irreducible {M : Matrix (Fin 10) (Fin 10) ℤ}
+    (hann : (Polynomial.aeval M) lehmerPolynomial = 0)
+    (hirr : Irreducible (lehmerPolynomial.map (Int.castRingHom ℚ))) :
+    (M.map (Int.castRingHom ℚ)).charpoly =
+      lehmerPolynomial.map (Int.castRingHom ℚ) := by
+  set Cq := M.map (Int.castRingHom ℚ) with hCq
+  set Lq := lehmerPolynomial.map (Int.castRingHom ℚ) with hLq
+  have hLmonic : Lq.Monic := lehmerPolynomial_monic.map _
+  have hLdeg : Lq.natDegree = 10 := by
+    rw [hLq, lehmerPolynomial_monic.natDegree_map]; exact lehmerPolynomial_natDegree
+  -- the annihilation over ℚ, by pushing the entry-cast ring hom through eval₂
+  have hannQ : (Polynomial.aeval Cq) Lq = 0 := by
+    have h2 := congrArg (RingHom.mapMatrix (Int.castRingHom ℚ)
+      (m := Fin 10)) hann
+    rw [map_zero, aeval_def, Polynomial.hom_eval₂] at h2
+    rw [hLq, aeval_def, Polynomial.eval₂_map]
+    have hcomp : ((RingHom.mapMatrix (Int.castRingHom ℚ) (m := Fin 10)).comp
+        (algebraMap ℤ (Matrix (Fin 10) (Fin 10) ℤ))) =
+        ((algebraMap ℚ (Matrix (Fin 10) (Fin 10) ℚ)).comp (Int.castRingHom ℚ)) :=
+      RingHom.ext_int _ _
+    rw [hcomp] at h2
+    exact h2
+  -- minpoly divides both L and charpoly
+  have hminL : minpoly ℚ Cq ∣ Lq := minpoly.dvd ℚ Cq hannQ
+  have hminC : minpoly ℚ Cq ∣ Cq.charpoly := Cq.minpoly_dvd_charpoly
+  -- irreducibility: minpoly = L (both monic, minpoly nonunit divisor)
+  have hint : IsIntegral ℚ Cq := Matrix.isIntegral Cq
+  have hmin_eq : minpoly ℚ Cq = Lq := by
+    obtain ⟨g, hg⟩ := hminL
+    rcases hirr.isUnit_or_isUnit hg with h | h
+    · exact absurd h (minpoly.not_isUnit ℚ Cq)
+    · obtain ⟨c, hcu, hc⟩ := Polynomial.isUnit_iff.mp h
+      have hLg : Lq = minpoly ℚ Cq * Polynomial.C c := by rw [hg, hc]
+      have hlead := congrArg Polynomial.leadingCoeff hLg
+      rw [Polynomial.leadingCoeff_mul, Polynomial.leadingCoeff_C,
+        (minpoly.monic hint).leadingCoeff, one_mul, hLmonic.leadingCoeff] at hlead
+      rw [hLg, ← hlead, Polynomial.C_1, mul_one]
+  -- charpoly: monic, degree 10, divisible by the degree-10 monic minpoly ⟹ equal
+  have hchdeg : Cq.charpoly.natDegree = 10 := by
+    simpa using Cq.charpoly_natDegree_eq_dim
+  have hchmonic : Cq.charpoly.Monic := Cq.charpoly_monic
+  have hdvd : Lq ∣ Cq.charpoly := hmin_eq ▸ hminC
+  obtain ⟨u, hu⟩ := hdvd
+  have hudeg : u.natDegree = 0 := by
+    have h0 : Cq.charpoly ≠ 0 := hchmonic.ne_zero
+    have := congrArg Polynomial.natDegree hu
+    rw [Polynomial.natDegree_mul hLmonic.ne_zero (by rintro rfl; simp at hu; exact h0 hu),
+      hchdeg, hLdeg] at this
+    omega
+  have hulead : u.leadingCoeff = 1 := by
+    have := congrArg Polynomial.leadingCoeff hu
+    rwa [Polynomial.leadingCoeff_mul, hLmonic.leadingCoeff, hchmonic.leadingCoeff,
+      one_mul, eq_comm] at this
+  have hu1 : u = 1 := by
+    have := Polynomial.eq_C_of_natDegree_eq_zero hudeg
+    rw [this]
+    rw [this, Polynomial.leadingCoeff_C] at hulead
+    rw [hulead, Polynomial.C_1]
+  rw [hu, hu1, mul_one]
+
+
+end LehmerE10

--- a/LeanPool/LehmerE10/Defs.lean
+++ b/LeanPool/LehmerE10/Defs.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 Dillon Ryan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dillon Ryan
+-/
+
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Basic
+import Mathlib.LinearAlgebra.Matrix.Notation
+
+/-!
+# the objects of the claim.
+This file is intentionally byte-identical (after the header) to the definitions in
+`Challenge.lean`: it defines Lehmer's polynomial, the generalized Cartan matrix of
+the hyperbolic Kac–Moody root system E₁₀, its simple reflections acting on the root
+lattice in the basis of simple roots, and a Coxeter element as the product of the
+ten simple reflections.
+-/
+
+open Polynomial
+
+/-- **Lehmer's polynomial** (Lehmer, 1933):
+`x¹⁰ + x⁹ − x⁷ − x⁶ − x⁵ − x⁴ − x³ + x + 1`.
+Its Mahler measure `λ ≈ 1.17628` is the smallest known Mahler measure `> 1` of an
+integer polynomial. -/
+noncomputable def lehmerPolynomial : Polynomial ℤ :=
+  X ^ 10 + X ^ 9 - X ^ 7 - X ^ 6 - X ^ 5 - X ^ 4 - X ^ 3 + X + 1
+
+/-- The generalized Cartan matrix of the rank-10 hyperbolic Kac–Moody root system
+**E₁₀**: nodes `0–8` form an A₉ chain and node `9` is attached to node `2`
+(Bourbaki-style E-series labelling, extended once more past E₉ = E₈⁽¹⁾). -/
+def cartanE10 : Matrix (Fin 10) (Fin 10) ℤ :=
+  !![ 2, -1,  0,  0,  0,  0,  0,  0,  0,  0;
+     -1,  2, -1,  0,  0,  0,  0,  0,  0,  0;
+      0, -1,  2, -1,  0,  0,  0,  0,  0, -1;
+      0,  0, -1,  2, -1,  0,  0,  0,  0,  0;
+      0,  0,  0, -1,  2, -1,  0,  0,  0,  0;
+      0,  0,  0,  0, -1,  2, -1,  0,  0,  0;
+      0,  0,  0,  0,  0, -1,  2, -1,  0,  0;
+      0,  0,  0,  0,  0,  0, -1,  2, -1,  0;
+      0,  0,  0,  0,  0,  0,  0, -1,  2,  0;
+      0,  0, -1,  0,  0,  0,  0,  0,  0,  2]
+
+/-- The simple reflection `sᵢ` of the E₁₀ Weyl group acting on the root lattice, in
+the basis of simple roots: `sᵢ(αⱼ) = αⱼ − aᵢⱼ αᵢ`, so as a matrix
+`(sᵢ)ⱼₖ = δⱼₖ − δⱼᵢ aᵢₖ`. -/
+def simpleReflection (i : Fin 10) : Matrix (Fin 10) (Fin 10) ℤ :=
+  Matrix.of fun j k => (if j = k then 1 else 0) - (if j = i then cartanE10 i k else 0)
+
+/-- A **Coxeter element** of the E₁₀ Weyl group: the product `s₀ s₁ ⋯ s₉` of the ten
+simple reflections, as a matrix acting on the root lattice. -/
+def coxeterE10 : Matrix (Fin 10) (Fin 10) ℤ :=
+  ((List.finRange 10).map simpleReflection).prod

--- a/LeanPool/LehmerE10/Ergodic.lean
+++ b/LeanPool/LehmerE10/Ergodic.lean
@@ -1,0 +1,43 @@
+/-
+Copyright (c) 2026 Dillon Ryan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dillon Ryan
+-/
+
+import LeanPool.LehmerE10.Main
+import LeanPool.LehmerE10.CyclotomicKill
+
+/-!
+# the E₁₀ Coxeter element as an ERGODIC toral automorphism.
+A matrix `M ∈ GL(n, ℤ)` acts on the torus `Tⁿ = ℝⁿ/ℤⁿ` as a group automorphism.  By the
+standard criterion (see Walters, *Ergodic Theory*), this automorphism is **ergodic** (with respect
+to Haar measure) iff **no eigenvalue of `M` is a root of unity**, equivalently iff the
+characteristic polynomial has **no cyclotomic factor**.
+For `coxeterE10` the characteristic polynomial is Lehmer's polynomial `L` (`main_theorem`), and
+`CyclotomicKill.no_cyclotomic_divisor` proves no cyclotomic polynomial divides `L`.  So the E₁₀
+toral automorphism is ergodic — the *unique* ergodic member of the finite/affine E₆..E₉ + hyperbolic
+Eₙ series, since E₆,E₇,E₈ (finite) and E₉ (affine) have all-cyclotomic characteristic polynomials.
+ERGODIC-THEORY READING (context, not formalized here — the entropy theorem is not in Mathlib):
+by Yuzvinskii / Lind–Schmidt–Ward the measure-theoretic entropy of this automorphism equals the
+logarithmic Mahler measure `log M(L) = log μ` (`Mahler.lehmer_mahlerMeasure`), the smallest known
+positive entropy of an ergodic compact-group automorphism.  Lind's dichotomy: the set of such
+entropies is all of `(0,∞]` or countable according to Lehmer's problem (`Mahler.LehmerConjecture`);
+via Ornstein's theorem (ergodic compact-group automorphism ≅ Bernoulli shift, classified by entropy)
+the moduli space of these automorphisms is uncountable or countable by the same dichotomy.  This
+lemma records the *ergodicity* half — provable now — not the entropy value.
+-/
+
+open Polynomial
+
+namespace LehmerE10
+
+/-- **The E₁₀ Coxeter toral automorphism is ergodic**: its characteristic polynomial has no
+cyclotomic factor, i.e. `coxeterE10` has no root-of-unity eigenvalue.  Immediate from
+`coxeter_charpoly_lehmer` (charpoly `= L`) and `no_cyclotomic_divisor` (no
+cyclotomic polynomial divides `L`). -/
+theorem coxeterE10_ergodic {k : ℕ} (hk : 1 ≤ k) :
+    ¬ (cyclotomic k ℤ ∣ coxeterE10.charpoly) := by
+  rw [coxeter_charpoly_lehmer]
+  exact no_cyclotomic_divisor hk
+
+end LehmerE10

--- a/LeanPool/LehmerE10/Kronecker.lean
+++ b/LeanPool/LehmerE10/Kronecker.lean
@@ -22,7 +22,7 @@ Contents:
     field ℚ⟮z⟯.
   • `totient_le_of_lehmer_root` — a primitive k-th root of unity that is a root of
     `L` has φ(k) ≤ 10 (cyclotomic = minimal polynomial + degree bound).
-No `sorry`; no axioms beyond `propext`, `Classical.choice`, `Quot.sound`.
+Axiom footprint: `propext`, `Classical.choice`, `Quot.sound` only.
 -/
 
 namespace LehmerE10

--- a/LeanPool/LehmerE10/Kronecker.lean
+++ b/LeanPool/LehmerE10/Kronecker.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 Dillon Ryan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dillon Ryan
+-/
+
+import LeanPool.LehmerE10.Defs
+import Mathlib.NumberTheory.NumberField.InfinitePlace.Embeddings
+import Mathlib.RingTheory.Polynomial.Cyclotomic.Roots
+import Mathlib.Tactic.ComputeDegree
+import Mathlib.Tactic.NormNum.Prime
+
+/-!
+# basic facts about Lehmer's polynomial `L`, and Kronecker's theorem.
+Contents:
+  • degree/monicity of `L` and the evaluation witnesses `L(1) = −1`, `L(−1) = 1`,
+    `L(2) = 1291` (prime);
+  • `kronecker_roots` — Kronecker's theorem (1857) in root form: every complex root
+    of a monic integer polynomial, all of whose complex roots lie on the unit
+    circle, is a root of unity.  Proved from Mathlib's
+    `NumberField.Embeddings.pow_eq_one_of_norm_eq_one` applied inside the number
+    field ℚ⟮z⟯.
+  • `totient_le_of_lehmer_root` — a primitive k-th root of unity that is a root of
+    `L` has φ(k) ≤ 10 (cyclotomic = minimal polynomial + degree bound).
+No `sorry`; no axioms beyond `propext`, `Classical.choice`, `Quot.sound`.
+-/
+
+namespace LehmerE10
+
+open Polynomial
+
+theorem lehmerPolynomial_natDegree : lehmerPolynomial.natDegree = 10 := by
+  unfold lehmerPolynomial; compute_degree!
+
+theorem lehmerPolynomial_monic : lehmerPolynomial.Monic := by
+  unfold lehmerPolynomial; monicity!
+
+theorem lehmerPolynomial_ne_zero : lehmerPolynomial ≠ 0 := lehmerPolynomial_monic.ne_zero
+
+/-! ### The eval-witness integers (the kill table's three points). -/
+
+theorem lehmer_eval_one : lehmerPolynomial.eval 1 = -1 := by
+  unfold lehmerPolynomial; simp
+
+theorem lehmer_eval_neg_one : lehmerPolynomial.eval (-1) = 1 := by
+  unfold lehmerPolynomial; norm_num
+
+theorem lehmer_eval_two : lehmerPolynomial.eval 2 = 1291 := by
+  unfold lehmerPolynomial; norm_num
+
+/-- 1291 is prime: the x = 2 witness kills every remaining non-prime-power modulus
+    (Φ₁₂(2)=13, Φ₁₅(2)=151, Φ₂₀(2)=205, Φ₂₄(2)=241, Φ₃₀(2)=331 — none divide 1291). -/
+theorem witness_1291_prime : Nat.Prime 1291 := by norm_num
+
+/-! ### Kronecker's theorem: roots of unit-circle monic ℤ-polynomials are roots of unity. -/
+
+/-- **Kronecker's theorem, root form**: every complex root of a monic integer
+    polynomial, all of whose complex roots lie on the unit circle, is a root of unity.
+    (The conclusion is stated root-wise: the `p ∣ xⁿ − 1` form fails for
+    non-squarefree `p`.) -/
+theorem kronecker_roots {p : Polynomial ℤ} (hm : p.Monic)
+    (h1 : ∀ w ∈ (p.map (Int.castRingHom ℂ)).roots, ‖w‖ = 1)
+    {z : ℂ} (hz : z ∈ (p.map (Int.castRingHom ℂ)).roots) :
+    ∃ n : ℕ, 0 < n ∧ z ^ n = 1 := by
+  have hmapne : p.map (Int.castRingHom ℂ) ≠ 0 := (hm.map _).ne_zero
+  have hroot : (Polynomial.aeval z) p = 0 := by
+    have h := (mem_roots hmapne).mp hz
+    rw [IsRoot.def, eval_map] at h
+    rwa [aeval_def, algebraMap_int_eq]
+  -- z is an algebraic integer
+  have hint : IsIntegral ℤ z := ⟨p, hm, by rw [← aeval_def]; exact hroot⟩
+  -- the number field K = ℚ⟮z⟯
+  have halg : IsAlgebraic ℚ z := (hint.tower_top (A := ℚ)).isAlgebraic
+  let K := IntermediateField.adjoin ℚ ({z} : Set ℂ)
+  haveI : FiniteDimensional ℚ K :=
+    IntermediateField.adjoin.finiteDimensional halg.isIntegral
+  haveI : NumberField K := ⟨⟩
+  -- the generator, its integrality, and its image
+  set x : K := IntermediateField.AdjoinSimple.gen ℚ z with hxdef
+  have hgen : (algebraMap K ℂ) x = z := IntermediateField.AdjoinSimple.algebraMap_gen ℚ z
+  have hinj : Function.Injective (algebraMap K ℂ) := (algebraMap K ℂ).injective
+  have hxi : IsIntegral ℤ x := by
+    exact (isIntegral_algebraMap_iff hinj).mp (hgen ▸ hint)
+  -- the generator is itself a root of p inside K
+  have hpx : (Polynomial.aeval x) p = 0 := by
+    apply hinj
+    rw [map_zero, ← Polynomial.aeval_algebraMap_apply, hgen]
+    exact hroot
+  -- every embedding sends x to a root of p, hence to the unit circle
+  have hφ : ∀ φ : K →+* ℂ, ‖φ x‖ = 1 := by
+    intro φ
+    apply h1
+    have hcomp : φ.comp (algebraMap ℤ K) = algebraMap ℤ ℂ := RingHom.ext_int _ _
+    have hφx : (Polynomial.aeval (φ x)) p = 0 := by
+      have h := congrArg φ hpx
+      rw [map_zero] at h
+      rw [aeval_def, ← hcomp, ← Polynomial.hom_eval₂, ← aeval_def, h]
+    refine (mem_roots hmapne).mpr ?_
+    rw [IsRoot.def, eval_map]
+    rw [aeval_def, algebraMap_int_eq] at hφx
+    exact hφx
+  obtain ⟨n, hn, hxn⟩ := NumberField.Embeddings.pow_eq_one_of_norm_eq_one K ℂ hxi hφ
+  refine ⟨n, hn, ?_⟩
+  have h := congrArg (algebraMap K ℂ) hxn
+  rwa [map_pow, map_one, hgen] at h
+
+/-! ### The order bound: root-of-unity roots of L live in the eligible census. -/
+
+/-- A primitive k-th root of unity that is a root of `lehmerPolynomial` (over ℚ) has
+    φ(k) ≤ 10: cyclotomic k = minpoly, and the minpoly divides the degree-10 image. -/
+theorem totient_le_of_lehmer_root {z : ℂ} {k : ℕ} (hk : 0 < k)
+    (hprim : IsPrimitiveRoot z k)
+    (hroot : (Polynomial.aeval z) (lehmerPolynomial.map (Int.castRingHom ℚ)) = 0) :
+    k.totient ≤ 10 := by
+  have hmin : cyclotomic k ℚ = minpoly ℚ z := cyclotomic_eq_minpoly_rat hprim hk
+  have hmapne : lehmerPolynomial.map (Int.castRingHom ℚ) ≠ 0 :=
+    (lehmerPolynomial_monic.map (Int.castRingHom ℚ)).ne_zero
+  have hdvd : minpoly ℚ z ∣ lehmerPolynomial.map (Int.castRingHom ℚ) := minpoly.dvd ℚ z hroot
+  have hdeg10 : (lehmerPolynomial.map (Int.castRingHom ℚ)).natDegree = 10 := by
+    rw [lehmerPolynomial_monic.natDegree_map]; exact lehmerPolynomial_natDegree
+  have hdeg := Polynomial.natDegree_le_of_dvd hdvd hmapne
+  rwa [← hmin, natDegree_cyclotomic, hdeg10] at hdeg
+
+/-- The moduli `k ≤ 66` with `φ(k) ≤ 10` — the only possible orders of
+    root-of-unity roots of a degree-10 polynomial. -/
+theorem eligible_totient_census :
+    ((List.range 66).filter fun n => (n + 1).totient ≤ 10).map (· + 1) =
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 16, 18, 20, 22, 24, 30] := by
+  decide
+
+
+end LehmerE10

--- a/LeanPool/LehmerE10/Mahler.lean
+++ b/LeanPool/LehmerE10/Mahler.lean
@@ -1,0 +1,170 @@
+/-
+Copyright (c) 2026 Dillon Ryan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dillon Ryan
+-/
+
+import LeanPool.LehmerE10.Main
+import Mathlib.Analysis.Polynomial.MahlerMeasure
+
+/-!
+# the Mahler measure of Lehmer's polynomial, in Mathlib's own API.
+Mathlib now has the Mahler measure (`Polynomial.mahlerMeasure`, Jensen-formula definition,
+with `mahlerMeasure_eq_leadingCoeff_mul_prod_roots`), Kronecker's theorem in Mahler form,
+and Northcott's theorem.  This file connects the repository to that API:
+* `lehmer_mahlerMeasure` : `M(L) = μ` — the Mahler measure of Lehmer's polynomial is
+  exactly the Salem root, computed (not estimated) from the root classification: eight
+  roots on the unit circle contribute `1`, `ν = 1/μ` lies inside, and `μ` alone lies
+  outside.
+* `one_lt_lehmer_mahlerMeasure`, `lehmer_mahlerMeasure_lt` : `1 < M(L) < 7/5`, from the
+  interval `y₅ ∈ (2, 21/10)` already isolated by the trace-quintic sign changes.
+* `LehmerConjecture`, `LehmerMinimal` : Lehmer's 1933 question, *stated* in Mathlib's
+  vocabulary (a hypothesis `Prop`, not claimed, not assumed): Mahler measures of integer
+  polynomials do not accumulate at `1`; strongly, `L` attains the minimum.
+  `lehmerConjecture_of_minimal` : the strong form implies the gap form, with the gap
+  witnessed by `M(L)` itself — which is `> 1` by this file.
+* `coxeterE10_infinite_order` : the E₁₀ Coxeter element has infinite order in
+  `GL(10, ℤ)`.  If `Cox^n = 1` then, since its characteristic polynomial `L` is
+  irreducible, `L` would be the minimal polynomial and would divide `Xⁿ − 1`; but `μ` is
+  a root of `L` with `μ > 1`, and every root of `Xⁿ − 1` has norm `1`.
+Together with `coxeterE8_*` facts (finite case) this locates E₁₀ precisely: the Coxeter
+series crosses from torsion (spectrum on the unit circle) to a Salem element exactly at
+rank 10, and the crossing value is Lehmer's number.
+-/
+
+open Polynomial
+
+namespace LehmerE10
+
+/-! ### The Mahler measure of `L` is the Salem root `μ`. -/
+
+/-- The classified product with `max 1 ‖·‖` weights: unit-circle roots contribute `1`,
+`ν < 1` contributes `1`, and each occurrence of `μ` contributes `μ`. -/
+lemma classified_prod_max (S : Multiset ℂ)
+    (hS : ∀ z ∈ S, ‖z‖ = 1 ∨ z = (mu : ℂ) ∨ z = (nu : ℂ)) :
+    (S.map fun z => max 1 ‖z‖).prod = mu ^ S.count (mu : ℂ) := by
+  induction S using Multiset.induction with
+  | empty => simp
+  | cons a s ih =>
+    have hs' : ∀ z ∈ s, ‖z‖ = 1 ∨ z = (mu : ℂ) ∨ z = (nu : ℂ) :=
+      fun z hz => hS z (Multiset.mem_cons_of_mem hz)
+    have ihs := ih hs'
+    rcases hS a (Multiset.mem_cons_self a s) with h1 | rfl | rfl
+    · have hamu : (mu : ℂ) ≠ a := by
+        intro h; rw [← h, norm_muC] at h1; linarith [mu_gt_one]
+      rw [Multiset.map_cons, Multiset.prod_cons, h1, max_self, one_mul, ihs,
+        Multiset.count_cons_of_ne hamu]
+    · rw [Multiset.map_cons, Multiset.prod_cons, norm_muC,
+        max_eq_right (le_of_lt mu_gt_one), ihs, Multiset.count_cons_self, pow_succ]
+      ring
+    · rw [Multiset.map_cons, Multiset.prod_cons, norm_nuC,
+        max_eq_left (le_of_lt nu_lt_one), one_mul, ihs,
+        Multiset.count_cons_of_ne muC_ne_nuC]
+
+/-- **The Mahler measure of Lehmer's polynomial is the Salem root**: `M(L) = μ`.
+Computed exactly from `mahlerMeasure_eq_leadingCoeff_mul_prod_roots` and the root
+classification — this is the number `≈ 1.17628`, the smallest known Mahler measure `> 1`
+of an integer polynomial. -/
+theorem lehmer_mahlerMeasure : LC.mahlerMeasure = mu := by
+  rw [mahlerMeasure_eq_leadingCoeff_mul_prod_roots, LC_monic.leadingCoeff, norm_one, one_mul,
+    classified_prod_max LC.roots (fun z hz => root_classification hz), count_muC, pow_one]
+
+/-- `M(L) > 1`: Lehmer's polynomial is not a product of cyclotomics, quantitatively. -/
+theorem one_lt_lehmer_mahlerMeasure : 1 < LC.mahlerMeasure :=
+  lehmer_mahlerMeasure ▸ mu_gt_one
+
+/-- The Salem square root is below `7/10`: `s₅² = y₅² − 4 < (21/10)² − 4 < (7/10)²`. -/
+lemma s5_lt : s5 < 7 / 10 := by
+  have h5 := Set.mem_Ioo.mp y5_mem
+  have hs := s5_sq
+  have hpos := s5_pos
+  nlinarith [hs, h5.1, h5.2, hpos]
+
+/-- `M(L) < 7/5`: an unconditional upper bound from the trace-root interval.  (The true
+value is `1.17628…`; sharper bounds need only a tighter sign-change interval for `y₅`.) -/
+theorem lehmer_mahlerMeasure_lt : LC.mahlerMeasure < 7 / 5 := by
+  rw [lehmer_mahlerMeasure]
+  have h5 := Set.mem_Ioo.mp y5_mem
+  have hs := s5_lt
+  unfold mu
+  linarith
+
+/-! ### Lehmer's question, stated in Mathlib's vocabulary.
+
+Both are hypothesis `Prop`s: *stated*, never claimed, never assumed. -/
+
+/-- **Lehmer's conjecture** (Lehmer 1933, gap form): Mahler measures of integer polynomials
+do not accumulate at `1` — there is a uniform gap `c > 1` below which the only Mahler
+measure is `1` itself. -/
+def LehmerConjecture : Prop :=
+  ∃ c : ℝ, 1 < c ∧ ∀ p : Polynomial ℤ,
+    1 < (p.map (Int.castRingHom ℂ)).mahlerMeasure →
+    c ≤ (p.map (Int.castRingHom ℂ)).mahlerMeasure
+
+/-- The strong form: Lehmer's polynomial attains the minimal Mahler measure `> 1`. -/
+def LehmerMinimal : Prop :=
+  ∀ p : Polynomial ℤ, 1 < (p.map (Int.castRingHom ℂ)).mahlerMeasure →
+    LC.mahlerMeasure ≤ (p.map (Int.castRingHom ℂ)).mahlerMeasure
+
+/-- The strong form implies the gap form, with the gap witnessed by `M(L)` itself —
+legitimate because `M(L) > 1` is proven above. -/
+theorem lehmerConjecture_of_minimal (h : LehmerMinimal) : LehmerConjecture :=
+  ⟨LC.mahlerMeasure, one_lt_lehmer_mahlerMeasure, fun p hp => h p hp⟩
+
+/-! ### The Coxeter element has infinite order. -/
+
+/-- **The E₁₀ Coxeter element has infinite order.**  If `Cox^n = 1`, then since its
+characteristic polynomial is the irreducible `L`, the minimal polynomial is `L` and
+divides `Xⁿ − 1`; evaluating at the Salem root `μ > 1` gives `μⁿ = 1`, impossible.
+
+Contrast: the Coxeter element of a *finite* Weyl group has order `h` (the Coxeter number
+— `30` for E₈); at E₁₀ the spectrum has left the unit circle and no power returns. -/
+theorem coxeterE10_infinite_order {n : ℕ} (hn : 0 < n) : coxeterE10 ^ n ≠ 1 := by
+  intro hpow
+  -- move to ℚ
+  have hpowq : (coxeterE10.map (Int.castRingHom ℚ)) ^ n = 1 := by
+    have h := congrArg (fun M : Matrix (Fin 10) (Fin 10) ℤ =>
+      (Int.castRingHom ℚ).mapMatrix M) hpow
+    simpa [map_pow, RingHom.mapMatrix_apply] using h
+  set Cq : Matrix (Fin 10) (Fin 10) ℚ := coxeterE10.map (Int.castRingHom ℚ) with hCq
+  -- the minimal polynomial of Cq is L (irreducible, monic, annihilating)
+  set Lq : Polynomial ℚ := lehmerPolynomial.map (Int.castRingHom ℚ) with hLq
+  have hLq_monic : Lq.Monic := lehmerPolynomial_monic.map _
+  have haev : aeval Cq Lq = 0 := by
+    have := Matrix.aeval_self_charpoly Cq
+    rwa [coxeter_charpoly_rat] at this
+  have hmin : minpoly ℚ Cq = Lq :=
+    (minpoly.eq_of_irreducible_of_monic lehmer_irreducible_rat haev hLq_monic).symm
+  -- L divides Xⁿ − 1
+  have hannX : aeval Cq ((X : Polynomial ℚ) ^ n - 1) = 0 := by
+    rw [map_sub, map_pow, aeval_X, map_one, hpowq, sub_self]
+  have hdvdQ : Lq ∣ (X : Polynomial ℚ) ^ n - 1 := hmin ▸ minpoly.dvd ℚ Cq hannX
+  -- transport to ℂ and evaluate at μ
+  have hdvdC : LC ∣ (X : Polynomial ℂ) ^ n - 1 := by
+    have h := Polynomial.map_dvd (algebraMap ℚ ℂ) hdvdQ
+    have hmapL : Lq.map (algebraMap ℚ ℂ) = LC := by
+      rw [hLq, Polynomial.map_map]
+      exact congrArg lehmerPolynomial.map (Subsingleton.elim _ _)
+    have hmapX : ((X : Polynomial ℚ) ^ n - 1).map (algebraMap ℚ ℂ)
+        = (X : Polynomial ℂ) ^ n - 1 := by
+      rw [Polynomial.map_sub, Polynomial.map_pow, Polynomial.map_X, Polynomial.map_one]
+    rwa [hmapL, hmapX] at h
+  obtain ⟨q, hq⟩ := hdvdC
+  have hmu_root : LC.eval (mu : ℂ) = 0 := by
+    have h := (mem_roots LC_ne_zero).mp muC_mem
+    rwa [IsRoot.def] at h
+  have hμn : ((mu : ℂ)) ^ n = 1 := by
+    have h := congrArg (Polynomial.eval ((mu : ℝ) : ℂ)) hq
+    simp only [eval_sub, eval_pow, eval_X, eval_one, eval_mul, hmu_root, zero_mul] at h
+    linear_combination h
+  have hμnR : mu ^ n = 1 := by exact_mod_cast hμn
+  have : (1 : ℝ) < mu ^ n := one_lt_pow₀ mu_gt_one hn.ne'
+  linarith [hμnR ▸ this]
+
+end LehmerE10
+
+#print axioms LehmerE10.lehmer_mahlerMeasure
+#print axioms LehmerE10.one_lt_lehmer_mahlerMeasure
+#print axioms LehmerE10.lehmer_mahlerMeasure_lt
+#print axioms LehmerE10.lehmerConjecture_of_minimal
+#print axioms LehmerE10.coxeterE10_infinite_order

--- a/LeanPool/LehmerE10/Mahler.lean
+++ b/LeanPool/LehmerE10/Mahler.lean
@@ -162,9 +162,3 @@ theorem coxeterE10_infinite_order {n : ℕ} (hn : 0 < n) : coxeterE10 ^ n ≠ 1 
   linarith [hμnR ▸ this]
 
 end LehmerE10
-
-#print axioms LehmerE10.lehmer_mahlerMeasure
-#print axioms LehmerE10.one_lt_lehmer_mahlerMeasure
-#print axioms LehmerE10.lehmer_mahlerMeasure_lt
-#print axioms LehmerE10.lehmerConjecture_of_minimal
-#print axioms LehmerE10.coxeterE10_infinite_order

--- a/LeanPool/LehmerE10/Main.lean
+++ b/LeanPool/LehmerE10/Main.lean
@@ -42,10 +42,16 @@ open Polynomial
 
 /-! ### The five trace roots, pinned from the RHLehmerTrace IVT witnesses. -/
 
+/-- The first trace root of the quintic `q`, in `(−2, −1)`. -/
 noncomputable def y1 : ℝ := traceQ_root_1.choose
+/-- The second trace root of the quintic `q`, in `(−1, 0)`. -/
 noncomputable def y2 : ℝ := traceQ_root_2.choose
+/-- The third trace root of the quintic `q`, in `(0, 1)`. -/
 noncomputable def y3 : ℝ := traceQ_root_3.choose
+/-- The fourth trace root of the quintic `q`, in `(1, 2)`. -/
 noncomputable def y4 : ℝ := traceQ_root_4.choose
+/-- The Salem trace root of the quintic `q`, in `(2, 21/10)` — the one root
+off `[−2, 2]`, giving the reciprocal pair `{μ, 1/μ}`. -/
 noncomputable def y5 : ℝ := traceQ_root_salem.choose
 
 lemma y1_mem : y1 ∈ Set.Ioo (-2 : ℝ) (-3/2) := traceQ_root_1.choose_spec.1
@@ -70,6 +76,8 @@ lemma y_chain : y1 < y2 ∧ y2 < y3 ∧ y3 < y4 ∧ y4 < y5 := by
 
 /-! ### The trace quintic as a polynomial over ℂ, and its root census. -/
 
+/-- The trace quintic over ℂ: `q(y) = y⁵ + y⁴ − 5y³ − 5y² + 4y + 3`, with
+`L(x) = x⁵·q(x + 1/x)`. -/
 noncomputable def tracePoly : Polynomial ℂ :=
   X ^ 5 + X ^ 4 - C 5 * X ^ 3 - C 5 * X ^ 2 + C 4 * X + C 3
 
@@ -86,6 +94,7 @@ lemma trace_root_mem {y : ℝ} (hy : traceQ y = 0) : (y : ℂ) ∈ tracePoly.roo
   rw [mem_roots tracePoly_monic.ne_zero, IsRoot.def, tracePoly_eval, traceQC_ofReal, hy]
   simp
 
+/-- The five trace roots as a multiset over ℂ. -/
 noncomputable def T5 : Multiset ℂ := {(y1 : ℂ), (y2 : ℂ), (y3 : ℂ), (y4 : ℂ), (y5 : ℂ)}
 
 lemma T5_nodup : T5.Nodup := by
@@ -148,6 +157,8 @@ lemma trace_factor :
 
 /-! ### The derivative of the trace quintic; the Salem trace root is simple. -/
 
+/-- The derivative of the trace quintic, evaluated over ℂ (used to show the
+trace roots are simple). -/
 noncomputable def dtraceQC (y : ℂ) : ℂ := 5 * y ^ 4 + 4 * y ^ 3 - 15 * y ^ 2 - 10 * y + 4
 
 lemma tracePoly_derivative_eval (w : ℂ) : (derivative tracePoly).eval w = dtraceQC w := by
@@ -175,6 +186,7 @@ lemma dtrace_y5_ne_zero : dtraceQC (y5 : ℂ) ≠ 0 := by
 
 /-! ### Lehmer over ℂ: evaluation bridge, derivative, and the derivative–trace identity. -/
 
+/-- Lehmer's polynomial over ℂ. -/
 noncomputable def LC : Polynomial ℂ := lehmerPolynomial.map (Int.castRingHom ℂ)
 
 lemma LC_poly : LC = X ^ 10 + X ^ 9 - X ^ 7 - X ^ 6 - X ^ 5 - X ^ 4 - X ^ 3 + X + 1 := by
@@ -221,8 +233,12 @@ lemma deriv_trace_identity {z : ℂ} (hz : z ≠ 0) :
 
 /-! ### The off-circle Salem pair `{μ, ν}`, `μν = 1`, `ν < 1 < μ`. -/
 
+/-- The square-root discriminant `√(y₅² − 4)` splitting the Salem trace root
+into the reciprocal pair. -/
 noncomputable def s5 : ℝ := Real.sqrt (y5 ^ 2 - 4)
+/-- Lehmer's number `μ ≈ 1.17628`: the larger root of `x² − y₅·x + 1`. -/
 noncomputable def mu : ℝ := (y5 + s5) / 2
+/-- The reciprocal root `1/μ`: the smaller root of `x² − y₅·x + 1`. -/
 noncomputable def nu : ℝ := (y5 - s5) / 2
 
 lemma y5_gt_two : 2 < y5 := (Set.mem_Ioo.mp y5_mem).1

--- a/LeanPool/LehmerE10/Main.lean
+++ b/LeanPool/LehmerE10/Main.lean
@@ -1,0 +1,603 @@
+/-
+Copyright (c) 2026 Dillon Ryan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dillon Ryan
+-/
+
+import LeanPool.LehmerE10.Defs
+import LeanPool.LehmerE10.UnitCircleFactors
+import LeanPool.LehmerE10.TraceQuintic
+
+/-!
+# the assembly:
+    `Irreducible lehmerPolynomial`   and   `coxeterE10.charpoly = lehmerPolynomial`.
+Route:
+  (1) TRACE CENSUS: the trace quintic q (with L(x) = x⁵·q(x + 1/x), TraceQuintic)
+      has EXACTLY the five IVT-located real roots y₁<y₂<y₃<y₄ ∈ (−2,2), y₅ ∈ (2,21/10):
+      five distinct roots of a degree-5 polynomial exhaust its complex roots, and
+      q = ∏(X − yᵢ) — so q'(y₅) = ∏_{i<5}(y₅ − yᵢ) ≠ 0: the Salem trace root is simple.
+  (2) ROOT CLASSIFICATION: every complex root z of L has trace z + 1/z ∈ {y₁..y₅};
+      the four ball traces force ‖z‖ = 1 (norm_eq_one_of_trace_in_ball), the Salem
+      trace forces z ∈ {μ, ν} with μν = 1, ν < 1 < μ (the off-circle Salem pair).
+  (3) SALEM PAIR SIMPLE: a double root of L at t ∈ {μ,ν} would kill L' there; the
+      derivative–trace identity  z²·L'(z) = 5z⁶·q(y) + (z⁷ − z⁵)·q'(y)  then forces
+      q'(y₅) = 0 (since t ∉ {0, ±1}) — refuted by (1).  count μ = count ν = 1 in L.
+  (4) THE FACTOR ARGUMENT: L = F·G proper monic ⟹ F(0)·G(0) = L(0) = 1 ⟹ ‖F(0)‖ = 1;
+      but ‖F(0)‖ = ∏‖roots F‖ = μ^a·ν^b with (a,b) ∈ {0,1}² by (3).  (1,0) gives μ = 1,
+      (0,1) gives ν = 1 — both refuted; (0,0) makes F all-on-circle, (1,1) makes G
+      all-on-circle — both killed by `no_unit_circle_factor` (Kronecker + the
+      uniform-1291 cyclotomic kill).  No proper factor exists.
+  (5) ASSEMBLY: `lehmer_irreducible` (ℤ, then ℚ by Gauss); the Coxeter element of
+      E₁₀ is annihilated by L (kernel computation), so by
+      `charpoly_eq_lehmer_of_irreducible` its characteristic polynomial is L —
+      first over ℚ, then over ℤ by injectivity of the coefficient map.
+SCOPE: Lehmer's 1933 conjecture (a positive lower bound for Mahler measures > 1)
+is NOT claimed anywhere in this repository.
+No `sorry`; no axioms beyond `propext`, `Classical.choice`, `Quot.sound`.
+-/
+
+namespace LehmerE10
+
+open Polynomial
+
+/-! ### The five trace roots, pinned from the RHLehmerTrace IVT witnesses. -/
+
+noncomputable def y1 : ℝ := traceQ_root_1.choose
+noncomputable def y2 : ℝ := traceQ_root_2.choose
+noncomputable def y3 : ℝ := traceQ_root_3.choose
+noncomputable def y4 : ℝ := traceQ_root_4.choose
+noncomputable def y5 : ℝ := traceQ_root_salem.choose
+
+lemma y1_mem : y1 ∈ Set.Ioo (-2 : ℝ) (-3/2) := traceQ_root_1.choose_spec.1
+lemma y2_mem : y2 ∈ Set.Ioo (-3/2 : ℝ) (-1) := traceQ_root_2.choose_spec.1
+lemma y3_mem : y3 ∈ Set.Ioo (-1 : ℝ) 0 := traceQ_root_3.choose_spec.1
+lemma y4_mem : y4 ∈ Set.Ioo (0 : ℝ) 1 := traceQ_root_4.choose_spec.1
+lemma y5_mem : y5 ∈ Set.Ioo (2 : ℝ) (21/10) := traceQ_root_salem.choose_spec.1
+
+lemma y1_root : traceQ y1 = 0 := traceQ_root_1.choose_spec.2
+lemma y2_root : traceQ y2 = 0 := traceQ_root_2.choose_spec.2
+lemma y3_root : traceQ y3 = 0 := traceQ_root_3.choose_spec.2
+lemma y4_root : traceQ y4 = 0 := traceQ_root_4.choose_spec.2
+lemma y5_root : traceQ y5 = 0 := traceQ_root_salem.choose_spec.2
+
+lemma y_chain : y1 < y2 ∧ y2 < y3 ∧ y3 < y4 ∧ y4 < y5 := by
+  have h1 := Set.mem_Ioo.mp y1_mem
+  have h2 := Set.mem_Ioo.mp y2_mem
+  have h3 := Set.mem_Ioo.mp y3_mem
+  have h4 := Set.mem_Ioo.mp y4_mem
+  have h5 := Set.mem_Ioo.mp y5_mem
+  exact ⟨by linarith, by linarith, by linarith, by linarith⟩
+
+/-! ### The trace quintic as a polynomial over ℂ, and its root census. -/
+
+noncomputable def tracePoly : Polynomial ℂ :=
+  X ^ 5 + X ^ 4 - C 5 * X ^ 3 - C 5 * X ^ 2 + C 4 * X + C 3
+
+lemma tracePoly_monic : tracePoly.Monic := by unfold tracePoly; monicity!
+
+lemma tracePoly_natDegree : tracePoly.natDegree = 5 := by unfold tracePoly; compute_degree!
+
+lemma tracePoly_eval (z : ℂ) : tracePoly.eval z = traceQC z := by
+  unfold tracePoly LehmerE10.traceQC
+  simp
+  try ring
+
+lemma trace_root_mem {y : ℝ} (hy : traceQ y = 0) : (y : ℂ) ∈ tracePoly.roots := by
+  rw [mem_roots tracePoly_monic.ne_zero, IsRoot.def, tracePoly_eval, traceQC_ofReal, hy]
+  simp
+
+noncomputable def T5 : Multiset ℂ := {(y1 : ℂ), (y2 : ℂ), (y3 : ℂ), (y4 : ℂ), (y5 : ℂ)}
+
+lemma T5_nodup : T5.Nodup := by
+  obtain ⟨c1, c2, c3, c4⟩ := y_chain
+  have hne : ∀ a b : ℝ, a < b → ¬((a : ℂ) = (b : ℂ)) := fun a b h => by
+    exact_mod_cast h.ne
+  have m1 : ((y1 : ℝ) : ℂ) ∉ ({(y2 : ℂ), (y3 : ℂ), (y4 : ℂ), (y5 : ℂ)} : Multiset ℂ) := by
+    simp only [Multiset.insert_eq_cons, Multiset.mem_cons, Multiset.mem_singleton, not_or]
+    exact ⟨hne y1 y2 c1, hne y1 y3 (by linarith), hne y1 y4 (by linarith),
+      hne y1 y5 (by linarith)⟩
+  have m2 : ((y2 : ℝ) : ℂ) ∉ ({(y3 : ℂ), (y4 : ℂ), (y5 : ℂ)} : Multiset ℂ) := by
+    simp only [Multiset.insert_eq_cons, Multiset.mem_cons, Multiset.mem_singleton, not_or]
+    exact ⟨hne y2 y3 c2, hne y2 y4 (by linarith), hne y2 y5 (by linarith)⟩
+  have m3 : ((y3 : ℝ) : ℂ) ∉ ({(y4 : ℂ), (y5 : ℂ)} : Multiset ℂ) := by
+    simp only [Multiset.insert_eq_cons, Multiset.mem_cons, Multiset.mem_singleton, not_or]
+    exact ⟨hne y3 y4 c3, hne y3 y5 (by linarith)⟩
+  have m4 : ((y4 : ℝ) : ℂ) ∉ ({(y5 : ℂ)} : Multiset ℂ) := by
+    simp only [Multiset.mem_singleton]
+    exact hne y4 y5 c4
+  simp only [T5, Multiset.insert_eq_cons, Multiset.nodup_cons]
+  exact ⟨m1, m2, m3, m4, Multiset.nodup_singleton _⟩
+
+lemma trace_roots_eq : tracePoly.roots = T5 := by
+  have hcard : tracePoly.roots.card = 5 := by
+    rw [splits_iff_card_roots.mp (IsAlgClosed.splits tracePoly), tracePoly_natDegree]
+  have hT5card : T5.card = 5 := by simp [T5]
+  have hle : T5 ≤ tracePoly.roots := by
+    rw [Multiset.le_iff_count]
+    intro a
+    by_cases ha : a ∈ T5
+    · rw [Multiset.count_eq_one_of_mem T5_nodup ha]
+      have hmem : a ∈ tracePoly.roots := by
+        rcases (by simpa [T5] using ha :
+            a = (y1 : ℂ) ∨ a = (y2 : ℂ) ∨ a = (y3 : ℂ) ∨ a = (y4 : ℂ) ∨ a = (y5 : ℂ)) with
+          rfl | rfl | rfl | rfl | rfl
+        exacts [trace_root_mem y1_root, trace_root_mem y2_root, trace_root_mem y3_root,
+          trace_root_mem y4_root, trace_root_mem y5_root]
+      exact Multiset.count_pos.mpr hmem
+    · rw [Multiset.count_eq_zero.mpr ha]; exact Nat.zero_le _
+  exact (Multiset.eq_of_le_of_card_le hle (by rw [hcard, hT5card])).symm
+
+/-- Trace exhaustion: every complex root of the trace quintic is one of the five. -/
+lemma trace_root_cases {w : ℂ} (hw : traceQC w = 0) :
+    w = (y1 : ℂ) ∨ w = (y2 : ℂ) ∨ w = (y3 : ℂ) ∨ w = (y4 : ℂ) ∨ w = (y5 : ℂ) := by
+  have hmem : w ∈ tracePoly.roots := by
+    rw [mem_roots tracePoly_monic.ne_zero, IsRoot.def, tracePoly_eval, hw]
+  rw [trace_roots_eq] at hmem
+  simpa [T5] using hmem
+
+/-- The spectral factorization of the trace quintic: `q = ∏ (X − yᵢ)`. -/
+lemma trace_factor :
+    tracePoly = (X - C (y1 : ℂ)) * (X - C (y2 : ℂ)) * (X - C (y3 : ℂ)) *
+      (X - C (y4 : ℂ)) * (X - C (y5 : ℂ)) := by
+  have h := (IsAlgClosed.splits tracePoly).eq_prod_roots_of_monic tracePoly_monic
+  rw [trace_roots_eq] at h
+  rw [h]
+  simp only [T5, Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
+    Multiset.prod_cons, Multiset.prod_singleton]
+  ring
+
+/-! ### The derivative of the trace quintic; the Salem trace root is simple. -/
+
+noncomputable def dtraceQC (y : ℂ) : ℂ := 5 * y ^ 4 + 4 * y ^ 3 - 15 * y ^ 2 - 10 * y + 4
+
+lemma tracePoly_derivative_eval (w : ℂ) : (derivative tracePoly).eval w = dtraceQC w := by
+  unfold tracePoly dtraceQC
+  simp
+  try ring
+
+/-- **THE SALEM TRACE ROOT IS SIMPLE**: `q'(y₅) = ∏_{i<5}(y₅ − yᵢ) ≠ 0`. -/
+lemma dtrace_y5_ne_zero : dtraceQC (y5 : ℂ) ≠ 0 := by
+  have h1 := Set.mem_Ioo.mp y1_mem
+  have h2 := Set.mem_Ioo.mp y2_mem
+  have h3 := Set.mem_Ioo.mp y3_mem
+  have h4 := Set.mem_Ioo.mp y4_mem
+  have h5 := Set.mem_Ioo.mp y5_mem
+  rw [← tracePoly_derivative_eval, trace_factor]
+  simp only [derivative_mul, derivative_sub, derivative_X, derivative_C, eval_add, eval_mul,
+    eval_sub, eval_X, eval_C, sub_self, sub_zero, mul_zero, zero_mul, mul_one, one_mul,
+    add_zero, zero_add]
+  have hne : ∀ a : ℝ, a < y5 → (y5 : ℂ) - (a : ℂ) ≠ 0 := by
+    intro a ha
+    rw [sub_ne_zero]
+    exact_mod_cast ha.ne'
+  exact mul_ne_zero (mul_ne_zero (mul_ne_zero (hne y1 (by linarith)) (hne y2 (by linarith)))
+    (hne y3 (by linarith))) (hne y4 (by linarith))
+
+/-! ### Lehmer over ℂ: evaluation bridge, derivative, and the derivative–trace identity. -/
+
+noncomputable def LC : Polynomial ℂ := lehmerPolynomial.map (Int.castRingHom ℂ)
+
+lemma LC_poly : LC = X ^ 10 + X ^ 9 - X ^ 7 - X ^ 6 - X ^ 5 - X ^ 4 - X ^ 3 + X + 1 := by
+  unfold LC lehmerPolynomial
+  simp [Polynomial.map_add, Polynomial.map_sub, Polynomial.map_pow, Polynomial.map_one,
+    Polynomial.map_X]
+
+lemma LC_eval (z : ℂ) : LC.eval z = lehmerC z := by
+  rw [LC_poly]
+  unfold LehmerE10.lehmerC
+  simp
+
+lemma LC_monic : LC.Monic := lehmerPolynomial_monic.map _
+lemma LC_ne_zero : LC ≠ 0 := LC_monic.ne_zero
+
+lemma LC_eval_zero : LC.eval 0 = 1 := by
+  rw [LC_eval]
+  unfold LehmerE10.lehmerC
+  norm_num
+
+lemma root_ne_zero {z : ℂ} (hz : z ∈ LC.roots) : z ≠ 0 := by
+  rintro rfl
+  have h := (mem_roots LC_ne_zero).mp hz
+  rw [IsRoot.def, LC_eval_zero] at h
+  exact one_ne_zero h
+
+lemma LC_derivative_eval (z : ℂ) :
+    (derivative LC).eval z =
+      10 * z ^ 9 + 9 * z ^ 8 - 7 * z ^ 6 - 6 * z ^ 5 - 5 * z ^ 4 - 4 * z ^ 3 - 3 * z ^ 2 + 1 := by
+  rw [LC_poly]
+  simp [derivative_add, derivative_sub, derivative_X_pow, derivative_X, derivative_one]
+  try push_cast
+  try ring
+
+/-- **THE DERIVATIVE–TRACE IDENTITY**: differentiating `L(z) = z⁵ q(z + 1/z)` and
+    clearing denominators: `z²·L'(z) = 5z⁶·q(y) + (z⁷ − z⁵)·q'(y)` at `y = z + 1/z`. -/
+lemma deriv_trace_identity {z : ℂ} (hz : z ≠ 0) :
+    z ^ 2 * (derivative LC).eval z =
+      5 * z ^ 6 * traceQC (z + 1 / z) + (z ^ 7 - z ^ 5) * dtraceQC (z + 1 / z) := by
+  rw [LC_derivative_eval]
+  unfold LehmerE10.traceQC dtraceQC
+  field_simp
+  ring
+
+/-! ### The off-circle Salem pair `{μ, ν}`, `μν = 1`, `ν < 1 < μ`. -/
+
+noncomputable def s5 : ℝ := Real.sqrt (y5 ^ 2 - 4)
+noncomputable def mu : ℝ := (y5 + s5) / 2
+noncomputable def nu : ℝ := (y5 - s5) / 2
+
+lemma y5_gt_two : 2 < y5 := (Set.mem_Ioo.mp y5_mem).1
+
+lemma s5_sq : s5 ^ 2 = y5 ^ 2 - 4 :=
+  Real.sq_sqrt (by nlinarith [y5_gt_two])
+
+lemma s5_pos : 0 < s5 := Real.sqrt_pos.mpr (by nlinarith [y5_gt_two])
+
+lemma mu_nu_sum : mu + nu = y5 := by unfold mu nu; ring
+
+lemma mu_nu_prod : mu * nu = 1 := by
+  have h := s5_sq
+  unfold mu nu
+  linear_combination (-1/4 : ℝ) * h
+
+lemma mu_gt_one : 1 < mu := by
+  have hs := s5_pos; have hy := y5_gt_two
+  unfold mu; linarith
+
+lemma nu_pos : 0 < nu := by nlinarith [mu_nu_prod, mu_gt_one]
+
+lemma nu_lt_one : nu < 1 := by nlinarith [mu_nu_prod, mu_gt_one, nu_pos]
+
+lemma muC_prod : (mu : ℂ) * (nu : ℂ) = 1 := by exact_mod_cast mu_nu_prod
+lemma muC_sum : (mu : ℂ) + (nu : ℂ) = (y5 : ℂ) := by exact_mod_cast mu_nu_sum
+
+lemma muC_ne_zero : (mu : ℂ) ≠ 0 := by
+  have h : mu ≠ 0 := by have := mu_gt_one; linarith
+  exact_mod_cast h
+
+lemma nuC_ne_zero : (nu : ℂ) ≠ 0 := by
+  have h : nu ≠ 0 := nu_pos.ne'
+  exact_mod_cast h
+
+lemma muC_ne_nuC : (mu : ℂ) ≠ (nu : ℂ) := by
+  exact_mod_cast ne_of_gt (lt_trans nu_lt_one mu_gt_one)
+
+lemma mu_trace : (mu : ℂ) + 1 / (mu : ℂ) = (y5 : ℂ) := by
+  have hinv : 1 / (mu : ℂ) = (nu : ℂ) := by
+    rw [eq_comm, eq_div_iff muC_ne_zero]
+    linear_combination muC_prod
+  rw [hinv]; exact muC_sum
+
+lemma nu_trace : (nu : ℂ) + 1 / (nu : ℂ) = (y5 : ℂ) := by
+  have hinv : 1 / (nu : ℂ) = (mu : ℂ) := by
+    rw [eq_comm, eq_div_iff nuC_ne_zero]
+    linear_combination muC_prod
+  rw [hinv]
+  linear_combination muC_sum
+
+lemma traceQC_y5 : traceQC (y5 : ℂ) = 0 := by
+  rw [traceQC_ofReal, y5_root]; simp
+
+/-! ### Root classification: on the circle, or in the Salem pair. -/
+
+/-- **ROOT CLASSIFICATION (proven)**: every complex root of Lehmer is on the unit
+    circle or equals `μ` or `ν` — the trace lands on one of the five census roots;
+    ball traces pin the circle, the Salem trace pins the pair. -/
+lemma root_classification {z : ℂ} (hz : z ∈ LC.roots) :
+    ‖z‖ = 1 ∨ z = (mu : ℂ) ∨ z = (nu : ℂ) := by
+  have hz0 : z ≠ 0 := root_ne_zero hz
+  have hroot : lehmerC z = 0 := by
+    have h := (mem_roots LC_ne_zero).mp hz
+    rwa [IsRoot.def, LC_eval] at h
+  have htr : traceQC (z + 1 / z) = 0 := by
+    have h := lehmer_trace_reduction z hz0
+    rw [hroot] at h
+    rcases mul_eq_zero.mp h.symm with h5 | h5
+    · exact absurd (by simpa using h5 : z = 0) hz0
+    · exact h5
+  have hb1 := Set.mem_Ioo.mp y1_mem
+  have hb2 := Set.mem_Ioo.mp y2_mem
+  have hb3 := Set.mem_Ioo.mp y3_mem
+  have hb4 := Set.mem_Ioo.mp y4_mem
+  rcases trace_root_cases htr with h | h | h | h | h
+  · exact Or.inl (norm_eq_one_of_trace_in_ball hz0 h (by linarith) (by linarith))
+  · exact Or.inl (norm_eq_one_of_trace_in_ball hz0 h (by linarith) (by linarith))
+  · exact Or.inl (norm_eq_one_of_trace_in_ball hz0 h (by linarith) (by linarith))
+  · exact Or.inl (norm_eq_one_of_trace_in_ball hz0 h (by linarith) (by linarith))
+  · right
+    have h1 : z * (1 / z) = 1 := by field_simp
+    have hexp : (z - (mu : ℂ)) * (z - (nu : ℂ)) = z ^ 2 - (y5 : ℂ) * z + 1 := by
+      linear_combination (-z) * muC_sum + muC_prod
+    have hquad : (z - (mu : ℂ)) * (z - (nu : ℂ)) = 0 := by
+      rw [hexp]
+      linear_combination z * h - h1
+    rcases mul_eq_zero.mp hquad with h' | h'
+    · exact Or.inl (sub_eq_zero.mp h')
+    · exact Or.inr (sub_eq_zero.mp h')
+
+lemma muC_mem : (mu : ℂ) ∈ LC.roots := by
+  rw [mem_roots LC_ne_zero, IsRoot.def, LC_eval, lehmer_trace_reduction _ muC_ne_zero,
+    mu_trace, traceQC_y5, mul_zero]
+
+lemma nuC_mem : (nu : ℂ) ∈ LC.roots := by
+  rw [mem_roots LC_ne_zero, IsRoot.def, LC_eval, lehmer_trace_reduction _ nuC_ne_zero,
+    nu_trace, traceQC_y5, mul_zero]
+
+/-! ### The Salem pair is SIMPLE in L (multiplicity one). -/
+
+/-- A real positive trace-`y₅` root of Lehmer other than `1` has multiplicity one:
+    a double root kills `L'` there, and the derivative–trace identity then forces
+    `q'(y₅)·t⁵(t² − 1) = 0` — refuted by the simple Salem trace root and `t ∉ {0, ±1}`. -/
+lemma salem_count_le_one {t : ℝ} (ht0 : 0 < t) (ht1 : t ≠ 1)
+    (htr : (t : ℂ) + 1 / (t : ℂ) = (y5 : ℂ)) : LC.roots.count (t : ℂ) ≤ 1 := by
+  by_contra hcon
+  push_neg at hcon
+  have h2 : 2 ≤ rootMultiplicity ((t : ℝ) : ℂ) LC := by
+    rw [← Polynomial.count_roots]; omega
+  have hdvd : (X - C ((t : ℝ) : ℂ)) ^ 2 ∣ LC :=
+    (pow_dvd_pow _ h2).trans (Polynomial.pow_rootMultiplicity_dvd LC _)
+  obtain ⟨g, hg⟩ := hdvd
+  have htC : (t : ℂ) ≠ 0 := by exact_mod_cast ht0.ne'
+  have hd0 : (derivative LC).eval (t : ℂ) = 0 := by
+    rw [hg]
+    simp [derivative_mul, derivative_pow, derivative_sub, derivative_X, derivative_C]
+  have hid := deriv_trace_identity htC
+  rw [hd0, htr, traceQC_y5, mul_zero, mul_zero, zero_add] at hid
+  rcases mul_eq_zero.mp hid.symm with h7 | h7
+  · have h7' : t ^ 7 - t ^ 5 = 0 := by exact_mod_cast h7
+    have hfac : t ^ 5 * (t ^ 2 - 1) = 0 := by linear_combination h7'
+    have ht5 : (0 : ℝ) < t ^ 5 := pow_pos ht0 5
+    have hsq : t ^ 2 = 1 := by
+      rcases mul_eq_zero.mp hfac with h | h
+      · exact absurd h ht5.ne'
+      · linarith
+    rcases lt_or_gt_of_ne ht1 with hlt | hgt
+    · nlinarith
+    · nlinarith
+  · exact dtrace_y5_ne_zero h7
+
+lemma count_muC : LC.roots.count (mu : ℂ) = 1 :=
+  le_antisymm
+    (salem_count_le_one (by linarith [mu_gt_one]) (ne_of_gt mu_gt_one) mu_trace)
+    (Multiset.count_pos.mpr muC_mem)
+
+lemma count_nuC : LC.roots.count (nu : ℂ) = 1 :=
+  le_antisymm
+    (salem_count_le_one nu_pos (ne_of_lt nu_lt_one) nu_trace)
+    (Multiset.count_pos.mpr nuC_mem)
+
+/-! ### Norm products over classified root multisets. -/
+
+lemma norm_multiset_prod (S : Multiset ℂ) : ‖S.prod‖ = (S.map fun z => ‖z‖).prod := by
+  induction S using Multiset.induction with
+  | empty => simp
+  | cons a s ih => simp [norm_mul, ih]
+
+lemma norm_muC : ‖((mu : ℝ) : ℂ)‖ = mu := by
+  rw [Complex.norm_real, Real.norm_eq_abs, abs_of_pos (by linarith [mu_gt_one])]
+
+lemma norm_nuC : ‖((nu : ℝ) : ℂ)‖ = nu := by
+  rw [Complex.norm_real, Real.norm_eq_abs, abs_of_pos nu_pos]
+
+lemma classified_prod (S : Multiset ℂ)
+    (hS : ∀ z ∈ S, ‖z‖ = 1 ∨ z = (mu : ℂ) ∨ z = (nu : ℂ)) :
+    (S.map fun z => ‖z‖).prod = mu ^ S.count (mu : ℂ) * nu ^ S.count (nu : ℂ) := by
+  induction S using Multiset.induction with
+  | empty => simp
+  | cons a s ih =>
+    have hs' : ∀ z ∈ s, ‖z‖ = 1 ∨ z = (mu : ℂ) ∨ z = (nu : ℂ) :=
+      fun z hz => hS z (Multiset.mem_cons_of_mem hz)
+    have ihs := ih hs'
+    rcases hS a (Multiset.mem_cons_self a s) with h1 | rfl | rfl
+    · have hamu : (mu : ℂ) ≠ a := by
+        intro h; rw [← h, norm_muC] at h1; linarith [mu_gt_one]
+      have hanu : (nu : ℂ) ≠ a := by
+        intro h; rw [← h, norm_nuC] at h1; linarith [nu_lt_one]
+      rw [Multiset.map_cons, Multiset.prod_cons, h1, one_mul, ihs,
+        Multiset.count_cons_of_ne hamu, Multiset.count_cons_of_ne hanu]
+    · rw [Multiset.map_cons, Multiset.prod_cons, norm_muC, ihs,
+        Multiset.count_cons_self, Multiset.count_cons_of_ne muC_ne_nuC.symm, pow_succ]
+      ring
+    · rw [Multiset.map_cons, Multiset.prod_cons, norm_nuC, ihs,
+        Multiset.count_cons_of_ne muC_ne_nuC, Multiset.count_cons_self, pow_succ]
+      ring
+
+/-- Norm of the constant term of a monic integer polynomial = product of root norms. -/
+lemma norm_eval_zero_eq_prod {H : Polynomial ℤ} (hHm : H.Monic) :
+    ‖(H.map (Int.castRingHom ℂ)).eval 0‖ =
+      ((H.map (Int.castRingHom ℂ)).roots.map fun z => ‖z‖).prod := by
+  rw [(IsAlgClosed.splits (H.map (Int.castRingHom ℂ))).eval_eq_prod_roots_of_monic
+    (hHm.map _), norm_multiset_prod, Multiset.map_map]
+  exact congrArg Multiset.prod (Multiset.map_congr rfl fun x _ => by simp)
+
+/-! ### THE FACTOR KILL: no proper monic factor of Lehmer exists. -/
+
+/-- **STAGE 2, ASSEMBLED (proven)**: a monic factor of Lehmer of degree 1–9 is
+    impossible.  `F(0)·G(0) = L(0) = 1` pins both constant terms at norm one; the
+    classified norm product is `μ^a·ν^b` with the pair counts `a, b ∈ {0,1}` summing
+    to one across the two factors; the split cases give `μ = 1` or `ν = 1` (refuted),
+    and the non-split cases leave an all-on-circle factor — killed by
+    `no_unit_circle_factor` (Kronecker + the uniform-1291 cyclotomic kill). -/
+theorem lehmer_no_proper_factor {F : Polynomial ℤ} (hFm : F.Monic)
+    (hd1 : 1 ≤ F.natDegree) (hd9 : F.natDegree ≤ 9) (hdvd : F ∣ lehmerPolynomial) : False := by
+  obtain ⟨G, hG⟩ := hdvd
+  have hGm : G.Monic := hFm.of_mul_monic_left (hG ▸ lehmerPolynomial_monic)
+  have hdeg : F.natDegree + G.natDegree = 10 := by
+    rw [← Polynomial.natDegree_mul hFm.ne_zero hGm.ne_zero, ← hG, lehmerPolynomial_natDegree]
+  have hGdvd : G ∣ lehmerPolynomial := ⟨F, by rw [hG]; ring⟩
+  -- constant terms multiply to L(0) = 1
+  have hev : F.eval 0 * G.eval 0 = 1 := by
+    have h := congrArg (Polynomial.eval 0) hG
+    rw [Polynomial.eval_mul] at h
+    rw [← h]
+    unfold lehmerPolynomial
+    simp
+  -- complex sides
+  have hLCsplit : LC = F.map (Int.castRingHom ℂ) * G.map (Int.castRingHom ℂ) := by
+    rw [LC, hG, Polynomial.map_mul]
+  have hroots_add : LC.roots =
+      (F.map (Int.castRingHom ℂ)).roots + (G.map (Int.castRingHom ℂ)).roots := by
+    rw [hLCsplit, Polynomial.roots_mul
+      (mul_ne_zero (hFm.map (Int.castRingHom ℂ)).ne_zero (hGm.map (Int.castRingHom ℂ)).ne_zero)]
+  have hFsub : ∀ z ∈ (F.map (Int.castRingHom ℂ)).roots, z ∈ LC.roots := by
+    intro z hz; rw [hroots_add]; exact Multiset.mem_add.mpr (Or.inl hz)
+  have hGsub : ∀ z ∈ (G.map (Int.castRingHom ℂ)).roots, z ∈ LC.roots := by
+    intro z hz; rw [hroots_add]; exact Multiset.mem_add.mpr (Or.inr hz)
+  -- pair counts split across the factors
+  have hcnt_mu : (F.map (Int.castRingHom ℂ)).roots.count (mu : ℂ) +
+      (G.map (Int.castRingHom ℂ)).roots.count (mu : ℂ) = 1 := by
+    rw [← Multiset.count_add, ← hroots_add, count_muC]
+  have hcnt_nu : (F.map (Int.castRingHom ℂ)).roots.count (nu : ℂ) +
+      (G.map (Int.castRingHom ℂ)).roots.count (nu : ℂ) = 1 := by
+    rw [← Multiset.count_add, ← hroots_add, count_nuC]
+  -- both constant terms have norm one
+  have hFev : ‖(F.map (Int.castRingHom ℂ)).eval 0‖ = 1 := by
+    have hcast : (F.map (Int.castRingHom ℂ)).eval 0 = ((F.eval 0 : ℤ) : ℂ) := by
+      rw [← Polynomial.coeff_zero_eq_eval_zero, Polynomial.coeff_map,
+        Polynomial.coeff_zero_eq_eval_zero]
+      rfl
+    rcases Int.eq_one_or_neg_one_of_mul_eq_one' hev with ⟨hf, _⟩ | ⟨hf, _⟩ <;>
+      rw [hcast, hf] <;> norm_num
+  have hGev : ‖(G.map (Int.castRingHom ℂ)).eval 0‖ = 1 := by
+    have hcast : (G.map (Int.castRingHom ℂ)).eval 0 = ((G.eval 0 : ℤ) : ℂ) := by
+      rw [← Polynomial.coeff_zero_eq_eval_zero, Polynomial.coeff_map,
+        Polynomial.coeff_zero_eq_eval_zero]
+      rfl
+    rcases Int.eq_one_or_neg_one_of_mul_eq_one' hev with ⟨_, hg⟩ | ⟨_, hg⟩ <;>
+      rw [hcast, hg] <;> norm_num
+  -- classified norm products
+  have hFprod : mu ^ (F.map (Int.castRingHom ℂ)).roots.count (mu : ℂ) *
+      nu ^ (F.map (Int.castRingHom ℂ)).roots.count (nu : ℂ) = 1 := by
+    rw [← classified_prod _ (fun z hz => root_classification (hFsub z hz)),
+      ← norm_eval_zero_eq_prod hFm, hFev]
+  have hGprod : mu ^ (G.map (Int.castRingHom ℂ)).roots.count (mu : ℂ) *
+      nu ^ (G.map (Int.castRingHom ℂ)).roots.count (nu : ℂ) = 1 := by
+    rw [← classified_prod _ (fun z hz => root_classification (hGsub z hz)),
+      ← norm_eval_zero_eq_prod hGm, hGev]
+  -- case analysis on the pair counts in F
+  have haF : (F.map (Int.castRingHom ℂ)).roots.count (mu : ℂ) = 0 ∨
+      (F.map (Int.castRingHom ℂ)).roots.count (mu : ℂ) = 1 := by omega
+  have hbF : (F.map (Int.castRingHom ℂ)).roots.count (nu : ℂ) = 0 ∨
+      (F.map (Int.castRingHom ℂ)).roots.count (nu : ℂ) = 1 := by omega
+  rcases haF with ha | ha <;> rcases hbF with hb | hb
+  · -- (0,0): F is all-on-circle
+    refine no_unit_circle_factor hFm (by omega) ⟨G, hG⟩ ?_
+    intro z hz
+    rcases root_classification (hFsub z hz) with h | rfl | rfl
+    · exact h
+    · exact absurd (Multiset.count_pos.mpr hz) (by omega)
+    · exact absurd (Multiset.count_pos.mpr hz) (by omega)
+  · -- (0,1): ν = 1
+    rw [ha, hb, pow_zero, pow_one, one_mul] at hFprod
+    linarith [nu_lt_one, hFprod.le]
+  · -- (1,0): μ = 1
+    rw [ha, hb, pow_one, pow_zero, mul_one] at hFprod
+    linarith [mu_gt_one, hFprod.ge]
+  · -- (1,1): G is all-on-circle
+    refine no_unit_circle_factor hGm (by omega) hGdvd ?_
+    intro z hz
+    rcases root_classification (hGsub z hz) with h | rfl | rfl
+    · exact h
+    · exact absurd (Multiset.count_pos.mpr hz) (by omega)
+    · exact absurd (Multiset.count_pos.mpr hz) (by omega)
+
+/-! ### FIRE: irreducibility over ℤ and ℚ, and the unconditional charpoly. -/
+
+/-- **IRREDUCIBILITY OF LEHMER'S POLYNOMIAL (proven, over ℤ)**. -/
+theorem lehmer_irreducible : Irreducible lehmerPolynomial := by
+  constructor
+  · intro hu
+    have h := Polynomial.natDegree_eq_zero_of_isUnit hu
+    rw [lehmerPolynomial_natDegree] at h
+    exact absurd h (by norm_num)
+  · intro a b hab
+    by_contra hcon
+    push_neg at hcon
+    obtain ⟨hua, hub⟩ := hcon
+    have ha0 : a ≠ 0 := by
+      rintro rfl; rw [zero_mul] at hab; exact lehmerPolynomial_monic.ne_zero hab
+    have hb0 : b ≠ 0 := by
+      rintro rfl; rw [mul_zero] at hab; exact lehmerPolynomial_monic.ne_zero hab
+    have hdeg : a.natDegree + b.natDegree = 10 := by
+      rw [← Polynomial.natDegree_mul ha0 hb0, ← hab, lehmerPolynomial_natDegree]
+    have hlc : a.leadingCoeff * b.leadingCoeff = 1 := by
+      rw [← Polynomial.leadingCoeff_mul, ← hab]
+      exact lehmerPolynomial_monic
+    have hdega : a.natDegree ≠ 0 := by
+      intro h0
+      apply hua
+      have hunit : IsUnit a.leadingCoeff := IsUnit.of_mul_eq_one _ hlc
+      rw [Polynomial.leadingCoeff, h0] at hunit
+      rw [Polynomial.eq_C_of_natDegree_eq_zero h0]
+      exact Polynomial.isUnit_C.mpr hunit
+    have hdegb : b.natDegree ≠ 0 := by
+      intro h0
+      apply hub
+      have hunit : IsUnit b.leadingCoeff :=
+        IsUnit.of_mul_eq_one_right _ hlc
+      rw [Polynomial.leadingCoeff, h0] at hunit
+      rw [Polynomial.eq_C_of_natDegree_eq_zero h0]
+      exact Polynomial.isUnit_C.mpr hunit
+    rcases Int.isUnit_iff.mp (IsUnit.of_mul_eq_one _ hlc) with h | h
+    · exact lehmer_no_proper_factor h (by omega) (by omega) ⟨b, hab⟩
+    · have hma : (-a).Monic := by
+        rw [Polynomial.Monic, Polynomial.leadingCoeff_neg, h, neg_neg]
+      exact lehmer_no_proper_factor hma
+        (by rw [Polynomial.natDegree_neg]; omega)
+        (by rw [Polynomial.natDegree_neg]; omega)
+        ⟨-b, by rw [hab]; ring⟩
+
+/-- **IRREDUCIBILITY OVER ℚ** (Gauss: primitivity transfers it from ℤ). -/
+theorem lehmer_irreducible_rat : Irreducible (lehmerPolynomial.map (Int.castRingHom ℚ)) :=
+  (Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast
+    lehmerPolynomial_monic.isPrimitive).mp lehmer_irreducible
+
+/-! ### The Coxeter element of E₁₀. -/
+
+/-- The Coxeter element `s₀ s₁ ⋯ s₉`, evaluated to an explicit matrix
+    (kernel computation). -/
+theorem coxeterE10_eq :
+    coxeterE10 =
+      !![ 0, 0, 1, 0, 0, 0, 0, 0, -1, -1;
+          1, 0, 1, 0, 0, 0, 0, 0, -1, -1;
+          0, 1, 1, 0, 0, 0, 0, 0, -1, -1;
+          0, 0, 1, 0, 0, 0, 0, 0, -1,  0;
+          0, 0, 0, 1, 0, 0, 0, 0, -1,  0;
+          0, 0, 0, 0, 1, 0, 0, 0, -1,  0;
+          0, 0, 0, 0, 0, 1, 0, 0, -1,  0;
+          0, 0, 0, 0, 0, 0, 1, 0, -1,  0;
+          0, 0, 0, 0, 0, 0, 0, 1, -1,  0;
+          0, 0, 1, 0, 0, 0, 0, 0,  0, -1] := by
+  decide
+
+set_option maxRecDepth 1000000 in
+/-- Lehmer's polynomial annihilates the Coxeter element (kernel computation). -/
+theorem coxeter_annihilation :
+    coxeterE10 ^ 10 + coxeterE10 ^ 9 - coxeterE10 ^ 7 - coxeterE10 ^ 6 - coxeterE10 ^ 5 -
+      coxeterE10 ^ 4 - coxeterE10 ^ 3 + coxeterE10 + 1 = 0 := by
+  rw [coxeterE10_eq]
+  decide
+
+/-- The annihilation, restated through `aeval`. -/
+theorem aeval_coxeterE10_lehmer :
+    (Polynomial.aeval coxeterE10) lehmerPolynomial = 0 := by
+  have h := coxeter_annihilation
+  unfold lehmerPolynomial
+  simpa [map_add, map_sub, map_pow, Polynomial.aeval_X, Polynomial.aeval_one] using h
+
+/-- The characteristic polynomial of the E₁₀ Coxeter element is Lehmer's polynomial,
+    over ℚ. -/
+theorem coxeter_charpoly_rat :
+    (coxeterE10.map (Int.castRingHom ℚ)).charpoly =
+      lehmerPolynomial.map (Int.castRingHom ℚ) :=
+  charpoly_eq_lehmer_of_irreducible aeval_coxeterE10_lehmer lehmer_irreducible_rat
+
+/-- **The characteristic polynomial of a Coxeter element of E₁₀ is Lehmer's
+    polynomial**, over ℤ (McMullen, *Coxeter groups, Salem numbers and the Hilbert
+    metric*, 2002 — here as a kernel-checked identity). -/
+theorem coxeter_charpoly_lehmer :
+    coxeterE10.charpoly = lehmerPolynomial := by
+  have h := coxeter_charpoly_rat
+  rw [Matrix.charpoly_map] at h
+  exact Polynomial.map_injective _ Int.cast_injective h
+
+end LehmerE10

--- a/LeanPool/LehmerE10/Main.lean
+++ b/LeanPool/LehmerE10/Main.lean
@@ -33,7 +33,7 @@ Route:
       first over ℚ, then over ℤ by injectivity of the coefficient map.
 SCOPE: Lehmer's 1933 conjecture (a positive lower bound for Mahler measures > 1)
 is NOT claimed anywhere in this repository.
-No `sorry`; no axioms beyond `propext`, `Classical.choice`, `Quot.sound`.
+Axiom footprint: `propext`, `Classical.choice`, `Quot.sound` only.
 -/
 
 namespace LehmerE10

--- a/LeanPool/LehmerE10/Main.lean
+++ b/LeanPool/LehmerE10/Main.lean
@@ -164,8 +164,8 @@ lemma dtrace_y5_ne_zero : dtraceQC (y5 : ℂ) ≠ 0 := by
   have h5 := Set.mem_Ioo.mp y5_mem
   rw [← tracePoly_derivative_eval, trace_factor]
   simp only [derivative_mul, derivative_sub, derivative_X, derivative_C, eval_add, eval_mul,
-    eval_sub, eval_X, eval_C, sub_self, sub_zero, mul_zero, zero_mul, mul_one, one_mul,
-    add_zero, zero_add]
+    eval_sub, eval_X, eval_C, sub_self, sub_zero, mul_zero, mul_one, one_mul,
+    zero_add]
   have hne : ∀ a : ℝ, a < y5 → (y5 : ℂ) - (a : ℂ) ≠ 0 := by
     intro a ha
     rw [sub_ne_zero]
@@ -205,7 +205,7 @@ lemma LC_derivative_eval (z : ℂ) :
     (derivative LC).eval z =
       10 * z ^ 9 + 9 * z ^ 8 - 7 * z ^ 6 - 6 * z ^ 5 - 5 * z ^ 4 - 4 * z ^ 3 - 3 * z ^ 2 + 1 := by
   rw [LC_poly]
-  simp [derivative_add, derivative_sub, derivative_X_pow, derivative_X, derivative_one]
+  simp [derivative_add, derivative_sub, derivative_X, derivative_one]
   try push_cast
   try ring
 
@@ -330,7 +330,7 @@ lemma nuC_mem : (nu : ℂ) ∈ LC.roots := by
 lemma salem_count_le_one {t : ℝ} (ht0 : 0 < t) (ht1 : t ≠ 1)
     (htr : (t : ℂ) + 1 / (t : ℂ) = (y5 : ℂ)) : LC.roots.count (t : ℂ) ≤ 1 := by
   by_contra hcon
-  push_neg at hcon
+  push Not at hcon
   have h2 : 2 ≤ rootMultiplicity ((t : ℝ) : ℂ) LC := by
     rw [← Polynomial.count_roots]; omega
   have hdvd : (X - C ((t : ℝ) : ℂ)) ^ 2 ∣ LC :=
@@ -370,7 +370,7 @@ lemma count_nuC : LC.roots.count (nu : ℂ) = 1 :=
 lemma norm_multiset_prod (S : Multiset ℂ) : ‖S.prod‖ = (S.map fun z => ‖z‖).prod := by
   induction S using Multiset.induction with
   | empty => simp
-  | cons a s ih => simp [norm_mul, ih]
+  | cons a s ih => simp [ih]
 
 lemma norm_muC : ‖((mu : ℝ) : ℂ)‖ = mu := by
   rw [Complex.norm_real, Real.norm_eq_abs, abs_of_pos (by linarith [mu_gt_one])]
@@ -511,7 +511,7 @@ theorem lehmer_irreducible : Irreducible lehmerPolynomial := by
     exact absurd h (by norm_num)
   · intro a b hab
     by_contra hcon
-    push_neg at hcon
+    push Not at hcon
     obtain ⟨hua, hub⟩ := hcon
     have ha0 : a ≠ 0 := by
       rintro rfl; rw [zero_mul] at hab; exact lehmerPolynomial_monic.ne_zero hab

--- a/LeanPool/LehmerE10/Main.lean
+++ b/LeanPool/LehmerE10/Main.lean
@@ -585,13 +585,12 @@ theorem coxeterE10_eq :
           0, 0, 1, 0, 0, 0, 0, 0,  0, -1] := by
   decide
 
-set_option maxRecDepth 1000000 in
 /-- Lehmer's polynomial annihilates the Coxeter element (kernel computation). -/
 theorem coxeter_annihilation :
     coxeterE10 ^ 10 + coxeterE10 ^ 9 - coxeterE10 ^ 7 - coxeterE10 ^ 6 - coxeterE10 ^ 5 -
       coxeterE10 ^ 4 - coxeterE10 ^ 3 + coxeterE10 + 1 = 0 := by
   rw [coxeterE10_eq]
-  decide
+  decide +kernel
 
 /-- The annihilation, restated through `aeval`. -/
 theorem aeval_coxeterE10_lehmer :

--- a/LeanPool/LehmerE10/SalemSymmetry.lean
+++ b/LeanPool/LehmerE10/SalemSymmetry.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2026 Dillon Ryan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dillon Ryan
+-/
+
+import LeanPool.LehmerE10.Defs
+import LeanPool.LehmerE10.Main
+
+/-!
+# unimodularity and the reciprocal (Salem-pair) symmetry.
+Two small facts, downstream of `main_theorem`, recording the structure of the Coxeter
+element as an integer lattice automorphism:
+* `coxeterE10_det_one` : the Coxeter element lies in `SL(10, ℤ)` — `det = 1`.  A product
+  of the ten simple reflections (each `det = -1`) is unimodular, and its determinant is
+  pinned by the charpoly identity to the constant coefficient of Lehmer's polynomial.
+* `lehmerPolynomial_selfReciprocal` : Lehmer's polynomial is palindromic, `coeff i =
+  coeff (10 - i)`.  This is the reciprocal / Salem-pair symmetry: the off-circle roots
+  come in a pair `{μ, 1/μ}`, so the spectral radius `μ` (Lehmer's number) has its inverse
+  as a conjugate.  Equivalently, the Coxeter element and its inverse share a charpoly.
+-/
+
+open Polynomial Matrix
+
+namespace LehmerE10
+
+/-- The E₁₀ Coxeter element is **unimodular**: `det = 1`, i.e. it lies in `SL(10, ℤ)`.
+Proof: `det = (-1)^(card) · charpoly.coeff 0`; the charpoly is Lehmer's polynomial, whose
+constant coefficient is `1`, and `card (Fin 10) = 10` is even. -/
+theorem coxeterE10_det_one : coxeterE10.det = 1 := by
+  rw [Matrix.det_eq_sign_charpoly_coeff, coxeter_charpoly_lehmer]
+  have hcard : Fintype.card (Fin 10) = 10 := Fintype.card_fin 10
+  have hc0 : lehmerPolynomial.coeff 0 = 1 := by
+    simp [lehmerPolynomial, coeff_X_pow]
+  rw [hcard, hc0]
+  norm_num
+
+/-- Lehmer's polynomial is **self-reciprocal** (palindromic): `coeff i = coeff (10 - i)`
+for `i ≤ 10`.  This is the Salem-pair symmetry `{μ, 1/μ}` off the unit circle. -/
+theorem lehmerPolynomial_selfReciprocal (i : ℕ) (hi : i ≤ 10) :
+    lehmerPolynomial.coeff i = lehmerPolynomial.coeff (10 - i) := by
+  interval_cases i <;> simp [lehmerPolynomial, coeff_X_pow, coeff_X, coeff_one]
+
+end LehmerE10

--- a/LeanPool/LehmerE10/TraceQuintic.lean
+++ b/LeanPool/LehmerE10/TraceQuintic.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 Dillon Ryan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dillon Ryan
+-/
+
+import Mathlib.Analysis.SpecialFunctions.Complex.Circle
+import Mathlib.Topology.Order.IntermediateValue
+import Mathlib.Topology.Algebra.Polynomial
+
+/-!
+# locating the roots of Lehmer's polynomial via its trace quintic.
+`L` is reciprocal, so with `y = x + 1/x` it factors through a degree-5 polynomial:
+  `L(x) = x⁵ · q(x + 1/x)`,  `q(y) = y⁵ + y⁴ − 5y³ − 5y² + 4y + 3`,
+and a root of `L` lies on `|z| = 1` iff its trace `y = x + 1/x` lies in `[−2, 2]`
+(`x = e^{iθ}`, `y = 2 cos θ`).  Salem's picture — 8 roots on the unit circle, one
+reciprocal pair `{λ, 1/λ}` off it — therefore reduces to "`q` has 4 real roots in
+`(−2, 2)` and one root in `(2, 21/10)`": five intermediate-value sign checks,
+carried out here.
+No `sorry`; no axioms beyond `propext`, `Classical.choice`, `Quot.sound`.
+-/
+
+namespace LehmerE10
+
+
+/-- Lehmer's polynomial as a function on ℂ. -/
+noncomputable def lehmerC (z : ℂ) : ℂ :=
+  z ^ 10 + z ^ 9 - z ^ 7 - z ^ 6 - z ^ 5 - z ^ 4 - z ^ 3 + z + 1
+
+/-- The degree-5 TRACE polynomial over ℝ (for root location). -/
+def traceQ (y : ℝ) : ℝ := y ^ 5 + y ^ 4 - 5 * y ^ 3 - 5 * y ^ 2 + 4 * y + 3
+
+/-- Trace polynomial over ℂ. -/
+noncomputable def traceQC (y : ℂ) : ℂ := y ^ 5 + y ^ 4 - 5 * y ^ 3 - 5 * y ^ 2 + 4 * y + 3
+
+@[simp] theorem traceQC_ofReal (y : ℝ) : traceQC (y : ℂ) = (traceQ y : ℂ) := by
+  unfold traceQC traceQ; push_cast; ring
+
+/-- **THE RECIPROCAL → TRACE REDUCTION: `L(x) = x⁵ · q(x + 1/x)`, PROVEN.** -/
+theorem lehmer_trace_reduction (z : ℂ) (hz : z ≠ 0) :
+    lehmerC z = z ^ 5 * traceQC (z + 1 / z) := by
+  unfold lehmerC traceQC
+  field_simp
+  ring
+
+/-! ### The five real roots of the trace polynomial (IVT). -/
+
+private theorem traceQ_cont : Continuous traceQ := by unfold traceQ; fun_prop
+
+/-- A trace root in `(−2, −3/2)` (endpoints: q(−2)=−1 < 0 < 3/32 = q(−3/2)). -/
+theorem traceQ_root_1 : ∃ y ∈ Set.Ioo (-2 : ℝ) (-3/2), traceQ y = 0 := by
+  have h : (0:ℝ) ∈ Set.Ioo (traceQ (-2)) (traceQ (-3/2)) := by
+    rw [Set.mem_Ioo]; unfold traceQ; norm_num
+  obtain ⟨y, hy, hy0⟩ := intermediate_value_Ioo (by norm_num : (-2:ℝ) ≤ -3/2)
+    traceQ_cont.continuousOn h
+  exact ⟨y, hy, hy0⟩
+
+/-- A trace root in `(−3/2, −1)`. -/
+theorem traceQ_root_2 : ∃ y ∈ Set.Ioo (-3/2 : ℝ) (-1), traceQ y = 0 := by
+  have h : (0:ℝ) ∈ Set.Ioo (traceQ (-1)) (traceQ (-3/2)) := by
+    rw [Set.mem_Ioo]; unfold traceQ; norm_num
+  obtain ⟨y, hy, hy0⟩ := intermediate_value_Ioo' (by norm_num : (-3/2:ℝ) ≤ -1)
+    traceQ_cont.continuousOn h
+  exact ⟨y, hy, hy0⟩
+
+/-- A trace root in `(−1, 0)`. -/
+theorem traceQ_root_3 : ∃ y ∈ Set.Ioo (-1 : ℝ) 0, traceQ y = 0 := by
+  have h : (0:ℝ) ∈ Set.Ioo (traceQ (-1)) (traceQ 0) := by
+    rw [Set.mem_Ioo]; unfold traceQ; norm_num
+  obtain ⟨y, hy, hy0⟩ := intermediate_value_Ioo (by norm_num : (-1:ℝ) ≤ 0)
+    traceQ_cont.continuousOn h
+  exact ⟨y, hy, hy0⟩
+
+/-- A trace root in `(0, 1)`. -/
+theorem traceQ_root_4 : ∃ y ∈ Set.Ioo (0 : ℝ) 1, traceQ y = 0 := by
+  have h : (0:ℝ) ∈ Set.Ioo (traceQ 1) (traceQ 0) := by
+    rw [Set.mem_Ioo]; unfold traceQ; norm_num
+  obtain ⟨y, hy, hy0⟩ := intermediate_value_Ioo' (by norm_num : (0:ℝ) ≤ 1)
+    traceQ_cont.continuousOn h
+  exact ⟨y, hy, hy0⟩
+
+/-- The Salem trace root in `(2, 21/10)` — `y_L = λ_L + 1/λ_L > 2`, the off-circle
+reciprocal pair. -/
+theorem traceQ_root_salem : ∃ y ∈ Set.Ioo (2 : ℝ) (21/10), traceQ y = 0 := by
+  have h : (0:ℝ) ∈ Set.Ioo (traceQ 2) (traceQ (21/10)) := by
+    rw [Set.mem_Ioo]; unfold traceQ; norm_num
+  obtain ⟨y, hy, hy0⟩ := intermediate_value_Ioo (by norm_num : (2:ℝ) ≤ 21/10)
+    traceQ_cont.continuousOn h
+  exact ⟨y, hy, hy0⟩
+
+/-! ### On-circle Lehmer roots from trace roots in `(−2,2)`. -/
+
+/-- Each trace root in `(−2,2)` gives a root of `L` on `|z| = 1`: for `y₀ ∈ (−2,2)`
+    with `q(y₀) = 0`, the explicit `z = (y₀ + i√(4−y₀²))/2` has `‖z‖ = 1` and
+    `z + 1/z = y₀`, so by the trace reduction `L(z) = z⁵ · q(y₀) = 0`. -/
+theorem lehmer_root_on_circle (y₀ : ℝ) (h0 : traceQ y₀ = 0) (hmem : y₀ ∈ Set.Ioo (-2 : ℝ) 2) :
+    ∃ z : ℂ, ‖z‖ = 1 ∧ lehmerC z = 0 := by
+  obtain ⟨hlo, hhi⟩ := hmem
+  have h4 : (0:ℝ) ≤ 4 - y₀ ^ 2 := by nlinarith
+  set r : ℝ := Real.sqrt (4 - y₀ ^ 2) with hrdef
+  have hrr : r * r = 4 - y₀ ^ 2 := Real.mul_self_sqrt h4
+  set z : ℂ := ⟨y₀ / 2, r / 2⟩ with hzdef
+  have hns : Complex.normSq z = 1 := by rw [hzdef, Complex.normSq_mk]; nlinarith [hrr]
+  have hznorm : ‖z‖ = 1 := by rw [Complex.norm_def, hns, Real.sqrt_one]
+  have hz0 : z ≠ 0 := Complex.normSq_pos.mp (by rw [hns]; norm_num)
+  have hzre : z.re = y₀ / 2 := by rw [hzdef]
+  have h1z : 1 / z = (starRingEnd ℂ) z := by
+    rw [one_div, Complex.inv_def, hns]; simp
+  have hsum : z + 1 / z = (y₀ : ℂ) := by
+    rw [h1z, Complex.add_conj, hzre]; push_cast; ring
+  refine ⟨z, hznorm, ?_⟩
+  rw [lehmer_trace_reduction z hz0, hsum, traceQC_ofReal, h0, Complex.ofReal_zero, mul_zero]
+
+/-- `L` has a root on the unit circle (combining the trace root in `(−1,0)` with
+    `lehmer_root_on_circle`). -/
+theorem elliptic_root_on_circle : ∃ z : ℂ, ‖z‖ = 1 ∧ lehmerC z = 0 := by
+  obtain ⟨y, hy, hy0⟩ := traceQ_root_3
+  exact lehmer_root_on_circle y hy0 ⟨by linarith [hy.1], by linarith [hy.2]⟩
+
+end LehmerE10
+

--- a/LeanPool/LehmerE10/TraceQuintic.lean
+++ b/LeanPool/LehmerE10/TraceQuintic.lean
@@ -17,7 +17,7 @@ and a root of `L` lies on `|z| = 1` iff its trace `y = x + 1/x` lies in `[−2, 
 reciprocal pair `{λ, 1/λ}` off it — therefore reduces to "`q` has 4 real roots in
 `(−2, 2)` and one root in `(2, 21/10)`": five intermediate-value sign checks,
 carried out here.
-No `sorry`; no axioms beyond `propext`, `Classical.choice`, `Quot.sound`.
+Axiom footprint: `propext`, `Classical.choice`, `Quot.sound` only.
 -/
 
 namespace LehmerE10

--- a/LeanPool/LehmerE10/UnitCircleFactors.lean
+++ b/LeanPool/LehmerE10/UnitCircleFactors.lean
@@ -20,7 +20,7 @@ Contents:
     `z + 1/z` real in `(−2, 2)` forces `‖z‖ = 1` (real `z` is excluded by AM–GM;
     the conjugate is then the reciprocal).
   • `two_le_self_add_inv` — the AM–GM inequality used above.
-No `sorry`; no axioms beyond `propext`, `Classical.choice`, `Quot.sound`.
+Axiom footprint: `propext`, `Classical.choice`, `Quot.sound` only.
 -/
 
 namespace LehmerE10

--- a/LeanPool/LehmerE10/UnitCircleFactors.lean
+++ b/LeanPool/LehmerE10/UnitCircleFactors.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2026 Dillon Ryan. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dillon Ryan
+-/
+
+import LeanPool.LehmerE10.CyclotomicKill
+import Mathlib.Analysis.SpecialFunctions.Complex.Circle
+
+/-!
+# no factor of Lehmer's polynomial lives on the unit circle.
+Contents:
+  • `no_unit_circle_factor` — a monic ℤ-factor of `L` of positive degree cannot
+    have all its complex roots on the unit circle: such a factor would carry a root
+    of unity (`kronecker_roots`), whose cyclotomic minimal polynomial would descend
+    to a cyclotomic ℤ-divisor of `L` (Gauss's lemma), refuted by
+    `no_cyclotomic_divisor`.  So every proper factor must touch the off-circle
+    Salem pair.
+  • `norm_eq_one_of_trace_in_ball` — the on-circle half of the root dichotomy:
+    `z + 1/z` real in `(−2, 2)` forces `‖z‖ = 1` (real `z` is excluded by AM–GM;
+    the conjugate is then the reciprocal).
+  • `two_le_self_add_inv` — the AM–GM inequality used above.
+No `sorry`; no axioms beyond `propext`, `Classical.choice`, `Quot.sound`.
+-/
+
+namespace LehmerE10
+
+open Polynomial
+
+/-! ### AM–GM face: a positive real plus its inverse is at least 2. -/
+
+theorem two_le_self_add_inv {t : ℝ} (ht : 0 < t) : 2 ≤ t + 1 / t := by
+  have hsq : 0 ≤ (t - 1) ^ 2 := sq_nonneg _
+  have hmul : t * (t + 1 / t) = t ^ 2 + 1 := by
+    field_simp
+  nlinarith
+
+/-! ### The on-circle half of the root dichotomy. -/
+
+/-- If z + 1/z is a real number strictly inside (−2, 2), then ‖z‖ = 1: z cannot be
+    real (AM–GM), and the conjugate — a root of the same real quadratic — must then
+    be the reciprocal, giving ‖z‖² = z·conj z = 1. -/
+theorem norm_eq_one_of_trace_in_ball {z : ℂ} {y : ℝ} (hz : z ≠ 0)
+    (htr : z + 1 / z = (y : ℂ)) (hy : -2 < y) (hy' : y < 2) : ‖z‖ = 1 := by
+  -- conj z satisfies the same relation
+  have hconj : (starRingEnd ℂ) z + 1 / (starRingEnd ℂ) z = (y : ℂ) := by
+    have := congrArg (starRingEnd ℂ) htr
+    simpa [map_add, map_div₀, Complex.conj_ofReal] using this
+  -- z and conj z are both roots of X² − yX + 1, whose roots are {z, 1/z}
+  -- (from z + 1/z = y: the quadratic factors as (X − z)(X − 1/z))
+  have hquad : ∀ w : ℂ, w ^ 2 - (y : ℂ) * w + 1 = (w - z) * (w - 1 / z) := by
+    intro w
+    have h1 : z * (1 / z) = 1 := by field_simp
+    calc w ^ 2 - (y : ℂ) * w + 1
+        = w ^ 2 - (z + 1 / z) * w + z * (1 / z) := by rw [htr, h1]
+      _ = (w - z) * (w - 1 / z) := by ring
+  -- conj z is a root of the quadratic
+  have hcz0 : (starRingEnd ℂ) z ≠ 0 := by simpa using hz
+  have hinvc : (starRingEnd ℂ) z * (1 / (starRingEnd ℂ) z) = 1 := by field_simp
+  have hzero : ((starRingEnd ℂ) z) ^ 2 - (y : ℂ) * ((starRingEnd ℂ) z) + 1 = 0 := by
+    linear_combination ((starRingEnd ℂ) z) * hconj - hinvc
+  have hcz : ((starRingEnd ℂ) z - z) * ((starRingEnd ℂ) z - 1 / z) = 0 := by
+    rw [← hquad ((starRingEnd ℂ) z)]
+    exact hzero
+  rcases mul_eq_zero.mp hcz with h | h
+  · -- conj z = z : z is real, contradiction with |y| < 2 via AM–GM
+    exfalso
+    have hreal : ∃ t : ℝ, (t : ℂ) = z := by
+      have := sub_eq_zero.mp h
+      exact ⟨z.re, by
+        have := Complex.conj_eq_iff_re.mp this
+        exact this⟩
+    obtain ⟨t, rfl⟩ := hreal
+    have ht0 : t ≠ 0 := by simpa using hz
+    have htr' : t + 1 / t = y := by
+      have : ((t + 1 / t : ℝ) : ℂ) = (y : ℂ) := by push_cast; simpa using htr
+      exact_mod_cast this
+    rcases lt_or_gt_of_ne ht0 with hneg | hpos
+    · have h2 := two_le_self_add_inv (t := -t) (by linarith)
+      have hneg' : -t + 1 / -t = -(t + 1 / t) := by ring
+      rw [hneg', htr'] at h2
+      linarith
+    · have h2 := two_le_self_add_inv hpos
+      rw [htr'] at h2
+      linarith
+  · -- conj z = 1/z : ‖z‖² = 1
+    have hczz : (starRingEnd ℂ) z = 1 / z := sub_eq_zero.mp h
+    have hprod : z * (starRingEnd ℂ) z = 1 := by rw [hczz]; field_simp
+    have h1 : ‖z * (starRingEnd ℂ) z‖ = 1 := by rw [hprod]; simp
+    rw [norm_mul, RCLike.norm_conj] at h1
+    rcases mul_self_eq_one_iff.mp h1 with h' | h'
+    · exact h'
+    · exfalso; have := norm_nonneg z; linarith
+
+/-! ### THE CIRCLE IS CLOSED: no all-on-circle factor. -/
+
+/-- **NO UNIT-CIRCLE FACTOR (proven)**: a monic factor of Lehmer with positive degree
+    and all complex roots on the unit circle is impossible — its root of unity would
+    give a cyclotomic ℤ-divisor of Lehmer, refuted by `no_cyclotomic_divisor`. -/
+theorem no_unit_circle_factor {F : Polynomial ℤ} (hFm : F.Monic)
+    (hdeg : 0 < F.natDegree) (hFdvd : F ∣ lehmerPolynomial)
+    (hcirc : ∀ z ∈ (F.map (Int.castRingHom ℂ)).roots, ‖z‖ = 1) : False := by
+  -- a complex root exists
+  have hFCm : (F.map (Int.castRingHom ℂ)).Monic := hFm.map _
+  have hFCdeg : 0 < (F.map (Int.castRingHom ℂ)).degree := by
+    rw [hFm.degree_map]
+    exact Polynomial.natDegree_pos_iff_degree_pos.mp hdeg
+  obtain ⟨z, hzroot⟩ := Complex.exists_root hFCdeg
+  have hz : z ∈ (F.map (Int.castRingHom ℂ)).roots :=
+    (mem_roots hFCm.ne_zero).mpr hzroot
+  -- z is a root of unity (Kronecker)
+  obtain ⟨n, hn, hzn⟩ := kronecker_roots hFm hcirc hz
+  have hfin : IsOfFinOrder z := isOfFinOrder_iff_pow_eq_one.mpr ⟨n, hn, hzn⟩
+  have hk : 0 < orderOf z := hfin.orderOf_pos
+  have hprim : IsPrimitiveRoot z (orderOf z) := IsPrimitiveRoot.orderOf z
+  -- z is a root of Lehmer over ℚ (through F ∣ L and the cast tower ℤ → ℚ → ℂ)
+  have hLC : z ∈ (lehmerPolynomial.map (Int.castRingHom ℂ)).roots := by
+    have hLne : lehmerPolynomial.map (Int.castRingHom ℂ) ≠ 0 :=
+      (lehmerPolynomial_monic.map _).ne_zero
+    exact Multiset.mem_of_le
+      (roots.le_of_dvd hLne (Polynomial.map_dvd _ hFdvd)) hz
+  have hzL : (Polynomial.aeval z) (lehmerPolynomial.map (Int.castRingHom ℚ)) = 0 := by
+    have hLne : lehmerPolynomial.map (Int.castRingHom ℂ) ≠ 0 :=
+      (lehmerPolynomial_monic.map _).ne_zero
+    have h := (mem_roots hLne).mp hLC
+    rw [IsRoot.def, eval_map] at h
+    rw [aeval_def, Polynomial.eval₂_map]
+    have hcomp : ((algebraMap ℚ ℂ).comp (Int.castRingHom ℚ)) = Int.castRingHom ℂ :=
+      RingHom.ext_int _ _
+    rwa [hcomp]
+  -- minpoly = cyclotomic (orderOf z) over ℚ divides L over ℚ, then descends to ℤ
+  have hdvdQ : cyclotomic (orderOf z) ℚ ∣ lehmerPolynomial.map (Int.castRingHom ℚ) :=
+    (cyclotomic_eq_minpoly_rat hprim hk) ▸ minpoly.dvd ℚ z hzL
+  have hdvdZ : cyclotomic (orderOf z) ℤ ∣ lehmerPolynomial := by
+    rw [IsPrimitive.Int.dvd_iff_map_cast_dvd_map_cast _ _
+      (cyclotomic.monic _ ℤ).isPrimitive lehmerPolynomial_monic.isPrimitive]
+    rwa [Polynomial.map_cyclotomic_int]
+  exact no_cyclotomic_divisor hk hdvdZ
+
+
+end LehmerE10

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -4556,3 +4556,49 @@ projects:
     msc:
       - "11B75"
       - "05D99"
+  - slug: lehmer-e10
+    title: Lehmer's Polynomial and the E10 Coxeter Element
+    summary: >-
+      Proves that Lehmer's degree-10 polynomial — the integer polynomial of
+      smallest known Mahler measure above 1 — is irreducible over the
+      integers, and that it is the characteristic polynomial of a Coxeter
+      element of the E10 Weyl group (the rank-10 instance of McMullen).
+      Against Mathlib's Mahler-measure API it computes M(L) exactly as the
+      Salem root with the unconditional bounds 1 < M(L) < 7/5, states
+      Lehmer's conjecture as a defined Prop (never assumed) with the strong
+      form implying the gap form, and contrasts the E8 Coxeter element
+      (order exactly 30) with the E10 element (infinite order in GL(10,Z)):
+      the E-series crosses from torsion to a Salem matrix at rank 10, and
+      the crossing value is Lehmer's number.
+    branch: number theory
+    entry_module: LeanPool.LehmerE10
+    authors:
+      - Dillon Ryan
+    source:
+      github_repo: dillon-11/lehmer-E10
+      url: https://github.com/dillon-11/lehmer-E10
+    license: Apache-2.0
+    status: verified
+    provenance: mix
+    main_declarations:
+      - LehmerE10.main_theorem
+    main_results:
+      - declaration: LehmerE10.main_theorem
+        informal: >-
+          Lehmer's polynomial L(x) = x^10 + x^9 - x^7 - x^6 - x^5 - x^4 -
+          x^3 + x + 1 is irreducible over the integers, and the
+          characteristic polynomial of a Coxeter element of the E10 Weyl
+          group equals L.
+      - declaration: LehmerE10.lehmer_mahlerMeasure
+        informal: >-
+          The Mahler measure of L equals its Salem root mu, with the
+          unconditional bounds 1 < M(L) < 7/5.
+    tags:
+      - number-theory
+      - mahler-measure
+      - salem-numbers
+      - coxeter-groups
+    msc:
+      - "11R06"
+      - "11C08"
+      - "20F55"


### PR DESCRIPTION
Adds the LehmerE10 project per CONTRIBUTING.md (content-only: `LeanPool/LehmerE10/`, `LeanPool/LehmerE10.lean`, `LeanPool/projects.yml`, index imports in `LeanPool.lean`).

**What is proved.** Lehmer's polynomial `L(x) = x^10 + x^9 - x^7 - x^6 - x^5 - x^4 - x^3 + x + 1` — the integer polynomial of smallest known Mahler measure above 1 — is irreducible over the integers, and it is the characteristic polynomial of a Coxeter element of the E10 Weyl group (the rank-10 instance of McMullen 2002). Downstream, against Mathlib's `Polynomial.mahlerMeasure`: `M(L)` equals the Salem root exactly, with `1 < M(L) < 7/5`; Lehmer's conjecture is *stated* as a defined Prop (never assumed) with the strong form implying the gap form; and the E8 Coxeter element has order exactly 30 while the E10 element has infinite order in `GL(10, ℤ)` — the E-series crosses from torsion to a Salem matrix at rank 10, and the crossing value is Lehmer's number.

**Provenance: mix** (declared in the project card). Proofs developed with substantial AI assistance under human direction and review; the source repository carries a comparator setup (challenge file + pinned axioms), PROVENANCE notes, and CI: https://github.com/dillon-11/lehmer-E10 (paper context archived at https://doi.org/10.5281/zenodo.21456694).

**Porting notes.** Same toolchain as the pool (v4.32.0-rc1), so no version bump. `main_theorem` is wrapped in the `LehmerE10` namespace to avoid top-level collisions. The source repo's `Challenge.lean` (which holds an intentional placeholder for its comparator) is deliberately not included — the pool copy is placeholder-free. Ten modules, ~1,500 lines.

Opening as draft since I could not run the full-pool linters locally; happy to fix whatever CI or review turns up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)