### PR TITLE
Formalize all-dimensional Conway–Guy gap rigidity

### DIFF
--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -163,6 +163,7 @@ import LeanPool.Biswal.Theorem1
 import LeanPool.Biswal.Theorem23
 import LeanPool.BooleanIsoperimetry
 import LeanPool.BooleanIsoperimetry.Cascade
+import LeanPool.BooleanIsoperimetry.CoherentGap
 import LeanPool.BooleanIsoperimetry.Compression
 import LeanPool.BooleanIsoperimetry.Cube
 import LeanPool.BooleanIsoperimetry.Harper

--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -165,6 +165,9 @@ import LeanPool.BooleanIsoperimetry
 import LeanPool.BooleanIsoperimetry.Cascade
 import LeanPool.BooleanIsoperimetry.CoherentGap
 import LeanPool.BooleanIsoperimetry.Compression
+import LeanPool.BooleanIsoperimetry.ConwayGuyCoherentGap
+import LeanPool.BooleanIsoperimetry.ConwayGuyHeight
+import LeanPool.BooleanIsoperimetry.ConwayGuyRigidity
 import LeanPool.BooleanIsoperimetry.Cube
 import LeanPool.BooleanIsoperimetry.Harper
 import LeanPool.BooleanIsoperimetry.KruskalKatona

--- a/LeanPool.lean
+++ b/LeanPool.lean
@@ -167,6 +167,7 @@ import LeanPool.BooleanIsoperimetry.CoherentGap
 import LeanPool.BooleanIsoperimetry.Compression
 import LeanPool.BooleanIsoperimetry.ConwayGuyCoherentGap
 import LeanPool.BooleanIsoperimetry.ConwayGuyHeight
+import LeanPool.BooleanIsoperimetry.ConwayGuyOrderBridge
 import LeanPool.BooleanIsoperimetry.ConwayGuyRigidity
 import LeanPool.BooleanIsoperimetry.Cube
 import LeanPool.BooleanIsoperimetry.Harper

--- a/LeanPool/BooleanIsoperimetry.lean
+++ b/LeanPool/BooleanIsoperimetry.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alexey Milovanov
 -/
 
+import LeanPool.BooleanIsoperimetry.CoherentGap
 import LeanPool.BooleanIsoperimetry.Harper
 import LeanPool.BooleanIsoperimetry.MacaulayMin
 import LeanPool.BooleanIsoperimetry.SetFamilyShadow

--- a/LeanPool/BooleanIsoperimetry.lean
+++ b/LeanPool/BooleanIsoperimetry.lean
@@ -5,7 +5,7 @@ Authors: Alexey Milovanov, Egor Lyfar
 -/
 
 import LeanPool.BooleanIsoperimetry.CoherentGap
-import LeanPool.BooleanIsoperimetry.ConwayGuyRigidity
+import LeanPool.BooleanIsoperimetry.ConwayGuyOrderBridge
 import LeanPool.BooleanIsoperimetry.Harper
 import LeanPool.BooleanIsoperimetry.MacaulayMin
 import LeanPool.BooleanIsoperimetry.SetFamilyShadow
@@ -16,7 +16,7 @@ import LeanPool.BooleanIsoperimetry.SetFamilyShadow
 Source: doi:10.1016/S0021-9800(66)80059-5, url:https://doi.org/10.1090/S0002-9939-96-03653-2
 Authors: Alexey Milovanov, Egor Lyfar
 Status: verified
-Main declarations: `BooleanIsoperimetry.harper_theorem`, `BooleanIsoperimetry.CoherentGap.conwayGuyNormalizedChamberRigidity`
+Main declarations: `BooleanIsoperimetry.harper_theorem`, `BooleanIsoperimetry.CoherentGap.conwayGuyRigidity_of_normalizedConsecutiveGaps`
 Tags: additive-combinatorics, extremal-combinatorics, isoperimetry, boolean-cube, subset-sums, coherent-orders
 MSC: 05D05, 05C35
 -/
@@ -37,11 +37,11 @@ shadow estimates, coordinate compressions, and the final induction over cube
 dimension.
 
 For the Conway--Guy distinct-subset-sum sequence, the development also proves
-an all-dimension certificate recurrence. Every real row satisfying its
-liftable unit-relation inequalities dominates the Conway--Guy row
-coordinatewise. Bohman's theorem that the sequence has distinct subset sums is
-kept as the external input connecting these unit relations to consecutive gaps
-of the induced Boolean term order.
+an all-dimension certificate recurrence. Every real row whose consecutive
+subset-sum gaps in the Conway--Guy order are at least one dominates the
+Conway--Guy row coordinatewise. Bohman's theorem that the sequence has
+distinct subset sums remains the external input showing that its subset-sum
+comparison is a total coherent Boolean term order.
 
 ## Provenance
 

--- a/LeanPool/BooleanIsoperimetry.lean
+++ b/LeanPool/BooleanIsoperimetry.lean
@@ -13,14 +13,11 @@ import LeanPool.BooleanIsoperimetry.SetFamilyShadow
 /-!
 # Boolean Isoperimetry and Conway--Guy Coherent Gaps
 
-Source: doi:10.1016/S0021-9800(66)80059-5,
-doi:10.1090/S0002-9939-96-03653-2
+Source: doi:10.1016/S0021-9800(66)80059-5, url:https://doi.org/10.1090/S0002-9939-96-03653-2
 Authors: Alexey Milovanov, Egor Lyfar
 Status: verified
-Main declarations: `BooleanIsoperimetry.harper_theorem`,
-`BooleanIsoperimetry.CoherentGap.conwayGuyNormalizedChamberRigidity`
-Tags: additive-combinatorics, extremal-combinatorics, isoperimetry,
-boolean-cube, subset-sums, coherent-orders
+Main declarations: `BooleanIsoperimetry.harper_theorem`, `BooleanIsoperimetry.CoherentGap.conwayGuyNormalizedChamberRigidity`
+Tags: additive-combinatorics, extremal-combinatorics, isoperimetry, boolean-cube, subset-sums, coherent-orders
 MSC: 05D05, 05C35
 -/
 

--- a/LeanPool/BooleanIsoperimetry.lean
+++ b/LeanPool/BooleanIsoperimetry.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Alexey Milovanov. All rights reserved.
+Copyright (c) 2026 Alexey Milovanov and Egor Lyfar. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Alexey Milovanov
+Authors: Alexey Milovanov, Egor Lyfar
 -/
 
 import LeanPool.BooleanIsoperimetry.CoherentGap
@@ -11,13 +11,16 @@ import LeanPool.BooleanIsoperimetry.MacaulayMin
 import LeanPool.BooleanIsoperimetry.SetFamilyShadow
 
 /-!
-# Harper's Vertex-Isoperimetric Theorem on the Boolean Cube
+# Boolean Isoperimetry and Conway--Guy Coherent Gaps
 
-Source: doi:10.1016/S0021-9800(66)80059-5
-Authors: Alexey Milovanov
+Source: doi:10.1016/S0021-9800(66)80059-5,
+doi:10.1090/S0002-9939-96-03653-2
+Authors: Alexey Milovanov, Egor Lyfar
 Status: verified
-Main declarations: `BooleanIsoperimetry.harper_theorem`
-Tags: extremal-combinatorics, isoperimetry, boolean-cube
+Main declarations: `BooleanIsoperimetry.harper_theorem`,
+`BooleanIsoperimetry.CoherentGap.conwayGuyNormalizedChamberRigidity`
+Tags: additive-combinatorics, extremal-combinatorics, isoperimetry,
+boolean-cube, subset-sums, coherent-orders
 MSC: 05D05, 05C35
 -/
 
@@ -36,6 +39,13 @@ development includes the required binomial-cascade identities, Kruskal--Katona
 shadow estimates, coordinate compressions, and the final induction over cube
 dimension.
 
+For the Conway--Guy distinct-subset-sum sequence, the development also proves
+an all-dimension certificate recurrence. Every real row satisfying its
+liftable unit-relation inequalities dominates the Conway--Guy row
+coordinatewise. Bohman's theorem that the sequence has distinct subset sums is
+kept as the external input connecting these unit relations to consecutive gaps
+of the induced Boolean term order.
+
 ## Provenance
 
 Imported from <https://github.com/AlexeyMilovanov/BooleanIsoperimetry>, branch
@@ -44,4 +54,9 @@ P. Frankl and Z. Füredi, "A short proof for a theorem of Harper about
 Hamming-spheres," *Discrete Mathematics* 34 (1981),
 doi:10.1016/0012-365X(81)90009-1. The formalization was developed with extensive
 LLM assistance under the author's supervision.
+
+The Conway--Guy recurrence follows T. Bohman, "A sum packing problem of Erdős
+and the Conway--Guy sequence," *Proceedings of the AMS* 124 (1996), 3627--3636,
+doi:10.1090/S0002-9939-96-03653-2. Its normalized chamber-rigidity certificate
+induction was added by Egor Lyfar with AI assistance.
 -/

--- a/LeanPool/BooleanIsoperimetry.lean
+++ b/LeanPool/BooleanIsoperimetry.lean
@@ -16,8 +16,8 @@ import LeanPool.BooleanIsoperimetry.SetFamilyShadow
 Source: doi:10.1016/S0021-9800(66)80059-5, url:https://doi.org/10.1090/S0002-9939-96-03653-2
 Authors: Alexey Milovanov, Egor Lyfar
 Status: verified
-Main declarations: `BooleanIsoperimetry.harper_theorem`, `BooleanIsoperimetry.CoherentGap.conwayGuyRigidity_of_normalizedConsecutiveGaps`
-Tags: additive-combinatorics, extremal-combinatorics, isoperimetry, boolean-cube, subset-sums, coherent-orders
+Main declarations: `BooleanIsoperimetry.harper_theorem`, `BooleanIsoperimetry.conwayGuyGapRigidity`
+Tags: additive-combinatorics, isoperimetry, boolean-cube, subset-sums, coherent-orders
 MSC: 05D05, 05C35
 -/
 

--- a/LeanPool/BooleanIsoperimetry.lean
+++ b/LeanPool/BooleanIsoperimetry.lean
@@ -5,6 +5,7 @@ Authors: Alexey Milovanov
 -/
 
 import LeanPool.BooleanIsoperimetry.CoherentGap
+import LeanPool.BooleanIsoperimetry.ConwayGuyRigidity
 import LeanPool.BooleanIsoperimetry.Harper
 import LeanPool.BooleanIsoperimetry.MacaulayMin
 import LeanPool.BooleanIsoperimetry.SetFamilyShadow

