### PR TITLE
fix: clear v4.33.0-rc2 build warnings in Vlasov and Erdos865

### DIFF
--- a/LeanPool/Erdos865/FoldedAux.lean
+++ b/LeanPool/Erdos865/FoldedAux.lean
@@ -131,7 +131,7 @@ None of the four sets contain `0`, so their union misses `0`.
 theorem union_card_le {m : ℕ} (hm : 2 ≤ m) {B : Finset ℕ} (hB : FoldedOK m B) (α β : ℕ) :
     haveI : NeZero m := ⟨by omega⟩
     (T1 m B ∪ T2 m B ∪ T3 m B α ∪ T4 m B β).card ≤ m - 1 := by
-  haveI : NeZero m := ⟨by omega⟩
+  have : NeZero m := ⟨by omega⟩
   have hsub : T1 m B ∪ T2 m B ∪ T3 m B α ∪ T4 m B β ⊆ Finset.univ.erase (0 : ZMod m) := by
     intro x hx
     rw [Finset.mem_erase]

--- a/LeanPool/Vlasov/Basic.lean
+++ b/LeanPool/Vlasov/Basic.lean
@@ -1088,7 +1088,7 @@ theorem exists_wasserstein1_limit_of_cauchy {d : ℕ}
     h_compact.tendsto_subseq (x := P) (fun n => subset_closure (Set.mem_range_self n))
   -- The limit measure.
   set μ : Measure (PhysSpace d) := (Plim : Measure (PhysSpace d)) with hμ_def
-  haveI : IsProbabilityMeasure μ := Plim.2
+  have : IsProbabilityMeasure μ := Plim.2
   -- === Step 3: narrow convergence in test-integral form. ===
   have h_narrow : ∀ g : BoundedContinuousFunction (PhysSpace d) ℝ,
       Filter.Tendsto (fun k => ∫ x, g x ∂(ν (φ k))) Filter.atTop
@@ -1500,7 +1500,7 @@ lemma continuousOn_integral_of_isLagrangianVlasovSolution
                     (fun y => norm_sub_le x y)
               _ = ‖x‖ + ∫ y, ‖y‖ ∂(ρ s) := by
                   have hρs : ρ s = spatialMarginal (f s) := rfl
-                  haveI : IsProbabilityMeasure (ρ s) := hρs ▸ inferInstance
+                  have : IsProbabilityMeasure (ρ s) := hρs ▸ inferInstance
                   have h_y_int_ρ : Integrable (fun y => ‖y‖) (ρ s) := hρs ▸ h_y_int s hs
                   rw [integral_add (integrable_const _) h_y_int_ρ, integral_const]
                   simp [measureReal_def]
@@ -1585,7 +1585,7 @@ lemma continuousOn_integral_of_isLagrangianVlasovSolution
       linarith
     linarith [h_flow_bound t ht z]
   · -- Integrable dominator
-    haveI : IsProbabilityMeasure (f 0) := hf_prob_0.1
+    have : IsProbabilityMeasure (f 0) := hf_prob_0.1
     have h_int_norm : Integrable (fun z : PhaseSpace d => ‖z‖) (f 0) := hf_prob_0.2
     have h_int_1 : Integrable (fun _ : PhaseSpace d => (1 : ℝ)) (f 0) :=
       integrable_const 1

--- a/LeanPool/Vlasov/OT/CharacteristicFlow.lean
+++ b/LeanPool/Vlasov/OT/CharacteristicFlow.lean
@@ -457,7 +457,7 @@ theorem integral_mild_bound
   have huIoc : Set.uIoc (0 : ℝ) t = Set.Ioc 0 t := Set.uIoc_of_le h0t
   have hvol_lt : MeasureTheory.volume (Set.uIoc (0 : ℝ) t) < ⊤ := by
     rw [huIoc, Real.volume_Ioc]; exact ENNReal.ofReal_lt_top
-  haveI hfin_restrict : IsFiniteMeasure (MeasureTheory.volume.restrict (Set.uIoc (0 : ℝ) t)) := by
+  have hfin_restrict : IsFiniteMeasure (MeasureTheory.volume.restrict (Set.uIoc (0 : ℝ) t)) := by
     refine ⟨?_⟩
     rw [Measure.restrict_apply_univ]; exact hvol_lt
   -- `ε` is integrable over `volume.restrict (uIoc 0 t)`
@@ -4240,8 +4240,8 @@ lemma supW1On_le_two_moment_of_VlasovMeasureCurve {d : ℕ} [NeZero d]
   -- Pointwise: W₁(ρ_t, σ_t) ≤ ofReal(∫‖y‖d(ρ_t) + ∫‖y‖d(σ_t)) ≤ ofReal(M + M)
   have h_bound : wasserstein1 (ρ.ρ t) (σ.ρ t) ≤
       ENNReal.ofReal (∫ y, ‖y‖ ∂(ρ.ρ t) + ∫ y, ‖y‖ ∂(σ.ρ t)) := by
-    haveI : IsProbabilityMeasure (ρ.ρ t) := ρ.isProb t
-    haveI : IsProbabilityMeasure (σ.ρ t) := σ.isProb t
+    have : IsProbabilityMeasure (ρ.ρ t) := ρ.isProb t
+    have : IsProbabilityMeasure (σ.ρ t) := σ.isProb t
     exact wasserstein1_le_moments_sum (ρ.ρ t) (σ.ρ t)
       (ρ.yIntegrable t ht) (σ.yIntegrable t ht)
   refine h_bound.trans ?_
@@ -4278,7 +4278,7 @@ lemma vlasovMeasureCurve_convCont {d : ℕ} [NeZero d]
   -- composes with the hW1Cont field (W₁(ρ_s, ρ_t).toReal → 0 as t → s within
   -- [0, T]) to give ContinuousWithinAt at s.
   intro s hs
-  haveI hPs : IsProbabilityMeasure (ρ.ρ s) := ρ.isProb s
+  have hPs : IsProbabilityMeasure (ρ.ρ s) := ρ.isProb s
   rw [Metric.continuousWithinAt_iff]
   intro ε hε
   have hCont := ρ.hW1Cont s hs
@@ -4298,7 +4298,7 @@ lemma vlasovMeasureCurve_convCont {d : ℕ} [NeZero d]
   have hW1_nn : 0 ≤ (wasserstein1 (ρ.ρ s) (ρ.ρ t)).toReal := ENNReal.toReal_nonneg
   have hW1_lt : (wasserstein1 (ρ.ρ s) (ρ.ρ t)).toReal < η := by
     rwa [abs_of_nonneg hW1_nn] at hδb
-  haveI hPt : IsProbabilityMeasure (ρ.ρ t) := ρ.isProb t
+  have hPt : IsProbabilityMeasure (ρ.ρ t) := ρ.isProb t
   have h_finite : wasserstein1 (ρ.ρ s) (ρ.ρ t) ≠ ⊤ :=
     wasserstein1_ne_top_of_finite_moment _ _
       (ρ.yIntegrable s hs) (ρ.yIntegrable t ht)
@@ -5085,9 +5085,9 @@ theorem Phi_hW1Cont {d : ℕ}
   -- Goal: dist ((wasserstein1 (Phi s) (Phi t)).toReal) 0 < ε.
   rw [Real.dist_eq, sub_zero]
   -- |(W₁ s t).toReal| ≤ |∫ ...|.
-  haveI hΦs_prob : IsProbabilityMeasure (Phi charX f₀ s) :=
+  have hΦs_prob : IsProbabilityMeasure (Phi charX f₀ s) :=
     Phi_isProbabilityMeasure charX f₀ h_meas s
-  haveI hΦt_prob : IsProbabilityMeasure (Phi charX f₀ t) :=
+  have hΦt_prob : IsProbabilityMeasure (Phi charX f₀ t) :=
     Phi_isProbabilityMeasure charX f₀ h_meas t
   have h_yint_s : Integrable (fun y : PhysSpace d => ‖y‖) (Phi charX f₀ s) :=
     Phi_yIntegrable charX f₀ h_meas T hT C_T hC_T_nn h_growth h_f₀_int s hs
@@ -5609,7 +5609,7 @@ theorem Phi_step
       ∃ σ : VlasovMeasureCurve d T (fun _ => C_T * (M_f₀ + 1)),
         ∀ t ∈ Set.Icc (0 : ℝ) T,
           σ.ρ t = Measure.map (fun z : PhaseSpace d => charX t z) f₀ := by
-  haveI hExt_prob : ∀ t, IsProbabilityMeasure (ρ.extend t) :=
+  have hExt_prob : ∀ t, IsProbabilityMeasure (ρ.extend t) :=
     VlasovMeasureCurve.extend_isProb ρ
   have hρ_cont : ∀ x : PhysSpace d,
       Continuous (fun t => convolveFunctionMeasure gradW (ρ.extend t) x) := by
@@ -5781,7 +5781,7 @@ theorem Phi_step_envelope
       ∃ σ : VlasovMeasureCurve d T m,
         ∀ t ∈ Set.Icc (0 : ℝ) T,
           σ.ρ t = Measure.map (fun z : PhaseSpace d => charX t z) f₀ := by
-  haveI hExt_prob : ∀ t, IsProbabilityMeasure (ρ.extend t) :=
+  have hExt_prob : ∀ t, IsProbabilityMeasure (ρ.extend t) :=
     VlasovMeasureCurve.extend_isProb ρ
   have hρ_cont : ∀ x : PhysSpace d,
       Continuous (fun t => convolveFunctionMeasure gradW (ρ.extend t) x) := by
@@ -6399,9 +6399,9 @@ theorem Phi_supW1_contraction {d : ℕ}
                    (Measure.map (fun z => charX_σ t z) f₀) ≤
       ENNReal.ofReal C_T := by
     intro t ht
