### PR TITLE
Keep partial repairs instead of discarding them

### DIFF
--- a/.github/BUMP_AUTOMATION.md
+++ b/.github/BUMP_AUTOMATION.md
@@ -147,6 +147,14 @@ The probe report (per-project errors and warnings) is attached to the run as the
 
 Failures are isolated: `fail-fast` is off, so one project failing does not stop
 the others, and `assemble` still opens a PR with whatever succeeded. The PR body
-lists how many repairs applied and which patches would not apply. Re-run just
-the failed jobs from the run page, or fix that project by hand on the `bump/*`
-branch.
+lists how many repairs applied and which patches would not apply.
+
+The usual failure is `error_max_turns` — the agent ran out of its turn budget
+mid-repair. Its work is still exported as a patch and applied, because partial
+progress on a hard project is worth keeping and the whole-pool build in
+`assemble` is what decides whether the result is actually correct. Re-running
+the bump lets the next agent start from that partial state rather than from
+scratch.
+
+Measured on the first real run (v4.32.0-rc1 → v4.33.0-rc1, 99 projects
+broken): 40 repaired cleanly, 59 hit the turn limit.

--- a/.github/workflows/mathlib-bump.yml
+++ b/.github/workflows/mathlib-bump.yml
@@ -388,12 +388,17 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: "/version-bump-project ${{ matrix.project }} ${{ needs.detect.outputs.target }}"
           claude_args: >-
-            --max-turns 60
+            --max-turns 200
             --model claude-opus-5
             --allowedTools "Bash,Read,Edit,Write,Grep,Glob"
 
       - name: Verify the repair
         id: verify
+        # Runs even when the Claude step failed. The common failure is
+        # `error_max_turns`, and an agent that ran out of turns has usually
+        # made real progress -- skipping these steps threw all of it away and
+        # made the project start from scratch on the next run.
+        if: always()
         env:
           PROJECT: ${{ matrix.project }}
           LEAN_NUM_THREADS: 2
@@ -417,6 +422,7 @@ jobs:
           fi
 
       - name: Export the repair as a patch
+        if: always()
         env:
           PROJECT: ${{ matrix.project }}
           CLEAN: ${{ steps.verify.outputs.clean }}
@@ -432,6 +438,7 @@ jobs:
           cat "repair-$PROJECT.json"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: always()
         with:
           name: repair-${{ matrix.project }}
           path: |


### PR DESCRIPTION
First real repair run ([30379491202](https://github.com/Vilin97/lean-pool/actions/runs/30379491202), 99 broken projects, Opus 5): **40 repaired cleanly, 59 failed**.

All 59 failed with `error_max_turns` — not genuine errors, just the 60-turn budget running out mid-repair. Lean repair is turn-hungry (every rebuild to check progress costs a turn), so hitting the limit on a hard project is the normal outcome.

Because the Claude step failed, `Verify`, `Export the repair as a patch` and the artifact upload were all **skipped** — so every one of those 59 agents' partial work was discarded, and those projects would restart from scratch next run.

Those steps now run with `if: always()`. A turn-exhausted agent's work is exported and applied like any other patch; the whole-pool build in `assemble` still decides whether the result is correct, and the job still reports failure so the run stays honest about which projects need another pass. Turn budget also raised 60 → 200.

The pipeline itself is now fully working end to end: 40 patches applied, PR #295 updated with 588 whole-pool errors / 299 warnings and gates correctly not run.