### PR TITLE
docs: link semantic search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 Lean Pool sits between [`mathlib`](https://github.com/leanprover-community/mathlib4) and [`merely-true`](https://github.com/merely-true/merely-true), preserving Lean 4 formalizations that don't fit mathlib's scope. Instead of mathlib's high-bar human review, it relies on deterministic linters and LLM judgment, so it can grow faster while staying `sorry`-free and pinned to the latest Mathlib. See [`MOTIVATION.md`](MOTIVATION.md) for the why, browse the API docs at <https://vilin97.github.io/lean-pool/>, and explore each project's dependency graph and declarations in the [exposition site](https://vilin97.github.io/lean-pool/exposition/).
 
+Semantic search is also available via the [API](https://search.octo.axiomatic-ai.com/api/search).
+
 <!-- BEGIN STATS -->
 **173** formalization projects · **1,474,530** lines of Lean · **2** open challenges
 <!-- END STATS -->


### PR DESCRIPTION
Adds a concise README link to the Octo semantic search HTTP API.\n\nVerification: `git diff --check`