### PR TITLE
Leave bump/* branches to the bump workflow

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -56,6 +56,7 @@ jobs:
             --json number,headRefName,headRepository,headRepositoryOwner,isCrossRepository,labels \
             --jq '[.[]
                   | select([.labels[].name] | index("needs-manual-rebase") | not)
+                  | select(.headRefName | startswith("bump/") | not)
                   | {number, branch: .headRefName,
                      repo: "\(.headRepositoryOwner.login)/\(.headRepository.name)",
                      fork: .isCrossRepository}]')"


### PR DESCRIPTION
Auto-rebase treated the bump PR like any open PR, so a content merge to main would push a main-merge into `bump/<version>` — redundant with the merge `pin` already performs each round, and a second writer racing an in-flight assemble's push. One branch, one owner: auto-rebase now skips `bump/*` heads.