### PR TITLE
Put the verification tools on PATH, and pin them in one shared file

### DIFF
--- a/.github/CODE_QUALITY.md
+++ b/.github/CODE_QUALITY.md
@@ -171,7 +171,14 @@ agree, and replays the proof through the Lean kernel accepting no axiom beyond
 `status: solved` a verified claim, and it is the check the solution review
 defers to.
 
-The three external tools are pinned to exact commits and cached by pin:
+The three external tools are pinned to exact commits in
+[`scripts/challenge/pins.env`](../scripts/challenge/pins.env), which both this
+workflow and `make comparator` read — so a local verification and a CI
+verification run the same judge. They once did not, and the difference hid a
+real failure: comparator's `main` resolves its tools from `COMPARATOR_*`
+environment variables, while the pinned commit hardcodes `landrun` and
+`lean4export` as PATH lookups, so passing paths worked locally and failed in
+CI. The pins are:
 
 - `landrun` (the sandbox comparator runs builds under), built with Go from
   `zouuup/landrun`

--- a/.github/workflows/challenge-verify.yml
+++ b/.github/workflows/challenge-verify.yml
@@ -51,14 +51,6 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  # landrun: zouuup/landrun main HEAD as of 2026-05-04. Tagged releases
-  # through v0.1.15 lack fixes comparator needs, so this is a commit pin.
-  LANDRUN_COMMIT: 5ed4a3db3a4ad930d577215c6b9abaa19df7f99f
-  # lean4export at refs/tags/v4.32.0-rc1 — it must match this repository's
-  # lean-toolchain, because it reads the oleans the build produced.
-  LEAN4EXPORT_COMMIT: 3de59f10bc4b4a0f2de698597aeb1246caa0df0a
-  COMPARATOR_COMMIT: 71b52ec29e06d4b7d882726553b1ceb99a2499e0
 
 jobs:
   verify:
@@ -67,6 +59,11 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      # `make comparator` reads the same file, so a local verification and a
+      # CI verification run the same judge.
+      - name: Load tool pins
+        run: cat scripts/challenge/pins.env | grep -E '^[A-Z0-9_]+=' >> "$GITHUB_ENV"
 
       - name: Restore caches
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
@@ -108,9 +105,8 @@ jobs:
             .ci/lean4export/.lake/build/bin/lean4export
             .ci/comparator/.lake/build/bin/comparator
           key: >-
-            challenge-tools-${{ runner.os }}-${{ env.LANDRUN_COMMIT }}-${{
-              env.LEAN4EXPORT_COMMIT }}-${{ env.COMPARATOR_COMMIT }}-${{
-              hashFiles('lean-toolchain') }}
+            challenge-tools-${{ runner.os }}-${{
+              hashFiles('scripts/challenge/pins.env', 'lean-toolchain') }}
 
       # actions/setup-go pinned to d35c59ab (= refs/tags/v5.5.0), the pin
       # leanprover/lean-eval uses to build the same landrun commit.
@@ -174,11 +170,12 @@ jobs:
           ~/.elan/bin/lake build comparator
 
       - name: Verify every solved challenge
-        env:
-          COMPARATOR_LANDRUN: /home/runner/go/bin/landrun
         run: |
           set -euo pipefail
-          export PATH="$HOME/.elan/bin:$PATH"
+          # The pinned comparator hardcodes `landrun` and `lean4export` as
+          # PATH lookups — the COMPARATOR_* environment variables are a newer
+          # feature — so the binaries have to be *on PATH*, not merely passed.
+          export PATH="$PWD/.ci/lean4export/.lake/build/bin:$HOME/go/bin:$HOME/.elan/bin:$PATH"
           slugs=$(cd python && uv run python -m lean_pool.challenge --repo .. solved)
           if [ -z "$slugs" ]; then
             echo "No solved challenges to verify."

--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,14 @@ comparator:
 	@mkdir -p $(COMPARATOR_CACHE)
 	@test -d $(COMPARATOR_CACHE)/comparator || \
 		git clone https://github.com/leanprover/comparator $(COMPARATOR_CACHE)/comparator
-	cd $(COMPARATOR_CACHE)/comparator && git pull --ff-only && lake build comparator
+	cd $(COMPARATOR_CACHE)/comparator && git fetch --quiet origin && \
+		git checkout --quiet $$(. $(CURDIR)/scripts/challenge/pins.env && echo $$COMPARATOR_COMMIT) && \
+		lake build comparator
 	@test -d $(COMPARATOR_CACHE)/lean4export || \
 		git clone https://github.com/leanprover/lean4export $(COMPARATOR_CACHE)/lean4export
