### PR TITLE
Vlasov (#327 follow-ups): wire stability to existence, empirical weak solutions, doc fixes

### DIFF
--- a/LeanPool/Vlasov/Basic.lean
+++ b/LeanPool/Vlasov/Basic.lean
@@ -126,6 +126,26 @@ class AssW2 (W : PhysSpace d → ℝ) : Prop extends AssW W where
   gradContDiff : ContDiff ℝ 1 (fun x => fderiv ℝ W x)
 
 omit [NeZero d] in
+/-- The zero potential satisfies the standing assumption ass:W — a
+machine-checked witness that the hypothesis class `AssW` is non-vacuous
+(interaction-free transport is an admissible instance of every headline
+theorem). -/
+theorem assW_zero : AssW (fun _ : PhysSpace d => (0 : ℝ)) where
+  differentiable := differentiable_const 0
+  even _ := rfl
+  lipschitzGrad := ⟨0, by
+    simpa only [fderiv_fun_const, Pi.zero_apply] using
+      LipschitzWith.const (0 : PhysSpace d →L[ℝ] ℝ)⟩
+
+omit [NeZero d] in
+/-- The zero potential satisfies the strengthened assumption ass:W2 — a
+machine-checked witness that `AssW2` (and hence the hypothesis class of the
+weak ⟹ Lagrangian bridge) is non-vacuous. -/
+theorem assW2_zero : AssW2 (fun _ : PhysSpace d => (0 : ℝ)) where
+  toAssW := assW_zero
+  gradContDiff := by simpa only [fderiv_fun_const, Pi.zero_apply] using contDiff_const
+
+omit [NeZero d] in
 /-- Helper: under `[AssW W]` (even + differentiable), the gradient of `W`
 at the origin vanishes.
 
@@ -568,6 +588,88 @@ lemma diagonalCorrection_bound (N : ℕ) [NeZero N]
         field_simp
 
 omit [NeZero d] in
+/-- Derivative-identity core of prop:weak, without the `L^∞` boundedness
+hypotheses.  Along a Newton solution the map `t ↦ ⟨μ_t^N, φ⟩` is
+differentiable, with derivative the Vlasov pairing plus the explicit diagonal
+correction `(1/N²) Σᵢ ⟨∇W(0), ∇_v φ(zᵢ)⟩`.  The `BddAbove` hypotheses of
+`weakEvolutionEmpiricalMeasure` feed only its quantitative
+`(1/N)‖∇W‖_∞‖∇_vφ‖_∞` bound conjunct, not this identity — keeping them out
+here is what lets `empiricalMeasureSolvesVlasov` (and the packaged
+`empiricalMeasure_isVlasovSolution`) run hypothesis-free beyond ass:W. -/
+theorem weakEvolutionEmpiricalMeasure_hasDerivAt
+    (N : ℕ)
+    (W : PhysSpace d → ℝ) [AssW W]
+    (gradW : PhysSpace d → PhysSpace d)
+    (hgradW : ∀ x, gradW x = gradient W x)
+    (X V : ℝ → Fin N → PhysSpace d)
+    (hSol : IsNewtonSolution N gradW X V)
+    (φ : PhaseSpace d → ℝ)
+    (hφ_smooth : ContDiff ℝ (⊤ : ℕ∞) φ)
+    (gradXφ gradVφ : PhaseSpace d → PhysSpace d)
+    (hgradXφ : ∀ z, gradXφ z = gradient (fun x => φ (x, z.2)) z.1)
+    (hgradVφ : ∀ z, gradVφ z = gradient (fun v => φ (z.1, v)) z.2)
+    (t : ℝ) :
+    HasDerivAt (fun s => ∫ z, φ z ∂(empiricalMeasureCurve N X V s)) (
+      ∫ z, (@inner ℝ (PhysSpace d) _ z.2 (gradXφ z) -
+              @inner ℝ (PhysSpace d) _
+                (convolveFunctionMeasure gradW
+                  (spatialMarginal (empiricalMeasureCurve N X V t)) z.1)
+                (gradVφ z))
+            ∂(empiricalMeasureCurve N X V t)
+        + (1 / (N : ℝ)^2) * ∑ i : Fin N,
+            @inner ℝ (PhysSpace d) _ (gradW 0) (gradVφ (X t i, V t i))) t := by
+  have hderiv := hasDerivAt_empiricalIntegral_sum N gradW X V hSol φ
+    hφ_smooth gradXφ gradVφ hgradXφ hgradVφ t
+  -- Derive Measurable gradW from AssW W (Lipschitz fderiv ⇒ continuous gradient ⇒ measurable).
+  have hgradW_meas : Measurable gradW := by
+    have hext : gradW = fun x => gradient W x := funext hgradW
+    rw [hext]
+    obtain ⟨_, hLip⟩ := (inferInstance : AssW W).lipschitzGrad
+    exact ((InnerProductSpace.toDual ℝ (PhysSpace d)).symm.continuous.comp
+      hLip.continuous).measurable
+  have hcorr := diagonalCorrection_eq N gradW hgradW_meas X V gradVφ t
+  -- Rearrange: the derivative value from hderiv equals (integral term) + r
+  -- after applying hcorr to split the velocity inner products.
+  refine hderiv.congr_deriv ?_
+  -- Convert the integral on the goal's RHS into a finite sum so we can
+  -- match against hderiv's value plus hcorr.
+  have hint : (∫ z, (@inner ℝ (PhysSpace d) _ z.2 (gradXφ z) -
+                @inner ℝ (PhysSpace d) _
+                  (convolveFunctionMeasure gradW
+                    (spatialMarginal (empiricalMeasureCurve N X V t)) z.1)
+                  (gradVφ z))
+              ∂(empiricalMeasureCurve N X V t)) =
+      (1 / (N : ℝ)) * ∑ i : Fin N,
+        (@inner ℝ (PhysSpace d) _ (V t i) (gradXφ (X t i, V t i)) -
+         @inner ℝ (PhysSpace d) _
+           (convolveFunctionMeasure gradW
+             (spatialMarginal (empiricalMeasureCurve N X V t)) (X t i))
+           (gradVφ (X t i, V t i))) := by
+    simp only [empiricalMeasureCurve]
+    exact empiricalMeasure_integral_eq N (X t) (V t)
+      (fun z => @inner ℝ (PhysSpace d) _ z.2 (gradXφ z) -
+                @inner ℝ (PhysSpace d) _
+                  (convolveFunctionMeasure gradW
+                    (spatialMarginal (empiricalMeasureCurve N X V t)) z.1)
+                  (gradVφ z))
+  rw [hint]
+  -- Goal: D(t) = (1/N) * Σᵢ (Aᵢ - Cᵢ) + r
+  -- where D(t) = (1/N) * Σᵢ (Aᵢ + Bᵢ),
+  --   Aᵢ = ⟨V t i, gradXφ (X t i, V t i)⟩,
+  --   Bᵢ = ⟨-(1/N) • Σⱼ≠ᵢ gradW(Xᵢ-Xⱼ), gradVφᵢ⟩,
+  --   Cᵢ = ⟨conv_i, gradVφᵢ⟩,
+  --   r  = (1/N²) * Σᵢ ⟨gradW 0, gradVφᵢ⟩.
+  -- hcorr says: (1/N) * Σᵢ Bᵢ = -(1/N) * Σᵢ Cᵢ + r.
+  -- So (1/N) * Σ (A+B) = (1/N) Σ A + (1/N) Σ B
+  --                   = (1/N) Σ A − (1/N) Σ C + r       [by hcorr]
+  --                   = (1/N) Σ (A − C) + r              [recombine]
+  -- Distribute Σ over (+) and (−) on both sides (keeping (1/N) outside),
+  -- then split (1/N) * (sum + sum) into (1/N)*sum + (1/N)*sum.  hcorr fits
+  -- the resulting linear identity directly.
+  rw [Finset.sum_add_distrib, Finset.sum_sub_distrib, mul_add, mul_sub]
+  linarith [hcorr]
+
+omit [NeZero d] in
 /-- (tex: prop:weak)
 Weak evolution of the empirical measure.
 
@@ -634,61 +736,13 @@ theorem weakEvolutionEmpiricalMeasure
       -- pointwise remainder bound
       ∧ |r| ≤ (1 / (N : ℝ)) *
           ⨆ x, ‖gradW x‖ * ⨆ z, ‖gradVφ z‖ := by
-  -- Provide the explicit diagonal correction as the remainder witness.
+  -- Provide the explicit diagonal correction as the remainder witness; the
+  -- derivative identity is the boundedness-free core lemma above, and the
+  -- bound conjunct is where the two `BddAbove` hypotheses are consumed.
   refine ⟨(1 / (N : ℝ)^2) * ∑ i : Fin N,
       @inner ℝ (PhysSpace d) _ (gradW 0) (gradVφ (X t i, V t i)), rfl, ?_, ?_⟩
-  · -- HasDerivAt: use hasDerivAt_empiricalIntegral_sum and diagonalCorrection_eq
-    -- to relate the finite-sum derivative to the integral + remainder form.
-    have hderiv := hasDerivAt_empiricalIntegral_sum N gradW X V hSol φ
+  · exact weakEvolutionEmpiricalMeasure_hasDerivAt N W gradW hgradW X V hSol φ
       hφ_smooth gradXφ gradVφ hgradXφ hgradVφ t
-    -- Derive Measurable gradW from AssW W (Lipschitz fderiv ⇒ continuous gradient ⇒ measurable).
-    have hgradW_meas : Measurable gradW := by
-      have hext : gradW = fun x => gradient W x := funext hgradW
-      rw [hext]
-      obtain ⟨_, hLip⟩ := (inferInstance : AssW W).lipschitzGrad
-      exact ((InnerProductSpace.toDual ℝ (PhysSpace d)).symm.continuous.comp
-        hLip.continuous).measurable
-    have hcorr := diagonalCorrection_eq N gradW hgradW_meas X V gradVφ t
-    -- Rearrange: the derivative value from hderiv equals (integral term) + r
-    -- after applying hcorr to split the velocity inner products.
-    refine hderiv.congr_deriv ?_
-    -- Convert the integral on the goal's RHS into a finite sum so we can
-    -- match against hderiv's value plus hcorr.
-    have hint : (∫ z, (@inner ℝ (PhysSpace d) _ z.2 (gradXφ z) -
-                  @inner ℝ (PhysSpace d) _
-                    (convolveFunctionMeasure gradW
-                      (spatialMarginal (empiricalMeasureCurve N X V t)) z.1)
-                    (gradVφ z))
-                ∂(empiricalMeasureCurve N X V t)) =
-        (1 / (N : ℝ)) * ∑ i : Fin N,
-          (@inner ℝ (PhysSpace d) _ (V t i) (gradXφ (X t i, V t i)) -
-           @inner ℝ (PhysSpace d) _
-             (convolveFunctionMeasure gradW
-               (spatialMarginal (empiricalMeasureCurve N X V t)) (X t i))
-             (gradVφ (X t i, V t i))) := by
-      simp only [empiricalMeasureCurve]
-      exact empiricalMeasure_integral_eq N (X t) (V t)
-        (fun z => @inner ℝ (PhysSpace d) _ z.2 (gradXφ z) -
-                  @inner ℝ (PhysSpace d) _
-                    (convolveFunctionMeasure gradW
-                      (spatialMarginal (empiricalMeasureCurve N X V t)) z.1)
-                    (gradVφ z))
-    rw [hint]
-    -- Goal: D(t) = (1/N) * Σᵢ (Aᵢ - Cᵢ) + r
-    -- where D(t) = (1/N) * Σᵢ (Aᵢ + Bᵢ),
-    --   Aᵢ = ⟨V t i, gradXφ (X t i, V t i)⟩,
-    --   Bᵢ = ⟨-(1/N) • Σⱼ≠ᵢ gradW(Xᵢ-Xⱼ), gradVφᵢ⟩,
-    --   Cᵢ = ⟨conv_i, gradVφᵢ⟩,
-    --   r  = (1/N²) * Σᵢ ⟨gradW 0, gradVφᵢ⟩.
-    -- hcorr says: (1/N) * Σᵢ Bᵢ = -(1/N) * Σᵢ Cᵢ + r.
-    -- So (1/N) * Σ (A+B) = (1/N) Σ A + (1/N) Σ B
-    --                   = (1/N) Σ A − (1/N) Σ C + r       [by hcorr]
-    --                   = (1/N) Σ (A − C) + r              [recombine]
-    -- Distribute Σ over (+) and (−) on both sides (keeping (1/N) outside),
-    -- then split (1/N) * (sum + sum) into (1/N)*sum + (1/N)*sum.  hcorr fits
-    -- the resulting linear identity directly.
-    rw [Finset.sum_add_distrib, Finset.sum_sub_distrib, mul_add, mul_sub]
-    linarith [hcorr]
   · -- Bound: direct application of diagonalCorrection_bound.
     exact diagonalCorrection_bound N gradW X V gradVφ hgradW_bdd hgradVφ_bdd t
 
@@ -728,7 +782,7 @@ Vlasov equation eq:vlasov with remainder R_N ≡ 0: for every φ ∈ C_c^∞(ℝ
   d/dt ⟨μ_t^N, φ⟩ = ⟨μ_t^N, v · ∇_x φ − (∇W * ρ_t^N) · ∇_v φ⟩.
 -/
 theorem empiricalMeasureSolvesVlasov
-    (N : ℕ) [NeZero N]
+    (N : ℕ)
     (W : PhysSpace d → ℝ) [hW : AssW W]
     (gradW : PhysSpace d → PhysSpace d)
     (hgradW : ∀ x, gradW x = gradient W x)
@@ -736,35 +790,34 @@ theorem empiricalMeasureSolvesVlasov
     (hSol : IsNewtonSolution N gradW X V)
     (φ : PhaseSpace d → ℝ)
     (hφ_smooth : ContDiff ℝ (⊤ : ℕ∞) φ)
-    (hφ_compact : HasCompactSupport φ)
+    -- Carried to document the intended `C_c^∞` test class (and so the
+    -- statement matches `IsVlasovSolution`'s quantification); the identity
+    -- itself holds for any smooth φ.
+    (_hφ_compact : HasCompactSupport φ)
     (gradXφ gradVφ : PhaseSpace d → PhysSpace d)
     (hgradXφ : ∀ z, gradXφ z = gradient (fun x => φ (x, z.2)) z.1)
-    (hgradVφ : ∀ z, gradVφ z = gradient (fun v => φ (z.1, v)) z.2)
-    -- Threaded through from `weakEvolutionEmpiricalMeasure`'s bound conjunct.
-    -- Not used in this corollary's body (we destructure the bound and
-    -- ignore it), but required by the signature of the prop:weak call.
-    (hgradW_bdd : BddAbove (Set.range (fun x => ‖gradW x‖)))
-    (hgradVφ_bdd : BddAbove (Set.range (fun z => ‖gradVφ z‖))) :
+    (hgradVφ : ∀ z, gradVφ z = gradient (fun v => φ (z.1, v)) z.2) :
     WeakEvolutionEq gradW (empiricalMeasureCurve N X V) φ gradXφ gradVφ (fun _ => 0) := by
   -- WeakEvolutionEq unfolds to `∀ t, HasDerivAt ... (... + (fun _ => 0) t) t`.
   intro t
-  -- Invoke prop:weak at this `t` and destructure the now-explicit witness.
-  obtain ⟨r, hr_eq, hr_deriv, _hr_bound⟩ :=
-    weakEvolutionEmpiricalMeasure N W gradW hgradW X V hSol φ
-      hφ_smooth hφ_compact gradXφ gradVφ hgradXφ hgradVφ hgradW_bdd hgradVφ_bdd t
+  -- Invoke the boundedness-free derivative-identity core at this `t`.
+  have hr_deriv := weakEvolutionEmpiricalMeasure_hasDerivAt N W gradW hgradW X V
+    hSol φ hφ_smooth gradXφ gradVφ hgradXφ hgradVφ t
   -- Under [AssW W] we have gradW 0 = gradient W 0 = 0 (the latter via
   -- the even-implies-zero-gradient helper).
   have hgrad0 : gradW 0 = 0 := by
     rw [hgradW]; exact gradient_zero_of_even W
-  -- The explicit formula for `r` collapses to 0 once gradW 0 = 0:
+  -- The explicit diagonal correction collapses to 0 once gradW 0 = 0:
   -- each inner product becomes ⟨0, _⟩ = 0, the finite sum is 0, and
   -- the leading scalar multiplication is 0.
-  have hr_zero : r = 0 := by
-    rw [hr_eq, hgrad0]
+  have hr_zero : (1 / (N : ℝ)^2) * ∑ i : Fin N,
+      @inner ℝ (PhysSpace d) _ (gradW 0) (gradVφ (X t i, V t i)) = 0 := by
+    rw [hgrad0]
     simp [inner_zero_left]
-  -- Substitute r = 0 into the HasDerivAt witness; the conclusion's
-  -- `(fun _ => 0) t` is definitionally 0.
-  simpa [hr_zero] using hr_deriv
+  -- Substitute the vanished remainder into the HasDerivAt witness; the
+  -- conclusion's `(fun _ => 0) t` is definitionally 0.
+  rw [hr_zero, add_zero] at hr_deriv
+  simpa using hr_deriv
 
 /-! ## §8 Equation (Vlasov equation)  (`tex: eq:vlasov`) -/
 
@@ -791,6 +844,29 @@ def IsVlasovSolution (gradW : PhysSpace d → PhysSpace d)
       (∀ z, gradVφ z = gradient (fun v => φ (z.1, v)) z.2) →
       WeakEvolutionEq gradW f φ gradXφ gradVφ (fun _ => 0)
 
+omit [NeZero d] in
+/-- (tex: cor:empirical-vlasov, packaged)
+The empirical measure curve of a global Newton solution **is** a global
+(two-sided) weak Vlasov solution — `empiricalMeasureSolvesVlasov` quantified
+over the full `C_c^∞` test class of `IsVlasovSolution`, with no hypotheses
+beyond ass:W.  Together with `empiricalMeasureCurve_hasFiniteFirstMoment`
+this discharges the weak-PDE and moment sides of the solution predicates on
+empirical curves; the remaining gap to the `IsLagrangianVlasovSolution` that
+`dobrushin` consumes is the characteristic-flow witness (the linear flow of
+the empirical field, with atoms following characteristics), which is not yet
+formalized. -/
+theorem empiricalMeasure_isVlasovSolution
+    (N : ℕ)
+    (W : PhysSpace d → ℝ) [AssW W]
+    (gradW : PhysSpace d → PhysSpace d)
+    (hgradW : ∀ x, gradW x = gradient W x)
+    (X V : ℝ → Fin N → PhysSpace d)
+    (hSol : IsNewtonSolution N gradW X V) :
+    IsVlasovSolution gradW (empiricalMeasureCurve N X V) :=
+  fun φ hφ_smooth hφ_compact gradXφ gradVφ hgradXφ hgradVφ =>
+    empiricalMeasureSolvesVlasov N W gradW hgradW X V hSol φ
+      hφ_smooth hφ_compact gradXφ gradVφ hgradXφ hgradVφ
+
 /-! ## §9 Theorem (Existence and uniqueness for Vlasov)  (`tex: thm:vlasov-wp`) -/
 
 -- TODO(mathlib): `𝒫_1` (probability measures with finite first moment) is
@@ -800,6 +876,28 @@ def IsVlasovSolution (gradW : PhysSpace d → PhysSpace d)
 /-- Predicate: μ is a probability measure on PhaseSpace d with finite first moment. -/
 def HasFiniteFirstMoment (μ : Measure (PhaseSpace d)) : Prop :=
   IsProbabilityMeasure μ ∧ Integrable (fun z : PhaseSpace d => ‖z‖) μ
+
+omit [NeZero d] in
+/-- Empirical measures lie in `𝒫₁`: probability (for `N ≥ 1`) plus finite
+first moment — the latter because integration against a finite weighted sum
+of Dirac masses is a finite sum.  Discharges, pointwise in time, the moment
+hypotheses that the Dobrushin-type estimates place on empirical curves. -/
+lemma empiricalMeasure_hasFiniteFirstMoment
+    (N : ℕ) [NeZero N] (X V : Fin N → PhysSpace d) :
+    HasFiniteFirstMoment (empiricalMeasure N X V) := by
+  refine ⟨empiricalMeasure_isProbabilityMeasure N X V, ?_⟩
+  simp only [empiricalMeasure]
+  refine Integrable.smul_measure ?_ (by simpa using NeZero.ne N)
+  rw [integrable_finsetSum_measure]
+  exact fun i _ => integrable_dirac (by simp)
+
+omit [NeZero d] in
+/-- Curve version of `empiricalMeasure_hasFiniteFirstMoment`: the empirical
+measure of a particle configuration lies in `𝒫₁` at every time. -/
+lemma empiricalMeasureCurve_hasFiniteFirstMoment
+    (N : ℕ) [NeZero N] (X V : ℝ → Fin N → PhysSpace d) (t : ℝ) :
+    HasFiniteFirstMoment (empiricalMeasureCurve N X V t) :=
+  empiricalMeasure_hasFiniteFirstMoment N (X t) (V t)
 
 -- The §9 statement `vlasovWellPosedness` (tex: thm:vlasov-wp) lives in
 -- `LeanPool/Vlasov/OT/CharacteristicFlow.lean`, where it composes directly with the
@@ -873,10 +971,12 @@ Producers:
     (`LeanPool/Vlasov/OT/CharacteristicFlow.lean`) — takes the flow as a hypothesis,
     and the pushforward equation holds by `vlasovSolutionViaPushforward`'s
     definition.
-  * `vlasovWellPosedness` produces `IsLagrangianVlasovSolution` from a Banach
-    fixed-point construction on spatial marginals — the characteristic flow
-    falls out of the existence proof, so the stronger conclusion costs no
-    extra infrastructure.
+  * `vlasovWellPosedness` produces the **per-window family**
+    `IsLagrangianVlasovSolutionOn gradW f T` for every horizon `T > 0` (not
+    this global predicate — the flow witnesses may differ per window) from a
+    Banach fixed-point construction on spatial marginals; the characteristic
+    flow falls out of the existence proof, so the windowed Lagrangian
+    conclusion costs no extra infrastructure.
 
 `IsLagrangianVlasovSolution gradW f → IsVlasovSolution gradW f` by `.1`. -/
 def IsLagrangianVlasovSolution (gradW : PhysSpace d → PhysSpace d)

--- a/LeanPool/Vlasov/OT/CharacteristicFlow.lean
+++ b/LeanPool/Vlasov/OT/CharacteristicFlow.lean
@@ -1193,10 +1193,10 @@ norm bound into a per-window `IsPicardLindelof`, invokes the vendored
 Picard-Lindelöf (`exists_vlasov_extend_one_window`), and stitches
 `N = ⌈T/δ⌉` windows per-`z` via `HasDerivWithinAt.union` under the
 position/velocity inductive invariant.  Downstream callers discharge its
-`hR`/`hbound` hypotheses; the single-ball-over-`[0,T+1]` `hR` discharge in
+`hR`/`hbound` hypotheses; the single-ball `hR` discharge in
 `exists_vlasov_trajectory` is what introduces the
-`LocalSmallnessPLBuffer L T := L·(T+1)² < 1` constraint — see that
-theorem's docstring for the `+1`-offset / arbitrary-`L` discussion. -/
+`LocalSmallnessPLBuffer L T := L·T² < 1` constraint — see that
+theorem's docstring for the arbitrary-`L` discussion. -/
 
 /-- Localized variant of `IsCharacteristicFlow` from `Basic.lean`:
 the same initial condition + position/velocity ODEs, but quantified
@@ -4507,7 +4507,7 @@ theorem exists_vlasov_trajectory
     have := mul_nonneg h1 hT1nn
     have := mul_nonneg h2 hT1sq
     rw [hN_z_def]; positivity
-  -- R_real := N(z) / (1 - L·(T+1)²)
+  -- R_real := N(z) / (1 - L·T²)
   set R_real : ℝ := N_z / (1 - (L : ℝ) * T ^ 2) with hR_real_def
   have hR_real_nn : 0 ≤ R_real := div_nonneg hN_z_nn (le_of_lt hTL_pos)
   set R : NNReal := Real.toNNReal R_real with hR_def
@@ -4525,10 +4525,10 @@ theorem exists_vlasov_trajectory
   set M : NNReal := Real.toNNReal M_real with hM_def
   have hM_eq : (M : ℝ) = M_real := Real.coe_toNNReal _ hM_real_nn
   -- ============================================================
-  -- Verify hR_local: 2·a + (‖z.2‖ + a/2)(T+1) + M·(T+1)² ≤ R
+  -- Verify hR_local: 2·a + (‖z.2‖ + a/2)·T + M·T² ≤ R
   -- with a = 1.
-  -- After substitution: this is N_z ≤ R = R_real * (1 - L·(T+1)²) + correction.
-  -- The construction gives R · (1 - L·(T+1)²) = N_z, so the inequality is tight.
+  -- After substitution: this is N_z ≤ R = R_real * (1 - L·T²) + correction.
+  -- The construction gives R · (1 - L·T²) = N_z, so the inequality is tight.
   -- ============================================================
   have ha : (0 : NNReal) < 1 := by norm_num
   have hR_local : 2 * ((1 : NNReal) : ℝ)
@@ -4552,7 +4552,7 @@ theorem exists_vlasov_trajectory
     rw [hM_eq, hR_eq, h_one]
     linarith [h_real]
   -- ============================================================
-  -- Verify hbound_local: force bound on closedBall z.1 R for t ∈ Icc 0 (T+1).
+  -- Verify hbound_local: force bound on closedBall z.1 R for t ∈ Icc 0 T.
   -- Uses ‖conv(ρ t, x)‖ ≤ ‖gradW(0)‖ + L · ∫‖x-y‖ dρ_t ≤ ‖gradW(0)‖ + L·(‖x‖ + M_ρ).
   -- For x ∈ closedBall z.1 R: ‖x‖ ≤ R + ‖z.1‖, so bound ≤ M_real = M.
   -- ============================================================

--- a/LeanPool/Vlasov/OT/Wasserstein.lean
+++ b/LeanPool/Vlasov/OT/Wasserstein.lean
@@ -26,9 +26,11 @@ defined via the Kantorovich–Rubinstein dual formula
 
   W₁(μ, ν) = sup { ∫ f dμ − ∫ f dν | f : 1-Lipschitz, f : α → ℝ }.
 
-Returns `ℝ≥0∞` so that unbounded suprema (e.g. when a measure has no finite
-first moment) are represented honestly as `⊤` rather than collapsing to the
-conditional-sup junk value `0` that `⨆` produces on `ℝ`.  Negative
+Returns `ℝ≥0∞` so the supremum is not artificially capped at a real value.
+(Caveat: each summand is a Bochner integral, whose junk value `0` for
+non-integrable test functions means the dual sup is only guaranteed to agree
+with the classical formula under the finite-first-moment hypotheses that
+every property lemma below carries.)  Negative
 arguments to `ENNReal.ofReal` round up to `0`; that is consistent with the
 dual formula because the family of 1-Lipschitz `f` is closed under `f ↦ -f`,
 so the positive parts already realise the absolute value of the signed
@@ -487,11 +489,13 @@ example {α : Type*} [MeasurableSpace α] [PseudoMetricSpace α]
 
 /-! ### `wassersteinBar` — the truncated (cutoff) Wasserstein-1 distance Wbar
 
-`Wbar := wassersteinCost (min(dist, 1))` (Dobrushin 1979 §5).  The bounded cost
-makes the dual test class *bounded* 1-Lipschitz, so Wbar metrizes narrow
-convergence directly and is always finite (no moment hypotheses).  The property
-layer instantiates verbatim from the cost-generic lemmas: `min(dist, 1)` is a
-continuous pseudometric dominated by `dist`, so every hypothesis is met. -/
+`Wbar := wassersteinCost (min(dist, 1))` (Dobrushin 1979 §5).  The bounded
+cost makes the dual test class *bounded* 1-Lipschitz (oscillation ≤ 1); on
+probability measures this classically makes `Wbar` finite without moment
+hypotheses and lets it metrize narrow convergence — neither fact is needed,
+or proved, in this development.  The property layer below instantiates
+verbatim from the cost-generic lemmas: `min(dist, 1)` is a continuous
+pseudometric dominated by `dist`, so every hypothesis is met. -/
 
 /-- The **truncated Wasserstein-1 distance** `Wbar` (Dobrushin 1979 §5): the
 `c = min(dist, 1)` instance of `wassersteinCost`. -/

--- a/LeanPool/Vlasov/OT/WellPosedness.lean
+++ b/LeanPool/Vlasov/OT/WellPosedness.lean
@@ -22,7 +22,11 @@ development:
   universal-in-`t` bridge to `IsLagrangianVlasovSolution`;
 * the §10 marquee results: `vlasovWellPosedness` (forward-in-time existence),
   `vlasovWellPosedness_uniqueness`, `dobrushin` (W₁ stability, proved by
-  coupling the two flows and a Grönwall estimate), and the mean-field limit.
+  coupling the two flows and a Grönwall estimate), and the mean-field limit;
+* the wiring layer `dobrushin_on` / `dobrushin_forward` /
+  `vlasovWellPosedness_stability`: the window and forward-global stability
+  forms with the explicit uniform constant `C = 2 · max 1 L`, whose
+  hypotheses are exactly the clauses `vlasovWellPosedness` emits.
 
 See `formalize/DESIGN.md` (in the source repository) for the overall design.
 -/
@@ -5619,7 +5623,6 @@ theorem vlasovWellPosedness_uniqueness
     (gradW : PhysSpace d → PhysSpace d)
     (_hgradW : ∀ x, gradW x = gradient W x)
     (L : NNReal) (hL : LipschitzWith L gradW)
-    (_hL_pos : (0 : ℝ) < L)
     (f₀ : Measure (PhaseSpace d))
     (_hf₀ : HasFiniteFirstMoment f₀)
     {T_target : ℝ} (hT_target : 0 < T_target)
@@ -5772,7 +5775,7 @@ theorem vlasovWellPosedness_universal_existence
     have h_sol_m_on_n : IsLagrangianVlasovSolutionOn gradW (sol m) ((n : ℝ) + 1) :=
       (h_sol_lag m).mono_window hnm_cast
     -- Apply vlasovWellPosedness_uniqueness on window [0, n+1]
-    exact vlasovWellPosedness_uniqueness W gradW hgradW L hL hL_pos f₀ hf₀
+    exact vlasovWellPosedness_uniqueness W gradW hgradW L hL f₀ hf₀
       (by linarith [Nat.cast_nonneg (α := ℝ) n] : (0 : ℝ) < (n : ℝ) + 1)
       (sol n) (sol m) (h_sol_init n) (h_sol_init m)
       (h_sol_mom n)
@@ -6318,7 +6321,12 @@ eq:vlasov,
 
 where W_1 is the Wasserstein-1 distance.
 The proof uses a coupling via the characteristic flows eq:char and a Gronwall
-inequality; the key estimate is |∇W * ρ − ∇W * σ|_∞ ≤ L · W_1(ρ, σ). -/
+inequality; the key estimate is |∇W * ρ − ∇W * σ|_∞ ≤ L · W_1(ρ, σ).
+
+The `[AssW W]` instance and `hgradW` record the standing setup ass:W (∇W the
+gradient of an even C^{1,1} potential); the inequality itself consumes only
+the Lipschitz bound `hL` — see `dobrushin_on` below for the minimal-hypothesis
+window form with the explicit constant `C = 2 · max 1 L`. -/
 theorem dobrushin
     {d : ℕ} [NeZero d]
     (W : PhysSpace d → ℝ) [hW : AssW W]
@@ -6352,6 +6360,99 @@ theorem dobrushin
     simpa only [dist_zero_right] using (hg_prob 0).2
   rw [wasserstein1_eq_coupling (f 0) (g 0) 0 hfm0 hgm0]
   exact hC_bound t ht
+
+/-- **Dobrushin stability on the window `[0, T]`** — the public form of the
+uniform-constant estimate, with the dual `W₁` metric on both sides.
+
+Unlike the marquee `dobrushin` (global two-sided solutions, existential
+constant), this form (i) consumes exactly what `vlasovWellPosedness` emits —
+per-window `IsLagrangianVlasovSolutionOn` plus window moments — and (ii)
+exposes the **explicit constant** `C = 2 · max 1 L`, which depends only on
+the force's Lipschitz bound, not on the solution pair.  That uniformity is
+what a mean-field argument quantifying over a family of solutions (e.g.
+empirical curves, once their flow witnesses are formalized) needs. -/
+theorem dobrushin_on
+    {d : ℕ} [NeZero d]
+    (gradW : PhysSpace d → PhysSpace d)
+    (L : NNReal) (hL : LipschitzWith L gradW)
+    (f g : ℝ → Measure (PhaseSpace d))
+    (T : ℝ) (hT : 0 < T)
+    (hf : IsLagrangianVlasovSolutionOn gradW f T)
+    (hg : IsLagrangianVlasovSolutionOn gradW g T)
+    (hf_mom : ∀ t ∈ Set.Icc (0 : ℝ) T, HasFiniteFirstMoment (f t))
+    (hg_mom : ∀ t ∈ Set.Icc (0 : ℝ) T, HasFiniteFirstMoment (g t)) :
+    ∀ t ∈ Set.Icc (0 : ℝ) T,
+      wasserstein1 (f t) (g t) ≤
+        ENNReal.ofReal (Real.exp (2 * ((max 1 L : NNReal) : ℝ) * t)) *
+          wasserstein1 (f 0) (g 0) := by
+  intro t ht
+  have h0 : (0 : ℝ) ∈ Set.Icc (0 : ℝ) T := ⟨le_refl 0, hT.le⟩
+  haveI : IsProbabilityMeasure (f 0) := (hf_mom 0 h0).1
+  haveI : IsProbabilityMeasure (g 0) := (hg_mom 0 h0).1
+  have hfm0 : Integrable (fun y => dist y (0 : PhaseSpace d)) (f 0) := by
+    simpa only [dist_zero_right] using (hf_mom 0 h0).2
+  have hgm0 : Integrable (fun y => dist y (0 : PhaseSpace d)) (g 0) := by
+    simpa only [dist_zero_right] using (hg_mom 0 h0).2
+  rw [wasserstein1_eq_coupling (f 0) (g 0) 0 hfm0 hgm0]
+  exact dobrushin_meanfield_On gradW L hL f g T hT hf hg hf_mom hg_mom t ht
+
+/-- **Forward-global Dobrushin stability with the explicit uniform constant.**
+
+Stability for the solution class `vlasovWellPosedness` constructs: the
+hypotheses are verbatim the existence theorem's conclusion clauses (the
+per-window `IsLagrangianVlasovSolutionOn` family on every horizon, moments on
+`Set.Ici 0`), and the estimate holds for all `t ≥ 0` with the
+pair-independent constant `C = 2 · max 1 L`.  This is the arrow that lets the
+existence output feed a Dobrushin-type stability input; see
+`vlasovWellPosedness_stability` for the packaged composition. -/
+theorem dobrushin_forward
+    {d : ℕ} [NeZero d]
+    (gradW : PhysSpace d → PhysSpace d)
+    (L : NNReal) (hL : LipschitzWith L gradW)
+    (f g : ℝ → Measure (PhaseSpace d))
+    (hf : ∀ T : ℝ, 0 < T → IsLagrangianVlasovSolutionOn gradW f T)
+    (hg : ∀ T : ℝ, 0 < T → IsLagrangianVlasovSolutionOn gradW g T)
+    (hf_mom : ∀ t ∈ Set.Ici (0 : ℝ), HasFiniteFirstMoment (f t))
+    (hg_mom : ∀ t ∈ Set.Ici (0 : ℝ), HasFiniteFirstMoment (g t)) :
+    ∀ t : ℝ, 0 ≤ t →
+      wasserstein1 (f t) (g t) ≤
+        ENNReal.ofReal (Real.exp (2 * ((max 1 L : NNReal) : ℝ) * t)) *
+          wasserstein1 (f 0) (g 0) := by
+  intro t ht
+  exact dobrushin_on gradW L hL f g (t + 1) (by linarith)
+    (hf (t + 1) (by linarith)) (hg (t + 1) (by linarith))
+    (fun s hs => hf_mom s hs.1) (fun s hs => hg_mom s hs.1) t ⟨ht, by linarith⟩
+
+/-- **Well-posedness package: existence + stability, chained.**
+
+For any two initial data `f₀, g₀ ∈ 𝒫₁`, the curves produced by
+`vlasovWellPosedness` satisfy the Dobrushin estimate with the explicit
+constant `C = 2 · max 1 L` at every `t ≥ 0` — the composition of the two
+headline theorems, recorded so that the existence output demonstrably feeds
+the stability input (`dobrushin_forward`). -/
+theorem vlasovWellPosedness_stability
+    {d : ℕ} [NeZero d]
+    (W : PhysSpace d → ℝ) [AssW W]
+    (gradW : PhysSpace d → PhysSpace d)
+    (hgradW : ∀ x, gradW x = gradient W x)
+    (L : NNReal) (hL : LipschitzWith L gradW)
+    (f₀ g₀ : Measure (PhaseSpace d))
+    (hf₀ : HasFiniteFirstMoment f₀) (hg₀ : HasFiniteFirstMoment g₀) :
+    ∃ f g : ℝ → Measure (PhaseSpace d),
+      f 0 = f₀ ∧ g 0 = g₀ ∧
+      (∀ T : ℝ, 0 < T → IsLagrangianVlasovSolutionOn gradW f T) ∧
+      (∀ T : ℝ, 0 < T → IsLagrangianVlasovSolutionOn gradW g T) ∧
+      ∀ t : ℝ, 0 ≤ t →
+        wasserstein1 (f t) (g t) ≤
+          ENNReal.ofReal (Real.exp (2 * ((max 1 L : NNReal) : ℝ) * t)) *
+            wasserstein1 f₀ g₀ := by
+  obtain ⟨f, hf_init, hf_mom, hf_lag, _⟩ :=
+    vlasovWellPosedness W gradW hgradW L hL f₀ hf₀
+  obtain ⟨g, hg_init, hg_mom, hg_lag, _⟩ :=
+    vlasovWellPosedness W gradW hgradW L hL g₀ hg₀
+  refine ⟨f, g, hf_init, hg_init, hf_lag, hg_lag, ?_⟩
+  have h := dobrushin_forward gradW L hL f g hf_lag hg_lag hf_mom hg_mom
+  simpa only [hf_init, hg_init] using h
 
 /-- **Coupling-metric Dobrushin stability estimate** — the `wasserstein1Coupling`
 (primal) analogue of `DobrushinStabilityEstimate` (Basic).  LHS is the genuine


