### PR TITLE
Challenge: degree six for the three largest distances in convex position (Erdős Problem 132, k = 3)

### DIFF
--- a/Challenge.lean
+++ b/Challenge.lean
@@ -1,3 +1,4 @@
+import Challenge.Erdos132ConvexK3Degree
 import Challenge.Mazur
 import Challenge.McKay
 import Challenge.Odlyzko

--- a/Challenge/Erdos132ConvexK3Degree.lean
+++ b/Challenge/Erdos132ConvexK3Degree.lean
@@ -73,8 +73,10 @@ noncomputable def topThreeDistanceDegree
       squaredDistance (points i) (points j) = d₂ ∨
         squaredDistance (points i) (points j) = d₃).card
 
-/-- The `k = 3` case of the minimum-degree question following Theorem 2.7 of
-Erdős--Lovász--Vesztergombi: the graph of the three largest distance classes
+/-- The `k = 3` case of the "perhaps degree at most `2k`" question posed by
+Erdős--Lovász--Vesztergombi (printed p. 542), which their Theorem 2.7
+(printed p. 548) answers only with the weaker bound `3k - 1`: the graph of
+the three largest distance classes
 of a finite strictly convex planar set has a vertex of degree at most six.
 Distances are represented by their squares, which preserves equality and
 order for Euclidean distances. -/

--- a/Challenge/Erdos132ConvexK3Degree.lean
+++ b/Challenge/Erdos132ConvexK3Degree.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 Egor Lyfar. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Egor Lyfar
+-/
+
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Fintype.Fin
+import Mathlib.Data.Real.Basic
+
+/-!
+# Degree six for the three largest distances in convex position
+
+Source: doi:10.1007/BF02187746, url:https://www.erdosproblems.com/132
+Proposed by: Egor Lyfar
+Open declarations: `Challenge.Erdos132ConvexK3Degree.degree_le_six`
+Tags: combinatorial-geometry, distance-graphs, convex-position, erdos-problems
+MSC: 52C10, 05C12
+Estimated size: ~10000 lines of Lean
+
+Informal statement:
+* `Challenge.Erdos132ConvexK3Degree.degree_le_six` — For every injectively labelled finite set of
+  points in the real Euclidean plane, listed in counterclockwise strictly convex position and having
+  at least three distinct interpoint distances, and for its explicitly named three largest
+  squared-distance classes, the graph joining pairs in those classes has a vertex of degree at most
+  six. Squaring preserves equality and order of Euclidean distances.
+-/
+
+namespace Challenge.Erdos132ConvexK3Degree
+
+/-- A point in the real Euclidean plane, represented by Cartesian coordinates. -/
+abbrev Point := ℝ × ℝ
+
+/-- Twice the signed area of the oriented triangle `abc`. -/
+def orientedArea (a b c : Point) : ℝ :=
+  (b.1 - a.1) * (c.2 - a.2) - (b.2 - a.2) * (c.1 - a.1)
+
+/-- Squared Euclidean distance between two Cartesian points. -/
+def squaredDistance (a b : Point) : ℝ :=
+  (b.1 - a.1) ^ 2 + (b.2 - a.2) ^ 2
+
+/-- The successor of an index in its cyclic order. -/
+def cyclicNext {n : ℕ} (i : Fin n) : Fin n :=
+  ⟨(i.val + 1) % n, Nat.mod_lt _ (Nat.zero_lt_of_lt i.isLt)⟩
+
+/-- An injectively labelled finite set in strictly convex position, listed in
+counterclockwise boundary order. Every point other than the endpoints of a
+boundary edge lies strictly to the left of that oriented edge. -/
+def StrictlyConvexPosition {n : ℕ} (points : Fin n → Point) : Prop :=
+  Function.Injective points ∧
+    ∀ i j, j ≠ i → j ≠ cyclicNext i →
+      0 < orientedArea (points i) (points (cyclicNext i)) (points j)
+
+/-- `d₁ > d₂ > d₃` are exactly the three largest squared-distance
+classes realized by distinct pairs of points. The witnesses force at least
+three distinct interpoint distances. -/
+def AreThreeLargestSquaredDistances
+    {n : ℕ} (points : Fin n → Point) (d₁ d₂ d₃ : ℝ) : Prop :=
+  d₃ < d₂ ∧ d₂ < d₁ ∧
+    (∃ i j, i < j ∧ squaredDistance (points i) (points j) = d₁) ∧
+    (∃ i j, i < j ∧ squaredDistance (points i) (points j) = d₂) ∧
+    (∃ i j, i < j ∧ squaredDistance (points i) (points j) = d₃) ∧
+    ∀ i j, i < j →
+      let d := squaredDistance (points i) (points j)
+      d ≤ d₁ ∧ (d < d₁ → d ≤ d₂) ∧ (d < d₂ → d ≤ d₃)
+
+/-- The degree of a vertex in the graph joining pairs whose squared distance
+is one of the three named largest classes. -/
+noncomputable def topThreeDistanceDegree
+    {n : ℕ} (points : Fin n → Point) (d₁ d₂ d₃ : ℝ) (i : Fin n) : ℕ :=
+  ((Finset.univ.erase i).filter fun j ↦
+    squaredDistance (points i) (points j) = d₁ ∨
+      squaredDistance (points i) (points j) = d₂ ∨
+        squaredDistance (points i) (points j) = d₃).card
+
+/-- The `k = 3` case of the minimum-degree question following Theorem 2.7 of
+Erdős--Lovász--Vesztergombi: the graph of the three largest distance classes
+of a finite strictly convex planar set has a vertex of degree at most six.
+Distances are represented by their squares, which preserves equality and
+order for Euclidean distances. -/
+theorem degree_le_six
+    {n : ℕ} (points : Fin n → Point) (d₁ d₂ d₃ : ℝ)
+    (hPosition : StrictlyConvexPosition points)
+    (hDistances : AreThreeLargestSquaredDistances points d₁ d₂ d₃) :
+    ∃ i, topThreeDistanceDegree points d₁ d₂ d₃ i ≤ 6 := sorry
+
+end Challenge.Erdos132ConvexK3Degree

