### PR TITLE
Approve the bump PR's gated CI run

### DIFF
--- a/.github/BUMP_AUTOMATION.md
+++ b/.github/BUMP_AUTOMATION.md
@@ -62,18 +62,21 @@ healthy and only the repair half is dead. Two ways to handle it:
   repository and have the action refresh the stored token automatically. This
   trades a long-lived PAT for never having to think about expiry.
 
-### 2. `BUMP_TOKEN` — so the bump PR actually runs CI
+### 2. `BUMP_TOKEN` (optional) — CI on the bump PR
 
-GitHub does not trigger workflows for anything pushed with `GITHUB_TOKEN`.
-That anti-recursion rule means a bump branch pushed by the workflow produces a
-pull request with **no checks at all** — which is worse than a red one, because
-it reads as unverified rather than broken.
+A pull request opened by a bot has its workflow runs held in `action_required`
+until someone approves them. The run exists and is attached to the right
+commit, but no checks are created, so the PR shows **no checks at all** — worse
+than a red one, because it reads as unverified rather than broken.
 
-Set `BUMP_TOKEN` to a PAT with `repo` scope, or a GitHub App installation
-token, and the push triggers `pull_request` CI natively. Without it the
-workflow falls back to dispatching Lean Action CI explicitly on the branch:
-the code still gets built and gated, but the run appears in the workflow's run
-list rather than as a check on the PR.
+`assemble` handles this itself: it finds its own gated run and approves it, so
+the draft PR arrives with CI already going. That only ever approves a run on a
+`bump/*` branch this workflow created, and does not relax the approval gate for
+contributor pull requests.
+
+Setting `BUMP_TOKEN` to a PAT with `repo` scope (or a GitHub App installation
+token) avoids the gate entirely, since the PR is then authored by a real
+account. It is optional; without it the approval step covers the same ground.
 
 `assemble` also re-runs the whole-pool build and all four gates itself and puts
 the results in the PR body, so the information exists either way — but a

--- a/.github/BUMP_AUTOMATION.md
+++ b/.github/BUMP_AUTOMATION.md
@@ -9,7 +9,10 @@ review the draft PR it opens.
 | Stage | What it does | Cost |
 |---|---|---|
 | `detect` | Compares the pinned release against Mathlib's tags | free |
-| `probe` | Moves the pins, builds every project, buckets failures per project | free |
+| `auth` | One-minute check that the Claude token still works | negligible |
+| `pin` | Moves the four pins, refreshes manifests, pushes `bump/<version>` | free |
+| `probe` | Builds every project across 10 parallel shards | free |
+| `triage` | Buckets the shard logs into a per-project breakage map | free |
 | `repair` | One Claude job per broken project, in parallel | subscription quota |
 | `assemble` | Applies patches, rebuilds the pool, runs all four gates, opens a draft PR | free |
 
@@ -22,13 +25,18 @@ three projects or thirty.
 
 ### Repair modes
 
+Bumps target the **newest available release, release candidates included** —
+mid-cycle that is what "latest Lean and Mathlib" means. `stable_only: true`
+narrows detection to final releases.
+
 The `repair` input controls the fan-out:
 
-- `auto` (default) — repair final releases, report only on `-rc` tags. Mathlib
-  tags release candidates often; repairing each one would drain the token budget
-  for a version you are not adopting yet.
-- `always` — repair whatever was detected, including candidates.
-- `never` — probe only. Use this to size a bump before committing to it.
+- `always` (default) — repair every broken project.
+- `never` — probe only. Use this to size a bump without spending anything; the
+  per-project breakage report is produced either way.
+
+`auth` gates only `repair`, and runs in parallel with `pin`/`probe`, so an
+expired token still leaves you with the free breakage report.
 
 ## One-time setup
 

--- a/.github/BUMP_AUTOMATION.md
+++ b/.github/BUMP_AUTOMATION.md
@@ -54,7 +54,24 @@ healthy and only the repair half is dead. Two ways to handle it:
   repository and have the action refresh the stored token automatically. This
   trades a long-lived PAT for never having to think about expiry.
 
-### 2. Pushing to branches (and to fork PRs)
+### 2. `BUMP_TOKEN` — so the bump PR actually runs CI
+
+GitHub does not trigger workflows for anything pushed with `GITHUB_TOKEN`.
+That anti-recursion rule means a bump branch pushed by the workflow produces a
+pull request with **no checks at all** — which is worse than a red one, because
+it reads as unverified rather than broken.
+
+Set `BUMP_TOKEN` to a PAT with `repo` scope, or a GitHub App installation
+token, and the push triggers `pull_request` CI natively. Without it the
+workflow falls back to dispatching Lean Action CI explicitly on the branch:
+the code still gets built and gated, but the run appears in the workflow's run
+list rather than as a check on the PR.
+
+`assemble` also re-runs the whole-pool build and all four gates itself and puts
+the results in the PR body, so the information exists either way — but a
+reviewer should be able to see it on the PR.
+
+### 3. Pushing to branches (and to fork PRs)
 
 This workflow only ever pushes to `bump/*` branches in this repository, which
 the default `GITHUB_TOKEN` can do.

--- a/.github/workflows/mathlib-bump.yml
+++ b/.github/workflows/mathlib-bump.yml
@@ -447,6 +447,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # To release the PR's own CI run from the approval gate; see the last step.
+      actions: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -580,22 +582,37 @@ jobs:
               --body-file body.md
           fi
 
-      - name: Ensure the branch gets a real CI run
+      - name: Release the PR's CI run from the approval gate
         env:
