### PR TITLE
Run bump repairs on Opus 5

### DIFF
--- a/.github/BUMP_AUTOMATION.md
+++ b/.github/BUMP_AUTOMATION.md
@@ -13,7 +13,7 @@ review the draft PR it opens.
 | `pin` | Moves the four pins, refreshes manifests, pushes `bump/<version>` | free |
 | `probe` | Builds every project across 10 parallel shards | free |
 | `triage` | Buckets the shard logs into a per-project breakage map | free |
-| `repair` | One Claude job per broken project, in parallel | subscription quota |
+| `repair` | One Claude job per broken project, in parallel (Opus 5) | subscription quota |
 | `assemble` | Applies patches, rebuilds the pool, runs all four gates, opens a draft PR | free |
 
 "Free" means GitHub-hosted runner minutes, which are unmetered for public
@@ -36,7 +36,14 @@ The `repair` input controls the fan-out:
   per-project breakage report is produced either way.
 
 `auth` gates only `repair`, and runs in parallel with `pin`/`probe`, so an
-expired token still leaves you with the free breakage report.
+expired token still leaves you with the free breakage report. It exercises the
+same model the fan-out uses, so it cannot pass while that model is unavailable.
+
+Repairs run on **Opus 5**, pinned explicitly rather than left to the action's
+default. A bump repair is the hardest work in this repository -- Mathlib API
+archaeology plus proof surgery under a no-statement-drops constraint -- and a
+weaker model spends the same runner hours to produce patches that do not
+apply.
 
 ## One-time setup
 

--- a/.github/workflows/claude-auth-check.yml
+++ b/.github/workflows/claude-auth-check.yml
@@ -43,7 +43,7 @@ jobs:
           prompt: "Reply with exactly: AUTH_OK"
           claude_args: >-
             --max-turns 1
-            --model claude-sonnet-5
+            --model claude-opus-5
 
       - name: Report
         if: always()

--- a/.github/workflows/mathlib-bump.yml
+++ b/.github/workflows/mathlib-bump.yml
@@ -147,7 +147,7 @@ jobs:
           prompt: "Reply with exactly: AUTH_OK"
           claude_args: >-
             --max-turns 1
-            --model claude-sonnet-5
+            --model claude-opus-5
 
       - name: Explain a failure
         if: failure()
@@ -389,6 +389,7 @@ jobs:
           prompt: "/version-bump-project ${{ matrix.project }} ${{ needs.detect.outputs.target }}"
           claude_args: >-
             --max-turns 60
+            --model claude-opus-5
             --allowedTools "Bash,Read,Edit,Write,Grep,Glob"
 
       - name: Verify the repair


### PR DESCRIPTION
The repair fan-out passed no `--model`, so it inherited the action's default — the first run initialised on `claude-sonnet-5`.

Bump repairs are the hardest work in this repo: Mathlib API archaeology plus proof surgery under a no-statement-drops constraint. A weaker model spends the same runner hours to produce patches that don't apply.

The auth preflight and the standalone canary move to Opus 5 too, so neither can pass while the model the fan-out actually needs is unavailable.