--- a/Challenge/challenges.yml
+++ b/Challenge/challenges.yml
@@ -157,3 +157,52 @@ challenges:
     msc:
       - "20C15"
       - "20D20"
+  - slug: erdos132-convex-k3-degree
+    title: Degree six for the three largest distances in convex position
+    summary: >-
+      Prove the k = 3 case of the minimum-degree question raised after Theorem
+      2.7 of Erdős, Lovász, and Vesztergombi's 1989 paper: for a finite set in
+      strictly convex position, the graph joining pairs at one of the three
+      largest distances has minimum degree at most six. The three classes are
+      required to be distinct and realized, so configurations with fewer than
+      three interpoint distances do not satisfy the hypotheses. The companion
+      conditional pooled project in Vilin97/lean-pool#340, from branch
+      lyfar/erdos132-convex-k3, formalizes the intended route except for one
+      coordinated-majorant selection step used but not stated in the 1989
+      sketch. A solution is expected to close that project boundary and then
+      provide a thin Solution bridge. The 10000-line estimate starts from the
+      existing roughly 5700-line conditional development and allows for the
+      missing step, whose eventual size is not yet known.
+    branch: discrete geometry
+    entry_module: Challenge.Erdos132ConvexK3Degree
+    proposers:
+      - Egor Lyfar
+    source:
+      title: On the graph of large distances
+      authors:
+        - Paul Erdős
+        - László Lovász
+        - Katalin Vesztergombi
+      doi: "10.1007/BF02187746"
+      url: https://www.erdosproblems.com/132
+    license: Apache-2.0
+    provenance: AI
+    status: open
+    estimated_lines: 10000
+    statements:
+      - declaration: Challenge.Erdos132ConvexK3Degree.degree_le_six
+        informal: >-
+          For every injectively labelled finite set of points in the real
+          Euclidean plane, listed in counterclockwise strictly convex position
+          and having at least three distinct interpoint distances, and for its
+          explicitly named three largest squared-distance classes, the graph
+          joining pairs in those classes has a vertex of degree at most six.
+          Squaring preserves equality and order of Euclidean distances.
+    tags:
+      - combinatorial-geometry
+      - distance-graphs
+      - convex-position
+      - erdos-problems
+    msc:
+      - "52C10"
+      - "05C12"

--- a/Challenge/challenges.yml
+++ b/Challenge/challenges.yml
@@ -160,10 +160,12 @@ challenges:
   - slug: erdos132-convex-k3-degree
     title: Degree six for the three largest distances in convex position
     summary: >-
-      Prove the k = 3 case of the minimum-degree question raised after Theorem
-      2.7 of Erdős, Lovász, and Vesztergombi's 1989 paper: for a finite set in
-      strictly convex position, the graph joining pairs at one of the three
-      largest distances has minimum degree at most six. The three classes are
+      Prove the k = 3 case of the minimum-degree question posed on printed
+      p. 542 of Erdős, Lovász, and Vesztergombi's 1989 paper ("perhaps degree
+      at most 2k"), which their Theorem 2.7 on printed p. 548 answers only
+      with the weaker bound 3k - 1: for a finite set in strictly convex
+      position, the graph joining pairs at one of the three largest distances
+      has minimum degree at most six. The three classes are
       required to be distinct and realized, so configurations with fewer than
       three interpoint distances do not satisfy the hypotheses. The companion
       conditional pooled project in Vilin97/lean-pool#340, from branch


### PR DESCRIPTION
This poses the k = 3 case of the ErLV89 Theorem 2.7 minimum-degree question as an open challenge: for a finite set in strictly convex position with at least three distinct interpoint distances, the graph joining pairs at one of the three largest distances has a vertex of degree at most six.

Registered declaration: `Challenge.Erdos132ConvexK3Degree.degree_le_six` — self-contained, Mathlib-only imports, 87 lines, single `sorry` at the registered statement.

Companion to draft PR #340, which formalizes the intended route conditionally: everything except one coordinated-majorant selection step used but not stated in the 1989 proof sketch (see the discussion comment there). A solution is expected to close that boundary in the pooled project and land a thin `Solution/` bridge — the vocabulary mapping from the pooled project to this statement was compiled as a temporary adapter during preparation and then removed, so the bridge is known writable.

Receipts: `lake build Challenge` — success, 3,305 jobs, only the expected registered `sorry` notices; challenge registry/static/axiom audit (12 declarations) green; `lake exe mk_all` and the card writer both current.

Opened as a draft pending the fit questions raised on #340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)