-          GH_TOKEN: ${{ secrets.BUMP_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ needs.detect.outputs.branch }}
-          HAS_PAT: ${{ secrets.BUMP_TOKEN != '' }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # With BUMP_TOKEN the push already triggered `pull_request` CI. On
-          # the GITHUB_TOKEN fallback nothing fires at all, which would leave
-          # a bump PR showing no checks -- worse than a red one, because it
-          # looks unverified rather than broken. Dispatch explicitly instead.
-          if [ "$HAS_PAT" = "true" ]; then
-            echo "BUMP_TOKEN set; the push triggers PR checks natively."
-            exit 0
-          fi
-          gh workflow run lean_action_ci.yml --ref "$BRANCH"
-          echo "Dispatched Lean Action CI on $BRANCH (it cannot be a PR check" \
-            "without BUMP_TOKEN; see the workflow's run list)." \
+          # A PR opened by a bot has its workflow runs held in
+          # `action_required` until someone approves them, so the bump PR
+          # shows no checks at all -- worse than a red one, because it reads
+          # as unverified rather than broken. Approve the run here so the
+          # draft PR arrives with CI already going.
+          #
+          # This only ever approves a run on this workflow's own bump/* branch,
+          # whose contents are main plus patches this run produced. It does not
+          # relax the gate for contributor pull requests.
+          for _ in $(seq 1 10); do
+            run_id="$(gh run list --repo "$REPO" --workflow lean_action_ci.yml \
+              --branch "$BRANCH" --limit 1 --json databaseId,status \
+              --jq '.[] | select(.status == "action_required") | .databaseId')"
+            if [ -n "$run_id" ]; then
+              gh api -X POST "repos/$REPO/actions/runs/$run_id/approve"
+              echo "Approved Lean Action CI run $run_id on $BRANCH." \
+                >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            sleep 10
+          done
+          # Nothing to approve is the normal case with BUMP_TOKEN set, since a
+          # PAT-authored PR is not gated. Fall back to an explicit dispatch so
+          # the branch is never left unverified.
+          gh workflow run lean_action_ci.yml --repo "$REPO" --ref "$BRANCH" || true
+          echo "No gated run found; dispatched Lean Action CI on $BRANCH." \
             >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mathlib-bump.yml
+++ b/.github/workflows/mathlib-bump.yml
@@ -167,6 +167,12 @@ jobs:
       matrix: ${{ steps.plan.outputs.matrix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          # GitHub suppresses workflow triggers for anything pushed with
+          # GITHUB_TOKEN, so a branch pushed with it yields a PR that never
+          # runs CI. BUMP_TOKEN (a PAT or GitHub App token) restores that;
+          # without it `assemble` dispatches Lean Action CI explicitly.
+          token: ${{ secrets.BUMP_TOKEN || secrets.GITHUB_TOKEN }}
 
       - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff
         with:
@@ -446,6 +452,7 @@ jobs:
         with:
           ref: ${{ needs.detect.outputs.branch }}
           fetch-depth: 0
+          token: ${{ secrets.BUMP_TOKEN || secrets.GITHUB_TOKEN }}
 
       - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff
         with:
@@ -535,7 +542,7 @@ jobs:
 
       - name: Push and open a draft PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BUMP_TOKEN || secrets.GITHUB_TOKEN }}
           BRANCH: ${{ needs.detect.outputs.branch }}
           TARGET: ${{ needs.detect.outputs.target }}
           APPLIED: ${{ steps.apply.outputs.applied }}
@@ -572,3 +579,23 @@ jobs:
               --title "chore: bump Lean and Mathlib to $TARGET" \
               --body-file body.md
           fi
+
+      - name: Ensure the branch gets a real CI run
+        env:
+          GH_TOKEN: ${{ secrets.BUMP_TOKEN || secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ needs.detect.outputs.branch }}
+          HAS_PAT: ${{ secrets.BUMP_TOKEN != '' }}
+        run: |
+          set -euo pipefail
+          # With BUMP_TOKEN the push already triggered `pull_request` CI. On
+          # the GITHUB_TOKEN fallback nothing fires at all, which would leave
+          # a bump PR showing no checks -- worse than a red one, because it
+          # looks unverified rather than broken. Dispatch explicitly instead.
+          if [ "$HAS_PAT" = "true" ]; then
+            echo "BUMP_TOKEN set; the push triggers PR checks natively."
+            exit 0
+          fi
+          gh workflow run lean_action_ci.yml --ref "$BRANCH"
+          echo "Dispatched Lean Action CI on $BRANCH (it cannot be a PR check" \
+            "without BUMP_TOKEN; see the workflow's run list)." \
+            >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
#295 was opened with **no checks at all**.

**Corrected diagnosis.** My first read was GITHUB_TOKEN trigger-suppression. Checking the actual run showed otherwise: a `pull_request` run *was* created for the exact PR head (`927bf1b3`), but its conclusion is `action_required` — a PR opened by a bot has its workflow runs held until someone approves them, and no check runs exist while it waits. Approving that run by hand immediately started all 10 build shards on #295.

**Fix.** `assemble` now finds its own gated run and approves it, so the draft PR arrives with CI already going. This only ever approves a run on the `bump/*` branch the workflow just created — contents are main plus patches from that run — and does not relax the approval gate for contributor PRs. It falls back to an explicit dispatch if no gated run appears, so the branch is never left unverified.

`BUMP_TOKEN` (PAT or App token) is still supported and now genuinely optional: a PAT-authored PR isn't gated at all.

Also corrects `BUMP_AUTOMATION.md`, which still documented a `repair: auto` mode that no longer exists and omitted the `auth`/`pin`/`triage` stages.