### PR TITLE
Exposition: raise the minimal-file baseline to 214

### DIFF
--- a/.github/workflows/exposition-verify.yml
+++ b/.github/workflows/exposition-verify.yml
@@ -102,7 +102,7 @@ jobs:
             --out ../exposition-verify \
             --jobs 2 \
             --lean /home/runner/.elan/bin/lean \
-            --baseline 207
+            --baseline 214
 
       - name: Upload verification report
         if: always()


### PR DESCRIPTION
CI measured **214/245** minimal files compiling on the merge of #283. That branch was gated at 207, which came from a local run over a smaller target set (238), so the ratchet had ~7 targets of slack — a real regression could have landed unnoticed.

Raises `--baseline` to the number CI actually measured. The gate's own run on this PR validates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)