-    haveI hΦρ_t : IsProbabilityMeasure (Measure.map (fun z => charX_ρ t z) f₀) :=
+    have hΦρ_t : IsProbabilityMeasure (Measure.map (fun z => charX_ρ t z) f₀) :=
       MeasureTheory.Measure.isProbabilityMeasure_map (h_meas_ρ t ht)
-    haveI hΦσ_t : IsProbabilityMeasure (Measure.map (fun z => charX_σ t z) f₀) :=
+    have hΦσ_t : IsProbabilityMeasure (Measure.map (fun z => charX_σ t z) f₀) :=
       MeasureTheory.Measure.isProbabilityMeasure_map (h_meas_σ t ht)
     -- W₁ is finite (probability + finite first moment).
     have h_W1_t_ne_top :
@@ -6685,7 +6685,7 @@ theorem picard_iterate_exists_limit {d : ℕ} [NeZero d]
       ∫ y, ‖y‖ ∂μ ≤ M t ∧
       Filter.Tendsto (fun n => wasserstein1 ((x n).ρ t) μ) Filter.atTop (nhds 0) := by
     intro t ht
-    haveI : ∀ n, IsProbabilityMeasure ((x n).ρ t) := fun n => (x n).isProb t
+    have : ∀ n, IsProbabilityMeasure ((x n).ρ t) := fun n => (x n).isProb t
     exact exists_wasserstein1_limit_of_cauchy (fun n => (x n).ρ t) (M t)
       (fun n => (x n).hasMoment t ht) (fun n => (x n).yIntegrable t ht)
       (h_per_t_cauchy t ht)
@@ -6758,8 +6758,8 @@ theorem picard_iterate_exists_limit {d : ℕ} [NeZero d]
     have h_W1_third : wasserstein1 ((x N).ρ t) (ρ_lim t) ≤ ENNReal.ofReal (ε / 3) :=
       hN_uniform N le_rfl t ht
     -- Finiteness of the limit's W₁.
-    haveI hPs_inf : IsProbabilityMeasure (ρ_lim s) := h_isProb s
-    haveI hPt_inf : IsProbabilityMeasure (ρ_lim t) := h_isProb t
+    have hPs_inf : IsProbabilityMeasure (ρ_lim s) := h_isProb s
+    have hPt_inf : IsProbabilityMeasure (ρ_lim t) := h_isProb t
     have h_finite : wasserstein1 (ρ_lim s) (ρ_lim t) ≠ ⊤ :=
       wasserstein1_ne_top_of_finite_moment _ _
         (h_yIntegrable s hs) (h_yIntegrable t ht)
@@ -6785,8 +6785,8 @@ theorem picard_iterate_exists_limit {d : ℕ} [NeZero d]
       ne_top_of_le_ne_top ENNReal.ofReal_ne_top h_W1_first
     have h_W1_third_ne_top : wasserstein1 ((x N).ρ t) (ρ_lim t) ≠ ⊤ :=
       ne_top_of_le_ne_top ENNReal.ofReal_ne_top h_W1_third
-    haveI hPNs : IsProbabilityMeasure ((x N).ρ s) := (x N).isProb s
-    haveI hPNt : IsProbabilityMeasure ((x N).ρ t) := (x N).isProb t
+    have hPNs : IsProbabilityMeasure ((x N).ρ s) := (x N).isProb s
+    have hPNt : IsProbabilityMeasure ((x N).ρ t) := (x N).isProb t
     have h_mid_ne_top : wasserstein1 ((x N).ρ s) ((x N).ρ t) ≠ ⊤ :=
       wasserstein1_ne_top_of_finite_moment _ _
         ((x N).yIntegrable s hs) ((x N).yIntegrable t ht)

--- a/LeanPool/Vlasov/OT/Coupling.lean
+++ b/LeanPool/Vlasov/OT/Coupling.lean
@@ -109,7 +109,7 @@ theorem wasserstein1_le_wasserstein1Coupling
   · rw [h_top]; exact le_top
   push Not at h_top
   -- Step 1: π inherits IsProbabilityMeasure from its first marginal μ.
-  haveI hπ_prob : IsProbabilityMeasure π := by
+  have hπ_prob : IsProbabilityMeasure π := by
     refine ⟨?_⟩
     have h_eq : π Set.univ = μ Set.univ := by
       rw [← hπ.1, Measure.map_apply measurable_fst MeasurableSet.univ,
@@ -288,19 +288,19 @@ theorem exists_coupling_glue
       ∫⁻ z, ENNReal.ofReal (c z.1 z.2) ∂π₃
         ≤ (∫⁻ z, ENNReal.ofReal (c z.1 z.2) ∂π₁)
           + (∫⁻ z, ENNReal.ofReal (c z.1 z.2) ∂π₂) := by
-  haveI : Nonempty α := nonempty_of_isProbabilityMeasure μ
-  haveI hπ₁ : IsProbabilityMeasure π₁ := by
+  have : Nonempty α := nonempty_of_isProbabilityMeasure μ
+  have hπ₁ : IsProbabilityMeasure π₁ := by
     constructor
     have h : π₁ Set.univ = μ Set.univ := by
       rw [← h₁.1, Measure.map_apply measurable_fst MeasurableSet.univ, Set.preimage_univ]
     rw [h, measure_univ]
-  haveI hπ₂ : IsProbabilityMeasure π₂ := by
+  have hπ₂ : IsProbabilityMeasure π₂ := by
     constructor
     have h : π₂ Set.univ = ρ Set.univ := by
       rw [← h₂.1, Measure.map_apply measurable_fst MeasurableSet.univ, Set.preimage_univ]
     rw [h, measure_univ]
   set κ₂ : Kernel α α := π₂.condKernel with hκ₂
-  haveI : IsMarkovKernel κ₂ := by rw [hκ₂]; infer_instance
+  have : IsMarkovKernel κ₂ := by rw [hκ₂]; infer_instance
   set κ₂' : Kernel (α × α) α := κ₂.comap Prod.snd measurable_snd with hκ₂'
   set glued : Measure ((α × α) × α) := π₁ ⊗ₘ κ₂' with hglued
   set proj : (α × α) × α → α × α := fun w => (w.1.1, w.2) with hproj
@@ -651,7 +651,7 @@ theorem exists_finiteRange_map_cost_le
     ∃ T : α → α, Measurable T ∧ (Set.range T).Finite ∧
       ∫⁻ x, ENNReal.ofReal (c x (T x)) ∂μ ≤ ENNReal.ofReal ε := by
   -- Step 1: get a dist-diameter partition (cells of diam ≤ ε/2)
-  haveI : TopologicalSpace.SeparableSpace α := inferInstance
+  have : TopologicalSpace.SeparableSpace α := inferInstance
   obtain ⟨As, hAs_mble, hAs_bdd, hAs_diam, hAs_cover, hAs_disj⟩ :=
     SeparableSpace.exists_measurable_partition_diam_le α (half_pos _hε)
   -- per-cell representatives (x₀ on empty cells)
@@ -768,14 +768,14 @@ theorem exists_transport_min
   -- closed: finite intersection of closed conditions
   have hFcl : IsClosed F := by
     have e1 : IsClosed {P : m → n → ℝ | ∀ i j, 0 ≤ P i j} := by
-      rw [Set.setOf_forall]; refine isClosed_iInter fun i => ?_
-      rw [Set.setOf_forall]; refine isClosed_iInter fun j => ?_
+      rw [Set.ofPred_forall]; refine isClosed_iInter fun i => ?_
+      rw [Set.ofPred_forall]; refine isClosed_iInter fun j => ?_
       exact isClosed_le continuous_const (by fun_prop)
     have e2 : IsClosed {P : m → n → ℝ | ∀ i, ∑ j, P i j = a i} := by
-      rw [Set.setOf_forall]; refine isClosed_iInter fun i => ?_
+      rw [Set.ofPred_forall]; refine isClosed_iInter fun i => ?_
       exact isClosed_eq (by fun_prop) continuous_const
     have e3 : IsClosed {P : m → n → ℝ | ∀ j, ∑ i, P i j = b j} := by
-      rw [Set.setOf_forall]; refine isClosed_iInter fun j => ?_
+      rw [Set.ofPred_forall]; refine isClosed_iInter fun j => ?_
       exact isClosed_eq (by fun_prop) continuous_const
     have hEq : F = {P : m → n → ℝ | ∀ i j, 0 ≤ P i j} ∩
         {P : m → n → ℝ | ∀ i, ∑ j, P i j = a i} ∩
@@ -820,7 +820,7 @@ theorem isClosed_transport_cone (Cost : m → n → ℝ) :
   apply IsSeqClosed.isClosed
   intro w p hw_mem hw_tend
   obtain ⟨p1, p2, p3⟩ := p
-  simp only [Set.mem_setOf_eq] at hw_mem
+  simp only [Set.mem_ofPred_eq] at hw_mem
   choose P s hPnn hsnn hweq using hw_mem
   -- componentwise convergence of `w`
   have hfst : Tendsto (fun k => (w k).1) atTop (𝓝 p1) := (continuous_fst.tendsto _).comp hw_tend
@@ -1143,13 +1143,13 @@ theorem finiteRange_transportation_dual
         ≤ ENNReal.ofReal ((∫ x, u x ∂(Measure.map T μ)) + ∫ x, v x ∂(Measure.map S ν))
           + ENNReal.ofReal ε := by
   classical
-  haveI hαne : Nonempty α := nonempty_of_isProbabilityMeasure μ
+  have hαne : Nonempty α := nonempty_of_isProbabilityMeasure μ
   -- finite index types = supports of the pushforwards
   obtain ⟨t₀, ht₀⟩ := Set.range_nonempty T
   obtain ⟨s₀, hs₀⟩ := Set.range_nonempty S
-  haveI : Nonempty (hTfin.toFinset) :=
+  have : Nonempty (hTfin.toFinset) :=
     ⟨⟨t₀, by rw [Set.Finite.mem_toFinset]; exact ht₀⟩⟩
-  haveI : Nonempty (hSfin.toFinset) :=
+  have : Nonempty (hSfin.toFinset) :=
     ⟨⟨s₀, by rw [Set.Finite.mem_toFinset]; exact hs₀⟩⟩
   -- weights and cost matrix over the finite supports
   set a : hTfin.toFinset → ℝ := fun i => ((Measure.map T μ) {(i : α)}).toReal with ha_def
@@ -1157,9 +1157,9 @@ theorem finiteRange_transportation_dual
   set Cost : hTfin.toFinset → hSfin.toFinset → ℝ := fun i j => c (i : α) (j : α) with hCost_def
   have ha_nn : ∀ i, 0 ≤ a i := fun _ => ENNReal.toReal_nonneg
   have hb_nn : ∀ j, 0 ≤ b j := fun _ => ENNReal.toReal_nonneg
-  haveI hμP : IsProbabilityMeasure (Measure.map T μ) :=
+  have hμP : IsProbabilityMeasure (Measure.map T μ) :=
     Measure.isProbabilityMeasure_map hT.aemeasurable
-  haveI hνP : IsProbabilityMeasure (Measure.map S ν) :=
+  have hνP : IsProbabilityMeasure (Measure.map S ν) :=
     Measure.isProbabilityMeasure_map hS.aemeasurable
   -- atom decompositions of the finite-range pushforwards
   have hμmap : Measure.map T μ
@@ -1344,7 +1344,7 @@ theorem cTransform_dual_witness
       (∫ x, u x ∂(Measure.map T μ)) + (∫ x, v x ∂(Measure.map S ν))
         ≤ ∫ x, g x ∂(Measure.map T μ) - ∫ x, g x ∂(Measure.map S ν) := by
   classical
-  haveI : Nonempty α := nonempty_of_isProbabilityMeasure μ
+  have : Nonempty α := nonempty_of_isProbabilityMeasure μ
   set A : Finset α := hTfin.toFinset with hA_def
   set B : Finset α := hSfin.toFinset with hB_def
   have hmemA : ∀ a ∈ Set.range T, a ∈ A := fun a ha => by
@@ -1648,8 +1648,8 @@ theorem wassersteinCostCoupling_le_dual
   obtain ⟨S, hS, hSfin, hScost⟩ :=
     exists_finiteRange_map_cost_le c hc_nonneg hc_le_dist ν x₀ hν_cm
       ((ε : ℝ) / 4) hε4
-  haveI : IsProbabilityMeasure (Measure.map T μ) := Measure.isProbabilityMeasure_map hT.aemeasurable
-  haveI : IsProbabilityMeasure (Measure.map S ν) := Measure.isProbabilityMeasure_map hS.aemeasurable
+  have : IsProbabilityMeasure (Measure.map T μ) := Measure.isProbabilityMeasure_map hT.aemeasurable
+  have : IsProbabilityMeasure (Measure.map S ν) := Measure.isProbabilityMeasure_map hS.aemeasurable
   set q : ℝ≥0∞ := ENNReal.ofReal ((ε : ℝ) / 4) with hq
   -- triangle through the two approximants
   have htri1 := wassersteinCostCoupling_triangle c hc_triangle hc_cont.measurable
@@ -1765,8 +1765,8 @@ lemma wasserstein1_pushforward_le_iInf
     wasserstein1 (Measure.map Φ μ) (Measure.map Ψ ν) ≤
       ⨅ (π : Measure (α × α)) (_ : IsCoupling π μ ν),
         ∫⁻ z, edist (Φ z.1) (Ψ z.2) ∂π := by
-  haveI := hΦμ_prob
-  haveI := hΨν_prob
+  have := hΦμ_prob
+  have := hΨν_prob
   -- Step 1: KR easy applied to (Φ_# μ, Ψ_# ν).
   have h_kr := wasserstein1_le_wasserstein1Coupling
     (Measure.map Φ μ) (Measure.map Ψ ν) x₀ hΦμ_fm hΨν_fm

--- a/LeanPool/Vlasov/OT/WeakToLagrangian.lean
+++ b/LeanPool/Vlasov/OT/WeakToLagrangian.lean
@@ -306,7 +306,7 @@ theorem exists_frozenField_charFlow_On
     exact continuous_const.max (continuous_id.min continuous_const)
   -- Clamped curve `ρ' := ρ ∘ clampT`, which satisfies the universal hypotheses.
   set ρ' : ℝ → Measure (PhysSpace d) := fun t => ρ (clampT t) with hρ'_def
-  haveI hρ'_prob : ∀ t, IsProbabilityMeasure (ρ' t) :=
+  have hρ'_prob : ∀ t, IsProbabilityMeasure (ρ' t) :=
     fun t => hρ_prob (clampT t) (hclampT_mem t)
   have h_int' : ∀ t (x : PhysSpace d), Integrable (fun y => gradW (x - y)) (ρ' t) :=
     fun t x => h_int (clampT t) (hclampT_mem t) x
