### PR TITLE
Fix the bump repair fan-out: OIDC permission and errexit

### DIFF
--- a/.github/workflows/mathlib-bump.yml
+++ b/.github/workflows/mathlib-bump.yml
@@ -297,6 +297,10 @@ jobs:
     name: Repair ${{ matrix.project }}
     permissions:
       contents: read
+      # claude-code-action exchanges a GitHub OIDC token for its credentials;
+      # without this it fails every attempt with "Unable to get
+      # ACTIONS_ID_TOKEN_REQUEST_URL".
+      id-token: write
     strategy:
       fail-fast: false
       # The free plan allows 20 concurrent jobs across the account; leave
@@ -349,6 +353,11 @@ jobs:
           PROJECT: ${{ matrix.project }}
           LEAN_NUM_THREADS: 2
         run: |
+          # `set +e`, not just `set -uo pipefail`: the runner's shell is
+          # `bash -e`, which would abort this step on a failing build before
+          # PIPESTATUS could be read. A project that still fails must be
+          # recorded, not silently lost.
+          set +e
           set -uo pipefail
           lake build "LeanPool.$PROJECT" 2>&1 | tee verify.log
           status=${PIPESTATUS[0]}
@@ -451,6 +460,9 @@ jobs:
         env:
           LEAN_NUM_THREADS: 2
         run: |
+          # See the repair job's verify step: the runner's `bash -e` would
+          # abort here on a failing build, skipping the PR that reports it.
+          set +e
           set -uo pipefail
           lake exe cache get
           # Whole-pool, not per-project: this is the pass that catches the
@@ -470,6 +482,9 @@ jobs:
         id: gates
         if: steps.build.outputs.status == '0'
         run: |
+          # Each gate's result is recorded rather than aborting the job, so the
+          # PR body can report which ones failed.
+          set +e
           set -uo pipefail
           results=""
           lake exe mk_all --check      && results="$results mk_all:pass" || results="$results mk_all:FAIL"


### PR DESCRIPTION
First end-to-end run of `mathlib-bump.yml` ([run 30335027247](https://github.com/Vilin97/lean-pool/actions/runs/30335027247)) got through `detect`, `pin`, all ten probe shards and `triage` — then all 99 repair jobs failed identically on a missing OIDC permission.

**`id-token: write`** — `claude-code-action` exchanges a GitHub OIDC token for its credentials; the repair job only granted `contents: read`.

**`set +e`** — three steps meant to *record* a failing build rather than die on it used `set -uo pipefail`, which does not clear the `-e` the runner's `bash -e {0}` already set. `lake build ... | tee` therefore aborted the step before `${PIPESTATUS[0]}` could be read. In `assemble` that skipped the step that opens the PR — turning an honest "0 repairs applied, build still failing" report into no report at all.

The free half is confirmed working end to end: **99 of 142 projects** fail to build on `v4.32.0-rc1` → `v4.33.0-rc1`, and per-project diagnostics extracted correctly (ZFLean's 5 errors with file and line, etc.).