### PR TITLE
Remove the turn limit from bump repairs

### DIFF
--- a/.github/BUMP_AUTOMATION.md
+++ b/.github/BUMP_AUTOMATION.md
@@ -149,12 +149,19 @@ Failures are isolated: `fail-fast` is off, so one project failing does not stop
 the others, and `assemble` still opens a PR with whatever succeeded. The PR body
 lists how many repairs applied and which patches would not apply.
 
-The usual failure is `error_max_turns` — the agent ran out of its turn budget
-mid-repair. Its work is still exported as a patch and applied, because partial
-progress on a hard project is worth keeping and the whole-pool build in
-`assemble` is what decides whether the result is actually correct. Re-running
-the bump lets the next agent start from that partial state rather than from
-scratch.
+Repair agents run with **no turn limit**. A repair is finished when the project
+builds, not after some number of turns, and an agent cut off mid-edit leaves
+behind a half-applied change that is worse than either outcome. The bound is
+wall clock instead — `timeout-minutes: 90` per project — which caps runner cost
+without deciding how much thinking a problem deserves.
 
-Measured on the first real run (v4.32.0-rc1 → v4.33.0-rc1, 99 projects
-broken): 40 repaired cleanly, 59 hit the turn limit.
+Whatever an agent has done is exported as a patch even when its job fails, so
+partial progress on a hard project is never thrown away, and a re-run resumes
+from it. The whole-pool build in `assemble` remains what decides whether the
+result is actually correct.
+
+Measured on the first real run (v4.32.0-rc1 → v4.33.0-rc1, 99 projects broken,
+with a 60-turn cap still in place): 40 repaired cleanly, 59 hit the cap. Those
+59 had a *lower* median runtime (5 min) than the successes (9 min) — they were
+burning turns in tight edit/build/fail loops, so the cap was stopping them
+early rather than after sustained work. That is what removing it addresses.

--- a/.github/workflows/mathlib-bump.yml
+++ b/.github/workflows/mathlib-bump.yml
@@ -333,6 +333,11 @@ jobs:
     if: needs.detect.outputs.repair == 'true' && needs.triage.outputs.has_breakage == 'true'
     runs-on: ubuntu-latest
     name: Repair ${{ matrix.project }}
+    # No turn limit -- a repair is done when the project builds, not after N
+    # turns, and a turn-capped agent leaves a half-finished edit behind. Wall
+    # clock is the honest bound: it caps runner cost without deciding how much
+    # thinking the problem deserves.
+    timeout-minutes: 90
     permissions:
       contents: read
       # claude-code-action exchanges a GitHub OIDC token for its credentials;
@@ -388,7 +393,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: "/version-bump-project ${{ matrix.project }} ${{ needs.detect.outputs.target }}"
           claude_args: >-
-            --max-turns 200
             --model claude-opus-5
             --allowedTools "Bash,Read,Edit,Write,Grep,Glob"
 


### PR DESCRIPTION
A repair is finished when the project builds, not after N turns. A cap stops an agent mid-edit and leaves a half-applied change behind — worse than either finishing or not starting — and it decides in advance how much thinking a problem deserves.

The action passes `maxTurns: undefined` when the flag is absent (`base-action/src/parse-sdk-options.ts`), so omitting it is genuinely unbounded rather than silently falling back to a default.

**Wall clock is the honest bound**, so the repair job gains `timeout-minutes: 90`. That caps runner cost without constraining reasoning — on round 1, successful repairs took a median of 9 minutes and at most 20.

Round 1 also showed the cap was firing *early* rather than after sustained effort: the 59 turn-capped jobs had a **lower** median runtime (5 min) than the 40 successes (9 min). They were burning turns in tight edit/build/fail loops, not working steadily toward a fix — so removing the cap should help precisely the projects that were failing.