@@ -385,13 +385,13 @@ lemma measure_eq_of_forall_Cc_integral_eq {μ ν : Measure (PhaseSpace d)}
       ∫ z, φ z ∂μ = ∫ z, φ z ∂ν) :
     μ = ν := by
   -- Haar instance on the ambient volume via the product reduction.
-  haveI hHaar : (volume : Measure (PhaseSpace d)).IsAddHaarMeasure := by
+  have hHaar : (volume : Measure (PhaseSpace d)).IsAddHaarMeasure := by
     rw [show (volume : Measure (PhaseSpace d)) = (volume : Measure (PhysSpace d)).prod volume from
       Measure.volume_eq_prod _ _]
     infer_instance
-  haveI hvolReg : (volume : Measure (PhaseSpace d)).Regular := inferInstance
-  haveI hμreg : μ.Regular := inferInstance
-  haveI hνreg : ν.Regular := inferInstance
+  have hvolReg : (volume : Measure (PhaseSpace d)).Regular := inferInstance
+  have hμreg : μ.Regular := inferInstance
+  have hνreg : ν.Regular := inferInstance
   -- Reduce `μ = ν` to equality of integrals against continuous compactly-supported `g`.
   refine MeasureTheory.Measure.ext_of_integral_eq_on_compactlySupported (fun g => ?_)
   set gf : PhaseSpace d → ℝ := ⇑g with hgf
@@ -937,7 +937,7 @@ theorem exists_linearODE_solution_Icc
   have hg_cont : ContinuousOn (fun s => 𝒜 s (M s)) (Set.Icc 0 T) := h𝒜.clm_apply hMcont
   refine ⟨M, ?_, hMcont, fun t ht => ?_⟩
   · rw [hMeq 0 ⟨le_refl 0, hT⟩, intervalIntegral.integral_same, add_zero]
-  · haveI : Fact (t ∈ Set.Icc (0 : ℝ) T) := ⟨ht⟩
+  · have : Fact (t ∈ Set.Icc (0 : ℝ) T) := ⟨ht⟩
     have hg_int : IntervalIntegrable (fun s => 𝒜 s (M s)) volume 0 t := by
       apply ContinuousOn.intervalIntegrable
       rw [Set.uIcc_of_le ht.1]
@@ -1257,7 +1257,7 @@ lemma fundamentalMatrix_spec {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ
     h𝒜cont.clm_apply hMcont
   refine ⟨?_, hMcont, fun t ht => ?_⟩
   · rw [hMeq 0 ⟨le_refl 0, hT⟩, intervalIntegral.integral_same, add_zero]
-  · haveI : Fact (t ∈ Set.Icc (0 : ℝ) T) := ⟨ht⟩
+  · have : Fact (t ∈ Set.Icc (0 : ℝ) T) := ⟨ht⟩
     have hg_int : IntervalIntegrable
         (fun s => ContinuousLinearMap.compL ℝ F F F (A s) (fundamentalMatrix A s)) volume 0 t := by
       apply ContinuousOn.intervalIntegrable
@@ -1453,7 +1453,7 @@ lemma gronwall_diffQuotient_bound
       (fun s _ => le_of_eq (dist_self _)) (le_refl _)
     have hkey := key t ⟨hs₀.2.le, le_refl t⟩
     simpa only [add_zero] using hkey
-  haveI : (𝓝[Set.Ioo 0 t] (0 : ℝ)).NeBot := left_nhdsWithin_Ioo_neBot ht.1
+  have : (𝓝[Set.Ioo 0 t] (0 : ℝ)).NeBot := left_nhdsWithin_Ioo_neBot ht.1
   have hT0 : (0 : ℝ) ≤ T := le_trans ht.1.le ht.2.le
   have hsub_Icc : Set.Ioo (0 : ℝ) t ⊆ Set.Icc 0 T := fun s hs => ⟨hs.1.le, le_trans hs.2.le ht.2.le⟩
   have htend_uh : Tendsto uh (𝓝[Set.Ioo 0 t] 0) (𝓝 (uh 0)) :=
@@ -2838,7 +2838,7 @@ theorem mollifier_tendstoUniformly {E : Type*}
     (hφ : Tendsto (fun n => (φ n).rOut) atTop (𝓝 0)) :
     TendstoUniformly
       (fun n x => ((φ n).normed volume ⋆[ContinuousLinearMap.lsmul ℝ ℝ, volume] g) x) g atTop := by
-  haveI hHaar : (volume : Measure (PhaseSpace d)).IsAddHaarMeasure := by
+  have hHaar : (volume : Measure (PhaseSpace d)).IsAddHaarMeasure := by
     rw [show (volume : Measure (PhaseSpace d)) = (volume : Measure (PhysSpace d)).prod volume from
       Measure.volume_eq_prod _ _]
     infer_instance
@@ -2873,7 +2873,7 @@ theorem mollifiedFDeriv_tendstoUniformly
     TendstoUniformly
       (fun n z => fderiv ℝ ((φ n).normed volume ⋆[ContinuousLinearMap.lsmul ℝ ℝ, volume] χ) z)
       (fderiv ℝ χ) atTop := by
-  haveI hHaar : (volume : Measure (PhaseSpace d)).IsAddHaarMeasure := by
+  have hHaar : (volume : Measure (PhaseSpace d)).IsAddHaarMeasure := by
     rw [show (volume : Measure (PhaseSpace d)) = (volume : Measure (PhysSpace d)).prod volume from
       Measure.volume_eq_prod _ _]
     infer_instance
@@ -3109,8 +3109,8 @@ lemma convolveField_window_setup
           ‖convolveFunctionMeasure gradW (spatialMarginal (f σ)) x‖ ≤ ε₀ + (L:ℝ) * ‖x‖)
       ∧ Continuous (fun x => convolveFunctionMeasure gradW (spatialMarginal (f σ)) x) := by
   intro σ hσ