--- a/LeanPool/BooleanIsoperimetry/CoherentGap.lean
+++ b/LeanPool/BooleanIsoperimetry/CoherentGap.lean
@@ -1,0 +1,555 @@
+/-
+Copyright (c) 2026 Egor Lyfar. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Egor Lyfar
+-/
+import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.Data.Real.Basic
+
+/-!
+# Coherent-gap certificates
+
+This file formalizes the algebraic certificate mechanism behind normalized
+chamber rigidity for a fixed coherent Boolean term order.  The motivating
+order is the Conway--Guy order from:
+
+* Tom Bohman, "A sum packing problem of Erdős and the Conway--Guy sequence,"
+  Proceedings of the AMS 124 (1996), 3627--3636.
+
+The definitions below do not assume Bohman's distinct-subset-sum theorem.
+That theorem is needed only to identify integral unit relations with
+consecutive gaps in the Conway--Guy subset-sum order.
+
+The open-problem context and the exact boundary of this formalization are
+recorded in `~/Knowledge/Construct/recon/erdos_001.md`.
+-/
+
+open scoped BigOperators
+
+namespace BooleanIsoperimetry.CoherentGap
+
+/-- An integer relation in dimension `n`. -/
+abbrev Relation (n : ℕ) := Fin n → ℤ
+
+/-- The coordinate sum of an integer relation. -/
+def coordinateSum {n : ℕ} (relation : Relation n) : ℤ :=
+  ∑ i, relation i
+
+/-- The scalar product of an integer relation with an integer weight row. -/
+def dot {n : ℕ} (relation weights : Relation n) : ℤ :=
+  ∑ i, relation i * weights i
+
+/-- The standard coordinate vector. -/
+def basis {n : ℕ} (coordinate : Fin n) : Relation n :=
+  fun i => if i = coordinate then 1 else 0
+
+/-- A relation whose entries and coordinate sum lie in `{-1, 0, 1}` and
+whose value on the weight row is one. -/
+def IsLiftableUnit {n : ℕ} (weights relation : Relation n) : Prop :=
+  (∀ i, relation i = -1 ∨ relation i = 0 ∨ relation i = 1) ∧
+    dot relation weights = 1 ∧
+    (coordinateSum relation = -1 ∨
+      coordinateSum relation = 0 ∨ coordinateSum relation = 1)
+
+/-- Pointwise sum of a list of relations. -/
+def aggregate {n : ℕ} (relations : List (Relation n)) : Relation n :=
+  relations.sum
+
+/-- A nonnegative integral dual certificate, represented as a list so that
+multiplicity is the coefficient of a relation. -/
+structure Certificate {n : ℕ} (weights target : Relation n) where
+  /-- Relations listed with their certificate multiplicities. -/
+  relations : List (Relation n)
+  /-- Every listed relation is a liftable unit relation. -/
+  valid : ∀ relation ∈ relations, IsLiftableUnit weights relation
+  /-- The listed relations sum to the certificate target. -/
+  target_eq : aggregate relations = target
+
+lemma coordinateSum_add {n : ℕ} (first second : Relation n) :
+    coordinateSum (first + second) =
+      coordinateSum first + coordinateSum second := by
+  simp [coordinateSum, Finset.sum_add_distrib]
+
+lemma dot_add {n : ℕ} (first second weights : Relation n) :
+    dot (first + second) weights = dot first weights + dot second weights := by
+  simp [dot, add_mul, Finset.sum_add_distrib]
+
+lemma dot_aggregate {n : ℕ} (relations : List (Relation n)) (weights : Relation n) :
+    dot (aggregate relations) weights =
+      (relations.map fun relation => dot relation weights).sum := by
+  induction relations with
+  | nil =>
+      simp [aggregate, dot]
+  | cons relation relations inductionHypothesis =>
+      change dot (relation + aggregate relations) weights =
+        dot relation weights +
+          (relations.map fun tailRelation => dot tailRelation weights).sum
+      rw [dot_add, inductionHypothesis]
+
+@[simp]
+lemma dot_basis {n : ℕ} (coordinate : Fin n) (weights : Relation n) :
+    dot (basis coordinate) weights = weights coordinate := by
+  classical
+  simp [dot, basis]
+
+/-- The mass of a certificate equals the value of its target on the weights. -/
+lemma Certificate.length_eq_dot_target {n : ℕ} {weights target : Relation n}
+    (certificate : Certificate weights target) :
+    (certificate.relations.length : ℤ) = dot target weights := by
+  have hmass : ∀ relations : List (Relation n),
+      (∀ relation ∈ relations, IsLiftableUnit weights relation) →
+        (relations.map fun relation => dot relation weights).sum =
+          (relations.length : ℤ) := by
+    intro relations
+    induction relations with
+    | nil =>
+        intro
+        simp
+    | cons relation relations inductionHypothesis =>
+        intro hvalid
+        have hunit := (hvalid relation List.mem_cons_self).2.1
+        have htail :
+            ∀ tailRelation ∈ relations,
+              IsLiftableUnit weights tailRelation := by
+          intro tailRelation htailRelation
+          exact hvalid tailRelation (List.mem_cons_of_mem relation htailRelation)
+        simp only [List.map_cons, List.sum_cons, hunit, List.length_cons,
+          Nat.cast_add, Nat.cast_one]
+        simpa [add_comm] using inductionHypothesis htail
+  have hcertificateMass := hmass certificate.relations certificate.valid
+  calc
+    (certificate.relations.length : ℤ) =
+        (certificate.relations.map fun relation => dot relation weights).sum :=
+      hcertificateMass.symm
+    _ = dot (aggregate certificate.relations) weights :=
+      (dot_aggregate certificate.relations weights).symm
+    _ = dot target weights := congrArg (fun relation => dot relation weights)
+      certificate.target_eq
+
+/-- A one-relation certificate. -/
+def Certificate.singleton {n : ℕ} {weights relation : Relation n}
+    (hrelation : IsLiftableUnit weights relation) :
+    Certificate weights relation where
+  relations := [relation]
+  valid := by simpa
+  target_eq := by simp [aggregate]
+
+/-- Add two certificates. -/
+def Certificate.add {n : ℕ} {weights firstTarget secondTarget : Relation n}
+    (first : Certificate weights firstTarget)
+    (second : Certificate weights secondTarget) :
+    Certificate weights (firstTarget + secondTarget) where
+  relations := first.relations ++ second.relations
+  valid := by
+    intro relation hrelation
+    rcases List.mem_append.mp hrelation with hfirst | hsecond
+    · exact first.valid relation hfirst
+    · exact second.valid relation hsecond
+  target_eq := by
+    unfold aggregate
+    rw [List.sum_append]
+    simpa only [aggregate] using
+      congrArg₂ (fun firstRelation secondRelation =>
+        firstRelation + secondRelation) first.target_eq second.target_eq
+
+/-- Reinterpret the target of a certificate along an equality. -/
+def Certificate.castTarget {n : ℕ} {weights firstTarget secondTarget : Relation n}
+    (certificate : Certificate weights firstTarget)
+    (htarget : firstTarget = secondTarget) :
+    Certificate weights secondTarget := by
+  subst secondTarget
+  exact certificate
+
+/-- The sum of a list of dependently packaged certificates. -/
+def Certificate.sum {n : ℕ} {weights : Relation n} :
+    (certificates : List (Σ target, Certificate weights target)) →
+      Certificate weights (certificates.map Sigma.fst).sum
+  | [] =>
+      { relations := []
+        valid := by simp
+        target_eq := by simp [aggregate] }
+  | ⟨target, certificate⟩ :: certificates => by
+      simpa using certificate.add (Certificate.sum certificates)
+
+/-- Add one coordinate at the front of a weight row. -/
+def extendWeights {n : ℕ} (head : ℤ) (weights : Relation n) : Relation (n + 1) :=
+  Fin.cases head fun i => head + weights i
+
+/-- Lift a relation by adding the negative coordinate sum at the front. -/
+def lift {n : ℕ} (relation : Relation n) : Relation (n + 1) :=
+  Fin.cases (-coordinateSum relation) relation
+
+@[simp]
+lemma coordinateSum_lift {n : ℕ} (relation : Relation n) :
+    coordinateSum (lift relation) = 0 := by
+  simp [coordinateSum, lift, Fin.sum_univ_succ]
+
+lemma lift_add {n : ℕ} (first second : Relation n) :
+    lift (first + second) = lift first + lift second := by
+  funext i
+  refine Fin.cases ?_ (fun j => ?_) i
+  · simp [lift, coordinateSum_add, add_comm]
+  · simp [lift]
+
+lemma lift_aggregate {n : ℕ} (relations : List (Relation n)) :
+    aggregate (relations.map lift) = lift (aggregate relations) := by
+  induction relations with
+  | nil =>
+      funext i
+      refine Fin.cases ?_ (fun j => ?_) i <;>
+        simp [aggregate, lift, coordinateSum]
+  | cons relation relations inductionHypothesis =>
+      change lift relation + aggregate (relations.map lift) =
+        lift (relation + aggregate relations)
+      rw [inductionHypothesis, lift_add]
+
+/-- Iterate the dimension lift. -/
+def iteratedLift {n : ℕ} (relation : Relation n) :
+    (steps : ℕ) → Relation (n + steps)
+  | 0 => relation
+  | steps + 1 => lift (iteratedLift relation steps)
+
+/-- Transport a relation through an equality of dimensions. -/
+def castRelation {firstDimension secondDimension : ℕ}
+    (hdimension : firstDimension = secondDimension)
+    (relation : Relation firstDimension) : Relation secondDimension := by
+  subst secondDimension
+  exact relation
+
+lemma dot_lift_extendWeights {n : ℕ} (head : ℤ)
+    (weights relation : Relation n) :
+    dot (lift relation) (extendWeights head weights) = dot relation weights := by
+  simp only [dot, lift, extendWeights, Fin.sum_univ_succ, Fin.cases_zero,
+    Fin.cases_succ, neg_mul, Finset.sum_add_distrib, mul_add]
+  rw [← Finset.sum_mul]
+  simp [coordinateSum]
+
+lemma IsLiftableUnit.lift {n : ℕ} {weights relation : Relation n}
+    (hrelation : IsLiftableUnit weights relation) (head : ℤ) :
+    IsLiftableUnit (extendWeights head weights) (lift relation) := by
+  refine ⟨?_, dot_lift_extendWeights head weights relation ▸ hrelation.2.1, ?_⟩
+  · intro i
+    refine Fin.cases ?_ (fun j => ?_) i
+    · rcases hrelation.2.2 with hsum | hsum | hsum
+      · right
+        right
+        change -coordinateSum relation = 1
+        rw [hsum]
+        norm_num
+      · right
+        left
+        change -coordinateSum relation = 0
+        rw [hsum]
+        norm_num
+      · left
+        change -coordinateSum relation = -1
+        rw [hsum]
+    · change relation j = -1 ∨ relation j = 0 ∨ relation j = 1
+      exact hrelation.1 j
+  · simp [coordinateSum_lift]
+
+/-- Lift every relation in a certificate by one dimension. -/
+def Certificate.lift {n : ℕ} {weights target : Relation n}
+    (certificate : Certificate weights target) (head : ℤ) :
+    Certificate (extendWeights head weights) (lift target) where
+  relations := certificate.relations.map CoherentGap.lift
+  valid := by
+    intro relation hrelation
+    obtain ⟨source, hsource, rfl⟩ := List.mem_map.mp hrelation
+    exact (certificate.valid source hsource).lift head
+  target_eq := by
+    rw [lift_aggregate, certificate.target_eq]
+
+@[simp]
+lemma lift_basis {n : ℕ} (coordinate : Fin n) :
+    lift (basis coordinate) =
+      basis coordinate.succ - basis (0 : Fin (n + 1)) := by
+  funext i
+  refine Fin.cases ?_ (fun j => ?_) i
+  · have hne : (0 : Fin (n + 1)) ≠ coordinate.succ := by
+      intro heq
+      have hval := congrArg Fin.val heq
+      simp at hval
+    simp [lift, coordinateSum, basis, hne]
+  · simp [lift, basis]
+
+/-- A tower of rows obtained by adjoining one new positive-linear coordinate
+at the front at each dimension. -/
+structure WeightTower where
+  /-- The reference row in each dimension. -/
+  weights : (n : ℕ) → Relation n
+  /-- The coordinate adjoined when passing from dimension `n` to `n + 1`. -/
+  head : ℕ → ℤ
+  /-- Every row is obtained from the preceding row by the dimension lift. -/
+  step : ∀ n, weights (n + 1) = extendWeights (head n) (weights n)
+
+/-- Transport a certificate through one step of a weight tower. -/
+def WeightTower.liftCertificate (tower : WeightTower) {n : ℕ}
+    {target : Relation n} (certificate : Certificate (tower.weights n) target) :
+    Certificate (tower.weights (n + 1)) (lift target) := by
+  rw [tower.step]
+  exact certificate.lift (tower.head n)
+
+/-- Repeatedly transport a certificate through a weight tower. -/
+def WeightTower.iteratedLiftCertificate (tower : WeightTower) {n : ℕ}
+    {target : Relation n} (certificate : Certificate (tower.weights n) target) :
+    (steps : ℕ) →
+      Certificate (tower.weights (n + steps)) (iteratedLift target steps)
+  | 0 => certificate
+  | steps + 1 =>
+      tower.liftCertificate
+        (tower.iteratedLiftCertificate certificate steps)
+
+/-- Reinterpret a certificate along an equality of dimensions. -/
+def Certificate.castDimension {firstDimension secondDimension : ℕ}
+    (tower : WeightTower) {target : Relation firstDimension}
+    (certificate : Certificate (tower.weights firstDimension) target)
+    (hdimension : firstDimension = secondDimension) :
+    Certificate (tower.weights secondDimension)
+      (castRelation hdimension target) := by
+  subst secondDimension
+  exact certificate
+
+/-- One correction in the strong-induction construction of a first-coordinate
+certificate. -/
+structure Correction (dimension : ℕ) where
+  /-- The source dimension is `sourceOffset + 1`. -/
+  sourceOffset : ℕ
+  /-- The smaller-dimensional coordinate whose certificate is lifted. -/
+  sourceCoordinate : Fin (sourceOffset + 1)
+  /-- Number of dimension lifts. -/
+  steps : ℕ
+  /-- Every correction comes from a strictly smaller dimension. -/
+  steps_pos : 0 < steps
+  /-- Lifting reaches the target dimension exactly. -/
+  dimension_eq : (sourceOffset + 1) + steps = dimension
+
+lemma Correction.sourceDimension_lt {dimension : ℕ}
+    (correction : Correction dimension) :
+    correction.sourceOffset + 1 < dimension := by
+  calc
+    correction.sourceOffset + 1 <
+        (correction.sourceOffset + 1) + correction.steps :=
+      Nat.lt_add_of_pos_right correction.steps_pos
+    _ = dimension := correction.dimension_eq
+
+lemma Correction.sourceOffset_lt {offset : ℕ}
+    (correction : Correction (offset + 2)) :
+    correction.sourceOffset < offset + 1 := by
+  have := correction.sourceDimension_lt
+  omega
+
+/-- The target contributed by a lifted smaller-dimensional basis certificate. -/
+def Correction.target {dimension : ℕ}
+    (correction : Correction dimension) : Relation dimension :=
+  castRelation correction.dimension_eq
+    (iteratedLift (basis correction.sourceCoordinate) correction.steps)
+
+/-- Realize a correction from a certificate in its source dimension. -/
+def Correction.liftCertificate {dimension : ℕ}
+    (correction : Correction dimension) (tower : WeightTower)
+    (certificate : Certificate (tower.weights (correction.sourceOffset + 1))
+      (basis correction.sourceCoordinate)) :
+    Certificate (tower.weights dimension) correction.target := by
+  unfold Correction.target
+  exact Certificate.castDimension tower
+    (tower.iteratedLiftCertificate certificate correction.steps)
+    correction.dimension_eq
+
+/-- Exact data needed at each dimension for the principal-relation
+strong-induction step.  Every load-bearing input is a field: the principal
+relation must be a liftable unit relation, and its sum with the explicitly
+listed lifted corrections must be the first basis vector. -/
+structure FirstCoordinateRecurrence (tower : WeightTower) where
+  /-- First-coordinate certificate in dimension one. -/
+  base : Certificate (tower.weights 1) (basis 0)
+  /-- The new principal relation in dimension `offset + 2`. -/
+  principal : ∀ offset, Relation (offset + 2)
+  /-- Every principal relation belongs to the liftable unit system. -/
+  principal_valid :
+    ∀ offset, IsLiftableUnit (tower.weights (offset + 2)) (principal offset)
+  /-- Smaller-dimensional certificate lifts used to cancel the principal relation. -/
+  corrections : ∀ offset, List (Correction (offset + 2))
+  /-- The principal relation plus all correction targets is the first basis vector. -/
+  decomposition : ∀ offset,
+    principal offset +
+      ((corrections offset).map Correction.target).sum = basis 0
+
+/-- If the first coordinate has a certificate in every positive dimension,
+the dimension lift supplies certificates for every coordinate. -/
+def allCoordinatesOfFirst (tower : WeightTower)
+    (first : ∀ n, Certificate (tower.weights (n + 1)) (basis 0)) :
+    ∀ n (coordinate : Fin n), Certificate (tower.weights n) (basis coordinate)
+  | 0, coordinate => Fin.elim0 coordinate
+  | n + 1, coordinate => by
+      refine Fin.cases (first n) (fun previous => ?_) coordinate
+      have shifted := tower.liftCertificate
+        (allCoordinatesOfFirst tower first n previous)
+      exact (first n).add shifted |>.castTarget (by
+        rw [lift_basis]
+        simp)
+
+/-- Strong induction on dimension constructs all coordinate certificates from
+the explicit principal relations and correction chains. -/
+theorem recurrenceCertificate_exists (tower : WeightTower)
+    (recurrence : FirstCoordinateRecurrence tower) :
+    ∀ dimension (coordinate : Fin dimension),
+      Nonempty (Certificate (tower.weights dimension) (basis coordinate)) := by
+  intro dimension
+  induction dimension using Nat.strong_induction_on with
+  | h dimension inductionHypothesis =>
+      intro coordinate
+      rcases dimension with _ | dimension
+      · exact Fin.elim0 coordinate
+      rcases dimension with _ | offset
+      · change Fin 1 at coordinate
+        have hcoordinate : coordinate = 0 := Fin.eq_zero coordinate
+        subst coordinate
+        exact ⟨recurrence.base⟩
+      · let correctionCertificates :
+            List (Σ target, Certificate (tower.weights (offset + 2)) target) :=
+          (recurrence.corrections offset).map fun correction =>
+            ⟨correction.target,
+              correction.liftCertificate tower
+                (Classical.choice
+                  (inductionHypothesis (correction.sourceOffset + 1)
+                    correction.sourceDimension_lt correction.sourceCoordinate))⟩
+        let combined :=
+          (Certificate.singleton (recurrence.principal_valid offset)).add
+            (Certificate.sum correctionCertificates)
+        have htarget :
+            recurrence.principal offset +
+              (correctionCertificates.map Sigma.fst).sum = basis 0 := by
+          have hcorrections :
+              correctionCertificates.map Sigma.fst =
+                (recurrence.corrections offset).map Correction.target := by
+            simp [correctionCertificates]
+          rw [hcorrections]
+          exact recurrence.decomposition offset
+        let first : Certificate (tower.weights (offset + 2)) (basis 0) :=
+          combined.castTarget htarget
+        refine Fin.cases ⟨first⟩ (fun previous => ?_) coordinate
+        have previousCertificate :=
+          Classical.choice
+            (inductionHypothesis (offset + 1) (by omega) previous)
+        have shifted := tower.liftCertificate previousCertificate
+        refine ⟨(first.add shifted).castTarget ?_⟩
+        rw [lift_basis]
+        simp
+
+/-- The full certificate family generated by an explicit principal/correction
+recurrence. -/
+noncomputable def recurrenceCertificates (tower : WeightTower)
+    (recurrence : FirstCoordinateRecurrence tower) :
+    ∀ n (coordinate : Fin n),
+      Certificate (tower.weights n) (basis coordinate) :=
+  fun n coordinate =>
+    Classical.choice (recurrenceCertificate_exists tower recurrence n coordinate)
+
+/-- Pair an integer relation with a real candidate row. -/
+def realDot {n : ℕ} (relation : Relation n) (candidate : Fin n → ℝ) : ℝ :=
+  ∑ i, (relation i : ℝ) * candidate i
+
+lemma realDot_add {n : ℕ} (first second : Relation n)
+    (candidate : Fin n → ℝ) :
+    realDot (first + second) candidate =
+      realDot first candidate + realDot second candidate := by
+  simp [realDot, add_mul, Finset.sum_add_distrib]
+
+lemma realDot_aggregate {n : ℕ} (relations : List (Relation n))
+    (candidate : Fin n → ℝ) :
+    realDot (aggregate relations) candidate =
+      (relations.map fun relation => realDot relation candidate).sum := by
+  induction relations with
+  | nil =>
+      simp [aggregate, realDot]
+  | cons relation relations inductionHypothesis =>
+      change realDot (relation + aggregate relations) candidate =
+        realDot relation candidate +
+          (relations.map fun tailRelation => realDot tailRelation candidate).sum
+      rw [realDot_add, inductionHypothesis]
+
+@[simp]
+lemma realDot_basis {n : ℕ} (coordinate : Fin n) (candidate : Fin n → ℝ) :
+    realDot (basis coordinate) candidate = candidate coordinate := by
+  classical
+  simp [realDot, basis]
+
+/-- Abstract normalized-chamber rigidity.  A certificate for a coordinate
+forces every real row satisfying all its unit-relation inequalities to dominate
+the corresponding reference weight. -/
+theorem coordinate_lower_bound {n : ℕ} {weights : Relation n}
+    {coordinate : Fin n} (certificate : Certificate weights (basis coordinate))
+    (candidate : Fin n → ℝ)
+    (hgap : ∀ relation, IsLiftableUnit weights relation →
+      1 ≤ realDot relation candidate) :
+    (weights coordinate : ℝ) ≤ candidate coordinate := by
+  have hsumGeneral : ∀ relations : List (Relation n),
+      (∀ relation ∈ relations, IsLiftableUnit weights relation) →
+        (relations.length : ℝ) ≤
+          (relations.map fun relation => realDot relation candidate).sum := by
+    intro relations
+    induction relations with
+    | nil =>
+        intro
+        simp
+    | cons relation relations inductionHypothesis =>
+        intro hvalid
+        have hhead := hgap relation (hvalid relation List.mem_cons_self)
+        have htail :
+            ∀ tailRelation ∈ relations,
+              IsLiftableUnit weights tailRelation := by
+          intro tailRelation htailRelation
+          exact hvalid tailRelation (List.mem_cons_of_mem relation htailRelation)
+        simp only [List.length_cons, Nat.cast_add, Nat.cast_one, List.map_cons,
+          List.sum_cons]
+        simpa [add_comm] using add_le_add hhead (inductionHypothesis htail)
+  have hsum := hsumGeneral certificate.relations certificate.valid
+  have hlength :
+      (certificate.relations.length : ℝ) = (weights coordinate : ℝ) := by
+    exact_mod_cast certificate.length_eq_dot_target.trans (dot_basis coordinate weights)
+  rw [hlength] at hsum
+  calc
+    (weights coordinate : ℝ) ≤
+        (certificate.relations.map fun relation =>
+          realDot relation candidate).sum := hsum
+    _ = realDot (aggregate certificate.relations) candidate :=
+      (realDot_aggregate certificate.relations candidate).symm
+    _ = realDot (basis coordinate) candidate :=
+      congrArg (fun relation => realDot relation candidate) certificate.target_eq
+    _ = candidate coordinate := realDot_basis coordinate candidate
+
+/-- Every recurrence certificate has mass equal to its Conway--Guy-style
+reference coordinate. -/
+theorem recurrenceCertificate_mass (tower : WeightTower)
+    (recurrence : FirstCoordinateRecurrence tower) {n : ℕ}
+    (coordinate : Fin n) :
+    ((recurrenceCertificates tower recurrence n coordinate).relations.length : ℤ) =
+      tower.weights n coordinate := by
+  exact (recurrenceCertificates tower recurrence n coordinate).length_eq_dot_target.trans
+    (dot_basis coordinate (tower.weights n))
+
+/-- **Normalized chamber rigidity.** An explicit principal/correction
+recurrence forces the reference row to be the coordinatewise minimum of its
+unit-relation chamber.
+
+For the Conway--Guy order, the remaining concrete instantiation consists of:
+
+1. the recurrence `W_(n+1) = (d_(n+1), d_(n+1) + W_n)`;
+2. the block identity proving that each published principal relation has
+   value one;
+3. the triangular-index correction list and its basis-vector decomposition.
+
+Bohman's distinct-subset-sum theorem is then used outside this algebraic
+statement to identify the unit relations with consecutive order gaps. -/
+theorem normalizedChamberRigidity (tower : WeightTower)
+    (recurrence : FirstCoordinateRecurrence tower) {n : ℕ}
+    (candidate : Fin n → ℝ)
+    (hgap : ∀ relation, IsLiftableUnit (tower.weights n) relation →
+      1 ≤ realDot relation candidate) :
+    ∀ coordinate, (tower.weights n coordinate : ℝ) ≤ candidate coordinate := by
+  intro coordinate
+  exact coordinate_lower_bound
+    (recurrenceCertificates tower recurrence n coordinate) candidate hgap
+
+end BooleanIsoperimetry.CoherentGap

