### PR TITLE
Give PRs stacked on a bump branch their checks back (and pin lean4export to the toolchain)

### DIFF
--- a/.github/workflows/challenge-verify.yml
+++ b/.github/workflows/challenge-verify.yml
@@ -16,9 +16,13 @@ name: Verify challenge solutions
 # landrun is defence in depth on top of the ephemeral runner.
 
 on:
+  # Deliberately not restricted to PRs targeting `main`. A solution lands
+  # wherever the work is happening — during a Lean/Mathlib bump, solution PRs
+  # stack on the bump branch — and whether a proof proves the challenge has
+  # nothing to do with which branch it is heading for. PR #301 (the first
+  # solution to the Odlyzko challenge) got no verification at all because it
+  # targeted `bump/v4.33.0-rc1`.
   pull_request:
-    branches:
-      - main
     paths:
       - 'Challenge/**'
       - 'Challenge.lean'
@@ -119,6 +123,37 @@ jobs:
       - name: Build landrun
         if: steps.tools.outputs.cache-hit != 'true'
         run: go install "github.com/zouuup/landrun/cmd/landrun@$LANDRUN_COMMIT"
+
+      # lean4export reads the oleans this repository's build produced, so its
+      # version has to track `lean-toolchain`. That coupling is invisible in a
+      # commit pin: a version bump that forgets it fails later, inside an
+      # export, with an error about the file format rather than the pin. Say
+      # it here instead, with the replacement SHA already resolved.
+      - name: Check the lean4export pin matches the toolchain
+        run: |
+          set -euo pipefail
+          toolchain="$(cut -d: -f2 lean-toolchain)"
+          # Annotated tags need the `^{}` dereference to reach the commit;
+          # lightweight ones (what lean4export uses today) answer only the
+          # plain query. Ask for both rather than depend on which it is.
+          expected="$(git ls-remote https://github.com/leanprover/lean4export \
+            "refs/tags/$toolchain^{}" | cut -f1)"
+          if [ -z "$expected" ]; then
+            expected="$(git ls-remote https://github.com/leanprover/lean4export \
+              "refs/tags/$toolchain" | cut -f1)"
+          fi
+          if [ -z "$expected" ]; then
+            echo "::warning::lean4export has no $toolchain tag; leaving the pin alone."
+            exit 0
+          fi
+          if [ "$expected" != "$LEAN4EXPORT_COMMIT" ]; then
+            echo "::error::LEAN4EXPORT_COMMIT is pinned to a lean4export that does"
+            echo "not match lean-toolchain ($toolchain). Comparator would fail"
+            echo "reading this repository's oleans. Set it in this workflow to:"
+            echo "  LEAN4EXPORT_COMMIT: $expected"
+            exit 1
+          fi
+          echo "lean4export pin matches $toolchain."
 
       - name: Build lean4export
         if: steps.tools.outputs.cache-hit != 'true'

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -42,6 +42,11 @@ on:
   pull_request:
     branches:
       - main
+      # Work stacks on the bump branch during a Lean/Mathlib migration, and
+      # a contribution that never builds is a contribution nobody can judge:
+      # PR #301 added a 210-file project onto `bump/v4.33.0-rc1` and got no
+      # build, no linters, and no quality checks at all.
+      - 'bump/**'
     paths:
       - '**/*.lean'
       - 'lakefile.toml'


### PR DESCRIPTION
[#301](https://github.com/Vilin97/lean-pool/pull/301) is the first real answer to a challenge — the Odlyzko bound, proved in a 210-file pooled project with a thin `Solution/Odlyzko.lean` bridge. Comparator never ran on it, and two separate things were in the way.

### The branch filter

`challenge-verify.yml` declared `pull_request: branches: [main]`, and #301 targets `bump/v4.33.0-rc1`. During a version bump that is exactly where solution work stacks, so the check that decides whether a solution is real was skipped precisely when a solution arrived.

Its draft status was never the cause — the workflows *without* a branch filter (the PR guard, the partial-port audit, the metadata advisory) all ran on that same draft PR. Whether a proof proves the challenge has nothing to do with which branch it is heading for, so the filter is gone.

### The lean4export pin

The bump is about to break verification in a way a commit pin hides. `lean4export` reads the oleans our build produced, so its version has to track [`lean-toolchain`](../blob/main/lean-toolchain); pinned at the `v4.32.0-rc1` tag it cannot read v4.33 oleans, and the failure would surface *inside an export* as a file-format error rather than as a stale pin.

So the workflow now asserts the coupling before building anything, and prints the replacement SHA:

```
::error::LEAN4EXPORT_COMMIT is pinned to a lean4export that does
not match lean-toolchain (v4.33.0-rc1). Comparator would fail
reading this repository's oleans. Set it in this workflow to:
  LEAN4EXPORT_COMMIT: af5aa64bb914c3c2c781f378088dbd38acf4f804
```

**This means [#295](https://github.com/Vilin97/lean-pool/pull/295) needs that one-line pin update** before or with the bump; otherwise `Verify challenge solutions` goes red on `main` the moment the bump lands.

Tested by extracting the check and running it against the current toolchain with the correct pin (passes), a simulated v4.33 bump with the stale pin (fails with the SHA above), and the same bump with the correct pin (passes). Lightweight tags answer only the plain `ls-remote` query while annotated ones need `^{}`, so it asks for both; an unknown tag warns and moves on rather than blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