### PR DESCRIPTION
Implements the follow-ups from the human review of #327. Closes #331.

**Item 1 — wire the headline theorems together** (`OT/WellPosedness.lean`):
- `dobrushin_on` (public): Dobrushin stability on `[0, T]` with the dual `W₁` metric on both sides and the **explicit pair-independent constant `C = 2 · max 1 L`** — the previously `private` uniform-constant estimate (`dobrushin_meanfield_On`), exposed through the KR duality bridge. Its hypotheses are exactly the per-window `IsLagrangianVlasovSolutionOn` + window-moment clauses.
- `dobrushin_forward`: the forward-global (`∀ t ≥ 0`) form whose hypotheses are **verbatim the conclusion clauses of `vlasovWellPosedness`** — the missing arrow from the existence theorem to the stability theorem.
- `vlasovWellPosedness_stability`: the packaged composition — for any two initial data in `𝒫₁`, the constructed solutions satisfy the estimate with the explicit constant. The existence output now demonstrably feeds the stability input, and the constant uniformity needed by `meanFieldLimit`-style arguments is public.

**Item 2 (tractable core) — empirical curves as weak Vlasov solutions** (`Basic.lean`):
- Extracted `weakEvolutionEmpiricalMeasure_hasDerivAt`, the derivative-identity core of prop:weak **without** the two `BddAbove` hypotheses (they feed only the quantitative `(1/N)‖∇W‖_∞‖∇_vφ‖_∞` bound conjunct, never the identity). `weakEvolutionEmpiricalMeasure` is now a thin wrapper with an unchanged statement.
- `empiricalMeasureSolvesVlasov` **drops** `hgradW_bdd`/`hgradVφ_bdd` (previously required, provably spurious — in particular `BddAbove (range ‖gradW·‖)` excluded harmonic-type potentials for no reason).
- New `empiricalMeasure_isVlasovSolution`: the empirical curve of a global Newton solution **is** a global `IsVlasovSolution`, hypothesis-free beyond ass:W.
- New `empiricalMeasure_hasFiniteFirstMoment` / `empiricalMeasureCurve_hasFiniteFirstMoment`: empirical measures lie in `𝒫₁` at every time.
- Together these discharge the weak-PDE and moment sides of the solution predicates on empirical curves, and item 1 supplies the uniform constant. The **remaining** gap to discharging `meanFieldLimit`'s hypothesis is the characteristic-flow witness for empirical curves (`IsLagrangianVlasovSolution`'s second conjunct: the linear flow of the empirical field, with atoms following characteristics) — deferred to the upstream consolidation, per the author's plan on #327.