--- a/LeanPool/BooleanIsoperimetry/CoherentGap.lean
+++ b/LeanPool/BooleanIsoperimetry/CoherentGap.lean
@@ -21,7 +21,7 @@ That theorem is needed only to identify integral unit relations with
 consecutive gaps in the Conway--Guy subset-sum order.
 
 The open-problem context and the exact boundary of this formalization are
-recorded in `~/Knowledge/Construct/recon/erdos_001.md`.
+recorded separately in the Construct research notes.
 -/
 
 open scoped BigOperators

--- a/LeanPool/BooleanIsoperimetry/CoherentGap.lean
+++ b/LeanPool/BooleanIsoperimetry/CoherentGap.lean
@@ -530,8 +530,8 @@ theorem recurrenceCertificate_mass (tower : WeightTower)
     (dot_basis coordinate (tower.weights n))
 
 /-- **Normalized chamber rigidity.** An explicit principal/correction
-recurrence forces the reference row to be the coordinatewise minimum of its
-unit-relation chamber.
+recurrence makes the reference row a coordinatewise lower bound for every row
+satisfying its unit-relation inequalities.
 
 For the Conway--Guy order, the remaining concrete instantiation consists of:
 

--- a/LeanPool/BooleanIsoperimetry/ConwayGuyCoherentGap.lean
+++ b/LeanPool/BooleanIsoperimetry/ConwayGuyCoherentGap.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Egor Lyfar
 -/
 import LeanPool.BooleanIsoperimetry.CoherentGap
