### PR TITLE
Add the McKay conjecture to the challenge board

### DIFF
--- a/Challenge.lean
+++ b/Challenge.lean
@@ -1,2 +1,3 @@
 import Challenge.Mazur
+import Challenge.McKay
 import Challenge.Odlyzko

--- a/Challenge/McKay.lean
+++ b/Challenge/McKay.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2026 Clawristotle contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Clawristotle contributors
+-/
+
+import Mathlib.Data.Complex.Basic
+import Mathlib.GroupTheory.Sylow
+import Mathlib.RepresentationTheory.Character
+
+/-!
+# The McKay conjecture
+
+Source: arxiv:2410.20392, doi:10.4007/annals.2026.203.3.5
+Proposed by: Vasily Ilin
+Open declarations: `Challenge.McKay.card_pPrimeCharacters_eq`
+Tags: group-theory, representation-theory, character-theory, mckay-conjecture
+MSC: 20C15, 20D20
+Estimated size: ~1000000 lines of Lean
+
+Informal statement:
+* `Challenge.McKay.card_pPrimeCharacters_eq` — For every finite group G, every prime p, and every
+  Sylow p-subgroup P of G, the set of character functions of simple finite-dimensional complex
+  representations of G whose dimension p does not divide has the same cardinality as the
+  corresponding set for the normalizer of P in G. Two simple representations have equal characters
+  exactly when they are isomorphic, so both sets are in bijection with the sets Irr_p'(G) and
+  Irr_p'(N_G(P)) that the McKay conjecture counts.
+-/
+
+open CategoryTheory
+
+namespace Challenge.McKay
+
+/-- The irreducible complex characters of `G` of `p'`-degree, as a set of functions: the
+characters of simple finite-dimensional complex representations whose dimension is not
+divisible by `p`. Two simple representations have equal characters exactly when they are
+isomorphic, so this set is in canonical bijection with the set `Irr_{p'}(G)` counted by
+the McKay conjecture. -/
+def pPrimeCharacters (G : Type*) [Group G] (p : ℕ) : Set (G → ℂ) :=
+  {χ | ∃ V : FDRep ℂ G, Simple V ∧ V.character = χ ∧ ¬p ∣ Module.finrank ℂ V}
+
+/-- The **McKay conjecture**, now the theorem of Cabanes and Späth: for every finite
+group `G`, every prime `p`, and every Sylow `p`-subgroup `P` of `G`, the irreducible
+complex characters of `G` of degree not divisible by `p` are equinumerous with those of
+the normalizer of `P` in `G`. -/
+theorem card_pPrimeCharacters_eq (G : Type*) [Group G] [Finite G] (p : ℕ) [Fact p.Prime]
+    (P : Sylow p G) :
+    Cardinal.mk (pPrimeCharacters G p) =
+      Cardinal.mk (pPrimeCharacters (Subgroup.normalizer (P : Set G)) p) := sorry
+
+end Challenge.McKay

--- a/Challenge/challenges.yml
+++ b/Challenge/challenges.yml
@@ -101,3 +101,53 @@ challenges:
     msc:
       - "11G05"
       - "11G18"