-  haveI : IsProbabilityMeasure (f σ) := (hf_mom σ hσ).1
-  haveI hprob_m : IsProbabilityMeasure (spatialMarginal (f σ)) :=
+  have : IsProbabilityMeasure (f σ) := (hf_mom σ hσ).1
+  have hprob_m : IsProbabilityMeasure (spatialMarginal (f σ)) :=
     Measure.isProbabilityMeasure_map measurable_fst.aemeasurable
   -- ‖·‖ integrable wrt the spatial marginal (from the finite first moment of f σ)
   have h_y_int : Integrable (fun y : PhysSpace d => ‖y‖) (spatialMarginal (f σ)) := by
@@ -3247,11 +3247,11 @@ theorem weakEvolution_test_C1c_On
                 (convolveFunctionMeasure gradW (spatialMarginal (f s)) z.1)
                 (gradVχ z)) ∂(f s)) s := by
   classical
-  haveI hHaar : (volume : Measure (PhaseSpace d)).IsAddHaarMeasure := by
+  have hHaar : (volume : Measure (PhaseSpace d)).IsAddHaarMeasure := by
     rw [show (volume : Measure (PhaseSpace d)) = (volume : Measure (PhysSpace d)).prod volume from
       Measure.volume_eq_prod _ _]
     infer_instance
-  haveI hvolReg : (volume : Measure (PhaseSpace d)).Regular := inferInstance
+  have hvolReg : (volume : Measure (PhaseSpace d)).Regular := inferInstance
   -- mollifier family (shrinking bumps); copy of #9's
   set φ : ℕ → ContDiffBump (0 : PhaseSpace d) :=
     fun n => ⟨1 / (n + 2), 2 / (n + 2), by positivity, by
@@ -3288,7 +3288,7 @@ theorem weakEvolution_test_C1c_On
   have hfg : ∀ σ ∈ Set.Ioo (0 : ℝ) T, Tendsto (fun n => ∫ z, χn n z ∂(f σ)) atTop
       (𝓝 (∫ z, χ z ∂(f σ))) := by
     intro σ hσ
-    haveI : IsProbabilityMeasure (f σ) := (hf_mom σ (Set.Ioo_subset_Icc_self hσ)).1
+    have : IsProbabilityMeasure (f σ) := (hf_mom σ (Set.Ioo_subset_Icc_self hσ)).1
     exact integral_tendsto_of_tendstoUniformly (f σ) χn χ
       (mollifier_tendstoUniformly χ hχ_C1.continuous hχc φ hrout_tendsto)
       (hχ_C1.continuous.integrable_of_hasCompactSupport hχc)
@@ -3377,7 +3377,7 @@ theorem weakEvolution_test_C1c_On
     filter_upwards [hH2 (ε/(C+1)) (by positivity)] with n hn
     intro σ hσ
     have hσ' : σ ∈ Set.Icc (0 : ℝ) T := Set.Ioo_subset_Icc_self hσ
-    haveI : IsProbabilityMeasure (f σ) := (hf_mom σ hσ').1
+    have : IsProbabilityMeasure (f σ) := (hf_mom σ hσ').1
     obtain ⟨_, _, hbnd, hfc⟩ := hfield_setup σ hσ'
     -- L15: make the field opaque so defeq never unfolds its Bochner integral
     set fldσ : PhysSpace d → PhysSpace d := convolveFunctionMeasure gradW (spatialMarginal (f σ))
@@ -3484,7 +3484,7 @@ theorem vlasovSolutionOn_integral_continuousOn
     exact IsCompact.of_isClosed_subset hK (isClosed_tsupport _) hsub
   have hGint : ∀ (a b : ℝ), b ∈ Set.Icc (0 : ℝ) T → Integrable (fun z => G a z) (f b) := by
     intro a b hb
-    haveI := (hf_mom b hb).1
+    have := (hf_mom b hb).1
     exact (hGs_cont a).integrable_of_hasCompactSupport (hGs_cs a)
   -- Uniform continuity of the uncurried G on the compact Icc 0 T ×ˢ K.
   have hC : IsCompact (Set.Icc (0 : ℝ) T ×ˢ K) := isCompact_Icc.prod hK
@@ -3502,7 +3502,7 @@ theorem vlasovSolutionOn_integral_continuousOn
   rw [Metric.continuousWithinAt_iff] at hterm2
   obtain ⟨δ₂, hδ₂, hδ₂_prop⟩ := hterm2 (ε/2) (by positivity)
   refine ⟨min δ₁ δ₂, lt_min hδ₁ hδ₂, fun s hs hsd => ?_⟩
-  haveI hp_s : IsProbabilityMeasure (f s) := (hf_mom s hs).1
+  have hp_s : IsProbabilityMeasure (f s) := (hf_mom s hs).1
   have hsd1 : dist s s₀ < δ₁ := lt_of_lt_of_le hsd (min_le_left _ _)
   have hsd2 : dist s s₀ < δ₂ := lt_of_lt_of_le hsd (min_le_right _ _)
   -- pointwise: |G s z - G s₀ z| ≤ ε/2 (uniform continuity on K; both zero off K)
@@ -3646,7 +3646,7 @@ lemma hasDerivAt_integral_sub_of_uniform_linearization
       ⟨(hab_sub ⟨le_of_lt hσab.1, le_of_lt hσab.2⟩).1.le,
         (hab_sub ⟨le_of_lt hσab.1, le_of_lt hσab.2⟩).2.le⟩
     have hσab' : σ ∈ Set.Icc a b := ⟨le_of_lt hσab.1, le_of_lt hσab.2⟩
-    haveI := (hf_mom σ hσIcc).1
+    have := (hf_mom σ hσIcc).1
     have hint : Integrable (fun z => ψ σ z - ψ s z - (σ - s) * D z) (f σ) :=
       ((hψr_int σ hσab' σ hσIcc).sub (hψr_int s
         ⟨le_of_lt hs_ab.1, le_of_lt hs_ab.2⟩ σ hσIcc)).sub ((hD_int σ hσIcc).const_mul _)
@@ -3679,7 +3679,7 @@ lemma hasDerivAt_integral_sub_of_uniform_linearization
     ⟨(hab_sub ⟨le_of_lt hσab.1, le_of_lt hσab.2⟩).1.le,
       (hab_sub ⟨le_of_lt hσab.1, le_of_lt hσab.2⟩).2.le⟩
   have hσab' : σ ∈ Set.Icc a b := ⟨le_of_lt hσab.1, le_of_lt hσab.2⟩
-  haveI := (hf_mom σ hσIcc).1
+  have := (hf_mom σ hσIcc).1
   have hi1 : Integrable (ψ σ) (f σ) := hψr_int σ hσab' σ hσIcc
   have hi2 : Integrable (ψ s) (f σ) := hψr_int s ⟨le_of_lt hs_ab.1, le_of_lt hs_ab.2⟩ σ hσIcc
   have hi3 : Integrable D (f σ) := hD_int σ hσIcc
@@ -3837,7 +3837,7 @@ theorem transportedIntegral_hasDerivAt_zero
       hK_compact.isClosed
   have hψr_int : ∀ r ∈ Set.Icc a b, ∀ σ ∈ Set.Icc (0 : ℝ) T, Integrable (ψ r) (f σ) := by
     intro r hr σ hσ
-    haveI := (hf_mom σ hσ).1
+    have := (hf_mom σ hσ).1
     exact (hψr_cont r (hab_sub hr)).integrable_of_hasCompactSupport (hψr_cs r hr)
   have hDQs_cont : Continuous (DQ s) :=
     hDQ_contOn.comp_continuous (continuous_const.prodMk continuous_id)
@@ -3849,7 +3849,7 @@ theorem transportedIntegral_hasDerivAt_zero
     exact (Function.mem_support.mp hz) (hDQ_zero z hzK)
   have hDQs_int : ∀ σ ∈ Set.Icc (0 : ℝ) T, Integrable (DQ s) (f σ) := by
     intro σ hσ
-    haveI := (hf_mom σ hσ).1
+    have := (hf_mom σ hσ).1
     exact hDQs_cont.integrable_of_hasCompactSupport hDQs_cs
   have hnarrow : ContinuousWithinAt (fun σ => ∫ z, DQ s z ∂(f σ)) (Set.Icc 0 T) s :=
     (hf_narrow (DQ s) hDQs_cont hDQs_cs) s ⟨hsIoo.1.le, hsIoo.2.le⟩
@@ -4315,8 +4315,8 @@ theorem frozenFlow_inverse_On
   have h_int_win : ∀ s ∈ Set.Icc (0 : ℝ) T, ∀ (x_pt : PhysSpace d),
       Integrable (fun y => gradW (x_pt - y)) (spatialMarginal (f s)) := by
     intro s hs x_pt
-    haveI : IsProbabilityMeasure (f s) := (hf_mom s hs).1
-    haveI : IsProbabilityMeasure (spatialMarginal (f s)) :=
+    have : IsProbabilityMeasure (f s) := (hf_mom s hs).1
+    have : IsProbabilityMeasure (spatialMarginal (f s)) :=
       Measure.isProbabilityMeasure_map measurable_fst.aemeasurable
     have h_aesm : AEStronglyMeasurable (fun y : PhysSpace d => gradW (x_pt - y))
         (spatialMarginal (f s)) :=
@@ -4362,9 +4362,9 @@ theorem frozenFlow_inverse_On
   have hclampT_cont : Continuous clampT := by
     simp only [hclampT_def]; exact continuous_const.max (continuous_id.min continuous_const)
   set ρ' : ℝ → Measure (PhysSpace d) := fun s => spatialMarginal (f (clampT s)) with hρ'_def
-  haveI hρ'_prob : ∀ s, IsProbabilityMeasure (ρ' s) := by
+  have hρ'_prob : ∀ s, IsProbabilityMeasure (ρ' s) := by
     intro s
