### PR TITLE
chore: refresh README stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Lean Pool sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and [`merely-true`](https://github.com/merely-true/merely-true), preserving Lean 4 formalizations that don't fit mathlib's scope. Instead of mathlib's high-bar human review, it relies on deterministic linters and LLM judgment, so it can grow faster while staying `sorry`-free and pinned to the latest Mathlib. See [`MOTIVATION.md`](MOTIVATION.md) for the why, browse the API docs at <https://vilin97.github.io/lean-pool/>, and explore each project's dependency graph and declarations in the [exposition site](https://vilin97.github.io/lean-pool/exposition/).
 
 <!-- BEGIN STATS -->
-**149** formalization projects · **1,306,391** lines of Lean · **2** open challenges
+**151** formalization projects · **1,322,171** lines of Lean · **2** open challenges
 <!-- END STATS -->
 
 <sub>(stats above are refreshed automatically by [`readme-stats.yml`](.github/workflows/readme-stats.yml) — edit [`python/lean_pool/stats.py`](python/lean_pool/stats.py), not the numbers)</sub>


### PR DESCRIPTION
Automated refresh of the generated statistics in README.md.

Generated by .github/workflows/readme-stats.yml.