### PR TITLE
Fail the bump fast on a bad Claude token

### DIFF
--- a/.github/workflows/mathlib-bump.yml
+++ b/.github/workflows/mathlib-bump.yml
@@ -124,6 +124,38 @@ jobs:
             echo "Target: **$TARGET** (repair fan-out: $REPAIR)" >> "$GITHUB_STEP_SUMMARY"
           fi
 
+  auth:
+    needs: detect
+    # Only gates the paid stage; the free probe runs regardless of the token.
+    if: needs.detect.outputs.found == 'true' && needs.detect.outputs.repair == 'true'
+    runs-on: ubuntu-latest
+    name: Preflight Claude auth
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      # A trivial round-trip. Without it an invalid or expired token is only
+      # discovered after the ~40-minute probe, by 99 repair jobs failing
+      # identically -- which is exactly how the first three runs were spent.
+      - uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: "Reply with exactly: AUTH_OK"
+          claude_args: >-
+            --max-turns 1
+            --model claude-sonnet-5
+
+      - name: Explain a failure
+        if: failure()
+        run: |
+          echo "::error::CLAUDE_CODE_OAUTH_TOKEN is invalid or expired." \
+            "Regenerate it with \`claude setup-token\` and update the secret," \
+            "then verify with the Claude auth check workflow."
+
   pin:
     needs: detect
     if: needs.detect.outputs.found == 'true'
@@ -291,7 +323,7 @@ jobs:
             build.log
 
   repair:
-    needs: [detect, triage]
+    needs: [detect, auth, triage]
     if: needs.detect.outputs.repair == 'true' && needs.triage.outputs.has_breakage == 'true'
     runs-on: ubuntu-latest
     name: Repair ${{ matrix.project }}


### PR DESCRIPTION
The canary from #297 gave a definitive answer in one minute:

```
Failed to authenticate. API Error: 401 OAuth access token is invalid.
```

Every one of the 99 repair jobs was failing on that. Discovering it cost a full ~40-minute probe build plus 99 doomed jobs — which is how three consecutive end-to-end runs were spent.

This adds the same one-minute round-trip as a preflight to `mathlib-bump.yml`. It gates only the paid `repair` stage and runs in parallel with `pin`/`probe`, so a bad token still produces the free per-project breakage report — that half of the workflow doesn't touch Claude at all.

Everything else in the pipeline is now confirmed working end to end: `detect` → `pin` → 10 probe shards → `triage` → `assemble`, which opened draft #295 with an honest "0 repairs applied" summary.