-	cd $(COMPARATOR_CACHE)/lean4export && git pull --ff-only
-	cp lean-toolchain $(COMPARATOR_CACHE)/lean4export/lean-toolchain
-	cd $(COMPARATOR_CACHE)/lean4export && lake build lean4export
+	cd $(COMPARATOR_CACHE)/lean4export && git fetch --quiet origin && \
+		git checkout --quiet $$(. $(CURDIR)/scripts/challenge/pins.env && echo $$LEAN4EXPORT_COMMIT) && \
+		lake build lean4export
 	@echo
 	@echo "comparator:  $(COMPARATOR_CACHE)/comparator/.lake/build/bin/comparator"
 	@echo "lean4export: $(COMPARATOR_CACHE)/lean4export/.lake/build/bin/lean4export"

--- a/scripts/challenge/pins.env
+++ b/scripts/challenge/pins.env
@@ -1,0 +1,19 @@
+# Pinned versions of the three external tools that decide whether a challenge
+# solution is real. They are part of the trusted base for every `status:
+# solved` claim, so bumping one is a deliberate change, not a floating `@main`.
+#
+# Read by .github/workflows/challenge-verify.yml and by `make comparator`, so
+# that a local verification and a CI verification run the same judge. They
+# once did not, and the difference hid a real failure: comparator's `main`
+# resolves its tools from COMPARATOR_* environment variables, while the pin
+# below still hardcodes `lean4export` and `landrun` as PATH lookups.
+
+# zouuup/landrun main HEAD as of 2026-05-04. Tagged releases through v0.1.15
+# lack fixes comparator needs, so this is a commit pin.
+LANDRUN_COMMIT=5ed4a3db3a4ad930d577215c6b9abaa19df7f99f
+
+# lean4export must match this repository's lean-toolchain: it reads the oleans
+# our build produced. The workflow asserts that, and prints the right SHA.
+LEAN4EXPORT_COMMIT=3de59f10bc4b4a0f2de698597aeb1246caa0df0a
+
+COMPARATOR_COMMIT=71b52ec29e06d4b7d882726553b1ceb99a2499e0

--- a/scripts/challenge/verify-solution.sh
+++ b/scripts/challenge/verify-solution.sh
@@ -140,6 +140,12 @@ echo "Building the challenge library..."
 lake build Challenge
 
 echo "Running comparator..."
+# Belt and braces: comparator's `main` resolves these from the environment,
+# while the commit CI pins hardcodes them as PATH lookups. Provide both, so a
+# local run and a CI run behave the same whichever judge is installed.
+lean4export_dir="$(dirname "$lean4export_bin")"
+landrun_dir="$(dirname "$landrun_bin")"
+export PATH="$lean4export_dir:$landrun_dir:$PATH"
 COMPARATOR_LANDRUN="$landrun_bin" COMPARATOR_LEAN4EXPORT="$lean4export_bin" \
   lake env "$comparator_bin" "$config"
 echo "Verified: challenge '$slug' is proved by the solution comparator checked."


### PR DESCRIPTION
Comparator on [#301](https://github.com/Vilin97/lean-pool/pull/301) got past `mktemp` and then failed with:

```
Failed to find binary: exec: "lean4export": executable file not found in $PATH
```

Reading [comparator at the commit we pin](https://github.com/leanprover/comparator/blob/71b52ec29e06d4b7d882726553b1ceb99a2499e0/Main.lean) settles it — it hardcodes the lookups:

```lean
cmd := "landrun",      -- lines 90, 100, 171
cmd := "lean4export",  -- line 138
```

The `COMPARATOR_LANDRUN` / `COMPARATOR_LEAN4EXPORT` environment variables are a *newer* feature. So the binaries must be **on PATH**, not merely passed as paths — which is exactly what `leanprover/lean-eval`'s CI does, and what I should have copied.

### Why local testing did not catch it

`make comparator` cloned comparator's `main` — which *does* read those environment variables — while CI built the pin, which does not. Local and CI were running different judges, so a green local run said nothing about CI. That is a worse bug than the missing PATH, because it makes every future local verification untrustworthy.

Both now read [`scripts/challenge/pins.env`](../blob/main/scripts/challenge/pins.env), so `make comparator` builds exactly what CI builds. The verify script also puts the resolved binaries on PATH *and* passes them in the environment, so it behaves the same against either comparator version. The tools cache keys on the pins file instead of three separate env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