-    haveI : IsProbabilityMeasure (f (clampT s)) := (hf_mom (clampT s) (hclampT_mem s)).1
+    have : IsProbabilityMeasure (f (clampT s)) := (hf_mom (clampT s) (hclampT_mem s)).1
     exact Measure.isProbabilityMeasure_map measurable_fst.aemeasurable
   have h_int' : ∀ s (x : PhysSpace d), Integrable (fun y => gradW (x - y)) (ρ' s) :=
     fun s x => h_int_win (clampT s) (hclampT_mem s) x
@@ -4436,9 +4436,9 @@ theorem dualCore_terminal
       ∫ z, φ z ∂(f t) = ∫ z, φ (charX t z, charV t z) ∂(f 0)) :
     ∫ z, φ z ∂(f T) = ∫ z, φ (charX T z, charV T z) ∂(f 0) := by
   classical
-  haveI : IsProbabilityMeasure (f 0) := (hf_mom 0 ⟨le_refl 0, hT.le⟩).1
+  have : IsProbabilityMeasure (f 0) := (hf_mom 0 ⟨le_refl 0, hT.le⟩).1
   -- the limit filter, nonempty since T is a left limit point of Ioo 0 T
-  haveI hl_neBot : (𝓝[Set.Ioo (0 : ℝ) T] T).NeBot := by
+  have hl_neBot : (𝓝[Set.Ioo (0 : ℝ) T] T).NeBot := by
     apply mem_closure_iff_nhdsWithin_neBot.mp
     rw [closure_Ioo (ne_of_lt hT)]
     exact ⟨hT.le, le_refl T⟩
@@ -4611,7 +4611,7 @@ theorem weak_eq_frozenField_pushforward_On
   have h_y_int : ∀ t ∈ Set.Icc (0 : ℝ) T,
       Integrable (fun y : PhysSpace d => ‖y‖) (spatialMarginal (f t)) := by
     intro t ht
-    haveI : IsProbabilityMeasure (f t) := (hf_mom t ht).1
+    have : IsProbabilityMeasure (f t) := (hf_mom t ht).1
     unfold spatialMarginal
     rw [integrable_map_measure
         (by exact (continuous_norm.measurable).aestronglyMeasurable)
@@ -4625,8 +4625,8 @@ theorem weak_eq_frozenField_pushforward_On
   have h_int_window : ∀ t ∈ Set.Icc (0 : ℝ) T, ∀ (x_pt : PhysSpace d),
       Integrable (fun y => gradW (x_pt - y)) (spatialMarginal (f t)) := by
     intro t ht x_pt
-    haveI : IsProbabilityMeasure (f t) := (hf_mom t ht).1
-    haveI : IsProbabilityMeasure (spatialMarginal (f t)) :=
+    have : IsProbabilityMeasure (f t) := (hf_mom t ht).1
+    have : IsProbabilityMeasure (spatialMarginal (f t)) :=
       Measure.isProbabilityMeasure_map measurable_fst.aemeasurable
     have h_aesm : AEStronglyMeasurable (fun y : PhysSpace d => gradW (x_pt - y))
         (spatialMarginal (f t)) :=
@@ -4654,9 +4654,9 @@ theorem weak_eq_frozenField_pushforward_On
     exact h_dom_int.mono' h_aesm (Filter.Eventually.of_forall fun y => h_dom y)
   -- Clamped curve `ρ'` with the universal probability instance + force integrability.
   set ρ' : ℝ → Measure (PhysSpace d) := fun t => spatialMarginal (f (clampT t)) with hρ'_def
-  haveI hρ'_prob : ∀ t, IsProbabilityMeasure (ρ' t) := by
+  have hρ'_prob : ∀ t, IsProbabilityMeasure (ρ' t) := by
     intro t
-    haveI : IsProbabilityMeasure (f (clampT t)) := (hf_mom (clampT t) (hclampT_mem t)).1
+    have : IsProbabilityMeasure (f (clampT t)) := (hf_mom (clampT t) (hclampT_mem t)).1
     exact Measure.isProbabilityMeasure_map measurable_fst.aemeasurable
   have h_int' : ∀ t (x : PhysSpace d), Integrable (fun y => gradW (x - y)) (ρ' t) :=
     fun t x => h_int_window (clampT t) (hclampT_mem t) x
@@ -4679,11 +4679,11 @@ theorem weak_eq_frozenField_pushforward_On
       hinit hcontIcc h_deriv_Ioo'
   -- Main reduction: `#9` + `integral_map` ⟹ the dual-transport core.
   intro t ht
-  haveI hft_prob : IsProbabilityMeasure (f t) := (hf_mom t ht).1
-  haveI hf0_prob : IsProbabilityMeasure (f 0) := (hf_mom 0 ⟨le_refl 0, hT.le⟩).1
+  have hft_prob : IsProbabilityMeasure (f t) := (hf_mom t ht).1
+  have hf0_prob : IsProbabilityMeasure (f 0) := (hf_mom 0 ⟨le_refl 0, hT.le⟩).1
   have hΦt_aem : AEMeasurable (fun z : PhaseSpace d => (charX t z, charV t z)) (f 0) :=
     (hΦ_meas t ht).aemeasurable
-  haveI hmap_prob :
+  have hmap_prob :
       IsProbabilityMeasure (Measure.map (fun z : PhaseSpace d => (charX t z, charV t z)) (f 0)) :=
     Measure.isProbabilityMeasure_map hΦt_aem
   refine measure_eq_of_forall_Cc_integral_eq (fun φ hφ hφc => ?_)
@@ -4734,12 +4734,12 @@ theorem weak_isLagrangianVlasovSolutionOn
   -- Frozen field `ρ^f := spatialMarginal ∘ f`: discharge the flow-construction hypotheses of #2.
   have hρ_prob : ∀ t ∈ Set.Icc (0 : ℝ) T, IsProbabilityMeasure (spatialMarginal (f t)) := by
     intro t ht
-    haveI : IsProbabilityMeasure (f t) := (hf_mom t ht).1
+    have : IsProbabilityMeasure (f t) := (hf_mom t ht).1
     exact Measure.isProbabilityMeasure_map measurable_fst.aemeasurable
   have h_y_int : ∀ t ∈ Set.Icc (0 : ℝ) T,
       Integrable (fun y : PhysSpace d => ‖y‖) (spatialMarginal (f t)) := by
     intro t ht
-    haveI : IsProbabilityMeasure (f t) := (hf_mom t ht).1
+    have : IsProbabilityMeasure (f t) := (hf_mom t ht).1
     unfold spatialMarginal
     rw [integrable_map_measure
         (by exact (continuous_norm.measurable).aestronglyMeasurable)
@@ -4752,8 +4752,8 @@ theorem weak_isLagrangianVlasovSolutionOn
   have h_int : ∀ t ∈ Set.Icc (0 : ℝ) T, ∀ (x_pt : PhysSpace d),
       Integrable (fun y => gradW (x_pt - y)) (spatialMarginal (f t)) := by
     intro t ht x_pt
-    haveI : IsProbabilityMeasure (f t) := (hf_mom t ht).1
-    haveI : IsProbabilityMeasure (spatialMarginal (f t)) :=
+    have : IsProbabilityMeasure (f t) := (hf_mom t ht).1
+    have : IsProbabilityMeasure (spatialMarginal (f t)) :=
       Measure.isProbabilityMeasure_map measurable_fst.aemeasurable
     have h_aesm : AEStronglyMeasurable (fun y : PhysSpace d => gradW (x_pt - y))
         (spatialMarginal (f t)) :=
@@ -4797,7 +4797,7 @@ theorem weak_isLagrangianVlasovSolutionOn
   -- AEMeasurability of the flow at each window time, from the pushforward identity: a
   -- non-measurable map would force `Measure.map _ (f 0) = 0 ≠ f s` (the latter a probability).
   intro s hs
-  haveI hfs_prob : IsProbabilityMeasure (f s) := (hf_mom s hs).1
+  have hfs_prob : IsProbabilityMeasure (f s) := (hf_mom s hs).1
   by_contra hcon
   have h0 : f s = 0 := by
     rw [hpush s hs]; exact Measure.map_of_not_aemeasurable hcon

--- a/LeanPool/Vlasov/OT/WellPosedness.lean
+++ b/LeanPool/Vlasov/OT/WellPosedness.lean
@@ -111,7 +111,7 @@ private lemma envelopeStep_contractionInputs {d : ℕ} [NeZero d]
       HasDerivWithinAt (fun s' => (cX s' z, cV s' z))
         (vlasovVectorField gradW (ν.extend) s (cX s z, cV s z))
         (Set.Ici s) s) := by
-  haveI : ∀ t, IsProbabilityMeasure (ν.extend t) := VlasovMeasureCurve.extend_isProb ν
+  have : ∀ t, IsProbabilityMeasure (ν.extend t) := VlasovMeasureCurve.extend_isProb ν
   obtain ⟨h_init, h_cont, h_deriv⟩ :=
     characteristicFlow_boundary_regularity gradW ν.extend cX cV T hT hflow hbdry
   have h_meas : ∀ t ∈ Set.Icc (0 : ℝ) T,
@@ -252,7 +252,7 @@ private lemma vlasovWellPosedness_local_picard_sequence
       Phi_step_envelope W gradW hgradW L hL f₀ hf₀_int hT.le m hm_mono hm_nn hm_inv hTL_PL
         ν (h_int_ext_gen ν)
     exact ⟨σ, cX, cV, hσ, hflow, hbdry⟩
-  haveI hμ₀_prob_inst : IsProbabilityMeasure (spatialMarginal f₀) := hμ₀_prob
+  have hμ₀_prob_inst : IsProbabilityMeasure (spatialMarginal f₀) := hμ₀_prob
   let base : VlasovMeasureCurve d T m := constantCurve (spatialMarginal f₀) hμ₀_int hμ₀_le_m
   let x : ℕ → VlasovMeasureCurve d T m :=
     fun n => Nat.rec base (fun _ ν => Classical.choose (step ν)) n
@@ -333,7 +333,7 @@ private lemma vlasovWellPosedness_local_picard_sequence
           wasserstein1 ((x k).extend s) ((x (k+1)).extend s) ≠ ⊤ := by
         intro s hs
         rw [he (x k) s hs, he (x (k+1)) s hs]
-        haveI := (x k).isProb s; haveI := (x (k+1)).isProb s
+        have := (x k).isProb s; have := (x (k+1)).isProb s
         exact wasserstein1_ne_top_of_finite_moment _ _
           ((x k).yIntegrable s hs) ((x (k+1)).yIntegrable s hs)
       have h_W1_bound : ∀ s ∈ Set.Icc (0 : ℝ) T,
@@ -344,7 +344,7 @@ private lemma vlasovWellPosedness_local_picard_sequence
             ≤ ENNReal.ofReal D :=
           le_trans (wasserstein1_le_supW1On _ _ _ s hs) ih
         have h_ne : wasserstein1 ((x k).ρ s) ((x (k+1)).ρ s) ≠ ⊤ := by
-          haveI := (x k).isProb s; haveI := (x (k+1)).isProb s
+          have := (x k).isProb s; have := (x (k+1)).isProb s
           exact wasserstein1_ne_top_of_finite_moment _ _
             ((x k).yIntegrable s hs) ((x (k+1)).yIntegrable s hs)
         calc (wasserstein1 ((x k).ρ s) ((x (k+1)).ρ s)).toReal
@@ -478,8 +478,8 @@ private lemma picardLimit_fixed_point_eq
                     (Measure.map (fun z => charX t z) f₀)).toReal ≤ Dn n * q) :
     ∀ t ∈ Set.Icc (0 : ℝ) T, ρl.ρ t = Measure.map (fun z => charX t z) f₀ := by
   intro t ht