+import Mathlib.Tactic.Abel
+import Mathlib.Tactic.Ring
 
 /-!
 # Conway--Guy coherent-gap data

--- a/LeanPool/BooleanIsoperimetry/ConwayGuyCoherentGap.lean
+++ b/LeanPool/BooleanIsoperimetry/ConwayGuyCoherentGap.lean
@@ -1,0 +1,536 @@
+/-
+Copyright (c) 2026 Egor Lyfar. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Egor Lyfar
+-/
+import LeanPool.BooleanIsoperimetry.CoherentGap
+
+/-!
+# Conway--Guy coherent-gap data
+
+This file instantiates the triangular correction pattern used by the
+Conway--Guy distinct-subset-sum sequence.  The recurrence and notation follow
+Section 2 of Tom Bohman's 1996 paper on the Conway--Guy sequence.
+-/
+
+open scoped BigOperators
+
+namespace BooleanIsoperimetry.CoherentGap
+
+/-- The triangular numbers, indexed from zero. -/
+def triangular : ℕ → ℕ
+  | 0 => 0
+  | index + 1 => triangular index + index + 1
+
+lemma self_le_triangular (index : ℕ) : index ≤ triangular index := by
+  induction index with
+  | zero => simp [triangular]
+  | succ index inductionHypothesis =>
+      simp only [triangular]
+      omega
+
+lemma triangular_mono : Monotone triangular := by
+  intro first second hle
+  induction second, hle using Nat.le_induction with
+  | base => exact le_rfl
+  | succ second hfirst inductionHypothesis =>
+      simp only [triangular]
+      omega
+
+lemma triangular_strictMono : StrictMono triangular := by
+  intro first second hlt
+  have hstep : triangular first < triangular (first + 1) := by
+    simp only [triangular]
+    omega
+  exact hstep.trans_le (triangular_mono (by omega))
+
+lemma triangular_add_index (index : ℕ) :
+    triangular index + index + 1 = triangular (index + 1) := by
+  rfl
+
+theorem guideWitness (dimension : ℕ) :
+    ∃ width, dimension - 1 ≤ triangular width :=
+  ⟨dimension, (Nat.sub_le dimension 1).trans (self_le_triangular dimension)⟩
+
+/-- The least triangular block containing `dimension - 1`. -/
+noncomputable def guide (dimension : ℕ) : ℕ :=
+  Nat.find (guideWitness dimension)
+
+lemma guide_upper (dimension : ℕ) :
+    dimension - 1 ≤ triangular (guide dimension) :=
+  Nat.find_spec (guideWitness dimension)
+
+lemma guide_pos {dimension : ℕ} (hdimension : 2 ≤ dimension) :
+    0 < guide dimension := by
+  by_contra hnot
+  have hzero : guide dimension = 0 := Nat.eq_zero_of_not_pos hnot
+  have := guide_upper dimension
+  simp [hzero, triangular] at this
+  omega
+
+lemma guide_lower {dimension : ℕ} (hdimension : 2 ≤ dimension) :
+    triangular (guide dimension - 1) + 2 ≤ dimension := by
+  have hpositive := guide_pos hdimension
+  have hpred : guide dimension - 1 < guide dimension := by omega
+  have hminimal :=
+    Nat.find_min (guideWitness dimension) hpred
+  have hnot : ¬ dimension - 1 ≤ triangular (guide dimension - 1) := hminimal
+  omega
+
+lemma guide_le_dimension {dimension : ℕ} (hdimension : 2 ≤ dimension) :
+    guide dimension ≤ dimension := by
+  have hpositive := guide_pos hdimension
+  have hlower := guide_lower hdimension
+  have htriangular := self_le_triangular (guide dimension - 1)
+  omega
+
+lemma correction_deep_bound {dimension index : ℕ}
+    (hdimension : 2 ≤ dimension)
+    (hindex : index < guide dimension - 1) :
+    triangular index + index + 3 ≤ dimension := by
+  have hindex_le : index + 1 ≤ guide dimension - 1 := by omega
+  have htriangular :=
+    triangular_mono hindex_le
+  have hlower := guide_lower hdimension
+  have hstep := triangular_add_index index
+  omega
+
+lemma negative_index_ge_guide {dimension index : ℕ}
+    (hdimension : 2 ≤ dimension)
+    (hindex : index < guide dimension - 1) :
+    guide dimension ≤ dimension - triangular index - 1 := by
+  have hwidth : 2 ≤ guide dimension := by omega
+  have hindex_le : index ≤ guide dimension - 2 := by omega
+  have htriangular :=
+    triangular_mono hindex_le
+  have hlower := guide_lower hdimension
+  have hstep :
+      triangular (guide dimension - 1) =
+        triangular (guide dimension - 2) + (guide dimension - 1) := by
+    have : guide dimension - 1 = (guide dimension - 2) + 1 := by omega
+    conv_lhs => rw [this, triangular]
+    omega
+  omega
+
+/-- The positive support of the Conway--Guy principal relation. -/
+noncomputable def positiveIndex (offset : ℕ)
+    (index : Fin (guide (offset + 2))) : Fin (offset + 2) :=
+  ⟨index.val, index.isLt.trans_le (guide_le_dimension (by omega))⟩
+
+/-- The triangular negative support of the Conway--Guy principal relation. -/
+noncomputable def negativeIndex (offset : ℕ)
+    (index : Fin (guide (offset + 2) - 1)) : Fin (offset + 2) := by
+  have hdeep := correction_deep_bound (dimension := offset + 2)
+    (index := index.val) (by omega) index.isLt
+  exact ⟨offset + 2 - triangular index.val - 1, by omega⟩
+
+/-- The smaller-dimensional certificate lift cancelling one negative support
+coordinate of the principal relation. -/
+noncomputable def correctionFor (offset : ℕ)
+    (index : Fin (guide (offset + 2) - 1)) :
+    Correction (offset + 2) where
+  sourceOffset := offset + 2 - index.val - 3
+  sourceCoordinate := by
+    have hdeep := correction_deep_bound (dimension := offset + 2)
+      (index := index.val) (by omega) index.isLt
+    exact ⟨offset + 2 - triangular index.val - index.val - 3, by omega⟩
+  steps := index.val + 2
+  steps_pos := by omega
+  dimension_eq := by
+    have hdeep := correction_deep_bound (dimension := offset + 2)
+      (index := index.val) (by omega) index.isLt
+    omega
+
+/-- The complete correction list in dimension `offset + 2`. -/
+noncomputable def corrections (offset : ℕ) :
+    List (Correction (offset + 2)) :=
+  List.ofFn (correctionFor offset)
+
+/-- The Conway--Guy triangular-block principal relation. -/
+noncomputable def principal (offset : ℕ) : Relation (offset + 2) :=
+  (∑ index : Fin (guide (offset + 2)),
+      basis (positiveIndex offset index)) -
+    ∑ index : Fin (guide (offset + 2) - 1),
+      basis (negativeIndex offset index)
+
+lemma coordinateSum_sub {n : ℕ} (first second : Relation n) :
+    coordinateSum (first - second) =
+      coordinateSum first - coordinateSum second := by
+  simp [coordinateSum, Finset.sum_sub_distrib]
+
+lemma coordinateSum_finset_sum {n : ℕ} {α : Type}
+    (set : Finset α) (relations : α → Relation n) :
+    coordinateSum (∑ index ∈ set, relations index) =
+      ∑ index ∈ set, coordinateSum (relations index) := by
+  classical
+  induction set using Finset.induction_on with
+  | empty => simp [coordinateSum]
+  | @insert element set hnotMember inductionHypothesis =>
+      simp [hnotMember, coordinateSum_add, inductionHypothesis]
+
+@[simp]
+lemma coordinateSum_basis {n : ℕ} (coordinate : Fin n) :
+    coordinateSum (basis coordinate) = 1 := by
+  classical
+  simp [coordinateSum, basis]
+
+lemma principal_coordinateSum (offset : ℕ) :
+    coordinateSum (principal offset) = 1 := by
+  rw [principal, coordinateSum_sub]
+  simp only [coordinateSum_finset_sum, coordinateSum_basis,
+    Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+  have hpositive := guide_pos (dimension := offset + 2) (by omega)
+  omega
+
+lemma positiveIndex_injective (offset : ℕ) :
+    Function.Injective (positiveIndex offset) := by
+  intro first second hequal
+  apply Fin.ext
+  simpa [positiveIndex] using congrArg Fin.val hequal
+
+lemma negativeIndex_injective (offset : ℕ) :
+    Function.Injective (negativeIndex offset) := by
+  intro first second hequal
+  have hvalue := congrArg Fin.val hequal
+  simp only [negativeIndex] at hvalue
+  have hfirst := correction_deep_bound (dimension := offset + 2)
+    (index := first.val) (by omega) first.isLt
+  have hsecond := correction_deep_bound (dimension := offset + 2)
+    (index := second.val) (by omega) second.isLt
+  have htriangular :
+      triangular first.val = triangular second.val := by
+    omega
+  apply Fin.ext
+  exact triangular_strictMono.injective htriangular
+
+lemma positiveIndex_ne_negativeIndex (offset : ℕ)
+    (positive : Fin (guide (offset + 2)))
+    (negative : Fin (guide (offset + 2) - 1)) :
+    positiveIndex offset positive ≠ negativeIndex offset negative := by
+  intro hequal
+  have hvalue := congrArg Fin.val hequal
+  simp only [positiveIndex, negativeIndex] at hvalue
+  have hseparated := negative_index_ge_guide (dimension := offset + 2)
+    (index := negative.val) (by omega) negative.isLt
+  omega
+
+lemma relation_finset_sum_apply {n : ℕ} {α : Type}
+    (set : Finset α) (relations : α → Relation n) (coordinate : Fin n) :
+    (∑ index ∈ set, relations index) coordinate =
+      ∑ index ∈ set, relations index coordinate := by
+  classical
+  induction set using Finset.induction_on with
+  | empty => simp
+  | @insert element set hnotMember inductionHypothesis =>
+      simp [hnotMember, inductionHypothesis]
+
+lemma sum_basis_apply {sourceDimension targetDimension : ℕ}
+    (embedding : Fin sourceDimension → Fin targetDimension)
+    (hinjective : Function.Injective embedding)
+    (coordinate : Fin targetDimension) :
+    (∑ index, basis (embedding index)) coordinate =
+      if coordinate ∈ Finset.univ.image embedding then 1 else 0 := by
+  classical
+  rw [relation_finset_sum_apply]
+  calc
+    (∑ index, basis (embedding index) coordinate) =
+        ∑ imageCoordinate ∈ Finset.univ.image embedding,
+          basis imageCoordinate coordinate := by
+      symm
+      simpa using Finset.sum_image hinjective.injOn
+    _ = if coordinate ∈ Finset.univ.image embedding then 1 else 0 := by
+      simp [basis]
+
+lemma principal_entry (offset : ℕ) (coordinate : Fin (offset + 2)) :
+    principal offset coordinate = -1 ∨
+      principal offset coordinate = 0 ∨
+      principal offset coordinate = 1 := by
+  classical
+  rw [principal, Pi.sub_apply]
+  rw [sum_basis_apply (positiveIndex offset) (positiveIndex_injective offset)]
+  rw [sum_basis_apply (negativeIndex offset) (negativeIndex_injective offset)]
+  by_cases hpositive :
+      coordinate ∈ Finset.univ.image (positiveIndex offset)
+  · have hnegative :
+        coordinate ∉ Finset.univ.image (negativeIndex offset) := by
+      intro hmember
+      rcases Finset.mem_image.mp hpositive with ⟨positive, _, hpositiveEqual⟩
+      rcases Finset.mem_image.mp hmember with ⟨negative, _, hnegativeEqual⟩
+      exact positiveIndex_ne_negativeIndex offset positive negative
+        (hpositiveEqual.trans hnegativeEqual.symm)
+    simp [hpositive, hnegative]
+  · by_cases hnegative :
+        coordinate ∈ Finset.univ.image (negativeIndex offset)
+    · simp [hpositive, hnegative]
+    · simp [hpositive, hnegative]
+
+lemma lift_sub {n : ℕ} (first second : Relation n) :
+    lift (first - second) = lift first - lift second := by
+  funext coordinate
+  refine Fin.cases ?_ (fun index => ?_) coordinate
+  · simp [lift, coordinateSum, Finset.sum_sub_distrib]
+    ring
+  · simp [lift]
+
+lemma iteratedLift_basis_eq {n : ℕ} (coordinate : Fin n) :
+    ∀ {steps : ℕ} (hsteps : 0 < steps),
+      iteratedLift (basis coordinate) steps =
+        basis (⟨coordinate.val + steps, by omega⟩ : Fin (n + steps)) -
+          basis (⟨steps - 1, by omega⟩ : Fin (n + steps))
+  | 0, hsteps => by omega
+  | 1, _ => by
+      change lift (basis coordinate) =
+        basis (⟨coordinate.val + 1, by omega⟩ : Fin (n + 1)) -
+          basis (⟨1 - 1, by omega⟩ : Fin (n + 1))
+      rw [lift_basis]
+      have hpositive :
+          coordinate.succ =
+            (⟨coordinate.val + 1, by omega⟩ : Fin (n + 1)) := by
+        apply Fin.ext
+        simp
+      have hnegative :
+          (0 : Fin (n + 1)) =
+            (⟨1 - 1, by omega⟩ : Fin (n + 1)) := by
+        apply Fin.ext
+        simp
+      rw [hpositive, hnegative]
+  | steps + 2, _ => by
+      have inductionHypothesis :=
+        iteratedLift_basis_eq coordinate (steps := steps + 1) (by omega)
+      rw [iteratedLift, inductionHypothesis, lift_sub, lift_basis, lift_basis]
+      have hpositive :
+          (⟨coordinate.val + (steps + 1), by omega⟩ :
+              Fin (n + (steps + 1))).succ =
+            (⟨coordinate.val + (steps + 2), by omega⟩ :
+              Fin (n + (steps + 2))) := by
+        apply Fin.ext
+        simp
+        omega
+      have hnegative :
+          (⟨steps + 1 - 1, by omega⟩ :
+              Fin (n + (steps + 1))).succ =
+            (⟨steps + 2 - 1, by omega⟩ :
+              Fin (n + (steps + 2))) := by
+        apply Fin.ext
+        simp
+      rw [hpositive, hnegative]
+      abel
+
+@[simp]
+lemma castRelation_apply {firstDimension secondDimension : ℕ}
+    (hdimension : firstDimension = secondDimension)
+    (relation : Relation firstDimension) (coordinate : Fin secondDimension) :
+    castRelation hdimension relation coordinate =
+      relation (Fin.cast hdimension.symm coordinate) := by
+  subst secondDimension
+  rfl
+
+lemma castRelation_sub {firstDimension secondDimension : ℕ}
+    (hdimension : firstDimension = secondDimension)
+    (first second : Relation firstDimension) :
+    castRelation hdimension (first - second) =
+      castRelation hdimension first - castRelation hdimension second := by
+  subst secondDimension
+  rfl
+
+lemma castRelation_basis {firstDimension secondDimension : ℕ}
+    (hdimension : firstDimension = secondDimension)
+    (coordinate : Fin firstDimension) :
+    castRelation hdimension (basis coordinate) =
+      basis (Fin.cast hdimension coordinate) := by
+  subst secondDimension
+  rfl
+
+lemma correctionFor_target (offset : ℕ)
+    (index : Fin (guide (offset + 2) - 1)) :
+    (correctionFor offset index).target =
+      basis (negativeIndex offset index) -
+        basis (⟨index.val + 1, by
+          have hdeep := correction_deep_bound (dimension := offset + 2)
+            (index := index.val) (by omega) index.isLt
+          omega⟩ : Fin (offset + 2)) := by
+  unfold Correction.target
+  rw [iteratedLift_basis_eq (hsteps := by simp [correctionFor])]
+  rw [castRelation_sub, castRelation_basis, castRelation_basis]
+  congr 1
+  · apply congrArg basis
+    apply Fin.ext
+    simp [correctionFor, negativeIndex]
+    have hdeep := correction_deep_bound (dimension := offset + 2)
+      (index := index.val) (by omega) index.isLt
+    omega
+
+lemma corrections_target_sum (offset : ℕ) :
+    ((corrections offset).map Correction.target).sum =
+      ∑ index : Fin (guide (offset + 2) - 1),
+        (basis (negativeIndex offset index) -
+          basis (⟨index.val + 1, by
+            have hdeep := correction_deep_bound (dimension := offset + 2)
+              (index := index.val) (by omega) index.isLt
+            omega⟩ : Fin (offset + 2))) := by
+  simp [corrections, List.sum_ofFn, correctionFor_target]
+
+lemma principal_corrections_decomposition (offset : ℕ) :
+    principal offset +
+        ((corrections offset).map Correction.target).sum =
+      basis 0 := by
+  rw [principal, corrections_target_sum, Finset.sum_sub_distrib]
+  have hpositive := guide_pos (dimension := offset + 2) (by omega)
+  have hguide :
+      guide (offset + 2) = (guide (offset + 2) - 1) + 1 := by
+    omega
+  let equivalence :
+      Fin ((guide (offset + 2) - 1) + 1) ≃
+        Fin (guide (offset + 2)) :=
+    Fin.castOrderIso hguide.symm
+  have hpartition :
+      (∑ index : Fin (guide (offset + 2)),
+          basis (positiveIndex offset index)) =
+        basis 0 +
+          ∑ index : Fin (guide (offset + 2) - 1),
+            basis (⟨index.val + 1, by
+              have hdeep := correction_deep_bound (dimension := offset + 2)
+                (index := index.val) (by omega) index.isLt
+              omega⟩ : Fin (offset + 2)) := by
+    rw [← equivalence.sum_comp]
+    rw [Fin.sum_univ_succ]
+    congr 1
+  rw [hpartition]
+  abel
+
+/-- The one-indexed Conway--Guy recurrence, stored with zero-based indices. -/
+def difference (blockGuide : ℕ → ℕ) : ℕ → ℕ
+  | 0 => 1
+  | index + 1 =>
+      ∑ offset ∈ Finset.range (blockGuide (index + 2)),
+        difference blockGuide (index - offset)
+termination_by index => index
+decreasing_by omega
+
+/-- The Conway--Guy difference sequence using the triangular block guide. -/
+noncomputable def conwayGuyDifference (index : ℕ) : ℕ :=
+  difference guide index
+
+/-- The cumulative Conway--Guy heights. -/
+noncomputable def conwayGuyHeight (dimension : ℕ) : ℤ :=
+  ∑ index ∈ Finset.range dimension, (conwayGuyDifference index : ℤ)
+
+@[simp]
+lemma conwayGuyHeight_zero : conwayGuyHeight 0 = 0 := by
+  simp [conwayGuyHeight]
+
+@[simp]
+lemma conwayGuyHeight_one : conwayGuyHeight 1 = 1 := by
+  simp [conwayGuyHeight, conwayGuyDifference, difference]
+
+lemma conwayGuyHeight_succ (dimension : ℕ) :
+    conwayGuyHeight (dimension + 1) =
+      conwayGuyHeight dimension + conwayGuyDifference dimension := by
+  simp [conwayGuyHeight, Finset.sum_range_succ]
+
+/-- Arithmetic data from which the coherent-gap weight tower is built. -/
+structure ConwayGuyArithmetic where
+  /-- Block guide for the recurrence. -/
+  guide : ℕ → ℕ
+  /-- Cumulative heights of the recurrence. -/
+  height : ℕ → ℤ
+  /-- The zero-dimensional height. -/
+  height_zero : height 0 = 0
+
+/-- The arithmetic data of the actual Conway--Guy sequence. -/
+noncomputable def conwayGuyArithmetic : ConwayGuyArithmetic where
+  guide := guide
+  height := conwayGuyHeight
+  height_zero := conwayGuyHeight_zero
+
+/-- The increasing Conway--Guy-style row obtained from cumulative heights. -/
+def ConwayGuyArithmetic.weights (data : ConwayGuyArithmetic)
+    (dimension : ℕ) : Relation dimension :=
+  fun coordinate =>
+    data.height dimension -
+      data.height (dimension - (coordinate.val + 1))
+
+/-- The coordinate adjoined at the front when the dimension increases. -/
+def ConwayGuyArithmetic.head (data : ConwayGuyArithmetic)
+    (dimension : ℕ) : ℤ :=
+  data.height (dimension + 1) - data.height dimension
+
+lemma ConwayGuyArithmetic.weights_step (data : ConwayGuyArithmetic)
+    (dimension : ℕ) :
+    data.weights (dimension + 1) =
+      extendWeights (data.head dimension) (data.weights dimension) := by
+  funext coordinate
+  refine Fin.cases ?_ (fun previous => ?_) coordinate
+  · simp [ConwayGuyArithmetic.weights, ConwayGuyArithmetic.head, extendWeights]
+  · simp only [ConwayGuyArithmetic.weights, ConwayGuyArithmetic.head,
+      extendWeights, Fin.cases_succ]
+    have hindex :
+        dimension + 1 - (previous.succ.val + 1) =
+          dimension - (previous.val + 1) := by
+      change dimension + 1 - ((previous.val + 1) + 1) =
+        dimension - (previous.val + 1)
+      omega
+    rw [hindex]
+    ring
+
+/-- The exact Conway--Guy-style dimension-lift tower. -/
+def ConwayGuyArithmetic.tower (data : ConwayGuyArithmetic) : WeightTower where
+  weights := data.weights
+  head := data.head
+  step := data.weights_step
+
+lemma dot_sub {n : ℕ} (first second weights : Relation n) :
+    dot (first - second) weights =
+      dot first weights - dot second weights := by
+  simp [dot, sub_mul, Finset.sum_sub_distrib]
+
+lemma dot_finset_sum {n : ℕ} {α : Type}
+    (set : Finset α) (relations : α → Relation n) (weights : Relation n) :
+    dot (∑ index ∈ set, relations index) weights =
+      ∑ index ∈ set, dot (relations index) weights := by
+  classical
+  induction set using Finset.induction_on with
+  | empty => simp [dot]
+  | @insert element set hnotMember inductionHypothesis =>
+      simp [hnotMember, dot_add, inductionHypothesis]
+
+lemma principal_dot (offset : ℕ)
+    (hblock :
+      conwayGuyHeight (offset + 2) -
+          ∑ index : Fin (guide (offset + 2)),
+            conwayGuyHeight (offset + 2 - index.val - 1) +
+        ∑ index : Fin (guide (offset + 2) - 1),
+          conwayGuyHeight (triangular index.val) = 1) :
+    dot (principal offset) (conwayGuyArithmetic.weights (offset + 2)) = 1 := by
+  rw [principal, dot_sub]
+  simp only [dot_finset_sum, dot_basis,
+    ConwayGuyArithmetic.weights, positiveIndex, negativeIndex]
+  rw [Finset.sum_sub_distrib, Finset.sum_sub_distrib]
+  push_cast
+  have hpositive := guide_pos (dimension := offset + 2) (by omega)
+  have hnegativeIndex :
+      ∀ index : Fin (guide (offset + 2) - 1),
+        offset + 1 -
+            (offset + 2 - triangular index.val - 1) =
+          triangular index.val := by
+    intro index
+    have hdeep := correction_deep_bound (dimension := offset + 2)
+      (index := index.val) (by omega) index.isLt
+    omega
+  simp_rw [hnegativeIndex]
+  have hpositiveIndex :
+      ∀ index : Fin (guide (offset + 2)),
+        offset + 2 - index.val - 1 = offset + 1 - index.val := by
+    intro index
+    omega
+  simp_rw [hpositiveIndex] at hblock
+  simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+  have hguide :
+      (guide (offset + 2) : ℤ) =
+        (guide (offset + 2) - 1 : ℕ) + 1 := by
+    omega
+  rw [hguide]
+  ring_nf
+  simpa [conwayGuyArithmetic, Nat.add_comm] using hblock
+
+end BooleanIsoperimetry.CoherentGap

--- a/LeanPool/BooleanIsoperimetry/ConwayGuyHeight.lean
+++ b/LeanPool/BooleanIsoperimetry/ConwayGuyHeight.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Egor Lyfar
 -/
 import LeanPool.BooleanIsoperimetry.ConwayGuyCoherentGap
+import Mathlib.Tactic.Linarith
 
 /-!
 # The Conway--Guy triangular-block identity

--- a/LeanPool/BooleanIsoperimetry/ConwayGuyHeight.lean
+++ b/LeanPool/BooleanIsoperimetry/ConwayGuyHeight.lean
@@ -1,0 +1,319 @@
+/-
+Copyright (c) 2026 Egor Lyfar. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Egor Lyfar
+-/
+import LeanPool.BooleanIsoperimetry.ConwayGuyCoherentGap
+
+/-!
+# The Conway--Guy triangular-block identity
+
+This file derives the height identity used by every Conway--Guy principal
+relation directly from the published difference recurrence.
+-/
+
+open scoped BigOperators
+
+namespace BooleanIsoperimetry.CoherentGap
+
+lemma guide_lt_dimension {dimension : ℕ} (hdimension : 2 ≤ dimension) :
+    guide dimension < dimension := by
+  have hpositive := guide_pos hdimension
+  have hlower := guide_lower hdimension
+  have htriangular := self_le_triangular (guide dimension - 1)
+  omega
+
+lemma guide_at_triangular_end (width : ℕ) :
+    guide (triangular width + 1) = width := by
+  unfold guide
+  apply Nat.find_eq_iff (guideWitness (triangular width + 1)) |>.mpr
+  constructor
+  · omega
+  · intro smaller hsmaller
+    have hstrict := triangular_strictMono hsmaller
+    omega
+
+lemma guide_eq_iff {dimension width : ℕ} (hwidth : 0 < width) :
+    guide dimension = width ↔
+      triangular (width - 1) + 2 ≤ dimension ∧
+        dimension ≤ triangular width + 1 := by
+  unfold guide
+  rw [Nat.find_eq_iff]
+  constructor
+  · intro ⟨hupper, hminimal⟩
+    constructor
+    · by_contra hnot
+      have hsmall : dimension - 1 ≤ triangular (width - 1) := by omega
+      exact hminimal (width - 1) (by omega) hsmall
+    · omega
+  · intro ⟨hlower, hupper⟩
+    constructor
+    · omega
+    · intro smaller hsmaller
+      have hle : smaller ≤ width - 1 := by omega
+      have htriangular := triangular_mono hle
+      omega
+
+/-- The left-hand residual of the Conway--Guy block recurrence. -/
+noncomputable def residual (width dimension : ℕ) : ℤ :=
+  conwayGuyHeight dimension -
+    ∑ index : Fin width,
+      conwayGuyHeight (dimension - index.val - 1)
+
+lemma conwayGuyDifference_succ (index : ℕ) :
+    conwayGuyDifference (index + 1) =
+      ∑ offset ∈ Finset.range (guide (index + 2)),
+        conwayGuyDifference (index - offset) := by
+  simp [conwayGuyDifference, difference]
+
+lemma residual_succ_eq {width dimension : ℕ}
+    (hdimension : 0 < dimension)
+    (hwidth : width ≤ dimension)
+    (hguide : guide (dimension + 1) = width) :
+    residual width (dimension + 1) = residual width dimension := by
+  have hheight :
+      ∀ index : Fin width,
+        conwayGuyHeight (dimension + 1 - index.val - 1) =
+          conwayGuyHeight (dimension - index.val - 1) +
+            conwayGuyDifference (dimension - index.val - 1) := by
+    intro index
+    have hindex : index.val < dimension := index.isLt.trans_le hwidth
+    have hsucc :
+        dimension + 1 - index.val - 1 =
+          (dimension - index.val - 1) + 1 := by
+      omega
+    rw [hsucc, conwayGuyHeight_succ]
+  rw [residual, residual, conwayGuyHeight_succ]
+  simp_rw [hheight]
+  rw [Finset.sum_add_distrib]
+  have hdifference :
+      conwayGuyDifference dimension =
+        ∑ index : Fin width,
+          (conwayGuyDifference (dimension - index.val - 1) : ℤ) := by
+    obtain ⟨previous, rfl⟩ :=
+      Nat.exists_eq_succ_of_ne_zero (by omega : dimension ≠ 0)
+    rw [conwayGuyDifference_succ, hguide]
+    push_cast
+    rw [← Fin.sum_univ_eq_sum_range]
+    apply Finset.sum_congr rfl
+    intro index hindex
+    have hargument :
+        previous.succ - index.val - 1 = previous - index.val := by
+      omega
+    rw [hargument]
+  rw [hdifference]
+  ring
+
+lemma reverse_difference_sum (dimension : ℕ) :
+    ∀ width : ℕ, width ≤ dimension →
+      (∑ index : Fin width,
+          (conwayGuyDifference (dimension - index.val - 1) : ℤ)) =
+        conwayGuyHeight dimension -
+          conwayGuyHeight (dimension - width)
+  | 0, _ => by simp
+  | width + 1, hwidth => by
+      have hdimension : 0 < dimension := by omega
+      obtain ⟨previous, rfl⟩ :=
+        Nat.exists_eq_succ_of_ne_zero (by omega : dimension ≠ 0)
+      rw [Fin.sum_univ_succ]
+      have inductionHypothesis :=
+        reverse_difference_sum previous width (by omega)
+      have hargument :
+          ∀ index : Fin width,
+            previous.succ - index.succ.val - 1 =
+              previous - index.val - 1 := by
+        intro index
+        change previous + 1 - (index.val + 1) - 1 =
+          previous - index.val - 1
+        omega
+      simp_rw [hargument]
+      rw [inductionHypothesis, conwayGuyHeight_succ]
+      have htail :
+          previous.succ - (width + 1) = previous - width := by
+        omega
+      rw [htail]
+      have hzero :
+          previous.succ - (0 : Fin (width + 1)).val - 1 = previous := by
+        simp
+      rw [hzero]
+      ring
+
+lemma conwayGuyDifference_eq_height_window (dimension : ℕ)
+    (hdimension : 0 < dimension) :
+    (conwayGuyDifference dimension : ℤ) =
+      conwayGuyHeight dimension -
+        conwayGuyHeight (dimension - guide (dimension + 1)) := by
+  obtain ⟨previous, rfl⟩ :=
+    Nat.exists_eq_succ_of_ne_zero (by omega : dimension ≠ 0)
+  rw [conwayGuyDifference_succ]
+  push_cast
+  rw [← Fin.sum_univ_eq_sum_range]
+  have hwindow :=
+    reverse_difference_sum previous.succ (guide (previous.succ + 1))
+      (guide_lt_dimension (dimension := previous.succ + 1) (by omega) |>
+        fun h => by omega)
+  have hargument :
+      ∀ index : Fin (guide (previous.succ + 1)),
+        previous - index.val =
+          previous.succ - index.val - 1 := by
+    intro index
+    omega
+  simp_rw [hargument]
+  exact hwindow
+
+lemma residual_succ_width (width dimension : ℕ) :
+    residual (width + 1) (dimension + 1) =
+      residual width dimension +
+        conwayGuyDifference dimension -
+          conwayGuyHeight dimension := by
+  rw [residual, residual, conwayGuyHeight_succ, Fin.sum_univ_succ]
+  have hargument :
+      ∀ index : Fin width,
+        dimension + 1 - index.succ.val - 1 =
+          dimension - index.val - 1 := by
+    intro index
+    change dimension + 1 - (index.val + 1) - 1 =
+      dimension - index.val - 1
+    omega
+  simp_rw [hargument]
+  have hzero :
+      dimension + 1 - (0 : Fin (width + 1)).val - 1 = dimension := by
+    simp
+  rw [hzero]
+  ring
+
+lemma residual_eq_block_start {width dimension : ℕ}
+    (hwidth : 0 < width)
+    (hguide : guide dimension = width) :
+    residual width dimension =
+      residual width (triangular (width - 1) + 2) := by
+  obtain ⟨hlower, hupper⟩ := (guide_eq_iff hwidth).mp hguide
+  induction dimension, hlower using Nat.le_induction with
+  | base => rfl
+  | succ dimension hbase inductionHypothesis =>
+      have hnextGuide : guide (dimension + 1) = width :=
+        (guide_eq_iff hwidth).mpr ⟨by omega, by omega⟩
+      have htriangular := self_le_triangular (width - 1)
+      have hwidthLe : width ≤ dimension := by omega
+      have hcurrentGuide : guide dimension = width :=
+        (guide_eq_iff hwidth).mpr ⟨hbase, by omega⟩
+      rw [residual_succ_eq (by omega) hwidthLe hnextGuide,
+        inductionHypothesis hcurrentGuide (by omega)]
+
+lemma residual_next_block_start (previous : ℕ) :
+    residual (previous + 2) (triangular (previous + 1) + 2) =
+      residual (previous + 1) (triangular (previous + 1) + 1) -
+        conwayGuyHeight (triangular previous) := by
+  have htriangular :
+      triangular (previous + 1) = triangular previous + previous + 1 := by
+    rfl
+  have hnextGuide :
+      guide (triangular (previous + 1) + 2) = previous + 2 := by
+    apply (guide_eq_iff (by omega)).mpr
+    constructor
+    · have hpred :
+          previous + 2 - 1 = previous + 1 := by omega
+      rw [hpred]
+    · have hnextTriangular :
+          triangular (previous + 2) =
+            triangular (previous + 1) + previous + 2 := by
+          change triangular ((previous + 1) + 1) =
+            triangular (previous + 1) + previous + 2
+          rw [triangular]
+          omega
+      rw [hnextTriangular]
+      omega
+  have hwindow :=
+    conwayGuyDifference_eq_height_window
+      (triangular (previous + 1) + 1) (by omega)
+  rw [hnextGuide] at hwindow
+  have htail :
+      triangular (previous + 1) + 1 - (previous + 2) =
+        triangular previous := by
+    omega
+  rw [htail] at hwindow
+  calc
+    residual (previous + 2) (triangular (previous + 1) + 2) =
+        residual (previous + 1) (triangular (previous + 1) + 1) +
+          conwayGuyDifference (triangular (previous + 1) + 1) -
+            conwayGuyHeight (triangular (previous + 1) + 1) := by
+      simpa [Nat.add_assoc] using
+        residual_succ_width (previous + 1)
+          (triangular (previous + 1) + 1)
+    _ = residual (previous + 1) (triangular (previous + 1) + 1) -
+          conwayGuyHeight (triangular previous) := by
+      rw [hwindow]
+      ring
+
+lemma correction_sum_succ (previous : ℕ) :
+    (∑ index : Fin (previous + 1),
+        conwayGuyHeight (triangular index.val)) =
+      (∑ index : Fin previous,
+          conwayGuyHeight (triangular index.val)) +
+        conwayGuyHeight (triangular previous) := by
+  rw [Fin.sum_univ_eq_sum_range
+      (fun index => conwayGuyHeight (triangular index)) (previous + 1),
+    Fin.sum_univ_eq_sum_range
+      (fun index => conwayGuyHeight (triangular index)) previous,
+    Finset.sum_range_succ]
+
+theorem block_identity_by_width :
+    ∀ previous dimension : ℕ,
+      guide dimension = previous + 1 →
+        residual (previous + 1) dimension +
+          ∑ index : Fin previous,
+            conwayGuyHeight (triangular index.val) = 1
+  | 0, dimension, hguide => by
+      have hdimension : dimension = 2 := by
+        obtain ⟨hlower, hupper⟩ :=
+          (guide_eq_iff (dimension := dimension) (width := 1) (by omega)).mp
+            hguide
+        simp [triangular] at hlower hupper
+        omega
+      subst dimension
+      have hguideTwo : guide 2 = 1 := by
+        simpa [triangular] using guide_at_triangular_end 1
+      have hheightOne : conwayGuyHeight 1 = 1 := by
+        simp [conwayGuyHeight, conwayGuyDifference, difference]
+      have hdifferenceOne : conwayGuyDifference 1 = 1 := by
+        rw [conwayGuyDifference_succ, hguideTwo]
+        simp [conwayGuyDifference, difference]
+      have hheightTwo : conwayGuyHeight 2 = 2 := by
+        rw [show 2 = 1 + 1 by omega, conwayGuyHeight_succ,
+          hheightOne, hdifferenceOne]
+        norm_num
+      simp [residual, hheightOne, hheightTwo]
+  | previous + 1, dimension, hguide => by
+      have hstart :=
+        residual_eq_block_start (width := previous + 2)
+          (dimension := dimension) (by omega) hguide
+      have hpreviousGuide :
+          guide (triangular (previous + 1) + 1) = previous + 1 :=
+        guide_at_triangular_end (previous + 1)
+      have inductionHypothesis :=
+        block_identity_by_width previous
+          (triangular (previous + 1) + 1) hpreviousGuide
+      have hpred :
+          previous + 2 - 1 = previous + 1 := by omega
+      rw [hpred] at hstart
+      rw [hstart, residual_next_block_start, correction_sum_succ]
+      linarith
+
+/-- The exact triangular-block identity for every Conway--Guy height. -/
+theorem conwayGuy_block_identity (dimension : ℕ)
+    (hdimension : 2 ≤ dimension) :
+    conwayGuyHeight dimension -
+          ∑ index : Fin (guide dimension),
+            conwayGuyHeight (dimension - index.val - 1) +
+        ∑ index : Fin (guide dimension - 1),
+          conwayGuyHeight (triangular index.val) = 1 := by
+  have hwidth := guide_pos hdimension
+  have hguide :
+      guide dimension - 1 + 1 = guide dimension := by
+    omega
+  have hidentity :=
+    block_identity_by_width (guide dimension - 1) dimension hguide.symm
+  rw [hguide] at hidentity
+  simpa only [residual] using hidentity
+
+end BooleanIsoperimetry.CoherentGap

--- a/LeanPool/BooleanIsoperimetry/ConwayGuyOrderBridge.lean
+++ b/LeanPool/BooleanIsoperimetry/ConwayGuyOrderBridge.lean
@@ -1,0 +1,182 @@
+/-
+Copyright (c) 2026 Egor Lyfar. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Egor Lyfar
+-/
+import LeanPool.BooleanIsoperimetry.ConwayGuyRigidity
+import LeanPool.BooleanIsoperimetry.Cube
+
+/-!
+# From unit relations to consecutive subset-sum gaps
+
+This file supplies the elementary order-theoretic bridge between the
+Conway--Guy unit-relation certificates and consecutive gaps in the coherent
+Boolean term order induced by the Conway--Guy weights.
+
+Tom Bohman's 1996 theorem that the Conway--Guy rows have distinct subset sums
+is still an external input if one wants the induced comparison to be a total
+order.  The bridge itself only uses integrality: two subset sums differing by
+one have no integer subset sum strictly between them.
+-/
+
+open scoped BigOperators
+
+namespace BooleanIsoperimetry.CoherentGap
+
+/-- The integer weight of a Boolean-cube vertex. -/
+def integerSubsetWeight {n : ℕ} (weights : Relation n) (vertex : Cube n) : ℤ :=
+  ∑ coordinate ∈ vertex, weights coordinate
+
+/-- The real weight of a Boolean-cube vertex. -/
+def realSubsetWeight {n : ℕ} (weights : Fin n → ℝ) (vertex : Cube n) : ℝ :=
+  ∑ coordinate ∈ vertex, weights coordinate
+
+/-- Coordinates with coefficient one in a signed relation. -/
+def positiveSupport {n : ℕ} (relation : Relation n) : Cube n :=
+  Finset.univ.filter fun coordinate => relation coordinate = 1
+
+/-- Coordinates with coefficient minus one in a signed relation. -/
+def negativeSupport {n : ℕ} (relation : Relation n) : Cube n :=
+  Finset.univ.filter fun coordinate => relation coordinate = -1
+
+/-- No subset sum lies strictly between the weights of `lower` and `upper`. -/
+def IsConsecutiveSubsetGap {n : ℕ} (weights : Relation n)
+    (lower upper : Cube n) : Prop :=
+  integerSubsetWeight weights lower < integerSubsetWeight weights upper ∧
+    ∀ middle,
+      ¬(integerSubsetWeight weights lower <
+          integerSubsetWeight weights middle ∧
+        integerSubsetWeight weights middle <
+          integerSubsetWeight weights upper)
+
+/-- Every consecutive gap of a reference integer row has size at least one
+when measured by the candidate real row. -/
+def SatisfiesNormalizedConsecutiveGaps {n : ℕ} (reference : Relation n)
+    (candidate : Fin n → ℝ) : Prop :=
+  ∀ lower upper,
+    IsConsecutiveSubsetGap reference lower upper →
+      1 ≤ realSubsetWeight candidate upper -
+        realSubsetWeight candidate lower
+
+lemma dot_eq_support_difference {n : ℕ} (weights relation : Relation n)
+    (hvalues : ∀ coordinate,
+      relation coordinate = -1 ∨
+        relation coordinate = 0 ∨ relation coordinate = 1) :
+    dot relation weights =
+      integerSubsetWeight weights (positiveSupport relation) -
+        integerSubsetWeight weights (negativeSupport relation) := by
+  classical
+  unfold dot integerSubsetWeight positiveSupport negativeSupport
+  calc
+    (∑ coordinate, relation coordinate * weights coordinate) =
+        ∑ coordinate,
+          ((if relation coordinate = 1 then weights coordinate else 0) -
+            if relation coordinate = -1 then weights coordinate else 0) := by
+      apply Finset.sum_congr rfl
+      intro coordinate _
+      rcases hvalues coordinate with hnegative | hzero | hpositive
+      · simp [hnegative]
+      · simp [hzero]
+      · simp [hpositive]
+    _ =
+        (∑ coordinate,
+          if relation coordinate = 1 then weights coordinate else 0) -
+          ∑ coordinate,
+            if relation coordinate = -1 then weights coordinate else 0 := by
+      rw [Finset.sum_sub_distrib]
+    _ =
+        (∑ coordinate ∈ Finset.univ.filter
+          (fun coordinate => relation coordinate = 1), weights coordinate) -
+          ∑ coordinate ∈ Finset.univ.filter
+            (fun coordinate => relation coordinate = -1), weights coordinate := by
+      simp only [Finset.sum_filter]
+
+lemma realDot_eq_support_difference {n : ℕ} (candidate : Fin n → ℝ)
+    (relation : Relation n)
+    (hvalues : ∀ coordinate,
+      relation coordinate = -1 ∨
+        relation coordinate = 0 ∨ relation coordinate = 1) :
+    realDot relation candidate =
+      realSubsetWeight candidate (positiveSupport relation) -
+        realSubsetWeight candidate (negativeSupport relation) := by
+  classical
+  unfold realDot realSubsetWeight positiveSupport negativeSupport
+  calc
+    (∑ coordinate, (relation coordinate : ℝ) * candidate coordinate) =
+        ∑ coordinate,
+          ((if relation coordinate = 1 then candidate coordinate else 0) -
+            if relation coordinate = -1 then candidate coordinate else 0) := by
+      apply Finset.sum_congr rfl
+      intro coordinate _
+      rcases hvalues coordinate with hnegative | hzero | hpositive
+      · simp [hnegative]
+      · simp [hzero]
+      · simp [hpositive]
+    _ =
+        (∑ coordinate,
+          if relation coordinate = 1 then candidate coordinate else 0) -
+          ∑ coordinate,
+            if relation coordinate = -1 then candidate coordinate else 0 := by
+      rw [Finset.sum_sub_distrib]
+    _ =
+        (∑ coordinate ∈ Finset.univ.filter
+          (fun coordinate => relation coordinate = 1), candidate coordinate) -
+          ∑ coordinate ∈ Finset.univ.filter
+            (fun coordinate => relation coordinate = -1), candidate coordinate := by
+      simp only [Finset.sum_filter]
+
+/-- A unit relation is realized by two subsets whose integer weights differ
+by exactly one. -/
+lemma unitRelation_support_gap {n : ℕ} {weights relation : Relation n}
+    (hrelation : IsLiftableUnit weights relation) :
+    integerSubsetWeight weights (positiveSupport relation) =
+      integerSubsetWeight weights (negativeSupport relation) + 1 := by
+  have hdot := hrelation.2.1
+  rw [dot_eq_support_difference weights relation hrelation.1] at hdot
+  omega
+
+/-- Integrality alone makes every realized gap of size one consecutive. -/
+lemma consecutive_of_integer_gap_one {n : ℕ} {weights : Relation n}
+    {lower upper : Cube n}
+    (hgap : integerSubsetWeight weights upper =
+      integerSubsetWeight weights lower + 1) :
+    IsConsecutiveSubsetGap weights lower upper := by
+  constructor
+  · omega
+  · intro middle hbetween
+    omega
+
+/-- Every liftable unit relation is a consecutive subset-sum gap. -/
+theorem unitRelation_isConsecutiveSubsetGap {n : ℕ}
+    {weights relation : Relation n}
+    (hrelation : IsLiftableUnit weights relation) :
+    IsConsecutiveSubsetGap weights
+      (negativeSupport relation) (positiveSupport relation) :=
+  consecutive_of_integer_gap_one (unitRelation_support_gap hrelation)
+
+/-- Normalized consecutive-gap inequalities imply all unit-relation
+inequalities used by the rigidity certificate. -/
+theorem normalizedConsecutiveGaps_imply_unitRelations {n : ℕ}
+    {reference : Relation n} {candidate : Fin n → ℝ}
+    (hnormalized : SatisfiesNormalizedConsecutiveGaps reference candidate) :
+    ∀ relation, IsLiftableUnit reference relation →
+      1 ≤ realDot relation candidate := by
+  intro relation hrelation
+  have hgap := hnormalized (negativeSupport relation) (positiveSupport relation)
+    (unitRelation_isConsecutiveSubsetGap hrelation)
+  rw [realDot_eq_support_difference candidate relation hrelation.1]
+  exact hgap
+
+/-- The Conway--Guy row is coordinatewise minimal among real rows with
+normalized consecutive gaps in its induced subset-sum order. -/
+theorem conwayGuyRigidity_of_normalizedConsecutiveGaps {n : ℕ}
+    (candidate : Fin n → ℝ)
+    (hnormalized : SatisfiesNormalizedConsecutiveGaps
+      (conwayGuyArithmetic.tower.weights n) candidate) :
+    ∀ coordinate,
+      (conwayGuyArithmetic.tower.weights n coordinate : ℝ) ≤
+        candidate coordinate :=
+  conwayGuyNormalizedChamberRigidity candidate
+    (normalizedConsecutiveGaps_imply_unitRelations hnormalized)
+
+end BooleanIsoperimetry.CoherentGap

--- a/LeanPool/BooleanIsoperimetry/ConwayGuyOrderBridge.lean
+++ b/LeanPool/BooleanIsoperimetry/ConwayGuyOrderBridge.lean
@@ -167,8 +167,8 @@ theorem normalizedConsecutiveGaps_imply_unitRelations {n : ℕ}
   rw [realDot_eq_support_difference candidate relation hrelation.1]
   exact hgap
 
-/-- The Conway--Guy row is coordinatewise minimal among real rows with
-normalized consecutive gaps in its induced subset-sum order. -/
+/-- The Conway--Guy row is a coordinatewise lower bound for every real row
+with normalized consecutive gaps relative to its subset sums. -/
 theorem conwayGuyRigidity_of_normalizedConsecutiveGaps {n : ℕ}
     (candidate : Fin n → ℝ)
     (hnormalized : SatisfiesNormalizedConsecutiveGaps
@@ -180,3 +180,12 @@ theorem conwayGuyRigidity_of_normalizedConsecutiveGaps {n : ℕ}
     (normalizedConsecutiveGaps_imply_unitRelations hnormalized)
 
 end BooleanIsoperimetry.CoherentGap
+
+namespace BooleanIsoperimetry
+
+/-- Public short name for the all-dimensional Conway--Guy gap-rigidity
+theorem. -/
+alias conwayGuyGapRigidity :=
+  CoherentGap.conwayGuyRigidity_of_normalizedConsecutiveGaps
+
+end BooleanIsoperimetry

--- a/LeanPool/BooleanIsoperimetry/ConwayGuyRigidity.lean
+++ b/LeanPool/BooleanIsoperimetry/ConwayGuyRigidity.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 Egor Lyfar. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Egor Lyfar
+-/
+import LeanPool.BooleanIsoperimetry.ConwayGuyHeight
+
+/-!
+# Conway--Guy normalized chamber rigidity
+
+This file packages the concrete Conway--Guy principal relations and triangular
+corrections as a `FirstCoordinateRecurrence`.  The separate height identity
+supplies the one remaining arithmetic input.
+-/
+
+namespace BooleanIsoperimetry.CoherentGap
+
+/-- The triangular-block identity needed to evaluate a Conway--Guy principal
+relation. -/
+def ConwayGuyBlockIdentity (offset : ℕ) : Prop :=
+  conwayGuyHeight (offset + 2) -
+      ∑ index : Fin (guide (offset + 2)),
+        conwayGuyHeight (offset + 2 - index.val - 1) +
+    ∑ index : Fin (guide (offset + 2) - 1),
+      conwayGuyHeight (triangular index.val) = 1
+
+/-- The dimension-one Conway--Guy basis certificate. -/
+noncomputable def conwayGuyBaseCertificate :
+    Certificate (conwayGuyArithmetic.tower.weights 1) (basis 0) :=
+  Certificate.singleton (by
+    refine ⟨?_, ?_, ?_⟩
+    · intro coordinate
+      right
+      right
+      have hcoordinate : coordinate = 0 := Fin.eq_zero coordinate
+      subst coordinate
+      simp [basis]
+    · rw [dot_basis]
+      simp [ConwayGuyArithmetic.tower, ConwayGuyArithmetic.weights,
+        conwayGuyArithmetic]
+    · right
+      right
+      exact coordinateSum_basis 0)
+
+lemma principal_valid (hblock : ∀ offset, ConwayGuyBlockIdentity offset)
+    (offset : ℕ) :
+    IsLiftableUnit (conwayGuyArithmetic.tower.weights (offset + 2))
+      (principal offset) := by
+  refine ⟨principal_entry offset, ?_, ?_⟩
+  · exact principal_dot offset (hblock offset)
+  · right
+    right
+    exact principal_coordinateSum offset
+
+/-- The concrete first-coordinate recurrence, conditional only on the explicit
+Conway--Guy block identity. -/
+noncomputable def conwayGuyFirstCoordinateRecurrence
+    (hblock : ∀ offset, ConwayGuyBlockIdentity offset) :
+    FirstCoordinateRecurrence conwayGuyArithmetic.tower where
+  base := conwayGuyBaseCertificate
+  principal := principal
+  principal_valid := principal_valid hblock
+  corrections := corrections
+  decomposition := principal_corrections_decomposition
+
+/-- Conditional concrete normalized chamber rigidity.  The height file
+discharges `hblock` from the published Conway--Guy recurrence. -/
+theorem conwayGuyNormalizedChamberRigidity_of_blockIdentity
+    (hblock : ∀ offset, ConwayGuyBlockIdentity offset) {n : ℕ}
+    (candidate : Fin n → ℝ)
+    (hgap : ∀ relation,
+      IsLiftableUnit (conwayGuyArithmetic.tower.weights n) relation →
+        1 ≤ realDot relation candidate) :
+    ∀ coordinate,
+      (conwayGuyArithmetic.tower.weights n coordinate : ℝ) ≤
+        candidate coordinate :=
+  normalizedChamberRigidity conwayGuyArithmetic.tower
+    (conwayGuyFirstCoordinateRecurrence hblock) candidate hgap
+
+lemma conwayGuyBlockIdentity_all (offset : ℕ) :
+    ConwayGuyBlockIdentity offset := by
+  exact conwayGuy_block_identity (offset + 2) (by omega)
+
+/-- The unconditional first-coordinate certificate recurrence for the
+Conway--Guy row. -/
+noncomputable def conwayGuyRecurrence :
+    FirstCoordinateRecurrence conwayGuyArithmetic.tower :=
+  conwayGuyFirstCoordinateRecurrence conwayGuyBlockIdentity_all
+
+/-- Every coordinate of every Conway--Guy row has a nonnegative integral
+certificate supported on liftable unit relations. -/
+theorem conwayGuyCertificate_exists (dimension : ℕ)
+    (coordinate : Fin dimension) :
+    Nonempty
+      (Certificate (conwayGuyArithmetic.tower.weights dimension)
+        (basis coordinate)) :=
+  recurrenceCertificate_exists conwayGuyArithmetic.tower
+    conwayGuyRecurrence dimension coordinate
+
+/-- **Conway--Guy normalized chamber rigidity.** Every real row satisfying all
+unit-relation inequalities of the Conway--Guy row dominates it coordinatewise.
+
+Bohman's distinct-subset-sum theorem is a separate external input identifying
+these unit relations with consecutive gaps of the induced Boolean term order.
+-/
+theorem conwayGuyNormalizedChamberRigidity {n : ℕ}
+    (candidate : Fin n → ℝ)
+    (hgap : ∀ relation,
+      IsLiftableUnit (conwayGuyArithmetic.tower.weights n) relation →
+        1 ≤ realDot relation candidate) :
+    ∀ coordinate,
+      (conwayGuyArithmetic.tower.weights n coordinate : ℝ) ≤
+        candidate coordinate :=
+  normalizedChamberRigidity conwayGuyArithmetic.tower
+    conwayGuyRecurrence candidate hgap
+
+end BooleanIsoperimetry.CoherentGap

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -7,8 +7,8 @@ projects:
       has the smallest closed radius-one Hamming neighborhood. Develops the
       supporting binomial-cascade identities, Kruskal--Katona shadow bounds,
       coordinate compressions, and the final dimension induction. Applies the
-      coherent-gap certificate method to prove normalized chamber rigidity for
-      the Conway--Guy sequence from its exact recurrence.
+      coherent-gap certificate method to prove normalized consecutive-gap
+      rigidity for the Conway--Guy sequence from its exact recurrence.
     branch: extremal and additive combinatorics
     entry_module: LeanPool.BooleanIsoperimetry
     authors:
@@ -29,7 +29,7 @@ projects:
     provenance: AI
     main_declarations:
       - BooleanIsoperimetry.harper_theorem
-      - BooleanIsoperimetry.CoherentGap.conwayGuyNormalizedChamberRigidity
+      - BooleanIsoperimetry.CoherentGap.conwayGuyRigidity_of_normalizedConsecutiveGaps
     main_results:
       - declaration: BooleanIsoperimetry.harper_theorem
         informal: >-
@@ -37,11 +37,11 @@ projects:
           simplicial initial segment of the same cardinality has a closed
           radius-one Hamming neighborhood no larger than that of the family.
       - declaration: >-
-          BooleanIsoperimetry.CoherentGap.conwayGuyNormalizedChamberRigidity
+          BooleanIsoperimetry.CoherentGap.conwayGuyRigidity_of_normalizedConsecutiveGaps
         informal: >-
-          In every dimension, any real row satisfying all liftable
-          unit-relation inequalities of the Conway--Guy reference row
-          dominates that row coordinatewise.
+          In every dimension, any real row whose consecutive subset-sum gaps
+          in the Conway--Guy reference order are at least one dominates that
+          row coordinatewise.
     tags:
       - additive-combinatorics
       - extremal-combinatorics

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -6,15 +6,20 @@ projects:
       among all families of a fixed cardinality, the simplicial initial segment
       has the smallest closed radius-one Hamming neighborhood. Develops the
       supporting binomial-cascade identities, Kruskal--Katona shadow bounds,
-      coordinate compressions, and the final dimension induction.
-    branch: extremal combinatorics
+      coordinate compressions, and the final dimension induction. Applies the
+      coherent-gap certificate method to prove normalized chamber rigidity for
+      the Conway--Guy sequence from its exact recurrence.
+    branch: extremal and additive combinatorics
     entry_module: LeanPool.BooleanIsoperimetry
     authors:
       - Alexey Milovanov
     source:
-      title: Optimal numberings and isoperimetric problems on graphs
+      title: >-
+        Optimal numberings and isoperimetric problems on graphs; A sum packing
+        problem of Erdős and the Conway--Guy sequence
       authors:
         - L. H. Harper
+        - Tom Bohman
       doi: "10.1016/S0021-9800(66)80059-5"
       github_repo: AlexeyMilovanov/BooleanIsoperimetry
     license: Apache-2.0
@@ -22,12 +27,19 @@ projects:
     provenance: AI
     main_declarations:
       - BooleanIsoperimetry.harper_theorem
+      - BooleanIsoperimetry.CoherentGap.conwayGuyNormalizedChamberRigidity
     main_results:
       - declaration: BooleanIsoperimetry.harper_theorem
         informal: >-
           For every family of vertices in an n-dimensional Boolean cube, the
           simplicial initial segment of the same cardinality has a closed
           radius-one Hamming neighborhood no larger than that of the family.
+      - declaration: >-
+          BooleanIsoperimetry.CoherentGap.conwayGuyNormalizedChamberRigidity
+        informal: >-
+          In every dimension, any real row satisfying all liftable
+          unit-relation inequalities of the Conway--Guy reference row
+          dominates that row coordinatewise.
     tags:
       - extremal-combinatorics
       - isoperimetry

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -29,7 +29,7 @@ projects:
     provenance: AI
     main_declarations:
       - BooleanIsoperimetry.harper_theorem
-      - BooleanIsoperimetry.CoherentGap.conwayGuyRigidity_of_normalizedConsecutiveGaps
+      - BooleanIsoperimetry.conwayGuyGapRigidity
     main_results:
       - declaration: BooleanIsoperimetry.harper_theorem
         informal: >-
@@ -37,14 +37,13 @@ projects:
           simplicial initial segment of the same cardinality has a closed
           radius-one Hamming neighborhood no larger than that of the family.
       - declaration: >-
-          BooleanIsoperimetry.CoherentGap.conwayGuyRigidity_of_normalizedConsecutiveGaps
+          BooleanIsoperimetry.conwayGuyGapRigidity
         informal: >-
           In every dimension, any real row whose consecutive subset-sum gaps
-          in the Conway--Guy reference order are at least one dominates that
-          row coordinatewise.
+          relative to the Conway--Guy reference row are at least one dominates
+          that row coordinatewise.
     tags:
       - additive-combinatorics
-      - extremal-combinatorics
       - isoperimetry
       - boolean-cube
       - subset-sums

--- a/LeanPool/projects.yml
+++ b/LeanPool/projects.yml
@@ -1,6 +1,6 @@
 projects:
   - slug: boolean-isoperimetry
-    title: Harper's Vertex-Isoperimetric Theorem on the Boolean Cube
+    title: Boolean Isoperimetry and Conway--Guy Coherent Gaps
     summary: >-
       Formalizes Harper's vertex-isoperimetric theorem for the Boolean cube:
       among all families of a fixed cardinality, the simplicial initial segment
@@ -13,6 +13,7 @@ projects:
     entry_module: LeanPool.BooleanIsoperimetry
     authors:
       - Alexey Milovanov
+      - Egor Lyfar
     source:
       title: >-
         Optimal numberings and isoperimetric problems on graphs; A sum packing
@@ -21,6 +22,7 @@ projects:
         - L. H. Harper
         - Tom Bohman
       doi: "10.1016/S0021-9800(66)80059-5"
+      url: "https://doi.org/10.1090/S0002-9939-96-03653-2"
       github_repo: AlexeyMilovanov/BooleanIsoperimetry
     license: Apache-2.0
     status: verified
@@ -41,9 +43,12 @@ projects:
           unit-relation inequalities of the Conway--Guy reference row
           dominates that row coordinatewise.
     tags:
+      - additive-combinatorics
       - extremal-combinatorics
       - isoperimetry
       - boolean-cube
+      - subset-sums
+      - coherent-orders
     msc:
       - "05D05"
       - "05C35"


### PR DESCRIPTION
## Summary

This extends the existing Boolean-isoperimetry project with an all-dimensional
certificate theorem for the Conway--Guy sequence.

- defines liftable integer unit relations and nonnegative integral
  certificates;
- proves that the dimension lift preserves both;
- derives a certificate for every coordinate from an explicit recurrence;
- formalizes the Conway--Guy triangular guide, difference sequence, height
  identity, principal relations, and correction chains;
- proves that an integer unit relation gives a consecutive subset-sum gap;
- proves `BooleanIsoperimetry.conwayGuyGapRigidity`.

The final theorem works for every dimension. If a real candidate satisfies
`SatisfiesNormalizedConsecutiveGaps` relative to the subset sums of the fixed
Conway--Guy reference row, then each candidate coordinate is at least the
corresponding reference coordinate.

Bohman's distinct-subset-sum theorem remains an external input. This PR does
not prove that the reference row is feasible, does not cover every coherent
order, and does not solve Erdős Problem 1.

Source:

- Tom Bohman, “A sum packing problem of Erdős and the Conway--Guy sequence,”
  https://doi.org/10.1090/S0002-9939-96-03653-2

## Verification

- `lake build LeanPool`
- `lake exe mk_all --check`
- `lake exe runLinter LeanPool.BooleanIsoperimetry`
- `lake exe lint-style LeanPool.BooleanIsoperimetry`
- `uv run python -m lean_pool.quality --repo ..`

The submitted files contain no `sorry`, custom axioms, custom elaborators, or
recursion-limit changes.

## AI disclosure

I used Codex for proof development, adversarial review, and repository
preparation. The project card records `provenance: AI`; Lean checks the
submitted declarations.
