### PR TITLE
Skip the Claude App token exchange in bump repair jobs

### DIFF
--- a/.github/workflows/mathlib-bump.yml
+++ b/.github/workflows/mathlib-bump.yml
@@ -342,6 +342,12 @@ jobs:
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Supplying a token short-circuits the action's OIDC-to-app-token
+          # exchange (OVERRIDE_GITHUB_TOKEN in its token.ts), which otherwise
+          # 401s with "Claude Code is not installed on this repository". These
+          # jobs only read the repo and write a patch artifact, so the default
+          # job token is sufficient and no GitHub App install is needed.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: "/version-bump-project ${{ matrix.project }} ${{ needs.detect.outputs.target }}"
           claude_args: >-
             --max-turns 60


### PR DESCRIPTION
Second failure mode from the end-to-end bump run. `id-token: write` fixed the OIDC step — the log now shows `OIDC token successfully obtained` — but the next step failed on all 99 repair jobs:

```
App token exchange failed: 401 Unauthorized - Claude Code is not installed on this repository.
```

The action trades the OIDC token for a **Claude GitHub App** installation token, which would mean installing that app on the repo. Its `src/github/token.ts` returns early when `OVERRIDE_GITHUB_TOKEN` is set:

```ts
const providedToken = process.env.OVERRIDE_GITHUB_TOKEN;
if (providedToken) {
  console.log("Using provided GITHUB_TOKEN for authentication");
  return providedToken;
}
```

`action.yml` maps the `github_token` input to that variable and documents it as *"optional if using GitHub App"* — this is the other side of that trade.

The repair jobs only read the repository and upload a patch artifact; they never comment or push, so the default job token is sufficient and no app install is needed. Claude itself still authenticates via `CLAUDE_CODE_OAUTH_TOKEN` against your subscription, which this does not touch.