-  haveI hP1 : IsProbabilityMeasure (ρl.ρ t) := ρl.isProb t
-  haveI hP2 : IsProbabilityMeasure (Measure.map (fun z => charX t z) f₀) :=
+  have hP1 : IsProbabilityMeasure (ρl.ρ t) := ρl.isProb t
+  have hP2 : IsProbabilityMeasure (Measure.map (fun z => charX t z) f₀) :=
     Measure.isProbabilityMeasure_map (h_aem_lim t ht)
   refine (wasserstein1_eq_zero_iff_measure_eq (ρl.ρ t)
     (Measure.map (fun z => charX t z) f₀)).mp ?_
@@ -499,7 +499,7 @@ private lemma picardLimit_fixed_point_eq
           rw [h_mid]
           have h_fin : wasserstein1 (Measure.map (fun z => charXs n t z) f₀)
               (Measure.map (fun z => charX t z) f₀) ≠ ⊤ := by
-            haveI : IsProbabilityMeasure (Measure.map (fun z => charXs n t z) f₀) :=
+            have : IsProbabilityMeasure (Measure.map (fun z => charXs n t z) f₀) :=
               Measure.isProbabilityMeasure_map (h_aem_n n t ht)
             exact wasserstein1_ne_top_of_finite_moment _ _
               (h_mom_n n t ht) (h_mom_lim t ht)
@@ -635,7 +635,7 @@ private lemma picardFlow_clamp_bundle
     exact VlasovMeasureCurve.extend_yIntegrable hT.le ρ_lim s
   · intro s
     rw [h_rho_clamp s]
-    haveI : IsProbabilityMeasure (ρ_lim.extend (clampToIcc T s)) :=
+    have : IsProbabilityMeasure (ρ_lim.extend (clampToIcc T s)) :=
       VlasovMeasureCurve.extend_isProb ρ_lim (clampToIcc T s)
     exact (convolveFunctionMeasure_lipschitz_in_x gradW L hL
       (ρ_lim.extend (clampToIcc T s)) (h_int_ρ_lim (clampToIcc T s))).continuous
@@ -752,7 +752,7 @@ private lemma picardLimit_self_consistency
       wasserstein1 ((x n).extend s) (ρ_lim.extend s) ≠ ⊤ := by
     intro n s hs
     rw [he (x n) s hs, he ρ_lim s hs]
-    haveI := (x n).isProb s; haveI := ρ_lim.isProb s
+    have := (x n).isProb s; have := ρ_lim.isProb s
     exact wasserstein1_ne_top_of_finite_moment _ _
       ((x n).yIntegrable s hs) (ρ_lim.yIntegrable s hs)
   have h_W1_bound_curve : ∀ n, ∀ s ∈ Set.Icc (0 : ℝ) T,
@@ -1120,7 +1120,7 @@ theorem vlasovWellPosedness_local_moment
   -- spatialMarginal μ = Measure.map Prod.fst μ, so IsProbabilityMeasure_map needs
   -- AEMeasurable Prod.fst (Measure.map ... f₀). Since Prod.fst is measurable,
   -- it is AEMeasurable wrt any measure.
-  haveI hρ_prob : ∀ s, IsProbabilityMeasure
+  have hρ_prob : ∀ s, IsProbabilityMeasure
       (spatialMarginal (vlasovSolutionViaPushforward charX charV f₀ s)) := by
     intro s
     unfold spatialMarginal vlasovSolutionViaPushforward
@@ -1241,7 +1241,7 @@ theorem vlasovWellPosedness_local_isLagrangian
     IsLagrangianVlasovSolutionOn gradW
       (vlasovSolutionViaPushforward charX charV f₀) T := by
   -- IsProbabilityMeasure for the spatial marginal (needed for the target typeclass).
-  haveI hρ_prob : ∀ s, IsProbabilityMeasure
+  have hρ_prob : ∀ s, IsProbabilityMeasure
       (spatialMarginal (vlasovSolutionViaPushforward charX charV f₀ s)) := by
     intro s
     unfold spatialMarginal vlasovSolutionViaPushforward
@@ -1393,7 +1393,7 @@ theorem vlasovWellPosedness_local
   --     `vlasovSolutionViaPushforward_isLagrangianVlasovSolutionOn`.
   --   * This body invokes both, derives `f 0 = f₀` inline, and assembles.
   obtain ⟨hf₀_prob, hf₀_int⟩ := hf₀
-  haveI : IsProbabilityMeasure f₀ := hf₀_prob
+  have : IsProbabilityMeasure f₀ := hf₀_prob
   -- Sub-helper invocation: produces the self-consistent flow + regularity
   -- + AEMeasurable witness + universal-in-s convolution integrability.
   obtain ⟨charX, charV, _M_ρ, _hM_ρ_nn, _hflow_on, _h_boundary,
@@ -2070,8 +2070,8 @@ private lemma dobrushinFlow_marginal_gradW_integrable
     ∀ t ∈ Set.Icc (0 : ℝ) T, ∀ (x_pt : PhysSpace d),
       Integrable (fun y => gradW (x_pt - y)) (spatialMarginal (μ t)) := by
   intro t ht x_pt
-  haveI : IsProbabilityMeasure (μ t) := (hμ_mom t ht).1
-  haveI : IsProbabilityMeasure (spatialMarginal (μ t)) :=
+  have : IsProbabilityMeasure (μ t) := (hμ_mom t ht).1
+  have : IsProbabilityMeasure (spatialMarginal (μ t)) :=
     Measure.isProbabilityMeasure_map measurable_fst.aemeasurable
   have h_y_int : Integrable (fun y : PhysSpace d => ‖y‖) (spatialMarginal (μ t)) := by
     unfold spatialMarginal
@@ -2091,7 +2091,7 @@ private lemma vlasovGlue_marginal_norm_integrable
     {d : ℕ} [NeZero d]
     (μ : Measure (PhaseSpace d)) (hμ : HasFiniteFirstMoment μ) :
     Integrable (fun y : PhysSpace d => ‖y‖) (spatialMarginal μ) := by
-  haveI : IsProbabilityMeasure μ := hμ.1
+  have : IsProbabilityMeasure μ := hμ.1
   unfold spatialMarginal
   rw [integrable_map_measure
     (by exact (continuous_norm.measurable).aestronglyMeasurable)
@@ -2296,9 +2296,9 @@ private lemma vlasovGlue_flow_growthBound
     simp only [hclampT_def, min_eq_left ht.2, max_eq_right ht.1]
   set ρc : ℝ → Measure (PhysSpace d) :=
     fun t => spatialMarginal (μ (clampT t)) with hρc_def
-  haveI hρc_isProb : ∀ t, IsProbabilityMeasure (ρc t) := by
+  have hρc_isProb : ∀ t, IsProbabilityMeasure (ρc t) := by
     intro t
-    haveI : IsProbabilityMeasure (μ (clampT t)) :=
+    have : IsProbabilityMeasure (μ (clampT t)) :=
       (hμ_mom (clampT t) (hclampT_mem t)).1
     exact Measure.isProbabilityMeasure_map measurable_fst.aemeasurable
   have hM_ρ : ∀ t ∈ Set.Icc (0 : ℝ) T, ∫ y, ‖y‖ ∂(ρc t) ≤ M := by
@@ -2398,7 +2398,7 @@ private lemma vlasovGlue_seam_forceIntegral_cont
       ‖convolveFunctionMeasure gradW (ρ s) x‖
         ≤ ‖gradW 0‖ + (L : ℝ) * ‖x‖ + (L : ℝ) * M := by
     intro s hs x
-    haveI := hρ_prob s hs
+    have := hρ_prob s hs
     exact vlasovGlue_conv_force_bound gradW L hL (ρ s) M (hM s hs)
       (h_y_int s hs) (h_int s hs) x
   have hB : ∀ s ∈ W, ∀ z : PhaseSpace d,
@@ -2462,7 +2462,7 @@ private lemma vlasovGlue_seam_forceIntegral_cont
           (fun z : PhaseSpace d => convolveFunctionMeasure gradW (ρ s) (X s z)) f₀ := by
         have hconv_cont' : Continuous (fun x : PhysSpace d =>
             convolveFunctionMeasure gradW (ρ s) x) := by