+  - slug: mckay-conjecture
+    title: The McKay conjecture
+    summary: >-
+      Prove the McKay conjecture: for every finite group G, every prime p, and
+      every Sylow p-subgroup P of G, the number of irreducible complex
+      characters of G of degree not divisible by p equals the same count for
+      the normalizer of P in G. Conjectured by McKay in 1972 and proved in
+      full by Cabanes and Späth (Annals of Mathematics, 2026) by completing
+      the Isaacs–Malle–Navarro programme: the conjecture reduces to the
+      inductive McKay condition for quasisimple groups, whose verification
+      rests on the classification of finite simple groups and on
+      Deligne–Lusztig theory. Irreducible characters are counted as character
+      functions of simple finite-dimensional complex representations, which
+      identifies exactly the isomorphism classes. The line estimate is a
+      guess at that programme — the character theory Mathlib is missing, the
+      reduction theorem, the classification, and the case-by-case
+      verification — not at any single write-up.
+    branch: group theory
+    entry_module: Challenge.McKay
+    proposers:
+      - Vasily Ilin
+    source:
+      title: The McKay Conjecture on character degrees
+      authors:
+        - Marc Cabanes
+        - Britta Späth
+      arxiv: "2410.20392"
+      doi: "10.4007/annals.2026.203.3.5"
+    license: Apache-2.0
+    provenance: AI
+    status: open
+    estimated_lines: 1000000
+    statements:
+      - declaration: Challenge.McKay.card_pPrimeCharacters_eq
+        informal: >-
+          For every finite group G, every prime p, and every Sylow p-subgroup
+          P of G, the set of character functions of simple finite-dimensional
+          complex representations of G whose dimension p does not divide has
+          the same cardinality as the corresponding set for the normalizer of
+          P in G. Two simple representations have equal characters exactly
+          when they are isomorphic, so both sets are in bijection with the
+          sets Irr_p'(G) and Irr_p'(N_G(P)) that the McKay conjecture counts.
+    tags:
+      - group-theory
+      - representation-theory
+      - character-theory
+      - mckay-conjecture
+    msc:
+      - "20C15"
+      - "20D20"


### PR DESCRIPTION
## What this adds

The McKay conjecture as a **Challenge-mode entry** — a statement, not a project:

- `Challenge/McKay.lean` (51 lines): one closed definition and one open theorem.
  - `Challenge.McKay.pPrimeCharacters G p` — the set of character functions of simple finite-dimensional complex representations of `G` whose dimension `p` does not divide. Two simple representations have equal characters exactly when they are isomorphic, so this set is in canonical bijection with `Irr_{p'}(G)`.
  - `Challenge.McKay.card_pPrimeCharacters_eq` (`:= sorry` — the challenge): for every finite group `G`, prime `p`, and Sylow `p`-subgroup `P`,
    ```lean
    Cardinal.mk (pPrimeCharacters G p) =
      Cardinal.mk (pPrimeCharacters (Subgroup.normalizer (P : Set G)) p)
    ```
- the `mckay-conjecture` entry in `Challenge/challenges.yml`, the generated card, and the regenerated `Challenge.lean` index.

Source: Cabanes–Späth, *The McKay Conjecture on character degrees*, Annals of Mathematics **203** (2026); arXiv 2410.20392 and doi:10.4007/annals.2026.203.3.5 both verified to resolve to that paper.

## Why this shape

The previous revision stated the conjecture as a ~1,000-line pooled project (`LeanPool/McKayChallenge/`, 13 files) with proved special cases, finiteness, and isomorphism transport. A challenge should be minimal — ideally just the statement, no proofs — and the repository has a mode built for exactly that: `Challenge/` statements are `sorry`-backed contracts with Mathlib-only imports, and comparator judges any future solution against this text. The scaffolding (finiteness via Schur orthogonality, normal-Sylow/nilpotent/coprime special cases, isomorphism transport) stays upstream in [Vilin97/Clawristotle](https://github.com/Vilin97/Clawristotle) for anyone who wants a head start.

Rebuilding the branch on latest `main` as a `Challenge/` entry also dissolves the merge conflicts: the PR no longer touches `LeanPool.lean` or `LeanPool/projects.yml` at all.

## Checks run locally

- `lake build Challenge` — clean; exactly the one registered `sorry` notice for `card_pPrimeCharacters_eq`
- `lake exe mk_all --check` — no update necessary
- `lake exe lint-style LeanPool Challenge Solution` — clean
- `lake exe runLinter Challenge` — clean
- quality gates scoped to the change (registry schema, card sync, Mathlib-only imports, sorry placement, headers, file sizes, reachability) — clean; the whole-pool audits run in CI as usual

🤖 Generated with [Claude Code](https://claude.com/claude-code)
