### PR TITLE
Resume the bump branch instead of recreating it

### DIFF
--- a/.github/BUMP_AUTOMATION.md
+++ b/.github/BUMP_AUTOMATION.md
@@ -161,9 +161,19 @@ limit is five days — worth doing only if projects ever start hitting six hours
 which is far from the observed maximum of 20 minutes.
 
 Whatever an agent has done is exported as a patch even when its job fails, so
-partial progress on a hard project is never thrown away, and a re-run resumes
-from it. The whole-pool build in `assemble` remains what decides whether the
-result is actually correct.
+partial progress on a hard project is never thrown away. The whole-pool build
+in `assemble` remains what decides whether the result is actually correct.
+
+**Runs accumulate.** `pin` resumes an existing `bump/<version>` branch rather
+than recreating it from main, so each run starts from every repair earlier runs
+landed. The probe then only finds the projects that are *still* broken, and the
+repair fan-out shrinks each round — that is what lets a large bump converge
+instead of re-repairing the same projects forever. If main has moved
+underneath, the branch merges it, resolving the generated index and the
+registry with the same mechanical resolver `auto-rebase.yml` uses.
+
+Re-running a bump is therefore the normal way to finish one. Dispatch it again
+and it picks up where the last run stopped.
 
 Measured on the first real run (v4.32.0-rc1 → v4.33.0-rc1, 99 projects broken,
 with a 60-turn cap still in place): 40 repaired cleanly, 59 hit the cap. Those

--- a/.github/workflows/mathlib-bump.yml
+++ b/.github/workflows/mathlib-bump.yml
@@ -181,6 +181,48 @@ jobs:
       - name: Install Python tooling
         run: cd python && uv sync --locked
 
+      - name: Resume the bump branch if one exists
+        env:
+          BRANCH: ${{ needs.detect.outputs.branch }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "No existing $BRANCH; starting from main."
+            git checkout -B "$BRANCH"
+            exit 0
+          fi
+          # Build on the repairs earlier runs already landed. Recreating the
+          # branch from main would discard them, so every run would re-repair
+          # the same projects from scratch and the bump could never converge.
+          echo "Resuming $BRANCH."
+          git fetch origin "$BRANCH"
+          git checkout -B "$BRANCH" "origin/$BRANCH"
+          if git merge --no-edit origin/main; then
+            exit 0
+          fi
+          # main moving under the branch conflicts only in the generated index
+          # and the registry, both of which resolve mechanically.
+          git diff --name-only --diff-filter=U > conflicts.txt
+          cat conflicts.txt
+          (cd python && uv run python -m lean_pool.rebase resolvable \
+            --conflicts ../conflicts.txt)
+          merge_base="$(git merge-base "origin/$BRANCH" origin/main)"
+          if grep -qx 'LeanPool/projects.yml' conflicts.txt; then
+            git show "$merge_base:LeanPool/projects.yml" > /tmp/base.yml
+            git show origin/main:LeanPool/projects.yml > /tmp/ours.yml
+            git show "origin/$BRANCH:LeanPool/projects.yml" > /tmp/theirs.yml
+            (cd python && uv run python -m lean_pool.rebase registry --repo .. \
+              --base /tmp/base.yml --ours /tmp/ours.yml --theirs /tmp/theirs.yml)
+            git add LeanPool/projects.yml
+          fi
+          if grep -qx 'LeanPool.lean' conflicts.txt; then
+            (cd python && uv run python -m lean_pool.rebase index --repo ..)
+            git add LeanPool.lean
+          fi
+          git commit --no-edit
+
       - name: Move the version pins
         env:
           TARGET: ${{ needs.detect.outputs.target }}
@@ -206,9 +248,7 @@ jobs:
           TARGET: ${{ needs.detect.outputs.target }}
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -B "$BRANCH"
+          # Already on $BRANCH, resumed or freshly created above.
           git add lean-toolchain lakefile.toml lake-manifest.json \
             docbuild/lean-toolchain docbuild/lakefile.toml docbuild/lake-manifest.json
           # A re-run against an already-pinned version has nothing to commit.
@@ -217,7 +257,10 @@ jobs:
           else
             git commit -m "chore: pin Lean and Mathlib to $TARGET"
           fi
-          git push --force origin "$BRANCH"
+          # --force-with-lease, never --force: the branch carries accumulated
+          # repairs, and a blind force would discard anything landed since this
+          # job checked it out.
+          git push --force-with-lease origin "$BRANCH"
 
       - name: Plan the build shards
         id: plan


### PR DESCRIPTION
**The automation could not converge.** `pin` did `git checkout -B $BRANCH` from main followed by `git push --force`, destroying every repair earlier runs had landed.

This already cost a full round: round 1 applied 40 repairs and pushed them, then round 2's `pin` force-pushed over them. The branch currently carries **no Lean changes at all**, and round 2 re-repaired the same projects from scratch. However many rounds ran, each started from zero — so any bump needing more than one round could never finish.

`pin` now resumes an existing `bump/<version>` branch and merges main into it, creating from main only when no branch exists. Conflicts from main moving underneath are the same two mechanical files `auto-rebase.yml` handles (`LeanPool.lean`, `LeanPool/projects.yml`), resolved with the same `lean_pool.rebase` resolver. The push becomes `--force-with-lease` so it can't silently discard work landed in between.

With this, each round's probe only finds the projects *still* broken and the repair fan-out shrinks round over round — re-running becomes the normal way to finish a large bump.