**Item 3 — documentation fixes**:
- `Basic.lean`: the `IsLagrangianVlasovSolution` "Producers" bullet now correctly says `vlasovWellPosedness` yields the per-window `IsLagrangianVlasovSolutionOn` family, not the global predicate (found by Greptile on #327).
- `OT/CharacteristicFlow.lean`: five stale comments from the pre-refactor `L·(T+1)² < 1` era now match the code (`L·T² < 1`, window `Icc 0 T`).
- `OT/Wasserstein.lean`: the header no longer claims unbounded suprema are "represented honestly as ⊤" (unproven outside the finite-moment regime — Bochner junk values); the `wassersteinBar` section now marks finiteness/metrization of narrow convergence as classical facts not proved here.

**Item 4 — machine-checked non-vacuity** (`Basic.lean`): `assW_zero` / `assW2_zero` — the zero potential inhabits `AssW` and `AssW2`, so the hypothesis classes of every headline theorem are kernel-checked non-vacuous.

**Item 5 — statement hygiene**:
- `vlasovWellPosedness_uniqueness`: dropped the vestigial unused `0 < L` hypothesis (call site updated).
- `dobrushin`: docstring now documents that `[AssW W]`/`hgradW` record the standing setup while the inequality consumes only `hL`, pointing to `dobrushin_on` for the minimal form.
- `empiricalMeasureSolvesVlasov`: unused `hφ_compact` binder underscore-marked with a note on why it is carried.

Not in scope (explicitly deferred upstream per #327 discussion): the `_on`/`_at` duplicate-proof-body consolidation and the removal of superseded proof-route lemmas.

**Gates run locally**: `lake build` of the full Vlasov cone green; `#print axioms` = `{propext, Classical.choice, Quot.sound}` on all new and changed declarations and re-verified on the four original headliners; no new files (`mk_all` unchanged); `projects.yml` untouched (card statements unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
