### PR TITLE
Remove the repair job timeout

### DIFF
--- a/.github/BUMP_AUTOMATION.md
+++ b/.github/BUMP_AUTOMATION.md
@@ -149,11 +149,16 @@ Failures are isolated: `fail-fast` is off, so one project failing does not stop
 the others, and `assemble` still opens a PR with whatever succeeded. The PR body
 lists how many repairs applied and which patches would not apply.
 
-Repair agents run with **no turn limit**. A repair is finished when the project
-builds, not after some number of turns, and an agent cut off mid-edit leaves
-behind a half-applied change that is worse than either outcome. The bound is
-wall clock instead — `timeout-minutes: 90` per project — which caps runner cost
-without deciding how much thinking a problem deserves.
+Repair agents run with **no turn limit and no job timeout**. A repair is
+finished when the project builds, not after some number of turns or minutes,
+and an agent cut off mid-edit leaves behind a half-applied change that is worse
+than either outcome.
+
+One ceiling remains and cannot be removed here: GitHub-hosted runners kill any
+job at **six hours**. That is the longest a single project's repair can run.
+Raising it would mean moving the repair jobs to a self-hosted runner, where the
+limit is five days — worth doing only if projects ever start hitting six hours,
+which is far from the observed maximum of 20 minutes.
 
 Whatever an agent has done is exported as a patch even when its job fails, so
 partial progress on a hard project is never thrown away, and a re-run resumes

--- a/.github/workflows/mathlib-bump.yml
+++ b/.github/workflows/mathlib-bump.yml
@@ -333,11 +333,11 @@ jobs:
     if: needs.detect.outputs.repair == 'true' && needs.triage.outputs.has_breakage == 'true'
     runs-on: ubuntu-latest
     name: Repair ${{ matrix.project }}
-    # No turn limit -- a repair is done when the project builds, not after N
-    # turns, and a turn-capped agent leaves a half-finished edit behind. Wall
-    # clock is the honest bound: it caps runner cost without deciding how much
-    # thinking the problem deserves.
-    timeout-minutes: 90
+    # No turn limit and no explicit timeout: a repair is done when the project
+    # builds, and any cap only ever stops an agent mid-edit, leaving a
+    # half-applied change behind. GitHub-hosted runners still enforce their own
+    # six-hour ceiling, which is the longest a job can run here; raising that
+    # would require a self-hosted runner.
     permissions:
       contents: read
       # claude-code-action exchanges a GitHub OIDC token for its credentials;


### PR DESCRIPTION
Same reasoning as removing the turn limit: a repair is finished when the project builds, and any cap only ever stops an agent mid-edit and leaves a half-applied change behind. The 90 minutes was a guess dressed up as a safeguard — the observed maximum was 20.

**One ceiling remains and can't be removed here.** GitHub-hosted runners kill any job at **six hours** regardless of what the workflow asks for, so that's now the effective limit. Lifting it would mean moving the repair fan-out to a self-hosted runner, where the cap is five days — not worth doing unless a project ever approaches six hours, which is a long way from 20 minutes.