-          haveI := hρ_prob s hs
+          have := hρ_prob s hs
           exact (convolveFunctionMeasure_lipschitz_in_x gradW L hL
             (ρ s) (h_int s hs)).continuous
         exact hconv_cont'.measurable.comp_aemeasurable h_aem_X
@@ -2580,8 +2580,8 @@ private lemma vlasovGlue_seam_contLeft
       Continuous (fun z : PhaseSpace d =>
         convolveFunctionMeasure gradW (spatialMarginal (f_prev s)) z.1) := by
     intro s hs
-    haveI : IsProbabilityMeasure (f_prev s) := (h_prev_mom s hs).1
-    haveI : IsProbabilityMeasure (spatialMarginal (f_prev s)) :=
+    have : IsProbabilityMeasure (f_prev s) := (h_prev_mom s hs).1
+    have : IsProbabilityMeasure (spatialMarginal (f_prev s)) :=
       Measure.isProbabilityMeasure_map measurable_fst.aemeasurable
     exact (convolveFunctionMeasure_lipschitz_in_x gradW L hL
       (spatialMarginal (f_prev s)) (h_int_marg s hs)).continuous.comp continuous_fst
@@ -2661,7 +2661,7 @@ private lemma vlasovGlue_seam_contLeft
       (fun s => spatialMarginal (f_prev s)) charX_prev charV_prev
       T (Set.Iic T) (Set.Icc 0 T) h_nhd_L
       (fun s hs => by
-        haveI : IsProbabilityMeasure (f_prev s) := (h_prev_mom s hs).1
+        have : IsProbabilityMeasure (f_prev s) := (h_prev_mom s hs).1
         exact Measure.isProbabilityMeasure_map measurable_fst.aemeasurable)
       M_ρ hM_ρ h_y_int_marg h_int_marg C_T hC_T_pair
       (fun s hs => h_prev_init ▸ h_prev_aemeas s hs)
@@ -3019,8 +3019,8 @@ private lemma vlasovGlue_seam_contRight
       Continuous (fun z : PhaseSpace d =>
         convolveFunctionMeasure gradW (spatialMarginal (g τ)) z.1) := by
     intro τ hτ
-    haveI : IsProbabilityMeasure (g τ) := (hg_mom τ hτ).1
-    haveI : IsProbabilityMeasure (spatialMarginal (g τ)) :=
+    have : IsProbabilityMeasure (g τ) := (hg_mom τ hτ).1
+    have : IsProbabilityMeasure (spatialMarginal (g τ)) :=
       Measure.isProbabilityMeasure_map measurable_fst.aemeasurable
     exact (convolveFunctionMeasure_lipschitz_in_x gradW L hL
       (spatialMarginal (g τ)) (h_int_marg_g τ hτ)).continuous.comp continuous_fst
@@ -3083,7 +3083,7 @@ private lemma vlasovGlue_seam_contRight
       (fun s hs => by
         have hsT_Icc : s - T ∈ Set.Icc (0 : ℝ) T_0 :=
           ⟨by linarith [hs.1], by linarith [hs.2]⟩
-        haveI : IsProbabilityMeasure (g (s - T)) := (hg_mom (s - T) hsT_Icc).1
+        have : IsProbabilityMeasure (g (s - T)) := (hg_mom (s - T) hsT_Icc).1
         exact Measure.isProbabilityMeasure_map measurable_fst.aemeasurable)
       M_g
       (fun s hs => hM_g_bd (s - T) ⟨by linarith [hs.1], by linarith [hs.2]⟩)
@@ -3939,7 +3939,7 @@ theorem vlasovWellPosedness_glue
             have hφ_cont : Continuous φ := hφ_smooth.continuous
             obtain ⟨Cφ, hCφ⟩ := hφ_cont.bounded_above_of_compact_support hφ_compact
             obtain ⟨hf₀_prob, hf₀_int⟩ := hf₀
-            haveI : IsProbabilityMeasure f₀ := hf₀_prob
+            have : IsProbabilityMeasure f₀ := hf₀_prob
             -- LEFT side: substantive close via DCT on f_prev's pushforward.
             have h_cont_f_left : ContinuousWithinAt (fun s => ∫ z, φ z ∂f_next s)
                 (Set.Iic T) T :=
@@ -4556,7 +4556,7 @@ private lemma dobrushinFlow_field_continuous
       dist z₁ z₂ * Real.exp (((K : NNReal) : ℝ) * (s - 0))) :
     ∀ ω, Continuous (fun s => b s (X s ω)) := by
   intro ω
-  haveI := hν_prob
+  have := hν_prob
   set EKT : ℝ := Real.exp (((K : NNReal) : ℝ) * T) with hEKT_def
   have hΦnorm : ∀ s : ℝ, ∀ z : PhaseSpace d,
       ‖(charX (clampT s) z, charV (clampT s) z)‖ ≤ EKT * ‖z‖ + Kc := by
@@ -4903,8 +4903,8 @@ private lemma dobrushinFlow_cross_field_bound
       ‖b_f s (X_g s ω) - b_g s (X_g s ω)‖ ≤
         ((max 1 L : NNReal) : ℝ) * ∫ ω', ‖X_f s ω' - X_g s ω'‖ ∂π₀ := by
   intro ω s hs
-  haveI : IsProbabilityMeasure (f s) := (hf_mom s hs).1
-  haveI : IsProbabilityMeasure (g s) := (hg_mom s hs).1
+  have : IsProbabilityMeasure (f s) := (hf_mom s hs).1
+  have : IsProbabilityMeasure (g s) := (hg_mom s hs).1
   have hL_le_max : (L : ℝ) ≤ ((max 1 L : NNReal) : ℝ) := by
     rw [NNReal.coe_max, NNReal.coe_one]; exact le_max_right _ _
   set x : PhysSpace d := (X_g s ω).1 with hx_def
@@ -5172,8 +5172,8 @@ private theorem dobrushin_integrated_flow_bound_On
     fun t ht => (hf_mom t ht).1
   have hg_isProb : ∀ t ∈ Set.Icc (0 : ℝ) T, IsProbabilityMeasure (g t) :=
     fun t ht => (hg_mom t ht).1
-  haveI hf0_prob : IsProbabilityMeasure (f 0) := (hf_mom 0 ⟨le_refl 0, hT.le⟩).1
-  haveI hg0_prob : IsProbabilityMeasure (g 0) := (hg_mom 0 ⟨le_refl 0, hT.le⟩).1
+  have hf0_prob : IsProbabilityMeasure (f 0) := (hf_mom 0 ⟨le_refl 0, hT.le⟩).1
+  have hg0_prob : IsProbabilityMeasure (g 0) := (hg_mom 0 ⟨le_refl 0, hT.le⟩).1
   -- Clamp into [0, T].
   set clampT : ℝ → ℝ := (fun s => max 0 (min s T)) with hclampT_def
   have hclampT_mem : ∀ s, clampT s ∈ Set.Icc (0 : ℝ) T := by
@@ -5203,11 +5203,11 @@ private theorem dobrushin_integrated_flow_bound_On
   have hgc_int : ∀ s (x : PhysSpace d),
       Integrable (fun y => gradW (x - y)) (spatialMarginal (g (clampT s))) :=
     fun s x => h_int_g (clampT s) (hclampT_mem s) x
-  haveI hfc_isProb : ∀ s, IsProbabilityMeasure (spatialMarginal (f (clampT s))) := by
-    intro s; haveI := hf_isProb (clampT s) (hclampT_mem s)
+  have hfc_isProb : ∀ s, IsProbabilityMeasure (spatialMarginal (f (clampT s))) := by
+    intro s; have := hf_isProb (clampT s) (hclampT_mem s)
     exact Measure.isProbabilityMeasure_map measurable_fst.aemeasurable
-  haveI hgc_isProb : ∀ s, IsProbabilityMeasure (spatialMarginal (g (clampT s))) := by
-    intro s; haveI := hg_isProb (clampT s) (hclampT_mem s)
+  have hgc_isProb : ∀ s, IsProbabilityMeasure (spatialMarginal (g (clampT s))) := by
+    intro s; have := hg_isProb (clampT s) (hclampT_mem s)
     exact Measure.isProbabilityMeasure_map measurable_fst.aemeasurable
   -- Universal (max 1 L)-Lipschitz of the clamped vector fields.
   have hL_f : ∀ s, LipschitzWith (max 1 L) (b_f s) := fun s =>
@@ -5424,7 +5424,7 @@ private theorem dobrushin_uniqueness_On
   -- Then the RHS base integral `∫ ‖id ω − id ω‖ = 0`, so the integrated bound
   -- forces `Φ_f t = Φ_g t` `f 0`-a.e., hence
   -- `f t = (Φ_f t)_# (f 0) = (Φ_g t)_# (f 0) = g t`.
-  haveI hf0_prob : IsProbabilityMeasure (f 0) := (hf_mom 0 ⟨le_refl 0, hT.le⟩).1
+  have hf0_prob : IsProbabilityMeasure (f 0) := (hf_mom 0 ⟨le_refl 0, hT.le⟩).1
   obtain ⟨_, charX_f, charV_f, hflow_f, hpush_f, haem_f, hcontIcc_f⟩ := hf
   obtain ⟨_, charX_g, charV_g, hflow_g, hpush_g, haem_g, hcontIcc_g⟩ := hg
   obtain ⟨hinit_f, hflow_f_x, hflow_f_v⟩ := hflow_f
@@ -5496,15 +5496,15 @@ private theorem dobrushin_meanfield_On
       wasserstein1 (f t) (g t)
         ≤ ENNReal.ofReal (Real.exp (2 * ((max 1 L : NNReal) : ℝ) * t))
             * wasserstein1Coupling (f 0) (g 0) := by
-  haveI hf0_prob : IsProbabilityMeasure (f 0) := (hf_mom 0 ⟨le_refl 0, hT.le⟩).1
-  haveI hg0_prob : IsProbabilityMeasure (g 0) := (hg_mom 0 ⟨le_refl 0, hT.le⟩).1
+  have hf0_prob : IsProbabilityMeasure (f 0) := (hf_mom 0 ⟨le_refl 0, hT.le⟩).1
+  have hg0_prob : IsProbabilityMeasure (g 0) := (hg_mom 0 ⟨le_refl 0, hT.le⟩).1
   obtain ⟨_, charX_f, charV_f, hflow_f, hpush_f, haem_f, hcontIcc_f⟩ := hf
   obtain ⟨_, charX_g, charV_g, hflow_g, hpush_g, haem_g, hcontIcc_g⟩ := hg
   obtain ⟨hinit_f, hflow_f_x, hflow_f_v⟩ := hflow_f
   obtain ⟨hinit_g, hflow_g_x, hflow_g_v⟩ := hflow_g
   intro t ht
-  haveI hft_prob : IsProbabilityMeasure (f t) := (hf_mom t ht).1
-  haveI hgt_prob : IsProbabilityMeasure (g t) := (hg_mom t ht).1
+  have hft_prob : IsProbabilityMeasure (f t) := (hf_mom t ht).1
+  have hgt_prob : IsProbabilityMeasure (g t) := (hg_mom t ht).1
   have hft : Measure.map (fun z => (charX_f t z, charV_f t z)) (f 0) = f t :=
     (hpush_f t ht).symm
   have hgt : Measure.map (fun z => (charX_g t z, charV_g t z)) (g 0) = g t :=
@@ -5525,7 +5525,7 @@ private theorem dobrushin_meanfield_On
         ≤ ENNReal.ofReal (Real.exp (2 * ((max 1 L : NNReal) : ℝ) * t))
             * ∫⁻ z, edist z.1 z.2 ∂π := by
     intro π hπ
-    haveI hπ_prob : IsProbabilityMeasure π := by
+    have hπ_prob : IsProbabilityMeasure π := by
       constructor
       have hmap : (Measure.map Prod.fst π) Set.univ = (1 : ENNReal) := by
         rw [hπ.1, measure_univ]
@@ -5869,7 +5869,7 @@ theorem vlasovWellPosedness_universal_existence
     intro g hg_cont hg_bdd
     -- Extract probability measure structure from hf₀
     obtain ⟨hf₀_prob, hf₀_int⟩ := hf₀
-    haveI hf₀_prob_inst : IsProbabilityMeasure f₀ := hf₀_prob
+    have hf₀_prob_inst : IsProbabilityMeasure f₀ := hf₀_prob
     -- Extract a uniform bound C for g from the bounded-range hypothesis
     obtain ⟨C, hg_range⟩ := hg_bdd.subset_closedBall (0 : ℝ)
     -- C is a non-negative bound: ∀ z, ‖g z‖ ≤ C
@@ -5980,7 +5980,7 @@ private lemma vlasovWellPosedness_zeroForce_solutionOn {d : ℕ} [NeZero d]
     (T : ℝ) (hT : 0 < T) :
     IsLagrangianVlasovSolutionOn gradW f_sol T := by
   subst hf_sol
-  haveI := hf₀.1
+  have := hf₀.1
   let charX : ℝ → PhaseSpace d → PhysSpace d := fun t z => z.1 + t • z.2
   let charV : ℝ → PhaseSpace d → PhysSpace d := fun _ z => z.2
   have hconv_zero : ∀ (ρ : Measure (PhysSpace d)) (x : PhysSpace d),
@@ -6035,7 +6035,7 @@ private lemma vlasovWellPosedness_zeroForce_solutionOn {d : ℕ} [NeZero d]
     have h_zero : (fun y : PhysSpace d => gradW (x - y)) = fun _ => (0 : PhysSpace d) := by
       funext y; exact hgradW_zero (x - y)
     rw [h_zero]; exact integrable_zero _ _ _
-  haveI hspatial_prob : ∀ s, IsProbabilityMeasure
+  have hspatial_prob : ∀ s, IsProbabilityMeasure
       (spatialMarginal (vlasovSolutionViaPushforward charX charV f₀ s)) := by
     intro s
     unfold spatialMarginal vlasovSolutionViaPushforward
@@ -6207,11 +6207,11 @@ theorem vlasovWellPosedness
       intro t
       constructor
       · -- IsProbabilityMeasure: pushforward of a probability measure under measurable map.
-        haveI := hf₀.1
+        have := hf₀.1
         apply Measure.isProbabilityMeasure_map
         fun_prop
       · -- Integrable ‖·‖: reduce to f₀ via integral_map, then bound by (1+|t|)·‖z‖.
-        haveI := hf₀.1
+        have := hf₀.1
         rw [integrable_map_measure (by fun_prop) (by fun_prop)]
         apply Integrable.mono' (hf₀.2.const_mul (1 + |t|))
         · fun_prop
@@ -6246,7 +6246,7 @@ theorem vlasovWellPosedness
         rw [integral_map (by fun_prop) (by fun_prop)]
       simp_rw [h_rw]
       -- Apply continuous_of_dominated.
-      haveI := hf₀.1
+      have := hf₀.1
       apply continuous_of_dominated
       · intro t; exact (hg_cont.comp (by fun_prop)).aestronglyMeasurable
       · intro t; apply Filter.Eventually.of_forall; intro z
@@ -6352,8 +6352,8 @@ theorem dobrushin
   obtain ⟨C, hC_pos, hC_bound⟩ :=
     dobrushin_package_exists W gradW hgradW L hL f g hf hg hf_prob hg_prob
   refine ⟨C, hC_pos, fun t ht => ?_⟩
-  haveI : IsProbabilityMeasure (f 0) := (hf_prob 0).1
-  haveI : IsProbabilityMeasure (g 0) := (hg_prob 0).1
+  have : IsProbabilityMeasure (f 0) := (hf_prob 0).1
+  have : IsProbabilityMeasure (g 0) := (hg_prob 0).1
   have hfm0 : Integrable (fun y => dist y (0 : PhaseSpace d)) (f 0) := by
     simpa only [dist_zero_right] using (hf_prob 0).2
   have hgm0 : Integrable (fun y => dist y (0 : PhaseSpace d)) (g 0) := by
@@ -6387,8 +6387,8 @@ theorem dobrushin_on
           wasserstein1 (f 0) (g 0) := by
   intro t ht
   have h0 : (0 : ℝ) ∈ Set.Icc (0 : ℝ) T := ⟨le_refl 0, hT.le⟩
-  haveI : IsProbabilityMeasure (f 0) := (hf_mom 0 h0).1
-  haveI : IsProbabilityMeasure (g 0) := (hg_mom 0 h0).1
+  have : IsProbabilityMeasure (f 0) := (hf_mom 0 h0).1
+  have : IsProbabilityMeasure (g 0) := (hg_mom 0 h0).1
   have hfm0 : Integrable (fun y => dist y (0 : PhaseSpace d)) (f 0) := by
     simpa only [dist_zero_right] using (hf_mom 0 h0).2
   have hgm0 : Integrable (fun y => dist y (0 : PhaseSpace d)) (g 0) := by


### PR DESCRIPTION
## Summary

Main's `Lean Action CI` has been red since the v4.33.0-rc2 bump (#326) merged: the bump landed right after the Vlasov follow-ups (#332), and while each PR passed CI on its own, the combination trips the rc2 toolchain's new lints. Build shards 08 and 09 fail the warning-free gate with 136 warnings, and everything downstream is skipped.

This PR clears all of them (content-only, no gate/config changes):

- **`haveI` → `have` at the 131 flagged positions** (`linter.style.haveILetI`: the goal is a proposition, so `have` is preferred) — 130 across `LeanPool/Vlasov/{Basic,OT/Coupling,OT/CharacteristicFlow,OT/WeakToLagrangian,OT/WellPosedness}.lean`, 1 in `LeanPool/Erdos865/FoldedAux.lean`. Replacements were applied at the exact linter-reported positions only; other `haveI` uses are untouched.
- **Deprecation renames in `LeanPool/Vlasov/OT/Coupling.lean`**: `Set.setOf_forall` → `Set.ofPred_forall` (4 uses), `Set.mem_setOf_eq` → `Set.mem_ofPred_eq` (1 use).

## Verification

- `lake build LeanPool.Erdos865 LeanPool.Vlasov` succeeds locally on rc2 (3132 jobs, fresh worktree).
- The CI gate's exact check, `grep -nE '(^|: )warning:' <build log>`, finds nothing.
- No line exceeds the 100-char style cap; the diff is pure token replacement (133 insertions, 133 deletions).

Note: the `Documentation` run on the same main commit failed separately — the site built fine but the Pages deployment sat in `deployment_queued` past `actions/deploy-pages`' 10-minute polling timeout. That looks transient; merging this will retrigger it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)